### PR TITLE
removed calls to cmsPatchCSRF since that function isn't defined anymore

### DIFF
--- a/cms/static/cms/js/change_list.js
+++ b/cms/static/cms/js/change_list.js
@@ -93,7 +93,6 @@
 	};
 	
 	$(document).ready(function() {
-		$.fn.cmsPatchCSRF();
 		selected_page = false;
 		action = false;
 

--- a/cms/static/cms/js/plugin_editor.js
+++ b/cms/static/cms/js/plugin_editor.js
@@ -7,7 +7,6 @@
 	cms_plugin_editor_jQuery = $;
 	$(document).ready(function() {
 		// Add Plugin Handler
-		$.fn.cmsPatchCSRF();
 		$('span.add-plugin').click(function(){
 		 var select = $(this).parent().children("select[name=plugins]");
 			var pluginvalue = select.attr('value');


### PR DESCRIPTION
without this patch, the page tree doesn't even load anymore, and the plugins in the page form are not editable anymore.

@FinalAngel, @neo64bit, please check if this is OK
