### PR TITLE
Added some inline comments to the infamous line

### DIFF
--- a/cms/admin/change_list.py
+++ b/cms/admin/change_list.py
@@ -196,7 +196,7 @@ class CMSChangeList(ChangeList):
                     # TODO: WTF!?!
                     # The last one is not the last... wait, what?
                     # children should NOT be a queryset. If it is, check that
-                    # you django-mptt version is NOT 0.5.2
+                    # your django-mptt version is 0.5.1
                     children[-1].last = False
                 page.menu_level = 0
                 root_pages.append(page)


### PR DESCRIPTION
Since this line is the one breaking when people run the CMS with mptt 0.5.2, it
is now explicit.
