### PR TITLE
Problem with spanish string in toolbar.html

### DIFF
--- a/cms/locale/es/LC_MESSAGES/django.po
+++ b/cms/locale/es/LC_MESSAGES/django.po
@@ -1799,7 +1799,7 @@ msgstr ""
 
 #: templates/cms/toolbar/toolbar.html:23
 msgid "Are you sure you want to delete this plugin?"
-msgstr "¿Seguro que desea eliminar este 'plugin'?"
+msgstr "¿Seguro que desea eliminar este plugin?"
 
 #: templates/cms/toolbar/toolbar.html:55
 msgid "up"


### PR DESCRIPTION
Removed quotes that break the toolbar with a javascript error.

The translated strings can't have the single quote character because it breaks the javascript code.

```
    'lang': {
        'move_warning': {% javascript_string %}{% trans "The selected element can not be moved to the desired location." %}{% end_javascript_string %},
        'delete_request': {% javascript_string %}{% trans "Are you sure you want to delete this plugin?" %}{% end_javascript_string %},
        'cancel': {% javascript_string %}{% trans "Cancel" %}{% end_javascript_string %}
    }
```

I'm Spanish and I can tell that the translation is ok without the quotes.
