### PR TITLE
Menus cache keys fix

### DIFF
--- a/menus/models.py
+++ b/menus/models.py
@@ -23,7 +23,7 @@ class CacheKeyManager(models.Manager):
         except CacheKey.MultipleObjectsReturned:
             # Truncate the table, we don't want a funny cache object to cause
             # mayhem!
-            CacheKey.object.all().delete()
+            CacheKey.objects.all().delete()
             return super(CacheKeyManager, self).get_or_create(**kwargs)
 
 


### PR DESCRIPTION
Fixes the ugly MultipleObjectsReturned exceptions in the cache table.
It might seem a little radical, but there is no reason to crash the request in case the cache does not work...
