### PR TITLE
Fixed #897 by only accessing request.POST in the middleware when we're pr

### DIFF
--- a/cms/cms_toolbar.py
+++ b/cms/cms_toolbar.py
@@ -219,11 +219,12 @@ class CMSToolbar(Toolbar):
         
     def _request_hook_post(self):
         # login hook
-        login_form = CMSToolbarLoginForm(self.request.POST)
-        if login_form.is_valid():
-            username = login_form.cleaned_data['cms_username']
-            password = login_form.cleaned_data['cms_password']
-            user = authenticate(username=username, password=password)
-            if user:
-                login(self.request, user)
-                self.init()
+        if 'cms-toolbar-login' in self.request.GET:
+            login_form = CMSToolbarLoginForm(self.request.POST)
+            if login_form.is_valid():
+                username = login_form.cleaned_data['cms_username']
+                password = login_form.cleaned_data['cms_password']
+                user = authenticate(username=username, password=password)
+                if user:
+                    login(self.request, user)
+                    self.init()

--- a/cms/templates/cms/toolbar/items/login.html
+++ b/cms/templates/cms/toolbar/items/login.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<form action="." method="post" id="cms_toolbar-item_login" class="cms_toolbar-item{% if auth_error %} cms_toolbar_error{% endif %}">
+<form action="?cms-toolbar-login=1" method="post" id="cms_toolbar-item_login" class="cms_toolbar-item{% if auth_error %} cms_toolbar_error{% endif %}">
 	<fieldset>
 		{% csrf_token %}
 		<label for="cms_toolbar-item_login-username">{% trans "Username" %}</label>


### PR DESCRIPTION
Fixed #897 by only accessing request.POST in the middleware when we're pretty sure the POST is for the toolbar (login)
