### PR TITLE
Fixed negative index exception

### DIFF
--- a/cms/admin/change_list.py
+++ b/cms/admin/change_list.py
@@ -192,10 +192,10 @@ class CMSChangeList(ChangeList):
                 
             if page.root_node or self.is_filtered():
                 page.last = True
-                if len(children):
+                if children.count():
                     # TODO: WTF!?!
                     # The last one is not the last... wait, what?
-                    children[-1].last = False
+                    children[children.count() - 1].last = False
                 page.menu_level = 0
                 root_pages.append(page)
                 if page.parent_id:


### PR DESCRIPTION
Related to this change:

https://github.com/divio/django-cms/commit/aa1e0ce2d3e54f6dceec6eda919dddec5da899b0#L0L120

Children variable was changed from empty list to queryset, but a negative index was still used later on causing an exception to be thrown.  Also changed how children length is calculated, opting to use the queryset method count instead of len function, to avoid loading the data before necessary.
