### PR TITLE
Added check to not show cms toolbar for static media requests

### DIFF
--- a/cms/middleware/toolbar.py
+++ b/cms/middleware/toolbar.py
@@ -5,7 +5,7 @@ Edit Toolbar middleware
 from cms import settings as cms_settings
 from cms.utils import get_template_from_request
 from cms.utils.plugins import get_placeholders
-from cms.utils.urlutils import is_media_request
+from cms.utils.urlutils import is_media_request, is_static_media_request
 from django.contrib.auth import authenticate, login, logout
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.template.context import RequestContext
@@ -54,6 +54,8 @@ class ToolbarMiddleware(object):
         except NoReverseMatch:
             pass
         if is_media_request(request):
+            return False
+        if is_static_media_request(request):
             return False
         if "edit" in request.GET:
             return True

--- a/cms/utils/urlutils.py
+++ b/cms/utils/urlutils.py
@@ -59,3 +59,11 @@ def is_media_request(request):
         else:
             return True
     return False 
+
+def is_static_media_request(request):
+    """
+    Check if a request is a static media request.
+    """
+    if request.path.startswith(settings.STATIC_URL):
+        return True
+    return False


### PR DESCRIPTION
I realised that my final comment in this thread:
https://groups.google.com/group/django-cms/browse_thread/thread/ff85b33225957569

was actually wrong and the toolbar was still showing at this url:
http://127.0.0.1:8000/site_media/static/admin/tiny_mce/themes/advanced/image.htm

So I made some changes to not show the toolbar if the request is for a static media file. Wondering if you will review. Obviously this only applies to 2.1.3 as as you mentioned this is all changing in 2.2.

Cheers,
Dan
