### PR TITLE
Feature/l10n fixes

### DIFF
--- a/cms/middleware/toolbar.py
+++ b/cms/middleware/toolbar.py
@@ -13,7 +13,7 @@ from django.template.defaultfilters import title, safe
 from django.template.loader import render_to_string
 from django.utils import simplejson
 from django.utils.encoding import smart_unicode
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext as _
 
 HTML_TYPES = ('text/html', 'application/xhtml+xml')
 


### PR DESCRIPTION
Building on previous pull request I've added gettext for placeholder name in toolbar middleware. Makes 'Move to [placeholder name]' show the correct translated value.
