### PR TITLE
Replaced a {{ ADMIN_MEDIA_URL }} reference by a {% admin_media_prefix %} 

### DIFF
--- a/cms/templates/admin/cms/page/change_form.html
+++ b/cms/templates/admin/cms/page/change_form.html
@@ -36,7 +36,7 @@
 	margin-bottom:-1px;
 	border-color:#ddd #aaa #ccc #ddd !important;
 	border:1px;
-	background:#fff url('{{ ADMIN_MEDIA_URL }}img/admin/nav-bg.gif') repeat-x center bottom !important;
+	background:#fff url('{% admin_media_prefix %}img/admin/nav-bg.gif') repeat-x center bottom !important;
 }
 
 #lang_tab_content h2.header {
@@ -45,7 +45,7 @@
 	font-size:11px;
 	text-align:left;
 	font-weight:bold;
-	background:#7ca0c7 url('{{ ADMIN_MEDIA_URL }}img/admin/default-bg.gif') repeat-x left top;
+	background:#7ca0c7 url('{% admin_media_prefix %}img/admin/default-bg.gif') repeat-x left top;
 	color:#fff;
 }
 


### PR DESCRIPTION
Replaced a {{ ADMIN_MEDIA_URL }} reference by a {% admin_media_prefix %} to avoid image 404.
This was causing issues when viewing a page version since the images were loaded relatively to
the page since ADMIN_MEDIA_URL was an empty string.

e.g. If viewing 'admin/cms/page/2/history/64565/' it attempted to load 'admin/cms/page/2/history/64565/img/admin/nav-bg.gif' which caused a error 500 since pageadmin was trying to cast '2/history/64565/img/admin/nav-bg.gif' to int: obj = self.model.objects.get(pk=object_id)
