### PR TITLE
Kezabelle test case 992

### DIFF
--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -56,8 +56,6 @@ class PluginModelBase(MPTTModelBase):
             if splitter in new_class._meta.db_table:
                 splitted = new_class._meta.db_table.split(splitter, 1)
                 table_name = 'cmsplugin_%s' % splitted[1]
-            elif not new_class._meta.db_table.startswith('cmsplugin_'):
-                table_name = 'cmsplugin_%s' % new_class._meta.db_table
             else:
                 table_name = new_class._meta.db_table
             new_class._meta.db_table = table_name

--- a/cms/tests/plugins.py
+++ b/cms/tests/plugins.py
@@ -658,7 +658,7 @@ class PluginsMetaOptionsTests(TestCase):
                 db_table = 'or_another'
 
         plugin = TestPlugin4()
-        self.assertEqual(plugin._meta.db_table, 'cmsplugin_or_another')
+        self.assertEqual(plugin._meta.db_table, 'or_another')
         self.assertEqual(plugin._meta.app_label, 'tests') # because it's inlined
 
     def test_meta_options_custom_both(self):
@@ -669,7 +669,7 @@ class PluginsMetaOptionsTests(TestCase):
                 db_table = 'or_another'
 
         plugin = TestPlugin5()
-        self.assertEqual(plugin._meta.db_table, 'cmsplugin_or_another')
+        self.assertEqual(plugin._meta.db_table, 'or_another')
         self.assertEqual(plugin._meta.app_label, 'one_thing')
 
 class SekizaiTests(TestCase):


### PR DESCRIPTION
Fix proposed by kezabelle (https://github.com/divio/django-cms/issues/992#issuecomment-2105013) slightly edited to always force a 'cmsplugin_' in front of plugin tables. if we do this kind of magic, let's do it consistently.
