### PR TITLE
fixing js issue: placeholder id on plugin-list-holder was not set.

### DIFF
--- a/cms/static/cms/js/plugin_editor.js
+++ b/cms/static/cms/js/plugin_editor.js
@@ -2,6 +2,11 @@
     $(document).ready(function() {
         // Add Plugin Handler
     	$.fn.cmsPatchCSRF();
+        $('div.plugin-list-holder').each(function() {
+            // placeholder id is 'placeholder-PK'
+            var my_id = $(this).attr('id').split('-');
+            $(this).data('id', my_id[1]);
+        });
         $('span.add-plugin').click(function(){
          var select = $(this).parent().children("select[name=plugins]");
             var pluginvalue = select.attr('value');


### PR DESCRIPTION
$(this).parent().parent().data('id');

is used for adding, copying and sorting plugins, but the property is not set?
so I added it for all div.plugin-list-holder elements...maybe this should work differently? but I don't see how at the moment.

regards
ben
