### PR TITLE
Fix post_copy method on Text model to work with text plugin subclasses

### DIFF
--- a/cms/plugins/text/models.py
+++ b/cms/plugins/text/models.py
@@ -50,7 +50,7 @@ class AbstractText(CMSPlugin):
         for new, old in ziplist:
             replace_ids[old.pk] = new.pk
 
-        self.body = replace_plugin_tags(old_instance.text.body, replace_ids)
+        self.body = replace_plugin_tags(old_instance.get_plugin_instance()[0].body, replace_ids)
         self.save()
             
 class Text(AbstractText):


### PR DESCRIPTION
This fixes issue with copying text-based plugins (eg: copy from other language)
