### PR TITLE
When the cms is mounted on non-root urls middleware path_info checks fail

### DIFF
--- a/cms/middleware/media.py
+++ b/cms/middleware/media.py
@@ -21,7 +21,8 @@ class PlaceholderMediaMiddleware(object):
             return False 
         if not response['Content-Type'].split(';')[0] in HTML_TYPES:
             return False
-        if request.path.startswith(urlparse.urlparse(settings.MEDIA_URL)[2]):
+        media = urlparse.urlparse(settings.MEDIA_URL)
+        if request.path.startswith(media.path) and request.get_host() == media.netloc:
             return False
         return True
     

--- a/cms/middleware/toolbar.py
+++ b/cms/middleware/toolbar.py
@@ -40,7 +40,7 @@ class ToolbarMiddleware(object):
         if request.is_ajax():
             return False
         if response.status_code != 200:
-            return False 
+            return False
         if not response['Content-Type'].split(';')[0] in HTML_TYPES:
             return False
         try:
@@ -48,7 +48,8 @@ class ToolbarMiddleware(object):
                 return False
         except NoReverseMatch:
             pass
-        if request.path.startswith(urlparse.urlparse(settings.MEDIA_URL)[2]):
+        media = urlparse.urlparse(settings.MEDIA_URL)
+        if request.path.startswith(media.path) and request.get_host() == media.netloc:
             return False
         if "edit" in request.GET:
             return True
@@ -57,7 +58,7 @@ class ToolbarMiddleware(object):
         if not request.user.is_authenticated() or not request.user.is_staff:
             return False
         return True
-    
+
     def process_request(self, request):
         if request.method == "POST":
             if "edit" in request.GET and "cms_username" in request.POST:
@@ -101,7 +102,7 @@ class ToolbarMiddleware(object):
                     name = placeholder
                 d['name'] = title(name)
                 plugins = plugin_pool.get_all_plugins(placeholder, page)
-                d['plugins'] = [] 
+                d['plugins'] = []
                 for p in plugins:
                     d['plugins'].append(p.value)
                 d['type'] = placeholder
@@ -125,4 +126,3 @@ class ToolbarMiddleware(object):
         #from django.core.context_processors import csrf
         #context.update(csrf(request))
         return render_to_string('cms/toolbar/toolbar.html', context, RequestContext(request))
-


### PR DESCRIPTION
If I run this with mod_wsgi on a non-root url (eg: WSGIScriptAlias /foobar blabla.wsgi) ToolbarMiddleware would run even on admin urls (django.core.urlresolvers.reverse includes script_info in the resolved path; path_info is the part _after_ script_info - thus the check breaks). 

Also, checks against MEDIA_URL in PlaceholderMediaMiddleware and ToolbarMiddleware exhibit the same problem.
