### PR TITLE
Respect settings.SEND_BROKEN_LINK_EMAILS and don't email_managers in case

### DIFF
--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -82,7 +82,8 @@ def _get_page_by_untyped_arg(page_lookup, request, site_id):
         if settings.DEBUG:
             raise Page.DoesNotExist(body)
         else:
-            mail_managers(subject, body, fail_silently=True)
+            if settings.SEND_BROKEN_LINK_EMAILS:
+                mail_managers(subject, body, fail_silently=True)
             return None
 
 class PageUrl(InclusionTag):

--- a/cms/tests/templatetags.py
+++ b/cms/tests/templatetags.py
@@ -76,12 +76,19 @@ class TemplatetagDatabaseTests(TwoPagesFixture, SettingsOverrideTestCase):
             )
             self.assertEqual(len(mail.outbox), 0)
             
-    def test_get_page_by_untyped_arg_dict_fail_nodebug(self):
-        with SettingsOverride(DEBUG=False, MANAGERS=[("Jenkins", "tests@django-cms.org")]):
+    def test_get_page_by_untyped_arg_dict_fail_nodebug_do_email(self):
+        with SettingsOverride(SEND_BROKEN_LINK_EMAILS=True, DEBUG=False, MANAGERS=[("Jenkins", "tests@django-cms.org")]):
             request = self.get_request('/')
             page = _get_page_by_untyped_arg({'pk': 3}, request, 1)
             self.assertEqual(page, None)
             self.assertEqual(len(mail.outbox), 1)
+
+    def test_get_page_by_untyped_arg_dict_fail_nodebug_no_email(self):
+        with SettingsOverride(SEND_BROKEN_LINK_EMAILS=False, DEBUG=False, MANAGERS=[("Jenkins", "tests@django-cms.org")]):
+            request = self.get_request('/')
+            page = _get_page_by_untyped_arg({'pk': 3}, request, 1)
+            self.assertEqual(page, None)
+            self.assertEqual(len(mail.outbox), 0)
     
     def test_get_page_by_untyped_arg_fail(self):
         request = self.get_request('/')


### PR DESCRIPTION
Respect settings.SEND_BROKEN_LINK_EMAILS and don't email_managers in case of a failed page lookup
