### PR TITLE
GoogleMap plugin: Moving HTML before JavaScript so that <div> container for google map is loaded before being manipulated

### DIFF
--- a/cms/plugins/googlemap/templates/cms/plugins/googlemap.html
+++ b/cms/plugins/googlemap/templates/cms/plugins/googlemap.html
@@ -1,7 +1,7 @@
 {% load i18n sekizai_tags %}
 {% addtoblock "js" %}<script type="text/javascript" src="https://maps-api-ssl.google.com/maps/api/js?v=3&sensor=true"></script>{% endaddtoblock %}
-{% endaddtoblock %}
 
+{% addtoblock "css" %}
 <style type="text/css">
 <!--
 	.google-map-container { width:100%; height:400px; }


### PR DESCRIPTION
This fixes an [existing issue](https://github.com/divio/django-cms/issues/1064)
