### PR TITLE
Fixed plugin_pool.register_plugin with a list of plugins

### DIFF
--- a/cms/plugin_pool.py
+++ b/cms/plugin_pool.py
@@ -6,6 +6,7 @@ from cms.utils.helpers import reversion_register
 from cms.utils.placeholder import get_placeholder_conf
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+import warnings
 
 class PluginPool(object):
     def __init__(self):
@@ -25,8 +26,10 @@ class PluginPool(object):
         If a plugin is already registered, this will raise PluginAlreadyRegistered.
         """
         if hasattr(plugin,'__iter__'):
+            warnings.warn("Registering more than one plugin at once will be deprecated in 2.3", DeprecationWarning)
             for single_plugin in plugin:
                 self.register_plugin(single_plugin)
+            return
         if not issubclass(plugin, CMSPluginBase):
             raise ImproperlyConfigured(
                 "CMS Plugins must be subclasses of CMSPluginBase, %r is not."
@@ -58,8 +61,10 @@ class PluginPool(object):
         If a plugin isn't already registered, this will raise PluginNotRegistered.
         """
         if hasattr(plugin,'__iter__'):
+            warnings.warn("Unregistering more than one plugin at once will be deprecated in 2.3", DeprecationWarning)
             for single_plugin in plugin:
                 self.unregister_plugin(single_plugin)
+            return 
         plugin_name = plugin.__name__
         if plugin_name not in self.plugins:
             raise PluginNotRegistered(


### PR DESCRIPTION
added a deprecation warning. registering lists will be removed in 2.3 (because there should be one way to do it)
