### PR TITLE
Fix for #560

### DIFF
--- a/example/settings.py
+++ b/example/settings.py
@@ -66,9 +66,6 @@ MIDDLEWARE_CLASSES = (
     'cms.middleware.user.CurrentUserMiddleware',
     'cms.middleware.page.CurrentPageMiddleware',
     'cms.middleware.toolbar.ToolbarMiddleware',
-    
-    #'debug_toolbar.middleware.DebugToolbarMiddleware'
-    
 )
 
 DEBUG_TOOLBAR_CONFIG = {


### PR DESCRIPTION
This pull request simply removes 'debug_toolbar.middleware.DebugToolbarMiddleware'
 from settings.py in example project. Without this settting, the project is working almost straight after installation - that's how things should look like!
