### PR TITLE
Use more correct path to jquery in toolbar template

### DIFF
--- a/cms/templates/cms/toolbar/toolbar.html
+++ b/cms/templates/cms/toolbar/toolbar.html
@@ -1,5 +1,5 @@
-{% load i18n %}
-<script type="text/javascript" src="{{ MEDIA_URL }}admin/js/jquery.min.js"></script>
+{% load i18n adminmedia %}
+<script type="text/javascript" src="{% admin_media_prefix %}js/jquery.min.js"></script>
 <script type="text/javascript">
     //<![CDATA[
     // When jQuery is sourced, it's going to overwrite whatever might be in the


### PR DESCRIPTION
Use {% admin_media_prefix %} instead of {{ MEDIA_URL }}. I think it is more correct because jquery.min.js taken from the admin-site. So it makes sense to load it just as is done in the admin-site templates.
