### PR TITLE
fixes #1008

### DIFF
--- a/cms/plugins/twitter/templates/cms/plugins/twitter_recent_entries.html
+++ b/cms/plugins/twitter/templates/cms/plugins/twitter_recent_entries.html
@@ -1,4 +1,5 @@
 {% load i18n sekizai_tags %}
+{% addtoblock "js" %}<script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.min.js"></script>{% endaddtoblock %}
 {% addtoblock "js" %}<script type="text/javascript" src="{{ STATIC_URL }}cms/js/libs/jquery.tweet.js"></script>{% endaddtoblock %}
 {% addtoblock "js" %}
 <script type="text/javascript">


### PR DESCRIPTION
Twitter plugin was only displaying posts for logged in users. 

This is because the jquery module was not loaded without the toolbar. It used to be loaded for all users by default, but in 2.2 this is not the case. Simple fix loads jquery into the plugin template.

Tested in a production enviroment
