### PR TITLE
django orm doesn't support negative indexing

### DIFF
--- a/cms/admin/change_list.py
+++ b/cms/admin/change_list.py
@@ -195,7 +195,7 @@ class CMSChangeList(ChangeList):
                 if len(children):
                     # TODO: WTF!?!
                     # The last one is not the last... wait, what?
-                    children[-1].last = False
+                    children[len(children)-1].last = False
                 page.menu_level = 0
                 root_pages.append(page)
                 if page.parent_id:


### PR DESCRIPTION
This was causing a traceback because the django ORM doesn't support negative indexing, at least under Django 1.2.7. It's ok to call len() here because it has already been called a few lines above. 
