### PR TITLE
Allowing multiple versions of `jQuery` and `$` variables

### DIFF
--- a/cms/templates/cms/toolbar/toolbar.html
+++ b/cms/templates/cms/toolbar/toolbar.html
@@ -1,11 +1,15 @@
 {% load i18n adminmedia %}
 {% include "cms/inc/csrf_js.html" %}
-<script type="text/javascript" src="{% admin_media_prefix %}js/jquery.min.js"></script>
 <script type="text/javascript">
     //<![CDATA[
     // When jQuery is sourced, it's going to overwrite whatever might be in the
-    // '$' variable, so store a reference of it in a temporary variable...
+    // '$' and jQuery variables, so store a reference of them in temporary variables.
     var _$ = window.$;
+    var _jQuery = window.jQuery;
+</script>
+<script type="text/javascript" src="{% admin_media_prefix %}js/jquery.min.js"></script>
+<script type="text/javascript">
+    //<![CDATA[
     // add stylesheets to head
     (function ($) {
 		$('<link>').appendTo('head').attr({
@@ -121,8 +125,9 @@
 <script type="text/javascript" src="{{ CMS_MEDIA_URL }}js/toolbar.js"></script>
 <script type="text/javascript" charset="utf-8">
     //<![CDATA[
-    // Now that jQuery is done loading, put the '$' variable back to what it was...
+    // Now that jQuery is done loading, put the '$' and jQuery variables back to what they were.
     var $ = _$;
+    var jQuery = _jQuery;
     //]]>
 </script>
 


### PR DESCRIPTION
If jQuery is already imported in the `<head>` tag of the a website, the django-cms jQuery import will overwrite the `$` and `jQuery` variables.  This is especially a problem if jQuery plugins are imported in the `<head>` tag as well, because the new `jQuery` and `$` variables will not have these plugin features attached.

The current solution of storing the `$` variable in `_$` does not work because jQuery has already been imported by this point, so the new `$` is used, not the old one.  I fixed this problem by simply moving the `_$ = window.$` statement above the jQuery `<script>` import.  I also added temporary storage of the `jQuery` variable through `_jQuery`.

This patch should allow jQuery to be run on a django-cms powered website without interfering with or being affected by the django-cms toolbar.
