### PR TITLE
make TEMPLATE_DIRS a tuple in example.

### DIFF
--- a/docs/getting_started/tutorial.rst
+++ b/docs/getting_started/tutorial.rst
@@ -152,7 +152,7 @@ Now add a little magic to the :setting:`django:TEMPLATE_DIRS` section of the fil
     TEMPLATE_DIRS = (
         # The docs say it should be absolute path: PROJECT_PATH is precisely one.
         # Life is wonderful!
-        os.path.join(PROJECT_PATH, "templates")
+        os.path.join(PROJECT_PATH, "templates"),
     )
 
 Add at least one template to :setting:`CMS_TEMPLATES`; for example::


### PR DESCRIPTION
a quirk of django's template processing allows TEMPLATE_DIRS to be a string. Presumably because of accidents like this, where TEMPLATE_DIRS should be a tuple. Simple doc fix in example.
