### PR TITLE
minor tidy up of the menu_item 'in_navigation' section.

### DIFF
--- a/cms/templates/admin/cms/page/menu_item.html
+++ b/cms/templates/admin/cms/page/menu_item.html
@@ -45,14 +45,10 @@
 		</div>	
 		
 		<div class="col-navigation">
-			{% if page.in_navigation %}<label>
-				<img alt="True" src="{% admin_media_prefix %}img/admin/icon-yes.gif"/>	
-				{% if has_change_permission %}<input type="checkbox" class="navigation-checkbox" name="navigation-{{ page.id }}" checked="checked" value="1" />{% endif %}
+			<label>
+                <img alt="{{ page.in_navigation|yesno:"True,False" }}" src="{% admin_media_prefix %}img/admin/icon-{{ page.in_navigation|yesno:"yes,no" }}.gif" />
+                {% if has_change_permission %}<input type="checkbox" class="navigation-checkbox" name="navigation-{{ page.id }}" {% if page.in_navigation %}checked="checked"{% endif %} value="{{ page.in_navigation|yesno:"1,0" }}" />{% endif %}
 			</label>
-			{% else %}<label>
-				<img alt="False" src="{% admin_media_prefix %}img/admin/icon-no.gif" />
-				{% if has_change_permission %}<input type="checkbox" class="navigation-checkbox" name="navigation-{{ page.id }}" value="0" />{% endif %}
-			</label>{% endif %}				
 		</div>
 		
 		{% if CMS_MODERATOR %}<div class="col-moderator">


### PR DESCRIPTION
Reduces code duplication by making use of django's [yesno](https://code.djangoproject.com/browser/django/trunk/django/template/defaultfilters.py#L768) filter to inline a lot of essentially boolean values. It hard codes the one instance of yes/no (for the icon) to avoid translation lookups that would render the icon broken under languages other than english.

I've only tackled it in this one place, as I was customising the template to specifically modify that functionality, so there may be more that _could_ make use of the same refactoring.
