### PR TITLE
Make djangoCMS compatible with django-mptt 0.5.2

### DIFF
--- a/cms/admin/change_list.py
+++ b/cms/admin/change_list.py
@@ -191,13 +191,10 @@ class CMSChangeList(ChangeList):
                 page._has_moderator_state_chache = page.pk in pagemoderator_states_id_set
                 
             if page.root_node or self.is_filtered():
+                # page.last is used only in the template to ease output of embedded <ul> lists
                 page.last = True
                 if len(children):
-                    # TODO: WTF!?!
-                    # The last one is not the last... wait, what?
-                    # children should NOT be a queryset. If it is, check that
-                    # your django-mptt version is 0.5.1
-                    children[-1].last = False
+                    children[children.count() - 1].last = False
                 page.menu_level = 0
                 root_pages.append(page)
                 if page.parent_id:

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'django-classy-tags>=0.3.4.1',
         'south>=0.7.2',
         'html5lib',
-        'django-mptt==0.5.1',
+        'django-mptt==0.5.2',
         'django-sekizai>=0.4.2',
     ],
     packages=find_packages(exclude=["project","project.*"]),

--- a/tests/buildout.cfg
+++ b/tests/buildout.cfg
@@ -40,4 +40,4 @@ coverage = 3.4
 unittest-xml-reporting = 1.0.3
 django-reversion = 1.4
 django = 1.2.5
-django-mptt = 0.5.1
+django-mptt = 0.5.2

--- a/tests/django-12.cfg
+++ b/tests/django-12.cfg
@@ -7,4 +7,4 @@ coverage = 3.4
 unittest-xml-reporting = 1.0.3
 django-reversion = 1.4
 django = 1.2.5
-django-mptt = 0.5.1
+django-mptt = 0.5.2

--- a/tests/django-13.cfg
+++ b/tests/django-13.cfg
@@ -6,4 +6,4 @@ coverage = 3.4
 unittest-xml-reporting = 1.0.3
 django-reversion = 1.4
 django = 1.3
-django-mptt = 0.5.1
+django-mptt = 0.5.2

--- a/tests/django-trunk.cfg
+++ b/tests/django-trunk.cfg
@@ -14,4 +14,4 @@ urls =
 coverage = 3.4
 unittest-xml-reporting = 1.0.3
 django-reversion = 1.4
-django-mptt = 0.5.1
+django-mptt = 0.5.2


### PR DESCRIPTION
As discussed in #1099 -- this commit makes djangoCMS not raise AssertionError anymore on page admin and allows to use django 0.5.2 which contains some fixes important for me 
https://github.com/django-mptt/django-mptt/issues/156

No unit tests for this one, as they would be redundant with cms.tests.admin.AdminTestCase.test_changelist_items 
