### PR TITLE
Slug clashes between sibling pages children of a root page

### DIFF
--- a/cms/tests/page.py
+++ b/cms/tests/page.py
@@ -91,8 +91,8 @@ class PagesTestCase(CMSTestCase):
             page1_2 = create_page('test page 1_2', 'nav_playground.html', 'en',
                                   published=True, parent=page1, slug="foo")
             # both sibling pages has same slug, so both pages has an invalid slug
-            self.assertTrue(is_valid_page_slug(page1_1,page1_1.parent,"en",page1_1.get_slug("en"),page1_1.site))
-            self.assertTrue(is_valid_page_slug(page1_2,page1_2.parent,"en",page1_2.get_slug("en"),page1_2.site))
+            self.assertFalse(is_valid_page_slug(page1_1,page1_1.parent,"en",page1_1.get_slug("en"),page1_1.site))
+            self.assertFalse(is_valid_page_slug(page1_2,page1_2.parent,"en",page1_2.get_slug("en"),page1_2.site))
 
     def test_slug_collisions_api_2(self):
         """ Checks for slug collisions on root (not home) page and a home page child - uses API to create pages

--- a/cms/utils/page.py
+++ b/cms/utils/page.py
@@ -21,12 +21,15 @@ def is_valid_page_slug(page, parent, lang, slug, site):
         qs = qs.filter(language=lang)
 
     if not settings.CMS_FLAT_URLS:
-        if parent:# and not parent.is_home():
+        if parent:
             if parent.is_home():
                 qs = qs.filter(Q(page__parent=parent) |
                                Q(page__parent__isnull=True))
             else:
                 qs = qs.filter(page__parent=parent)
+        else:
+            qs = qs.filter(page__parent__isnull=True)
+
     if page.pk:
         qs = qs.exclude(language=lang, page=page)
     if qs.count():


### PR DESCRIPTION
Fixed error in slug checks: direct child of root nodes aren't checked for slug clashing against siblings.
This fix paves the way for #1166 fix
