### PR TITLE
Language chooser

### DIFF
--- a/menus/templatetags/menu_tags.py
+++ b/menus/templatetags/menu_tags.py
@@ -371,7 +371,13 @@ class PageLanguageUrl(InclusionTag):
                 url = page.get_absolute_url(language=lang, fallback=False)
                 url = "/" + lang + url
             except:
-                # no localized path/slug, redirect to root url
-                url = '/' + lang + '/'
+                # no localized path/slug
+                if settings.CMS_HIDE_UNTRANSLATED:
+                    # redirect to root url if CMS_HIDE_UNTRANSLATED
+                    url = '/' + lang + '/'
+                else:
+                    # If untranslated pages are shown, this will not redirect
+                    # at all.
+                    url = ''
         return {'content':url}
 register.tag(PageLanguageUrl)


### PR DESCRIPTION
I tried to fix #1087 in a way that should stay with old behavior if CMS_HIDE_UNTRANSLATED is not True. This should make behavior consistent with current documentation, see last paragraph in docs/advanced/i18n.rst
