### PR TITLE
Add CDATA sections around javascript in text widgets

### DIFF
--- a/cms/plugins/text/templates/cms/plugins/widgets/wymeditor.html
+++ b/cms/plugins/text/templates/cms/plugins/widgets/wymeditor.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <script type="text/javascript">
-
+//<![CDATA[
 // Global var, for storing callbacks, see below.
 var editPluginPopupCallbacks = {};
 
@@ -116,4 +116,5 @@ function get_plugin_html(){
 return html;
 
 }
-    </script>
+//]]>
+</script>

--- a/cms/plugins/text/widgets/tinymce_widget.py
+++ b/cms/plugins/text/widgets/tinymce_widget.py
@@ -77,7 +77,7 @@ class TinyMCEEditor(TinyMCE):
             }
             c_json = simplejson.dumps(compressor_config)
             html.append(u'<script type="text/javascript">tinyMCE_GZ.init(%s);</script>' % (c_json))
-        html.append(u'<script type="text/javascript">%s;\ntinyMCE.init(%s);</script>' % (self.render_additions(name, value, attrs), json))
+        html.append(u'<script type="text/javascript">//<![CDATA[\n%s;\ntinyMCE.init(%s);\n//]]></script>' % (self.render_additions(name, value, attrs), json))
         return mark_safe(u'\n'.join(html))
     
     


### PR DESCRIPTION
This should fix this problem:
ValueError: invalid literal for int() with base 10: "17/edit-plugin/139/' + escapeHtml(icon_src) + '"

Seems that some browsers actually parse the widget javascript as html.
