### PR TITLE
Preventing jQuery from overwriting variables

### DIFF
--- a/cms/media/cms/css/toolbar.css
+++ b/cms/media/cms/css/toolbar.css
@@ -772,7 +772,7 @@ a#closeBut:hover strong
 
 /* button 
 ---------------------------------------------- */
-.button {
+.cms_button {
     float:left;
 	display: inline-block;
 	zoom: 1; /* zoom and *display = ie7 hack for display:inline-block */
@@ -793,22 +793,22 @@ a#closeBut:hover strong
 	-moz-box-shadow: 0 1px 2px rgba(0,0,0,.2);
 	box-shadow: 0 1px 2px rgba(0,0,0,.2);
 }
-.button:hover {
+.cms_button:hover {
 	text-decoration: none;
 }
-.button:active {
+.cms_button:active {
 	position: relative;
 	top: 1px;
 }
-a.button {
+a.cms_button {
     color:white;
 }
-a.button:hover {
+a.cms_button:hover {
     color:white;
 }
 
 /* green */
-.green {
+.cms_button.green {
 	color: #e8f0de;
 	border: solid 1px #538312;
 	background: #64991e;
@@ -816,20 +816,20 @@ a.button:hover {
 	background: -moz-linear-gradient(top,  #7db72f,  #4e7d0e);
 	filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#7db72f', endColorstr='#4e7d0e');
 }
-.green:hover {
+.cms_button.green:hover {
 	background: #538018;
 	background: -webkit-gradient(linear, left top, left bottom, from(#6b9d28), to(#436b0c));
 	background: -moz-linear-gradient(top,  #6b9d28,  #436b0c);
 	filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#6b9d28', endColorstr='#436b0c');
 }
-.green:active {
+.cms_button.green:active {
 	color: #a9c08c;
 	background: -webkit-gradient(linear, left top, left bottom, from(#4e7d0e), to(#7db72f));
 	background: -moz-linear-gradient(top,  #4e7d0e,  #7db72f);
 	filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#4e7d0e', endColorstr='#7db72f');
 }
 /* blue */
-.blue {
+.cms_button.blue {
 	color: #d9eef7;
 	border: solid 1px #0076a3;
 	background: #0095cd;
@@ -837,13 +837,13 @@ a.button:hover {
 	background: -moz-linear-gradient(top,  #00adee,  #0078a5);
 	filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#00adee', endColorstr='#0078a5');
 }
-.blue:hover {
+.cms_button.blue:hover {
 	background: #007ead;
 	background: -webkit-gradient(linear, left top, left bottom, from(#0095cc), to(#00678e));
 	background: -moz-linear-gradient(top,  #0095cc,  #00678e);
 	filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#0095cc', endColorstr='#00678e');
 }
-.blue:active {
+.cms_button.blue:active {
 	color: #80bed6;
 	background: -webkit-gradient(linear, left top, left bottom, from(#0078a5), to(#00adee));
 	background: -moz-linear-gradient(top,  #0078a5,  #00adee);

--- a/cms/templates/cms/toolbar/toolbar.html
+++ b/cms/templates/cms/toolbar/toolbar.html
@@ -169,16 +169,16 @@
         {% if edit and page %}
         {% if auth and moderator %}
             {% if moderator_should_approve and has_moderate_permission %}
-            <a id="cms_toolbar_approvebutton" href="{% url admin:cms_page_approve_page page.pk %}" class="button green" title="{% trans 'Approve directly' %}">
+            <a id="cms_toolbar_approvebutton" href="{% url admin:cms_page_approve_page page.pk %}" class="cms_button green" title="{% trans 'Approve directly' %}">
                 <span class="state">{{ page_moderator_state.label }}</span>
             </a>
             {% else %}
                 {% if has_publish_permission %}
-                <a id="cms_toolbar_publishbutton" href="{% url admin:cms_page_publish_page page.pk %}" class="button blue" title="{% trans 'Publish' %}">
+                <a id="cms_toolbar_publishbutton" href="{% url admin:cms_page_publish_page page.pk %}" class="cms_button blue" title="{% trans 'Publish' %}">
                     <span class="state">Publish</span>
                 </a>
                 {% else %}
-                    <a id="cms_toolbar_requestapproval" href="{% url admin:cms_page_approve_page page.pk %}" class="button blue" title="{% trans 'Request Approval' %}">
+                    <a id="cms_toolbar_requestapproval" href="{% url admin:cms_page_approve_page page.pk %}" class="cms_button blue" title="{% trans 'Request Approval' %}">
                         <span class="state">Request Approval</span>
                     </a>
                 {% endif %}


### PR DESCRIPTION
If jQuery is already imported in the `<head>` tag of the a website, the django-cms jQuery import will overwrite the `$` and `jQuery` variables.  This is especially a problem if jQuery plugins are imported in the `<head>` tag as well, because the new `jQuery` and `$` variables will not have these plugin features attached.

The current solution of storing the `$` variable in `_$` does not work because jQuery has already been imported by this point, so the new `$` is used, not the old one.  I fixed this problem by simply moving the `_$ = window.$` statement above the jQuery `<script>` import.  I also added temporary storage of the `jQuery` variable through `_jQuery`.
