### PR TITLE
A way of ensuring the X-CSRFToken header is only set once

### DIFF
--- a/cms/static/cms/js/csrf.js
+++ b/cms/static/cms/js/csrf.js
@@ -2,6 +2,7 @@
 $.fn.cmsPatchCSRF = function () {
 $.ajaxSetup({
 beforeSend: function(xhr, settings) {
+if (typeof(settings.csrfTokenSet) != undefined && settings.csrfTokenSet) {return true;} 
 function getCookie(name) {
 var cookieValue = null;
 if (document.cookie && document.cookie != '') {
@@ -25,6 +26,7 @@ base_settings_url = base_settings_url[0];
 if (!(/^http:.*/.test(settings.url) || /^https:.*/.test(settings.url)) || base_doc_url == base_settings_url) {
 // Only send the token to relative URLs i.e. locally.
 xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+settings.csrfTokenSet = true;
 }
 }
 });

--- a/cms/static/cms/js/plugins/cms.base.js
+++ b/cms/static/cms/js/plugins/cms.base.js
@@ -23,6 +23,10 @@ jQuery(document).ready(function ($) {
 		csrf: function () {
 			$.ajaxSetup({
 				beforeSend: function (xhr, settings) {
+					if (typeof(settings.csrfTokenSet) != undefined && settings.csrfTokenSet) {
+						// CSRF token has already been set elsewhere so we won't touch it.
+						return true; 
+					} 
 					// get cookies without jquery.cookie.js
 					function getCookie(name) {
 						var cookieValue = null;
@@ -48,6 +52,7 @@ jQuery(document).ready(function ($) {
 					if(!(/^http:.*/.test(settings.url) || /^https:.*/.test(settings.url)) || base_doc_url == base_settings_url) {
 						// Only send the token to relative URLs i.e. locally.
 						xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+						settings.csrfTokenSet = true;
 					}
 				}
 			});


### PR DESCRIPTION
I was having a problem on my site, where I followed the Django documentation and installed a jQuery AJAX handler to add the CSRF token to every AJAX request ( https://docs.djangoproject.com/en/dev/ref/contrib/csrf/ ). However, when I use the CMS toolbar on my site, the CMS JavaScript also registers an AJAX handler with jQuery. The end result is that `xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));` gets called twice. According to the W3C XmlHttpRequest spec, this results in a header like the following:
`X-CSRFToken: 46cd8ee5f1d3ce4374f3592abc123456, 46cd8ee5f1d3ce4374f3592abc123456`

This ultimately causes all AJAX requests to fail because of an invalid CSRF header.

Unfortunately, I couldn't find a clean way to modify the CMS handler to check if the X-CSRF token has already been set. With this pull request, I've modified the code so that in addition to adding the CSRF header to each AJAX request, another property will be set on a per-request basis indicating that the CSRF token has been added. If I make the same change to the code I'm using on my site, then there are no duplicate headers and the AJAX requests work properly. I don't think this is the best solution, but it does work, so I'd like to submit this for discussion.
