### PR TITLE
Remove extra context.push since context.update pushes the stack already

### DIFF
--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -151,13 +151,12 @@ def render_placeholder_toolbar(placeholder, context, content, name_fallback=None
     installed_plugins = plugin_pool.get_all_plugins(slot, page)
     name = get_placeholder_conf(slot, template, "name", title(slot))
     name = _(name)
-    context.update({
-        'installed_plugins': installed_plugins,
-        'language': get_language_from_request(request),
-        'placeholder_label': name,
-        'placeholder': placeholder,
-        'page': page,
-    })
+    context.push()
+    context['installed_plugins'] = installed_plugins
+    context['language'] = get_language_from_request(request)
+    context['placeholder_label'] = name
+    context['placeholder'] = placeholder
+    context['page'] = page
     toolbar = render_to_string("cms/toolbar/placeholder.html", context)
     context.pop()
     return "".join([toolbar, content])


### PR DESCRIPTION
I found context leaking between placeholders when activating edit mode on a site (upgraded to 2.2) and this seems to be the root. 

Context.update described here: https://docs.djangoproject.com/en/dev/ref/templates/api/#update
The ambiguosity of the method has been discussed earlier: https://code.djangoproject.com/ticket/3529 
