### PR TITLE
Fixes bug in publishing due to not committing/rolling back

### DIFF
--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -375,6 +375,7 @@ class Page(Mptt):
         """
         # Publish can only be called on moderated and draft pages
         if not self.publisher_is_draft:
+            transaction.rollback()
             return
 
         # publish, but only if all parents are published!!
@@ -459,6 +460,9 @@ class Page(Mptt):
         # fire signal after publishing is done
         import cms.signals as cms_signals
         cms_signals.post_publish.send(sender=Page, instance=self)
+
+        transaction.commit()
+
         return published
         
     def delete(self):


### PR DESCRIPTION
I was investigating issue #760 and ending up following gmcguire's link:

http://groups.google.com/group/django-cms/browse_thread/thread/bdc8d229f2d6b665/0dea65df7e35aad1

wherein user Peja puts forth a way of reproducing the bug possibly related to the mailing list thread.

This may not be the same problem, but I found a bug which I can reproduce using the example project with default settings and the following environment:

Django-CMS hotfix-2.1.2 branch 
Django 1.3
Python 2.6.5
Scientific Linux 6

Traceback: https://gist.github.com/1085975

I'm able to reproduce it via these steps:
- Create a page.
- Create a child of that page.
- Attempt to publish the root page. (It's more apparent if you use the admin detail form for the root page, check the 'is published' box and then save.)

The attached patch adds a commit at the end of the page publish method, which fixes this case. It also includes a rollback at the top which would fix the case where publish is attempted on a non-draft page.
