### PR TITLE
Output valid sanitized HTML instead of XHTML

### DIFF
--- a/cms/utils/html.py
+++ b/cms/utils/html.py
@@ -1,27 +1,9 @@
 # -*- coding: utf-8 -*-
+from html5lib import sanitizer, serializer, treebuilders, treewalkers
 import html5lib
-from html5lib import sanitizer
 
 
-DEFAULT_PARSER = html5lib.HTMLParser(tokenizer=sanitizer.HTMLSanitizer)
-
-
-def _get_inner_body(doc):
-    # find 'body'
-    def _rec(node):
-        if node.type == 5: # Element Type
-            if node.name == 'body': # the body element
-                return node
-        for child in node.childNodes:
-            childfound = _rec(child)
-            if childfound:
-                return childfound
-        return None
-    body = _rec(doc)
-    out = []
-    for node in body.childNodes:
-        out.append(node.toxml())
-    return u''.join(out)
+DEFAULT_PARSER = html5lib.HTMLParser(tree=treebuilders.getTreeBuilder("dom"))
 
 def clean_html(data, full=True, parser=DEFAULT_PARSER):
     """
@@ -30,8 +12,12 @@ def clean_html(data, full=True, parser=DEFAULT_PARSER):
     If full is False, only the contents inside <body> will be returned (without
     the <body> tags).
     """
-    doc = parser.parse(data)
     if full:
-        return doc.toxml()
+        dom_tree = parser.parse(data)
     else:
-        return _get_inner_body(doc)
+        dom_tree = parser.parseFragment(data)
+    walker = treewalkers.getTreeWalker("dom")
+    stream = walker(dom_tree)
+    s = serializer.htmlserializer.HTMLSerializer(sanitize=True, 
+                                                 omit_optional_tags=False)
+    return u''.join(s.serialize(stream))


### PR DESCRIPTION
Fixes conversion of &lt;div class="something"&gt;&lt;/div&gt; -&gt; &lt;div class="something" /&gt; which isn't valid HTML5.

I need to write some unit tests for this still but wanted to run this by the devs first.  
