### PR TITLE
fix testsuite for Django 1.3

### DIFF
--- a/cms/test/testcases.py
+++ b/cms/test/testcases.py
@@ -270,6 +270,7 @@ class CMSTestCase(TestCase):
             'wsgi.multiprocess': True,
             'wsgi.multithread':  False,
             'wsgi.run_once':     False,
+            'wsgi.input': None,
         }
         request = WSGIRequest(environ)
         request.session = self.client.session


### PR DESCRIPTION
Django changeset 14394[1](http://code.djangoproject.com/changeset/14394) added code that accesses
`self.environ['wsgi.input']` of the WSGIRequest instance. Our
WSGIRequest environ mock didn't contain that key, which led to
dozens of test failures
