### PR TITLE
Fixed multilingual middleware so it doesn't set django.session["django_language"] every time

### DIFF
--- a/cms/middleware/multilingual.py
+++ b/cms/middleware/multilingual.py
@@ -70,7 +70,8 @@ class MultilingualURLMiddleware:
             t = prefix
             if t in SUPPORTED:
                 lang = t
-                if hasattr(request, "session"):
+                if hasattr(request, "session") and \
+                        request.session.get("django_language", None) != lang:
                     request.session["django_language"] = lang
                 changed = True
         else:
@@ -88,12 +89,12 @@ class MultilingualURLMiddleware:
                 lang = translation.get_language_from_request(request)
         lang = get_default_language(lang)
         return lang
-    
+
     def process_request(self, request):
         language = self.get_language_from_request(request)
         translation.activate(language)
         request.LANGUAGE_CODE = language
-       
+
     def process_response(self, request, response):
         language = getattr(request, 'LANGUAGE_CODE', self.get_language_from_request(request))
         local_middleware = LocaleMiddleware()
@@ -102,7 +103,7 @@ class MultilingualURLMiddleware:
 
         # note: pages_root is assumed to end in '/'.
         #       testing this and throwing an exception otherwise, would probably be a good idea
-        
+
         if not path.startswith(settings.MEDIA_URL) and \
                 not path.startswith(settings.ADMIN_MEDIA_PREFIX) and \
                 response.status_code == 200 and \


### PR DESCRIPTION
Fixed multilingual middleware so it doesn't set django.session["django_language"] if it doesn't need to (so django doesn't save the session every time).
