### PR TITLE
Remove phantom empty plugins before adding a new plugin in a placeholder

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -1089,6 +1089,13 @@ class PageAdmin(ModelAdmin):
         # page add-plugin
         if page:
             language = request.POST['language'] or get_language_from_request(request)
+            # Remove empty plugins (created by adding it and then pressing
+            # cancel button in admin popup.
+            # It is needed to avoid enforcing limits with this pahantom
+            # plugins stealing free slots.
+            for pl in CMSPlugin.objects.filter(language=language, placeholder=placeholder):
+                if pl.get_plugin_instance()[0] is None:
+                    pl.delete()
             position = CMSPlugin.objects.filter(language=language, placeholder=placeholder).count()
             limits = placeholder_utils.get_placeholder_conf("limits", placeholder.slot, page.get_template())
             if limits:


### PR DESCRIPTION
I call "phantom" a plugin that does not have a real (non-abstract) model associated to it.

This can happen when:
- a user clicks the "add" button in a  placehoder using the cms-toolbar 
- the admin form for the custom model associated with the plugin is shown
- the user clicks "cancel"

Phantom plugins can't be deleted by toolbar contextual editing, but they still occupy a place
in the placeholder.

If the placeholder has a plugin limit on it, phantom plugins prevent insertion of new plugins.
