### PR TITLE
Sometimes rendering the admin change_list page chokes (not sure what leads to it) because of attempted use of negative indexing

### DIFF
--- a/cms/admin/change_list.py
+++ b/cms/admin/change_list.py
@@ -195,7 +195,7 @@ class CMSChangeList(ChangeList):
                 if len(children):
                     # TODO: WTF!?!
                     # The last one is not the last... wait, what?
-                    children[-1].last = False
+                    children[len(children)-1].last = False
                 page.menu_level = 0
                 root_pages.append(page)
                 if page.parent_id:


### PR DESCRIPTION
Uses len(children)-1 in place of -1, as children is/can be a QuerySet, which doesn't support negative indexing

This fixes the issue, but I am really stabbing in the dark as to the purpose and proper solution here.
