### PR TITLE
Context handling in Placeholder.render

### DIFF
--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -27,7 +27,8 @@ class Placeholder(models.Model):
         from cms.plugin_rendering import render_placeholder
         if not 'request' in context:
             return '<!-- missing request -->'
-        context.update({'width': width or self.default_width})
+        if width or self.default_width:
+            context.update({'width': width or self.default_width})
         return render_placeholder(self, context)
 
     def get_media(self, request, context):


### PR DESCRIPTION
Say that we have a placeholder field and we didn't set a default width for it in the model.
Currently, using 
    {% render_placeholder ph_field %}
the code at https://github.com/divio/django-cms/blob/master/cms/plugin_rendering.py#L148 will never be able to fallback on the width specified in CMS_PLACEHOLDER_CONF due to None being put in context here https://github.com/divio/django-cms/blob/master/cms/models/placeholdermodel.py#L30.

I propose that width is not set in context if None.
