### PR TITLE
Test to expose overwrite_url bug in 2.2

### DIFF
--- a/cms/tests/page.py
+++ b/cms/tests/page.py
@@ -533,6 +533,8 @@ class PagesTestCase(CMSTestCase):
         self.assertEqual(page3.get_absolute_url(),
             self.get_pages_root()+'i-want-another-url/')
 
+        # tests a bug found in 2.2 where saving an ancestor page
+        # wiped out the overwrite_url for child pages
         page2.save()
         self.assertEqual(page3.get_absolute_url(),
             self.get_pages_root()+'i-want-another-url/')


### PR DESCRIPTION
[claimed by @pascalmouret]
This is a test to expose a bug found in version 2.2.  When saving an ancestor page of a child that has an overwrite_url set, the overwrite_url is changed to the original page path.

According to this test, this bug doesn't exist in develop of develop-2.2.1
