### PR TITLE
tweak the clean_overwrite_url method to check that page.pk is not the page.publisher_public_id. 

### DIFF
--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -177,7 +177,9 @@ class PageForm(PageAddForm):
                 if not any_path_re.match(url):
                     raise forms.ValidationError(_('Invalid URL, use /my/url format.'))
                 page = get_page_from_path(url.strip('/'))
-                if page and page.pk != self.instance.pk:
+                if (page and
+                    page.pk not in [self.instance.pk,
+                                    self.instance.publisher_public_id]):
                     raise forms.ValidationError(_('Page with redirect url %r already exist') % url)
         return url
 


### PR DESCRIPTION
tweak the clean_overwrite_url method to check that page.pk is not the page.publisher_public_id. 

This pull request fix this bug: page.publisher_public_id. 
