### PR TITLE
Attempt to differentiate 'real' import problems from modules that are simply missing during discovery

### DIFF
--- a/cms/utils/django_load.py
+++ b/cms/utils/django_load.py
@@ -18,8 +18,12 @@ def get_module(app, modname, verbose, failfast):
     """
     module_name = '%s.%s' % (app, modname)
     try:
-        module = import_module(module_name)
+        module = __import__(module_name)
     except ImportError, e:
+        failed_mod = e.message.split(' ')[-1]
+        if not module_name.endswith(failed_mod):
+            raise
+
         if failfast:
             raise e
         elif verbose:


### PR DESCRIPTION
Raise ImportErrors in get_module if it looks like the error's caused by
a 'real' import problem rather than a module just being unavailable for
discovery.
