### PR TITLE
Make images and other in-text plugins editable directly with tinymce or wymeditor

### DIFF
--- a/cms/plugins/picture/templates/cms/plugins/picture.html
+++ b/cms/plugins/picture/templates/cms/plugins/picture.html
@@ -1,4 +1,4 @@
-<span class="plugin_picture{% if picture.float %} align-{{ picture.float }}{% endif %} {{ admin_tag_attributes.class }}" style="{{ admin_tag_attributes.style }}">
+<span class="plugin_picture{% if picture.float %} align-{{ picture.float }}{% endif %} {{ placeholder_attributes.class }}" style="{{ placeholder_attributes.style }}">
 {% if link %}<a href="{{ link }}">{% endif %}
 <img src="{{ picture.image.url }}" alt="{{ picture.alt }}"{% if picture.longdesc %} title="{{ picture.longdesc }}"{% endif %} />
 {% if link %}</a>{% endif %}

--- a/cms/plugins/text/utils.py
+++ b/cms/plugins/text/utils.py
@@ -43,8 +43,8 @@ def plugin_tags_to_user_html(text, context, placeholder):
         try:
             obj = CMSPlugin.objects.get(pk=plugin_id)
             obj._render_meta.text_enabled = True
-            context['admin_tag'] = m.group(0)
-            context['admin_tag_attributes'] = dict(
+            context['placeholder_tag'] = m.group(0)
+            context['placeholder_attributes'] = dict(
             	re.compile(r'(\S+)=["\']?((?:.(?!["\']?\s+(?:\S+)=|[>"\']))+.)["\']?').findall(m.group(0))
             )
         except CMSPlugin.DoesNotExist:


### PR DESCRIPTION
Make images and other in-text plugins editable directly with tinymce or wymeditor by 
forwarding the attributes of the placeholders (particularly class and style) to the rendering context. (Useful for example in picture.html)
