### PR TITLE
Using Static URL for images inside Toolbar items

### DIFF
--- a/cms/toolbar/items.py
+++ b/cms/toolbar/items.py
@@ -13,7 +13,7 @@ def _media(suffix):
     Helper that prefixes a URL with MEDIA_URL
     """
     if suffix:
-        return u'%s%s' % (settings.MEDIA_URL, suffix)
+        return u'%s%s' % (settings.STATIC_URL, suffix)
     return ''
 
 


### PR DESCRIPTION
Really small bug fix so that the images on the toolbar buttons are loaded when you've collected the django-cms using the django contrib static module
