### PR TITLE
Pass page URL through javascript for a surer refresh

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -1267,6 +1267,7 @@ class PageAdmin(model_admin):
                 'plugin_id': plugin_id,
                 'icon': force_escape(escapejs(saved_object.get_instance_icon_src())),
                 'alt': force_escape(escapejs(saved_object.get_instance_icon_alt())),
+                'page': page,
             }
             return render_to_response('admin/cms/page/plugin_forms_ok.html', context, RequestContext(request))
 

--- a/cms/media/cms/js/toolbar.js
+++ b/cms/media/cms/js/toolbar.js
@@ -2,12 +2,12 @@
 
 jQuery.noConflict();
 
-function hide_iframe(){
+function hide_iframe(id, type, title, msg, url){
     // needs to be a global function because it gets called 
     // from the iframe as `parent.hide_iframe`
     jQuery.nyroModalRemove();
     jQuery("#nyroModalWrapper .wrapperIframe").html("");
-    window.location = window.location.href;
+    window.location = url;
 }
 
 jQuery(document).ready(function($) {

--- a/cms/templates/admin/cms/page/plugin_forms_ok.html
+++ b/cms/templates/admin/cms/page/plugin_forms_ok.html
@@ -14,7 +14,7 @@
 //<![CDATA[	
 (function($) {
 	if(parent != self){
-		parent.hide_iframe({{ plugin.pk }}, "{{ type }}", "{{ name }}", "{% trans "Plugin saved successfully." %}");
+		parent.hide_iframe({{ plugin.pk }}, "{{ type }}", "{{ name }}", "{% trans "Plugin saved successfully." %}", "{{ page.get_absolute_url }}");
 	}else{
 		opener.dismissEditPluginPopup(window, "{{ plugin_id }}", "{{ icon }}", "{{ alt }}");
 	}


### PR DESCRIPTION
The page URL may change during editing through popup (like overriding the plugin save() method).

So 404 errors can be avoided passing the page URL to the javascript function that refreshes the actual page.
