### PR TITLE
Apply default filters to get_next_filtered_sibling

### DIFF
--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -934,6 +934,15 @@ class Page(MPTTModel):
                 '%s__gt' % opts.left_attr: getattr(self, opts.right_attr),
             })
 
+        # publisher stuff
+        filters.update({
+            'publisher_is_draft': self.publisher_is_draft
+        })
+        # multisite
+        filters.update({
+            'site__id': self.site_id
+        })
+
         sibling = None
         try:
             sibling = self._tree_manager.filter(**filters)[0]
@@ -984,7 +993,7 @@ class Page(MPTTModel):
             obj - public variant of `self` to be saved.
 
         """
-        prev_sibling = self.get_previous_filtered_sibling(publisher_is_draft=True, publisher_public__isnull=False)
+        prev_sibling = self.get_previous_filtered_sibling(publisher_public__isnull=False)
 
         if not self.publisher_public_id:
             # is there anybody on left side?

--- a/cms/tests/page.py
+++ b/cms/tests/page.py
@@ -515,6 +515,22 @@ class PagesTestCase(CMSTestCase):
             resp = self.client.get('/en/page/')
             self.assertEqual(resp.status_code, HttpResponseNotFound.status_code)
 
+    def test_public_home_page_replaced(self):
+        """Test that publishing changes to the home page doesn't move the public version"""
+        home = create_page('home', 'nav_playground.html', 'en', published = True, slug = 'home')
+        self.assertEqual(Page.objects.drafts().get_home().get_slug(), 'home')
+        home.publish()
+        self.assertEqual(Page.objects.public().get_home().get_slug(), 'home')
+        other = create_page('other', 'nav_playground.html', 'en', published = True, slug = 'other')
+        other.publish()
+        self.assertEqual(Page.objects.drafts().get_home().get_slug(), 'home')
+        self.assertEqual(Page.objects.public().get_home().get_slug(), 'home')
+        home = Page.objects.get(pk = home.id)
+        home.in_navigation = True
+        home.save()
+        home.publish()
+        self.assertEqual(Page.objects.drafts().get_home().get_slug(), 'home')
+        self.assertEqual(Page.objects.public().get_home().get_slug(), 'home')
 
 class NoAdminPageTests(CMSTestCase):
     urls = 'project.noadmin_urls'


### PR DESCRIPTION
This is related to #985.
The same default filters on draft status and site added to get_previous_sibling need to be applied to get_next_filtered_sibling, or the problem with the public home page being replaced will still occur.

I am also resubmitting the test on home page publication because I think it's useful, even though lower level tests on get_previous_filtered_sibling are being added.

Finally, I removed the publisher_is_draft parameter from a call to get_previous_sibling because it is now redundant.
