### PR TITLE
Placeholder scanning is broken with cached template loader.

### DIFF
--- a/cms/utils/plugins.py
+++ b/cms/utils/plugins.py
@@ -30,7 +30,9 @@ def _extend_blocks(extend_node, blocks):
         else:
             # set this node as the super node (for {{ block.super }})
             block = blocks[node.name]
-            while hasattr(block.super, 'nodelist'):
+            seen_supers = []
+            while hasattr(block.super, 'nodelist') and block.super not in seen_supers:
+                seen_supers.append(block.super)
                 block = block.super
             block.super = node
     # search for further ExtendsNodes

--- a/tests/project/settings.py
+++ b/tests/project/settings.py
@@ -43,10 +43,18 @@ FIXTURE_DIRS = [os.path.join(PROJECT_DIR, 'fixtures')]
 
 SECRET_KEY = '*xq7m@)*f2awoj!spa0(jibsrz9%c0d=e(g)v*!17y(vx0ue_3'
 
+#TEMPLATE_LOADERS = (
+#    'django.template.loaders.filesystem.Loader',
+#    'django.template.loaders.app_directories.Loader',
+#    'django.template.loaders.eggs.Loader',
+#)
+
 TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-    'django.template.loaders.eggs.Loader',
+    ('django.template.loaders.cached.Loader', (
+        'django.template.loaders.filesystem.Loader',
+        'django.template.loaders.app_directories.Loader',
+        'django.template.loaders.eggs.Loader',
+    )),
 )
 
 TEMPLATE_CONTEXT_PROCESSORS = [


### PR DESCRIPTION
This fixes the placeholder scanning/template parsing when using the cached template loader.

Without this fix the test suite will freeze/infinite loop while parsing the templates.

To test this, we need to run the test suite two times, 1) without cached template loader 2) with cached template loader. I don't know if a testcase with settings override will work.
