### PR TITLE
Minor patch to enforce migrations follow database structure changes

### DIFF
--- a/cms/plugins/file/migrations/0005_publisher2.py
+++ b/cms/plugins/file/migrations/0005_publisher2.py
@@ -4,6 +4,11 @@ from django.db import models
 from cms.plugins.file.models import *
 
 class Migration:
+    needed_by = (
+        # Migration after cms.publisher2, keep migrations in sync with real db
+        # Fixes migration error in MySQL
+        ("cms", "0022_login_required_added.py"),
+    )
     
     def forwards(self, orm):
         

--- a/cms/plugins/flash/migrations/0005_publisher2.py
+++ b/cms/plugins/flash/migrations/0005_publisher2.py
@@ -4,6 +4,11 @@ from django.db import models
 from cms.plugins.flash.models import *
 
 class Migration:
+    needed_by = (
+        # Migration after cms.publisher2, keep migrations in sync with real db
+        # Fixes migration error in MySQL
+        ("cms", "0022_login_required_added.py"),
+    )
     
     def forwards(self, orm):
         

--- a/cms/plugins/googlemap/migrations/0006_publisher2.py
+++ b/cms/plugins/googlemap/migrations/0006_publisher2.py
@@ -4,6 +4,11 @@ from django.db import models
 from cms.plugins.googlemap.models import *
 
 class Migration:
+    needed_by = (
+        # Migration after cms.publisher2, keep migrations in sync with real db
+        # Fixes migration error in MySQL
+        ("cms", "0022_login_required_added.py"),
+    )
     
     def forwards(self, orm):
         

--- a/cms/plugins/link/migrations/0007_publisher2.py
+++ b/cms/plugins/link/migrations/0007_publisher2.py
@@ -4,6 +4,11 @@ from django.db import models
 from cms.plugins.link.models import *
 
 class Migration:
+    needed_by = (
+        # Migration after cms.publisher2, keep migrations in sync with real db
+        # Fixes migration error in MySQL
+        ("cms", "0022_login_required_added.py"),
+    )
     
     def forwards(self, orm):
         

--- a/cms/plugins/picture/migrations/0007_publisher2.py
+++ b/cms/plugins/picture/migrations/0007_publisher2.py
@@ -4,6 +4,11 @@ from django.db import models
 from cms.plugins.picture.models import *
 
 class Migration:
+    needed_by = (
+        # Migration after cms.publisher2, keep migrations in sync with real db
+        # Fixes migration error in MySQL
+        ("cms", "0022_login_required_added.py"),
+    )
     
     def forwards(self, orm):
         

--- a/cms/plugins/snippet/migrations/0004_publisher2.py
+++ b/cms/plugins/snippet/migrations/0004_publisher2.py
@@ -4,6 +4,11 @@ from django.db import models
 from cms.plugins.snippet.models import *
 
 class Migration:
+    needed_by = (
+        # Migration after cms.publisher2, keep migrations in sync with real db
+        # Fixes migration error in MySQL
+        ("cms", "0022_login_required_added.py"),
+    )
     
     def forwards(self, orm):
         

--- a/cms/plugins/teaser/migrations/0002_publisher2.py
+++ b/cms/plugins/teaser/migrations/0002_publisher2.py
@@ -4,6 +4,11 @@ from django.db import models
 from cms.plugins.teaser.models import *
 
 class Migration:
+    needed_by = (
+        # Migration after cms.publisher2, keep migrations in sync with real db
+        # Fixes migration error in MySQL
+        ("cms", "0022_login_required_added.py"),
+    )
     
     def forwards(self, orm):
         

--- a/cms/plugins/text/migrations/0005_publisher2.py
+++ b/cms/plugins/text/migrations/0005_publisher2.py
@@ -4,6 +4,11 @@ from django.db import models
 from cms.plugins.text.models import *
 
 class Migration:
+    needed_by = (
+        # Migration after cms.publisher2, keep migrations in sync with real db
+        # Fixes migration error in MySQL
+        ("cms", "0022_login_required_added.py"),
+    )
     
     def forwards(self, orm):
         


### PR DESCRIPTION
When publisher2 migration in cms deletes the cmspluginpublic table
This patch forces the dependent plugins to rename in sync avoiding a
MySQL migration error in south

This replaces pull request #1098, which contains some unrelated changes
