### PR TITLE
A brief note on the placeholder template tag.

### DIFF
--- a/docs/advanced/templatetags.rst
+++ b/docs/advanced/templatetags.rst
@@ -14,6 +14,8 @@ top of your template::
 ***********
 placeholder
 ***********
+.. versionchanged:: 2.1
+    The placeholder name became case sensitive.
 
 The ``placeholder`` templatetag defines a placeholder on a page. All
 placeholders in a template will be auto-detected and can be filled with


### PR DESCRIPTION
As of version 2.1 (seems so long ago), the placeholder tag became case sensitive, as reported (only recently!) in #1059. As such, despite being somewhat archaic, there ought to be a note that it changed.
