### PR TITLE
Fix and test for #588

### DIFF
--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -119,9 +119,9 @@ class CMSPlugin(Mptt):
         if plugin.model != self.__class__: # and self.__class__ == CMSPlugin:
             # (if self is actually a subclass, getattr below would break)
             try:
-                instance = getattr(self, plugin.model.__name__.lower())
+                #instance = getattr(self, plugin.model.__name__.lower())
                 # could alternatively be achieved with:
-                # instance = plugin_class.model.objects.get(cmsplugin_ptr=self)
+                instance = plugin_class.model.objects.get(cmsplugin_ptr=self)
                 instance._render_meta = self._render_meta
             except (AttributeError, ObjectDoesNotExist):
                 instance = None

--- a/tests/testapp/sampleapp/cms_plugins.py
+++ b/tests/testapp/sampleapp/cms_plugins.py
@@ -1,0 +1,8 @@
+from cms.plugin_pool import plugin_pool
+from cms.plugins.link.cms_plugins import LinkPlugin
+from models import CustomLink
+
+class ExtendedLinkPlugin(LinkPlugin):
+    model = CustomLink
+     
+plugin_pool.register_plugin(ExtendedLinkPlugin)

--- a/tests/testapp/sampleapp/models.py
+++ b/tests/testapp/sampleapp/models.py
@@ -1,4 +1,5 @@
 from cms.models.fields import PlaceholderField
+from cms.plugins.link.models import Link as CMSLink
 from django.core.urlresolvers import reverse
 from django.db import models
 import mptt
@@ -25,3 +26,6 @@ except mptt.AlreadyRegistered:
 class Picture(models.Model):
     image = models.ImageField(upload_to="pictures")
     category = models.ForeignKey(Category)
+
+class CustomLink(CMSLink):
+    custom_field = models.CharField(max_length=20, blank=True)


### PR DESCRIPTION
Issue #588 identifies that when a model extends an existing plugin model rather than extending CMSPlugin directly,  the plugin instance is not returned correctly from get_plugin_instance()

This patch includes a simple test case to demonstrate the problem, along with a fix that repairs the problem.

However, I don't think this is the best fix for this issue.  The fix came from a comment left by the original developer, however the existing code was obviously intended to take advantage of the fact that the plugin model was already loaded, thus avoiding an extra DB fetch.
I am not familiar enough with this code to find where the plugin model is being attached to the CMSPlugin object - but I suspect that is where the actual fix should be made to permanently resolve this issue.
