### PR TITLE
Docs for #909 (redux)

### DIFF
--- a/docs/extending_cms/custom_plugins.rst
+++ b/docs/extending_cms/custom_plugins.rst
@@ -237,7 +237,10 @@ else clause.
     ``file``, ``flash``, ``googlemap``, ``link``, ``picture``, ``snippetptr``,
     ``teaser``, ``twittersearch``, ``twitterrecententries`` and ``video``.
 
-
+    Additionally, it is *recommended* that you avoid using ``page`` as a model
+    field, as it is declared as a property of :class:`cms.models.pluginmodel.CMSPlugin`,
+    and your plugin will not work as intended in the administration without
+    further work.
 
 Handling Relations
 ==================


### PR DESCRIPTION
Attempt number two (previously #915)

Provides a warning about an additional field to be avoided on CMSPlugins. Note the original comment in #909 mentions CMSPluginBase, but I don't know why I thought that was where the property was.

I struggle with git, I really do. I've managed to 'fix' the commits so that only the changes I've actually made are present in the diff, but it does seem to think that should involve 16 commits in total. Realistically, the only one of concern is 9ba5fbc8d46a8a67e33cc8b9600a4a467fd3752b (which basically got merged in again at 9ba5fbc8d46a8a67e33cc8b9600a4a467fd3752b), so if there's a way to cherry-pick that, perhaps that's a better idea? Magic git voodoo evades my understanding, unfortunately.
