### PR TITLE
Exclude blank app hooks for all databases

### DIFF
--- a/cms/appresolver.py
+++ b/cms/appresolver.py
@@ -177,7 +177,7 @@ def get_app_patterns():
         hooked_applications = []
     
     # Loop over all titles with an application hooked to them
-    for title in title_qs.exclude(application_urls=None).select_related():
+    for title in title_qs.exclude(application_urls=None).exclude(application_urls='').select_related():
         if settings.CMS_FLAT_URLS:
             if title.language in home_slugs:
                 path = title.slug.split(home_slugs[title.language] + "/", 1)[-1]

--- a/cms/tests/apphooks.py
+++ b/cms/tests/apphooks.py
@@ -68,13 +68,20 @@ class ApphooksTestCase(CMSTestCase):
             superuser = User.objects.create_superuser('admin', 'admin@admin.com', 'admin')
             page = create_page("apphooked-page", "nav_playground.html", "en",
                                created_by=superuser, published=True, apphook="SampleApp")
+            blank_page = create_page("not-apphooked-page", "nav_playground.html", "en",
+                                     created_by=superuser, published=True, apphook="", slug='blankapp')
             english_title = page.title_set.all()[0]
             self.assertEquals(english_title.language, 'en')
             create_title("de", "aphooked-page-de", page, apphook="SampleApp")
             self.assertTrue(page.publish())
+            self.assertTrue(blank_page.publish())
     
             response = self.client.get(self.get_pages_root())
             self.assertTemplateUsed(response, 'sampleapp/home.html')
+
+            response = self.client.get('/en/blankapp/')
+            self.assertTemplateUsed(response, 'nav_playground.html')
+
             apphook_pool.clear()
     
     def test_get_page_for_apphook(self):


### PR DESCRIPTION
This patch fixes issue #790. I have tested it on sqlite and Oracle. The two excludes is less elegant, but is the equivalent of the old method using `application_urls > ''`, which didn't work on all databases.

Thank you,
Mike Johnson
