### PR TITLE
fixed link in installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,7 +3,7 @@ Installation
 
 This document assumes that you are familiar with python and django.
 
-A more beginner friendly tutorial can be found `here <tutorial>`_.
+A more beginner friendly tutorial can be found :doc:`here <tutorial>`.
 
 Requirements
 ------------


### PR DESCRIPTION
the tutorial link was broken (pointing to "tutorial" instead of "tutorial.html")
