### PR TITLE
added longdesk now to image plugin as a title. Longdesc should be a url i

### DIFF
--- a/cms/plugins/picture/templates/cms/plugins/picture.html
+++ b/cms/plugins/picture/templates/cms/plugins/picture.html
@@ -1,5 +1,5 @@
 <span class="plugin_picture{% if picture.float %} {{ picture.float }}{% endif %}">
 {% if link %}<a href="{{ link }}">{% endif %}
-<img src="{{ picture.image.url }}" alt="{{ picture.alt }}" />
+<img src="{{ picture.image.url }}" alt="{{ picture.alt }}"{% if picture.longdesc %} title="{{ picture.longdesc }}"{% endif %} />
 {% if link %}</a>{% endif %}
 </span>


### PR DESCRIPTION
added longdesk now to image plugin as a title. Longdesc should be a url in general so someone should change the label to Title description rather than Long description. Fixes #484
