### PR TITLE
[Docs] warning regarding template names.

### DIFF
--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -37,10 +37,10 @@ Example::
 
 .. warning::
 
-    django-CMS relies on a number of templates to function correctly; using a
-    template name that clashes with them may lead to issues. Thus, it is
-    recommended you avoid using ``cms/content.html``, ``cms/dummy.html``, and
-    ``cms/new.html`` as options for :setting:`CMS_TEMPLATES`
+    django-CMS internally relies on a number of templates to function correctly;
+    these exist beneath ``cms`` within the templates directory. As such, it
+    is highly recommended you avoid using the same directory name for your own
+    project templates.
 
 *******************
 Basic Customization


### PR DESCRIPTION
Adds a warning to the configuration document that certain template names may break the CMS in exciting ways. Added because of the user configuration issue present in #1041.
