### PR TITLE
Move the unique constraint ValidationError for reverse_id.

### DIFF
--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -167,7 +167,7 @@ class PageForm(PageAddForm):
             site_id = cleaned_data['site']
             if id:
                 if Page.objects.filter(reverse_id=id, site=site_id, publisher_is_draft=True).exclude(pk=self.instance.pk).count():
-                    raise forms.ValidationError(_('A page with this reverse URL id exists already.'))
+                    self._errors['reverse_id'] = self.error_class([_('A page with this reverse URL id exists already.')])
         return cleaned_data
 
     def clean_overwrite_url(self):


### PR DESCRIPTION
Previously stored in `__all__` in `form.errors` it was displayed at the top of the admin change form. This isn't immediately useful, because it's an advanced setting people may not use often; additionally, the field is just labeled 'Id' in the change form, so the concept of the 'reverse URL id' is somewhat murky. I've had a couple of people assume it means the slug. 

Now it highlights the form row & field itself, as with every other field on the change form. 

This should be backwards compatible, as the [JavaScript responsible for collapsing fieldsets](https://code.djangoproject.com/browser/django/tags/releases/1.2/django/contrib/admin/media/js/collapse.js) skips over anything with errors (note: that link goes to 1.2 to demonstrate it has been this way for _ages_) and I've added a test case to `AdminFormsTests` that tests the `PageForm` output, as well as the admin change form response.
