### PR TITLE
Feature/publish btn

### DIFF
--- a/cms/middleware/toolbar.py
+++ b/cms/middleware/toolbar.py
@@ -121,6 +121,7 @@ class ToolbarMiddleware(object):
             'auth_error':not auth and 'cms_username' in request.POST,
             'placeholder_data':data,
             'edit':edit,
+            'moderator': cms_settings.CMS_MODERATOR,
             'CMS_MEDIA_URL': cms_settings.CMS_MEDIA_URL,
         })
         #from django.core.context_processors import csrf

--- a/cms/templates/cms/toolbar/toolbar.html
+++ b/cms/templates/cms/toolbar/toolbar.html
@@ -157,7 +157,7 @@
     </div>
     <div id="cms_toolbar_col2">
         {% if edit and page %}
-        {% if auth %}
+        {% if auth and moderator %}
             {% if moderator_should_approve and has_moderate_permission %}
             <a id="cms_toolbar_approvebutton" href="{% url admin:cms_page_approve_page page.pk %}" class="button green" title="{% trans 'Approve directly' %}">
                 <span class="state">{{ page_moderator_state.label }}</span>


### PR DESCRIPTION
Publish/moderator button is visible even though CMS_MODERATOR = False (which makes the publish button's action denied). 
This commit adds a moderator variable to toolbar context and hides the button when moderator is False. 
