### PR TITLE
Fix for Text Migration Error

### DIFF
--- a/cms/plugins/text/migrations/0004_table_rename.py
+++ b/cms/plugins/text/migrations/0004_table_rename.py
@@ -12,13 +12,13 @@ class Migration:
     def forwards(self, orm):    
         db.rename_table("text_text", "cmsplugin_text")
         db.rename_table("text_publictext", "cmsplugin_textpublic")
+        db.rename_column("cmsplugin_textpublic", "publiccmsplugin_ptr_id", "cmspluginpublic_ptr_id")
         db.alter_column('cmsplugin_text', 'public_id', orm['text.text:public'])
         try:
             db.delete_foreign_key('cmsplugin_text' ,'public_id')
         except:
             pass
-        db.drop_primary_key("cmsplugin_textpublic")
-        db.rename_column("cmsplugin_textpublic", "publiccmsplugin_ptr_id", "cmspluginpublic_ptr_id")
+        db.drop_primary_key("cmsplugin_textpublic")  
         db.create_primary_key("cmsplugin_textpublic", ("cmspluginpublic_ptr_id",))
         db.foreign_key_sql('cmsplugin_text' ,'public_id', 'cmsplugin_textpublic', 'cmspluginpublic_ptr_id')
         


### PR DESCRIPTION
This will fix the text plugin migration error on migration 0004 that occurs when starting from a clean database. I think there are similar problems with other plugins, that I can fix as well. This is my first time committing to a project, so I'm not sure what the protocol is on pull requests. I can make all of the migration fixes and send you another pull request if you need.
