### PR TITLE
Floating placeholders

### DIFF
--- a/cms/media/cms/css/toolbar.css
+++ b/cms/media/cms/css/toolbar.css
@@ -619,6 +619,7 @@ span.cms_toolbar_icon.cms_toolbar_state-icon.del
     padding-left:10px;
     padding-right:10px;
     position:relative;
+    overflow:hidden;
 }
 
 .cms_toolbar_placeholder_plugins_title


### PR DESCRIPTION
This appears to fix an issue where the placeholder toolbar's contents is missing when there is another placeholder floated directly beside.
