### PR TITLE
Making cms/models more pep8 compliant

### DIFF
--- a/cms/models/fields.py
+++ b/cms/models/fields.py
@@ -8,29 +8,28 @@ from django.db import models
 from django.utils.text import capfirst
 
 
-
 class PlaceholderField(models.ForeignKey):
     def __init__(self, slotname, default_width=None, actions=PlaceholderNoAction, **kwargs):
         validate_placeholder_name(slotname)
         self.slotname = slotname
         self.default_width = default_width
         self.actions = actions()
-        kwargs.update({'null':True}) # always allow Null
+        kwargs.update({'null': True})  # always allow Null
         super(PlaceholderField, self).__init__(Placeholder, **kwargs)
-    
+
     def formfield(self, **kwargs):
         """
         Returns a django.forms.Field instance for this database Field.
         """
         return self.formfield_for_admin(None, lambda qs: qs, **kwargs)
-    
+
     def formfield_for_admin(self, request, filter_func, **kwargs):
         defaults = {'label': capfirst(self.verbose_name), 'help_text': self.help_text}
         defaults.update(kwargs)
         widget = PlaceholderPluginEditorWidget(request, filter_func)
         widget.choices = []
         return PlaceholderFormField(required=False, widget=widget, **defaults)
-    
+
     def _get_new_placeholder(self):
         return Placeholder.objects.create(slot=self.slotname,
             default_width=self.default_width)
@@ -48,7 +47,7 @@ class PlaceholderField(models.ForeignKey):
             if not isinstance(data, Placeholder):
                 data = self._get_new_placeholder()
         super(PlaceholderField, self).save_form_data(instance, data)
-    
+
     def south_field_triple(self):
         "Returns a suitable description of this field for South."
         # We'll just introspect ourselves, since we inherit.
@@ -57,7 +56,7 @@ class PlaceholderField(models.ForeignKey):
         args, kwargs = introspector(self)
         # That's our definition!
         return (field_class, args, kwargs)
-    
+
     def contribute_to_class(self, cls, name):
         super(PlaceholderField, self).contribute_to_class(cls, name)
         if not hasattr(cls._meta, 'placeholder_field_names'):
@@ -68,10 +67,11 @@ class PlaceholderField(models.ForeignKey):
         cls._meta.placeholder_fields[self] = name
         self.model = cls
 
-        
+
 class PageField(models.ForeignKey):
     default_form_class = PageSelectFormField
     default_model_class = Page
+
     def __init__(self, **kwargs):
         # we call ForeignKey.__init__ with the Page model as parameter...
         # a PageField can only be a ForeignKey to a Page

--- a/cms/models/managers.py
+++ b/cms/models/managers.py
@@ -10,51 +10,49 @@ from django.db import models
 from django.db.models import Q
 
 
-
 class PageManager(PublisherManager):
     """Use draft() and public() methods for accessing the corresponding
     instances.
     """
-    
+
     def get_query_set(self):
         """Change standard model queryset to our own.
         """
         return PageQuerySet(self.model)
-    
+
     def drafts(self):
         return super(PageManager, self).drafts().exclude(
             publisher_state=self.model.PUBLISHER_STATE_DELETE
         )
-    
+
     def public(self):
         return super(PageManager, self).public().exclude(
             publisher_state=self.model.PUBLISHER_STATE_DELETE
         )
 
-    
-    # !IMPORTANT: following methods always return access to draft instances, 
+    # !IMPORTANT: following methods always return access to draft instances,
     # take care on what you do one them. use Page.objects.public() for accessing
     # the published page versions
-    
-    # Just some of the queryset methods are implemented here, access queryset 
+
+    # Just some of the queryset methods are implemented here, access queryset
     # for more getting more supporting methods.
-    
+
     # TODO: check which from following methods are really required to be on
     # manager, maybe some of them can be just accessible over queryset...?
-    
-    def on_site(self, site=None): 
+
+    def on_site(self, site=None):
         return self.get_query_set().on_site(site)
-        
+
     def root(self):
         """
         Return a queryset with pages that don't have parents, a.k.a. root. For
         current site - used in frontend
         """
         return self.get_query_set().root()
-    
+
     def all_root(self):
         """
-        Return a queryset with pages that don't have parents, a.k.a. root. For 
+        Return a queryset with pages that don't have parents, a.k.a. root. For
         all sites - used in frontend
         """
         return self.get_query_set().all_root()
@@ -67,11 +65,11 @@ class PageManager(PublisherManager):
 
     def published(self, site=None):
         return self.get_query_set().published(site)
-        
+
     def expired(self):
         return self.drafts().expired()
-        
-#    - seems this is not used anymore...  
+
+#    - seems this is not used anymore...
 #    def get_pages_with_application(self, path, language):
 #        """Returns all pages containing application for current path, or
 #        any parrent. Returned list is sorted by path length, longer path first.
@@ -85,35 +83,33 @@ class PageManager(PublisherManager):
 #        # add proper ordering
 #        app_pages.query.order_by.extend(('LENGTH(`cms_title`.`path`) DESC',))
 #        return app_pages
-    
 
     def get_all_pages_with_application(self):
         """Returns all pages containing applications for all sites.
-        
-        Doesn't cares about the application language. 
+
+        Doesn't cares about the application language.
         """
         return self.get_query_set().filter(title_set__application_urls__gt='').distinct()
-    
+
     def get_home(self, site=None):
         return self.get_query_set().get_home(site)
 
-    
     def search(self, q, language=None, current_site_only=True):
         """Simple search function
-        
+
         Plugins can define a 'search_fields' tuple similar to ModelAdmin classes
         """
         from cms.plugin_pool import plugin_pool
         qs = self.get_query_set()
         if settings.CMS_MODERATOR:
             qs = qs.public()
-        
+
         if current_site_only:
             site = Site.objects.get_current()
             qs = qs.filter(site=site)
-        
+
         qt = Q(title_set__title__icontains=q)
-        
+
         # find 'searchable' plugins and build query
         qp = Q()
         plugins = plugin_pool.get_all_plugins()
@@ -122,16 +118,16 @@ class PageManager(PublisherManager):
             if hasattr(c, 'search_fields'):
                 for field in c.search_fields:
                     qp |= Q(**{'placeholders__cmsplugin__%s__%s__icontains' % \
-                                   (c.__name__.lower(), field):q})
+                                   (c.__name__.lower(), field): q})
         if language:
             qt &= Q(title_set__language=language)
             qp &= Q(cmsplugin__language=language)
-         
+
         qs = qs.filter(qt | qp)
-            
+
         return qs.distinct()
-        
-        
+
+
 class TitleManager(PublisherManager):
     def get_title(self, page, language, language_fallback=False):
         """
@@ -155,11 +151,11 @@ class TitleManager(PublisherManager):
                     pass
             else:
                 raise
-        return None        
-    
+        return None
+
     def get_page_slug(self, slug, site=None):
         """
-        Returns the latest slug for the given slug and checks if it's available 
+        Returns the latest slug for the given slug and checks if it's available
         on the current site.
         """
         if not site:
@@ -168,19 +164,19 @@ class TitleManager(PublisherManager):
             titles = self.filter(
                 slug=slug,
                 page__site=site,
-            ).select_related()#'page')
+            ).select_related()  # 'page')
         except self.model.DoesNotExist:
             return None
         else:
             return titles
-            
+
     # created new public method to meet test case requirement and to get a list of titles for published pages
     def public(self):
         return self.get_query_set().filter(page__publisher_is_draft=False, page__published=True)
-        
+
     def drafts(self):
         return self.get_query_set().filter(page__publisher_is_draft=True)
-        
+
     def set_or_create(self, request, page, form, language):
         """
         set or create a title for a particular page and language
@@ -217,7 +213,7 @@ class TitleManager(PublisherManager):
                     if value:
                         data[field] = value
             return self.create(**data)
-        
+
         for name in base_fields:
             value = cleaned_data.get(name, None)
             setattr(obj, name, value)
@@ -234,57 +230,59 @@ class TitleManager(PublisherManager):
 # Permissions
 ################################################################################
 
+
 class BasicPagePermissionManager(models.Manager):
     """Global page permission manager accessible under objects.
-    
-    !IMPORTANT: take care, PagePermissionManager extends this manager 
+
+    !IMPORTANT: take care, PagePermissionManager extends this manager
     """
     def with_user(self, user):
         """Get all objects for given user, also takes look if user is in some
         group.
         """
         return self.filter(Q(user=user) | Q(group__user=user))
-    
+
     def with_can_change_permissions(self, user):
         """Set of objects on which user haves can_change_permissions. !But only
-        the ones on which is this assigned directly. For getting reall 
-        permissions use page.permissions manager. 
+        the ones on which is this assigned directly. For getting reall
+        permissions use page.permissions manager.
         """
         return self.with_user(user).filter(can_change_permissions=True)
-    
+
+
 class PagePermissionManager(BasicPagePermissionManager):
     """Page permission manager accessible under objects.
     """
     def subordinate_to_user(self, user):
-        """Get all page permission objects on which user/group is lover in 
+        """Get all page permission objects on which user/group is lover in
         hierarchy then given user and given user can change permissions on them.
-        
+
         !IMPORTANT, but exclude objects with given user, or any group containing
-        this user - he can't be able to change his own permissions, because if 
-        he does, and removes some permissions from himself, he will not be able 
-        to add them anymore. 
-        
+        this user - he can't be able to change his own permissions, because if
+        he does, and removes some permissions from himself, he will not be able
+        to add them anymore.
+
         Example:
                                        A
                                     /    \
                                   user    B,E
                                 /     \
                               C,X     D,Y
-            
-            Gives permission nodes C,X,D,Y under user, so he can edit 
+
+            Gives permission nodes C,X,D,Y under user, so he can edit
             permissions if he haves can_change_permission.
-                  
+
         Example:
                                       A,Y
                                     /    \
                                   user    B,E,X
                                 /     \
                               C,X     D,Y
-                              
+
             Gives permission nodes C,D under user, so he can edit, but not
             anymore to X,Y, because this users are on the same level or higher
             in page hierarchy. (but only if user have can_change_permission)
-        
+
         Example:
                                         A
                                     /      \
@@ -293,18 +291,18 @@ class PagePermissionManager(BasicPagePermissionManager):
                               C,X     D,Y    user
                                             /    \
                                            I      J,A
-            
-            User permissions can be assigned to multiple page nodes, so merge of 
-            all of them is required. In this case user can see permissions for 
+
+            User permissions can be assigned to multiple page nodes, so merge of
+            all of them is required. In this case user can see permissions for
             users C,X,D,Y,I,J but not A, because A user in higher in hierarchy.
-        
-        If permission object holds group, this permission object can be visible 
-        to user only if all of the group members are lover in hierarchy. If any 
+
+        If permission object holds group, this permission object can be visible
+        to user only if all of the group members are lover in hierarchy. If any
         of members is higher then given user, this entry must stay invisible.
-        
+
         If user is superuser, or haves global can_change_permission permissions,
         show him everything.
-        
+
         Result of this is used in admin for page permissions inline.
         """
         from cms.models import GlobalPagePermission, Page
@@ -312,7 +310,7 @@ class PagePermissionManager(BasicPagePermissionManager):
             GlobalPagePermission.objects.with_can_change_permissions(user):
             # everything for those guys
                 return self.all()
-        
+
         # get user level
         from cms.utils.permissions import get_user_permission_level
         try:
@@ -322,33 +320,33 @@ class PagePermissionManager(BasicPagePermissionManager):
         # get current site
         site = Site.objects.get_current()
         # get all permissions
-        page_id_allow_list = Page.permissions.get_change_permissions_id_list(user,site)
-        
-        # get permission set, but without objects targeting user, or any group 
+        page_id_allow_list = Page.permissions.get_change_permissions_id_list(user, site)
+
+        # get permission set, but without objects targeting user, or any group
         # in which he can be
         qs = self.filter(
-            page__id__in=page_id_allow_list, 
+            page__id__in=page_id_allow_list,
             page__level__gte=user_level,
         )
         qs = qs.exclude(user=user).exclude(group__user=user)
         return qs
-    
+
     def for_page(self, page):
-        """Returns queryset containing all instances somehow connected to given 
+        """Returns queryset containing all instances somehow connected to given
         page. This includes permissions to page itself and permissions inherited
         from higher pages.
-        
+
         NOTE: this returns just PagePermission instances, to get complete access
         list merge return of this function with Global permissions.
         """
         from cms.models import ACCESS_DESCENDANTS, ACCESS_CHILDREN,\
-            ACCESS_PAGE_AND_CHILDREN, ACCESS_PAGE_AND_DESCENDANTS 
+            ACCESS_PAGE_AND_CHILDREN, ACCESS_PAGE_AND_DESCENDANTS
         # code taken from
         # https://github.com/divio/django-cms/issues/1113#issuecomment-3376790
         q_tree = Q(page__tree_id=page.tree_id)
         q_page = Q(page=page)
-        
-        # NOTE:  '... or 0' is used for test cases, 
+
+        # NOTE:  '... or 0' is used for test cases,
         #        if the page is not saved through mptt
         left_right = {
               'page__%s__lte' % page._meta.left_attr: getattr(page, page._meta.left_attr) or 0,
@@ -359,71 +357,69 @@ class PagePermissionManager(BasicPagePermissionManager):
         q_kids = (Q(page__level=page.level - 1) & (Q(grant_on=ACCESS_CHILDREN) | Q(grant_on=ACCESS_PAGE_AND_CHILDREN)))
         q = q_tree & q_parents & (q_page | q_desc | q_kids)
         return self.filter(q).order_by('page__level')
-        
+
 
 class PagePermissionsPermissionManager(models.Manager):
     """Page permissions permission manager.
-    
+
     !IMPORTANT: this actually points to Page model, not to PagePermission.
     Seems this will be better approach. Accessible under permissions.
-    
+
     Maybe this even shouldn't be a manager - it mixes different models together.
     """
     # we will return this in case we have a superuser, or permissions are not
     # enabled/configured in settings
     GRANT_ALL = 'All'
-    
+
     def get_publish_id_list(self, user, site):
         """
         Give a list of page where the user has publish rights or the string "All" if
         the user has all rights.
         """
         return self.__get_id_list(user, site, "can_publish")
-    
-    
+
     def get_change_id_list(self, user, site):
         """
         Give a list of page where the user has edit rights or the string "All" if
         the user has all rights.
         """
         return self.__get_id_list(user, site, "can_change")
-    
-    
+
     def get_add_id_list(self, user, site):
         """
-        Give a list of page where the user has add page rights or the string 
+        Give a list of page where the user has add page rights or the string
         "All" if the user has all rights.
         """
         return self.__get_id_list(user, site, "can_add")
-    
+
     def get_delete_id_list(self, user, site):
         """
         Give a list of page where the user has delete rights or the string "All" if
         the user has all rights.
         """
         return self.__get_id_list(user, site, "can_delete")
-    
+
     def get_advanced_settings_id_list(self, user, site):
         """
-        Give a list of page where the user can change advanced settings or the 
+        Give a list of page where the user can change advanced settings or the
         string "All" if the user has all rights.
         """
         return self.__get_id_list(user, site, "can_change_advanced_settings")
-    
+
     def get_change_permissions_id_list(self, user, site):
         """Give a list of page where the user can change permissions.
         """
         return self.__get_id_list(user, site, "can_change_permissions")
-    
+
     def get_move_page_id_list(self, user, site):
         """Give a list of pages which user can move.
         """
         return self.__get_id_list(user, site, "can_move_page")
-    
+
     def get_moderate_id_list(self, user, site):
-        """Give a list of pages which user can moderate. If moderation isn't 
-        installed, nobody can moderate. 
-        """        
+        """Give a list of pages which user can moderate. If moderation isn't
+        installed, nobody can moderate.
+        """
         if not settings.CMS_MODERATOR:
             return []
         return self.__get_id_list(user, site, "can_moderate")
@@ -432,13 +428,13 @@ class PagePermissionsPermissionManager(models.Manager):
         """Give a list of pages which user can view.
         """
         return self.__get_id_list(user, site, "can_view")
-    
+
     '''
     def get_change_list_id_list(self, user, site):
         """This is used just in admin now. Gives all ids where user haves can_edit
         and can_add merged together.
-        
-        There is for sure a better way how to do this over sql, need to be 
+
+        There is for sure a better way how to do this over sql, need to be
         optimized...
         """
         can_change = self.get_change_id_list(user)
@@ -447,14 +443,14 @@ class PagePermissionsPermissionManager(models.Manager):
             # GRANT_ALL case
             page_id_list = can_change
         else:
-            permission_set = filter(lambda i: not i is PagePermissionsPermissionManager.GRANT_ALL, [can_change, can_add])   
+            permission_set = filter(lambda i: not i is PagePermissionsPermissionManager.GRANT_ALL, [can_change, can_add])
             if len(permission_set) is 1:
                 page_id_list = permission_set[0]
             else:
                 page_id_list = list(set(can_change).union(set(can_add)))
         return page_id_list
-    '''    
-    
+    '''
+
     def __get_id_list(self, user, site, attr):
         from cms.models import (GlobalPagePermission, PagePermission,
                                 MASK_PAGE, MASK_CHILDREN, MASK_DESCENDANTS)
@@ -462,7 +458,7 @@ class PagePermissionsPermissionManager(models.Manager):
             if not user.is_authenticated() or not user.is_staff:
                 return []
         if user.is_superuser or not settings.CMS_PERMISSION:
-            # got superuser, or permissions aren't enabled? just return grant 
+            # got superuser, or permissions aren't enabled? just return grant
             # all mark
             return PagePermissionsPermissionManager.GRANT_ALL
         # read from cache if posssible
@@ -472,7 +468,7 @@ class PagePermissionsPermissionManager(models.Manager):
         # check global permissions
         global_permissions = GlobalPagePermission.objects.with_user(user)
         if global_permissions.filter(**{
-                attr: True, 'sites__in':[site]
+                attr: True, 'sites__in': [site]
             }).exists():
             # user or his group are allowed to do `attr` action
             # !IMPORTANT: page permissions must not override global permissions
@@ -483,7 +479,7 @@ class PagePermissionsPermissionManager(models.Manager):
         qs.order_by('page__tree_id', 'page__level', 'page__lft')
         # default is denny...
         page_id_allow_list = []
-        
+
         for permission in qs:
             if getattr(permission, attr):
 

--- a/cms/models/metaclasses.py
+++ b/cms/models/metaclasses.py
@@ -11,7 +11,7 @@ class PageMetaClass(MPTTModelBase):
         super_new = super(PageMetaClass, cls).__new__
         if not settings.CMS_MODERATOR:
             return super_new(cls, name, bases, attrs)
-        
+
         if 'objects' in attrs:
             if not isinstance(attrs['objects'], PublisherManager):
                 raise ValueError, ("Model %s extends Publisher, " +
@@ -19,11 +19,11 @@ class PageMetaClass(MPTTModelBase):
                                    "a subclass of publisher.PublisherManager") % (name,)
         else:
             attrs['objects'] = PublisherManager()
-        
+
         attrs['_is_publisher_model'] = lambda self: True
-        
+
         # build meta object
         publisher_meta = attrs.pop('PublisherMeta', None)
         attrs['_publisher_meta'] = PublisherOptions(name, bases, publisher_meta)
-        
+
         return super_new(cls, name, bases, attrs)

--- a/cms/models/moderatormodels.py
+++ b/cms/models/moderatormodels.py
@@ -11,9 +11,9 @@ from cms.models.pagemodel import Page
 # NOTE: those are not just numbers!! we will do binary AND on them,
 # so pay attention when adding/changing them, or MASKs..
 ACCESS_PAGE = 1
-ACCESS_CHILDREN = 2 # just immediate children (1 level)
-ACCESS_PAGE_AND_CHILDREN = 3 # just immediate children (1 level)
-ACCESS_DESCENDANTS = 4 
+ACCESS_CHILDREN = 2  # just immediate children (1 level)
+ACCESS_PAGE_AND_CHILDREN = 3  # just immediate children (1 level)
+ACCESS_DESCENDANTS = 4
 ACCESS_PAGE_AND_DESCENDANTS = 5
 
 # binary masks for ACCESS permissions
@@ -40,86 +40,86 @@ class PageModerator(models.Model):
     assigned to any page (to which he haves permissions), and say which
     moderation depth he requires.
     """
-    MAX_MODERATION_LEVEL = sys.maxint # just an number
-    
-    page = models.ForeignKey(Page, verbose_name=_('Page')) 
+    MAX_MODERATION_LEVEL = sys.maxint  # just an number
+
+    page = models.ForeignKey(Page, verbose_name=_('Page'))
     user = models.ForeignKey(User, verbose_name=_('User'))
-    
+
     # TODO: permission stuff could be changed to this structure also, this gives
     # better querying performance
     moderate_page = models.BooleanField(_('Moderate page'), blank=True)
     moderate_children = models.BooleanField(_('Moderate children'), blank=True)
     moderate_descendants = models.BooleanField(_('Moderate descendants'), blank=True)
-    
+
     class Meta:
-        verbose_name=_('PageModerator')
-        verbose_name_plural=_('PageModerator')
+        verbose_name = _('PageModerator')
+        verbose_name_plural = _('PageModerator')
         app_label = 'cms'
-    
+
     def set_decimal(self, state):
         """Converts and sets binary state to local attributes
         """
         self.moderate_page = bool(state & MASK_PAGE)
         moderate_children = bool(state & MASK_CHILDREN)
         moderate_descendants = bool(state & MASK_DESCENDANTS)
-        
+
         if moderate_descendants:
             moderate_children = True
-        
+
         self.moderate_children = moderate_children
         self.moderate_descendants = moderate_descendants
-    
+
     def get_decimal(self):
         return self.moderate_page * MASK_PAGE + \
             self.moderate_children * MASK_CHILDREN + \
             self.moderate_descendants * MASK_DESCENDANTS
-    
+
     def __unicode__(self):
         return u"%s on %s mod: %d" % (self.user, self.page, self.get_decimal())
 
 
 class PageModeratorState(models.Model):
     """PageModeratorState memories all actions made on page.
-    Page can be in only one advanced state. 
+    Page can be in only one advanced state.
     """
     ACTION_ADD = "ADD"
     ACTION_CHANGED = "CHA"
-    
+
     ACTION_PUBLISH = "PUB"
     ACTION_UNPUBLISH = "UNP"
     ACTION_MOVE = "MOV"
-    
+
     # advanced states
     ACTION_DELETE = "DEL"
-    
+
     # approve state
     ACTION_APPROVE = "APP"
-    
+
     _action_choices = (
-        (ACTION_ADD, _('created')), 
-        (ACTION_CHANGED, _('changed')), 
+        (ACTION_ADD, _('created')),
+        (ACTION_CHANGED, _('changed')),
         (ACTION_DELETE, _('delete req.')),
         (ACTION_MOVE, _('move req.')),
         (ACTION_PUBLISH, _('publish req.')),
         (ACTION_UNPUBLISH, _('unpublish req.')),
-        (ACTION_APPROVE, _('approved')), # Approved by somebody in approvement process
+        (ACTION_APPROVE, _('approved')),  # Approved by somebody in approvement process
     )
-    
+
     page = models.ForeignKey(Page)
     user = models.ForeignKey(User, null=True)
     created = models.DateTimeField(auto_now_add=True)
     action = models.CharField(max_length=3, choices=_action_choices, null=True, blank=True)
     message = models.TextField(max_length=1000, blank=True, default="")
-    
+
     objects = PageModeratorStateManager()
-    
+
     class Meta:
-        verbose_name=_('Page moderator state')
-        verbose_name_plural=_('Page moderator states')
-        ordering = ('page', 'action', '-created') # newer first
+        verbose_name = _('Page moderator state')
+        verbose_name_plural = _('Page moderator states')
+        ordering = ('page', 'action', '-created')  # newer first
         app_label = 'cms'
-    
+
     css_class = lambda self: self.action.lower()
-    
+
     def __unicode__(self):
         return u"%s: %s" % (self.page, self.get_action_display())

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -23,10 +23,6 @@ from os.path import join
 import copy
 
 
-
-
-
-
 class Page(MPTTModel):
     """
     A simple hierarchical page model
@@ -38,7 +34,7 @@ class Page(MPTTModel):
     MODERATOR_APPROVED = 10
     # special case - page was approved, but some of page parents are not approved yet
     MODERATOR_APPROVED_WAITING_FOR_PARENTS = 11
-    
+
     moderator_state_choices = (
         (MODERATOR_CHANGED, _('changed')),
         (MODERATOR_NEED_APPROVEMENT, _('req. app.')),
@@ -46,17 +42,17 @@ class Page(MPTTModel):
         (MODERATOR_APPROVED, _('approved')),
         (MODERATOR_APPROVED_WAITING_FOR_PARENTS, _('app. par.')),
     )
-    
+
     LIMIT_VISIBILITY_IN_MENU_CHOICES = (
-        (1,_('for logged in users only')),
-        (2,_('for anonymous users only')),
+        (1, _('for logged in users only')),
+        (2, _('for anonymous users only')),
     )
     PUBLISHER_STATE_DEFAULT = 0
     PUBLISHER_STATE_DIRTY = 1
     PUBLISHER_STATE_DELETE = 2
-    
-    template_choices = [(x, _(y)) for x,y in settings.CMS_TEMPLATES]
-    
+
+    template_choices = [(x, _(y)) for x, y in settings.CMS_TEMPLATES]
+
     created_by = models.CharField(_("created by"), max_length=70, editable=False)
     changed_by = models.CharField(_("changed by"), max_length=70, editable=False)
     parent = models.ForeignKey('self', null=True, blank=True, related_name='children', db_index=True)
@@ -69,29 +65,29 @@ class Page(MPTTModel):
     reverse_id = models.CharField(_("id"), max_length=40, db_index=True, blank=True, null=True, help_text=_("An unique identifier that is used with the page_url templatetag for linking to this page"))
     navigation_extenders = models.CharField(_("attached menu"), max_length=80, db_index=True, blank=True, null=True)
     published = models.BooleanField(_("is published"), blank=True)
-    
+
     template = models.CharField(_("template"), max_length=100, choices=template_choices, help_text=_('The template used to render the content.'))
     site = models.ForeignKey(Site, help_text=_('The site the page is accessible at.'), verbose_name=_("site"))
-    
+
     moderator_state = models.SmallIntegerField(_('moderator state'), choices=moderator_state_choices, default=MODERATOR_NEED_APPROVEMENT, blank=True)
-    
+
     level = models.PositiveIntegerField(db_index=True, editable=False)
     lft = models.PositiveIntegerField(db_index=True, editable=False)
     rght = models.PositiveIntegerField(db_index=True, editable=False)
     tree_id = models.PositiveIntegerField(db_index=True, editable=False)
-    
+
     login_required = models.BooleanField(_("login required"), default=False)
     limit_visibility_in_menu = models.SmallIntegerField(_("menu visibility"), default=None, null=True, blank=True, choices=LIMIT_VISIBILITY_IN_MENU_CHOICES, db_index=True, help_text=_("limit when this page is visible in the menu"))
-    
+
     # Placeholders (plugins)
     placeholders = models.ManyToManyField(Placeholder, editable=False)
-    
+
     # Publisher fields
 
     publisher_is_draft = models.BooleanField(default=1, editable=False, db_index=True)
     publisher_public = models.OneToOneField('self', related_name='publisher_draft',  null=True, editable=False)
     publisher_state = models.SmallIntegerField(default=0, editable=False, db_index=True)
-    
+
     # Managers
     objects = PageManager()
     permissions = PagePermissionsPermissionManager()
@@ -102,15 +98,15 @@ class Page(MPTTModel):
         )
         verbose_name = _('page')
         verbose_name_plural = _('pages')
-        ordering = ('site','tree_id', 'lft')
+        ordering = ('site', 'tree_id', 'lft')
         app_label = 'cms'
-    
+
     class PublisherMeta:
         exclude_fields_append = ['id', 'publisher_is_draft', 'publisher_public',
                                  'publisher_state', 'moderator_state',
                                  'placeholders', 'lft', 'rght', 'tree_id',
                                  'parent']
-    
+
     def __unicode__(self):
         title = self.get_menu_title(fallback=True)
         if title is None:
@@ -126,7 +122,7 @@ class Page(MPTTModel):
         # else
         path = self.get_path(language, fallback)
         return urlutils.urljoin(reverse('pages-root'), path)
-    
+
     def move_page(self, target, position='first-child'):
         """Called from admin interface when page is moved. Should be used on
         all the places which are changing page position. Used like an interface
@@ -138,41 +134,40 @@ class Page(MPTTModel):
             and self.template == settings.CMS_TEMPLATE_INHERITANCE_MAGIC):
             self.template = self.get_template()
         self.move_to(target, position)
-        
+
         # fire signal
         from cms.models.moderatormodels import PageModeratorState
         self.force_moderation_action = PageModeratorState.ACTION_MOVE
         import cms.signals as cms_signals
-        cms_signals.page_moved.send(sender=Page, instance=self) #titles get saved before moderation
-        self.save(change_state=True) # always save the page after move, because of publisher
-        
+        cms_signals.page_moved.send(sender=Page, instance=self)  # titles get saved before moderation
+        self.save(change_state=True)  # always save the page after move, because of publisher
+
         # check the slugs
         page_utils.check_title_slugs(self)
-        
+
     def copy_page(self, target, site, position='first-child',
                   copy_permissions=True, copy_moderation=True,
                   public_copy=False):
         """
         copy a page [ and all its descendants to a new location ]
         Doesn't checks for add page permissions anymore, this is done in PageAdmin.
-        
+
         Note: public_copy was added in order to enable the creation of a copy for creating the public page during
         the publish operation as it sets the publisher_is_draft=False.
         """
         from cms.utils.moderator import update_moderation_message
-        
+
         page_copy = None
-        
-        
+
         if public_copy:
-            # create a copy of the draft page - existing code loops through pages so added it to a list 
-            pages = [copy.copy(self)]            
+            # create a copy of the draft page - existing code loops through pages so added it to a list
+            pages = [copy.copy(self)]
         else:
             pages = [self] + list(self.get_descendants().order_by('-rght'))
-            
-        if not public_copy:    
+
+        if not public_copy:
             site_reverse_ids = Page.objects.filter(site=site, reverse_id__isnull=False).values_list('reverse_id', flat=True)
-        
+
             if target:
                 target.old_pk = -1
                 if position == "first-child":
@@ -185,8 +180,7 @@ class Page(MPTTModel):
                 tree = []
             if tree:
                 tree[0].old_pk = tree[0].pk
-        
-            
+
         first = True
         # loop over all affected pages (self is included in descendants)
         for page in pages:
@@ -229,21 +223,21 @@ class Page(MPTTModel):
                         page.parent = None
                 tree.append(page)
             page.site = site
-             
+
             # override default page settings specific for public copy
             if public_copy:
                 page.published = True
-                page.publisher_is_draft=False
+                page.publisher_is_draft = False
                 page.moderator_state = Page.MODERATOR_APPROVED
                 # we need to set relate this new public copy to its draft page (self)
                 page.publisher_public = self
-                
+
                 # code taken from Publisher publish() overridden here as we need to save the page
                 # before we are able to use the page object for titles, placeholders etc.. below
                 # the method has been modified to return the object after saving the instance variable
                 page = self._publisher_save_public(page)
                 page_copy = page    # create a copy used in the return
-            else:    
+            else:
                 # only need to save the page if it isn't public since it is saved above otherwise
                 page.save()
 
@@ -260,38 +254,37 @@ class Page(MPTTModel):
                     moderator.pk = None
                     moderator.page = page
                     moderator.save()
-                    
+
             # update moderation message for standard copy
             if not public_copy:
                 update_moderation_message(page, unicode(_('Page was copied.')))
-            
+
             # copy titles of this page
             for title in titles:
-                title.pk = None # setting pk = None creates a new instance
+                title.pk = None  # setting pk = None creates a new instance
                 title.publisher_public_id = None
                 title.published = False
                 title.page = page
-                
+
                 # create slug-copy for standard copy
                 if not public_copy:
                     title.slug = page_utils.get_available_slug(title)
                 title.save()
-                
+
             # copy the placeholders (and plugins on those placeholders!)
             for ph in placeholders:
                 plugins = list(ph.cmsplugin_set.all().order_by('tree_id', '-rght'))
                 try:
                     ph = page.placeholders.get(slot=ph.slot)
                 except Placeholder.DoesNotExist:
-                    ph.pk = None # make a new instance
+                    ph.pk = None  # make a new instance
                     ph.save()
                     page.placeholders.add(ph)
                     # update the page copy
                     page_copy = page
                 if plugins:
                     copy_plugins_to(plugins, ph)
-                    
-        
+
         # invalidate the menu for this site
         menu_pool.clear(site_id=site.pk)
         return page_copy   # return the page_copy or None
@@ -300,22 +293,22 @@ class Page(MPTTModel):
              force_with_moderation=False, force_state=None, **kwargs):
         """
         Args:
-            
+
             commit: True if model should be really saved
-            force_with_moderation: can be true when new object gets added under 
-                some existing page and this new page will require moderation; 
+            force_with_moderation: can be true when new object gets added under
+                some existing page and this new page will require moderation;
                 this is because of how this adding works - first save, then move
         """
-        
+
         # Published pages should always have a publication date
         publish_directly, under_moderation = False, False
         if self.publisher_is_draft:
-            # publisher specific stuff, but only on draft model, this is here 
+            # publisher specific stuff, but only on draft model, this is here
             # because page initializes publish process
-            
+
             if settings.CMS_MODERATOR:
                 under_moderation = force_with_moderation or self.pk and bool(self.get_moderator_queryset().count())
-            
+
             created = not bool(self.pk)
             if settings.CMS_MODERATOR:
                 if change_state:
@@ -325,27 +318,27 @@ class Page(MPTTModel):
                     elif not self.requires_approvement():
                         # always change state to need approvement when there is some change
                         self.moderator_state = Page.MODERATOR_NEED_APPROVEMENT
-                    
+
                     if not under_moderation and (self.published or self.publisher_public):
-                        # existing page without moderator - publish it directly if 
+                        # existing page without moderator - publish it directly if
                         # published is True
                         publish_directly = True
-                    
+
             elif change_state:
                 self.moderator_state = Page.MODERATOR_CHANGED
                 #publish_directly = True - no publisher, no publishing!! - we just
                 # use draft models in this case
-            
+
             if force_state is not None:
                 self.moderator_state = force_state
-            
+
         # if the page is published we set the publish date if not set yet.
         if self.publication_date is None and self.published:
             self.publication_date = datetime.now()
-        
+
         if self.reverse_id == "":
             self.reverse_id = None
-        
+
         from cms.utils.permissions import _thread_locals
         user = getattr(_thread_locals, "user", None)
         if user:
@@ -354,20 +347,20 @@ class Page(MPTTModel):
             self.changed_by = "script"
         if not self.pk:
             self.created_by = self.changed_by
-        
+
         if commit:
-            if no_signals:# ugly hack because of mptt
+            if no_signals:  # ugly hack because of mptt
                 self.save_base(cls=self.__class__, **kwargs)
             else:
                 super(Page, self).save(**kwargs)
-        
+
         #if commit and (publish_directly or created and not under_moderation):
         if self.publisher_is_draft:
             if self.published:
                 if commit and publish_directly:
-                    
+
                     self.publish()
-                
+
     def save_base(self, *args, **kwargs):
         """Overriden save_base. If an instance is draft, and was changed, mark
         it as dirty.
@@ -388,7 +381,7 @@ class Page(MPTTModel):
 
     def publish(self):
         """Overrides Publisher method, because there may be some descendants, which
-        are waiting for parent to publish, so publish them if possible. 
+        are waiting for parent to publish, so publish them if possible.
 
         IMPORTANT: @See utils.moderator.approve_page for publishing permissions
 
@@ -482,25 +475,24 @@ class Page(MPTTModel):
         """Mark public instance for deletion and delete draft.
         """
         placeholders = self.placeholders.all()
-        
+
         for ph in placeholders:
             plugin = CMSPlugin.objects.filter(placeholder=ph)
             plugin.delete()
             ph.delete()
-    
+
         if self.publisher_public_id:
             # mark the public instance for deletion
             self.publisher_public.publisher_state = self.PUBLISHER_STATE_DELETE
             self.publisher_public.save()
         super(Page, self).delete()
 
-
     def delete_with_public(self):
-        
+
         placeholders = list(self.placeholders.all())
         if self.publisher_public_id:
             placeholders = placeholders + list(self.publisher_public.placeholders.all())
-            
+
         for ph in placeholders:
             plugin = CMSPlugin.objects.filter(placeholder=ph)
             plugin.delete()
@@ -508,13 +500,13 @@ class Page(MPTTModel):
         if self.publisher_public_id:
             self.publisher_public.delete()
         super(Page, self).delete()
-                        
+
     def get_draft_object(self):
         return self
 
     def get_public_object(self):
         return self.publisher_public
-        
+
     def get_languages(self):
         """
         get the list of all existing languages for this page
@@ -524,30 +516,30 @@ class Page(MPTTModel):
         if not hasattr(self, "all_languages"):
             self.all_languages = Title.objects.filter(page=self).values_list("language", flat=True).distinct()
             self.all_languages = list(self.all_languages)
-            self.all_languages.sort()    
+            self.all_languages.sort()
         return self.all_languages
-    
+
     def get_cached_ancestors(self, ascending=True):
         if ascending:
             if not hasattr(self, "ancestors_ascending"):
-                self.ancestors_ascending = list(self.get_ancestors(ascending)) 
+                self.ancestors_ascending = list(self.get_ancestors(ascending))
             return self.ancestors_ascending
         else:
             if not hasattr(self, "ancestors_descending"):
                 self.ancestors_descending = list(self.get_ancestors(ascending))
             return self.ancestors_descending
-    
+
     def get_title_obj(self, language=None, fallback=True, version_id=None, force_reload=False):
-        """Helper function for accessing wanted / current title. 
+        """Helper function for accessing wanted / current title.
         If wanted title doesn't exists, EmptyTitle instance will be returned.
         """
-        
+
         language = self._get_title_cache(language, fallback, version_id, force_reload)
         if language in self.title_cache:
             return self.title_cache[language]
         from cms.models.titlemodels import EmptyTitle
         return EmptyTitle()
-    
+
     def get_title_obj_attribute(self, attrname, language=None, fallback=True, version_id=None, force_reload=False):
         """Helper function for getting attribute or None from wanted/current title.
         """
@@ -557,7 +549,7 @@ class Page(MPTTModel):
             return attribute
         except AttributeError:
             return None
-    
+
     def get_path(self, language=None, fallback=True, version_id=None, force_reload=False):
         """
         get the path of the page depending on the given language
@@ -569,13 +561,13 @@ class Page(MPTTModel):
         get the slug of the page depending on the given language
         """
         return self.get_title_obj_attribute("slug", language, fallback, version_id, force_reload)
-        
+
     def get_title(self, language=None, fallback=True, version_id=None, force_reload=False):
         """
         get the title of the page depending on the given language
         """
         return self.get_title_obj_attribute("title", language, fallback, version_id, force_reload)
-    
+
     def get_menu_title(self, language=None, fallback=True, version_id=None, force_reload=False):
         """
         get the menu title of the page depending on the given language
@@ -584,7 +576,7 @@ class Page(MPTTModel):
         if not menu_title:
             return self.get_title(language, True, version_id, force_reload)
         return menu_title
-    
+
     def get_page_title(self, language=None, fallback=True, version_id=None, force_reload=False):
         """
         get the page title of the page depending on the given language
@@ -605,19 +597,19 @@ class Page(MPTTModel):
         get content for the keywords meta tag for the page depending on the given language
         """
         return self.get_title_obj_attribute("meta_keywords", language, fallback, version_id, force_reload)
-        
+
     def get_application_urls(self, language=None, fallback=True, version_id=None, force_reload=False):
         """
         get application urls conf for application hook
         """
         return self.get_title_obj_attribute("application_urls", language, fallback, version_id, force_reload)
-    
+
     def get_redirect(self, language=None, fallback=True, version_id=None, force_reload=False):
         """
         get redirect
         """
         return self.get_title_obj_attribute("redirect", language, fallback, version_id, force_reload)
-    
+
     def _get_title_cache(self, language, fallback, version_id, force_reload):
         if not language:
             language = get_language()
@@ -630,8 +622,8 @@ class Page(MPTTModel):
                 fallback_langs = i18n.get_fallback_languages(language)
                 for lang in fallback_langs:
                     if lang in self.title_cache:
-                        return lang    
-            load = True 
+                        return lang
+            load = True
         if load:
             from cms.models.titlemodels import Title
             if version_id:
@@ -645,10 +637,10 @@ class Page(MPTTModel):
             else:
                 title = Title.objects.get_title(self, language, language_fallback=fallback)
                 if title:
-                    self.title_cache[title.language] = title 
+                    self.title_cache[title.language] = title
                 language = title.language
         return language
-                
+
     def get_template(self):
         """
         get the template of this page if defined or if closer parent if
@@ -666,7 +658,7 @@ class Page(MPTTModel):
         if not template:
             template = settings.CMS_TEMPLATES[0][0]
         return template
-    
+
     def get_template_name(self):
         """
         get the textual name (2nd parameter in settings.CMS_TEMPLATES)
@@ -676,13 +668,13 @@ class Page(MPTTModel):
         template = self.get_template()
         for t in settings.CMS_TEMPLATES:
             if t[0] == template:
-                return t[1] 
+                return t[1]
         return _("default")
-    
+
     def has_view_permission(self, request):
         from cms.models.permissionmodels import PagePermission, GlobalPagePermission
         from cms.utils.plugins import current_site
-                        
+
         if not self.publisher_is_draft and self.publisher_public:
             return self.publisher_public.has_view_permission(request)
         # does any restriction exist?
@@ -699,21 +691,20 @@ class Page(MPTTModel):
             # a global permission was given to the request's user
             if global_view_perms:
                 return True
-                
+
             elif not is_restricted:
-            	if ((settings.CMS_PUBLIC_FOR == 'all') or
-            	    (settings.CMS_PUBLIC_FOR == 'staff' and
-            		 request.user.is_staff)):
-            			return True
+                if ((settings.CMS_PUBLIC_FOR == 'all') or
+                    (settings.CMS_PUBLIC_FOR == 'staff' and
+                    request.user.is_staff)):
+                    return True
 
             # a restricted page and an authenticated user
             elif is_restricted:
                 opts = self._meta
                 codename = '%s.view_%s' % (opts.app_label, opts.object_name.lower())
                 user_perm = request.user.has_perm(codename)
-                generic_perm = self.has_generic_permission(request, "view")  
+                generic_perm = self.has_generic_permission(request, "view")
                 return (user_perm or generic_perm)
-    
 
         else:
             #anonymous user
@@ -729,44 +720,44 @@ class Page(MPTTModel):
         codename = '%s.view_%s' % (opts.app_label, opts.object_name.lower())
         return (request.user.has_perm(codename) or
                 self.has_generic_permission(request, "view"))
-    
+
     def has_change_permission(self, request):
         opts = self._meta
         if request.user.is_superuser:
             return True
         return request.user.has_perm(opts.app_label + '.' + opts.get_change_permission()) and \
             self.has_generic_permission(request, "change")
-    
+
     def has_delete_permission(self, request):
         opts = self._meta
         if request.user.is_superuser:
             return True
         return request.user.has_perm(opts.app_label + '.' + opts.get_delete_permission()) and \
             self.has_generic_permission(request, "delete")
-    
+
     def has_publish_permission(self, request):
         return self.has_generic_permission(request, "publish")
-    
+
     def has_advanced_settings_permission(self, request):
         return self.has_generic_permission(request, "advanced_settings")
-    
+
     def has_change_permissions_permission(self, request):
         """
         Has user ability to change permissions for current page?
         """
         return self.has_generic_permission(request, "change_permissions")
-    
+
     def has_add_permission(self, request):
         """
         Has user ability to add page under current page?
         """
         return self.has_generic_permission(request, "add")
-    
+
     def has_move_page_permission(self, request):
         """Has user ability to move current page?
         """
         return self.has_generic_permission(request, "move_page")
-    
+
     def has_moderate_permission(self, request):
         """
         Has user ability to moderate current page? If moderation isn't
@@ -775,7 +766,7 @@ class Page(MPTTModel):
         if not settings.CMS_MODERATOR:
             return False
         return self.has_generic_permission(request, "moderate")
-    
+
     def has_generic_permission(self, request, perm_type):
         """
         Return true if the current user has permission on the page.
@@ -791,7 +782,7 @@ class Page(MPTTModel):
             if getattr(self, att_name):
                 self.permission_edit_cache = True
         return getattr(self, att_name)
-    
+
     def is_home(self):
         if self.parent_id:
             return False
@@ -801,66 +792,66 @@ class Page(MPTTModel):
             except NoHomeFound:
                 pass
         return False
-    
+
     def get_home_pk_cache(self):
         attr = "%s_home_pk_cache_%s" % (self.publisher_is_draft and "draft" or "public", self.site_id)
         if not hasattr(self, attr):
             setattr(self, attr, self.get_object_queryset().get_home(self.site).pk)
         return getattr(self, attr)
-    
+
     def set_home_pk_cache(self, value):
         attr = "%s_home_pk_cache_%s" % (self.publisher_is_draft and "draft" or "public", self.site_id)
         setattr(self, attr, value)
     home_pk_cache = property(get_home_pk_cache, set_home_pk_cache)
-    
+
     def get_media_path(self, filename):
         """
         Returns path (relative to MEDIA_ROOT/MEDIA_URL) to directory for storing page-scope files.
         This allows multiple pages to contain files with identical names without namespace issues.
-        Plugins such as Picture can use this method to initialise the 'upload_to' parameter for 
+        Plugins such as Picture can use this method to initialise the 'upload_to' parameter for
         File-based fields. For example:
             image = models.ImageField(_("image"), upload_to=CMSPlugin.get_media_path)
         where CMSPlugin.get_media_path calls self.page.get_media_path
-        
+
         This location can be customised using the CMS_PAGE_MEDIA_PATH setting
         """
         return join(settings.CMS_PAGE_MEDIA_PATH, "%d" % self.id, filename)
-    
+
     def last_page_states(self):
         """Returns last five page states, if they exist, optimized, calls sql
         query only if some states available
         """
-        # TODO: optimize SQL... 1 query per page 
+        # TODO: optimize SQL... 1 query per page
         if settings.CMS_MODERATOR:
             has_moderator_state = getattr(self, '_has_moderator_state_chache', None)
             if has_moderator_state == False:
                 return self.pagemoderatorstate_set.none()
             return self.pagemoderatorstate_set.all().order_by('created',)[:5]
         return self.pagemoderatorstate_set.none()
-    
+
     def get_moderator_queryset(self):
-        """Returns ordered set of all PageModerator instances, which should 
+        """Returns ordered set of all PageModerator instances, which should
         moderate this page
         """
         from cms.models.moderatormodels import PageModerator
         if not settings.CMS_MODERATOR or not self.tree_id:
             return PageModerator.objects.get_empty_query_set()
-        
+
         q = Q(page__tree_id=self.tree_id, page__level__lt=self.level, moderate_descendants=True) | \
             Q(page__tree_id=self.tree_id, page__level=self.level - 1, moderate_children=True) | \
             Q(page__pk=self.pk, moderate_page=True)
-        
+
         return PageModerator.objects.distinct().filter(q).order_by('page__level')
-    
+
     def is_under_moderation(self):
         return bool(self.get_moderator_queryset().count())
-    
+
     def is_approved(self):
         """Returns true, if page is approved and published, or approved, but
         parents are missing..
         """
         return self.moderator_state in (Page.MODERATOR_APPROVED, Page.MODERATOR_APPROVED_WAITING_FOR_PARENTS)
-    
+
     def is_public_published(self):
         """Returns true if public model is published.
         """
@@ -872,16 +863,16 @@ class Page(MPTTModel):
             return self.publisher_public.published
         #return is_public_published(self)
         return False
-    
+
     def reload(self):
         """
         Reload a page from the database
         """
         return Page.objects.get(pk=self.pk)
-        
+
     def requires_approvement(self):
         return self.moderator_state in (Page.MODERATOR_NEED_APPROVEMENT, Page.MODERATOR_NEED_DELETE_APPROVEMENT)
-    
+
     def get_moderation_value(self, user):
         """Returns page moderation value for given user, moderation value is
         sum of moderations.
@@ -893,13 +884,13 @@ class Page(MPTTModel):
             page_moderator = self.pagemoderator_set.get(user=user)
         except ObjectDoesNotExist:
             return 0
-        
+
         moderation_value = page_moderator.get_decimal()
-        
+
         self._moderation_value_cahce = moderation_value
         self._moderation_value_cache_for_user_id = user
-            
-        return moderation_value 
+
+        return moderation_value
 
     def get_object_queryset(self):
         """Returns smart queryset depending on object type - draft / public
@@ -978,7 +969,7 @@ class Page(MPTTModel):
                 '%s__lt' % opts.right_attr: getattr(self, opts.left_attr),
             })
             order_by = '-%s' % opts.right_attr
-        
+
         # publisher stuff
         filters.update({
             'publisher_is_draft': self.publisher_is_draft
@@ -987,7 +978,7 @@ class Page(MPTTModel):
         filters.update({
             'site__id': self.site_id
         })
-        
+
         sibling = None
         try:
             sibling = self._tree_manager.filter(**filters).order_by(order_by)[0]
@@ -1054,7 +1045,7 @@ class Page(MPTTModel):
         # or none structural change, just save
         obj.save()
         return obj
-    
+
     def rescan_placeholders(self):
         """
         Rescan and if necessary create placeholders in the current template.
@@ -1072,9 +1063,10 @@ class Page(MPTTModel):
                 self.placeholders.add(placeholder)
                 found[placeholder_name] = placeholder
 
+
 def _reversion():
     exclude_fields = ['publisher_is_draft', 'publisher_public', 'publisher_state']
-            
+
     reversion_register(
         Page,
         follow=["title_set", "placeholders", "pagepermission_set"],

--- a/cms/models/permissionmodels.py
+++ b/cms/models/permissionmodels.py
@@ -9,13 +9,14 @@ from cms.models import Page, ACCESS_CHOICES, ACCESS_PAGE_AND_DESCENDANTS
 from cms.models.managers import BasicPagePermissionManager, PagePermissionManager
 from cms.utils.helpers import reversion_register
 
+
 class AbstractPagePermission(models.Model):
     """Abstract page permissions
     """
     # who:
     user = models.ForeignKey(User, verbose_name=_("user"), blank=True, null=True)
     group = models.ForeignKey(Group, verbose_name=_("group"), blank=True, null=True)
-    
+
     # what:
     can_change = models.BooleanField(_("can edit"), default=True)
     can_add = models.BooleanField(_("can add"), default=True)
@@ -26,18 +27,18 @@ class AbstractPagePermission(models.Model):
     can_move_page = models.BooleanField(_("can move"), default=True)
     can_moderate = models.BooleanField(_("can moderate"), default=True)
     can_view = models.BooleanField(_("view restricted"), default=False, help_text=_("frontend view restriction"))
-    
+
     class Meta:
         abstract = True
         app_label = 'cms'
-    
+
     @property
     def audience(self):
         """Return audience by priority, so: All or User, Group
         """
         targets = filter(lambda item: item, (self.user, self.group,))
         return ", ".join([unicode(t) for t in targets]) or 'No one'
-    
+
     def save(self, *args, **kwargs):
         if not self.user and not self.group:
             # don't allow `empty` objects
@@ -50,31 +51,31 @@ class GlobalPagePermission(AbstractPagePermission):
     """
     can_recover_page = models.BooleanField(_("can recover pages"), default=True, help_text=_("can recover any deleted page"))
     sites = models.ManyToManyField(Site, null=True, blank=True, help_text=_('If none selected, user haves granted permissions to all sites.'), verbose_name=_('sites'))
-    
+
     objects = BasicPagePermissionManager()
-    
+
     class Meta:
         verbose_name = _('Page global permission')
         verbose_name_plural = _('Pages global permissions')
         app_label = 'cms'
-    
+
     def __unicode__(self):
         return "%s :: GLOBAL" % self.audience
 
 
 class PagePermission(AbstractPagePermission):
     """Page permissions for single page
-    """ 
+    """
     grant_on = models.IntegerField(_("Grant on"), choices=ACCESS_CHOICES, default=ACCESS_PAGE_AND_DESCENDANTS)
     page = models.ForeignKey(Page, null=True, blank=True, verbose_name=_("page"))
-    
+
     objects = PagePermissionManager()
-    
+
     class Meta:
         verbose_name = _('Page permission')
         verbose_name_plural = _('Page permissions')
         app_label = 'cms'
-    
+
     def __unicode__(self):
         page = self.page_id and unicode(self.page) or "None"
         return "%s :: %s has: %s" % (page, self.audience, unicode(dict(ACCESS_CHOICES)[self.grant_on]))
@@ -84,7 +85,7 @@ class PageUser(User):
     """Cms specific user data, required for permission system
     """
     created_by = models.ForeignKey(User, related_name="created_users")
-    
+
     class Meta:
         verbose_name = _('User (page)')
         verbose_name_plural = _('Users (page)')
@@ -92,10 +93,10 @@ class PageUser(User):
 
 
 class PageUserGroup(Group):
-    """Cms specific group data, required for permission system 
+    """Cms specific group data, required for permission system
     """
     created_by = models.ForeignKey(User, related_name="created_usergroups")
-    
+
     class Meta:
         verbose_name = _('User group (page)')
         verbose_name_plural = _('User groups (page)')

--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -7,6 +7,7 @@ from django.forms.widgets import Media
 from django.utils.translation import ugettext_lazy as _
 import operator
 
+
 class Placeholder(models.Model):
     slot = models.CharField(_("slot"), max_length=50, db_index=True, editable=False)
     default_width = models.PositiveSmallIntegerField(_("width"), null=True, editable=False)
@@ -16,19 +17,19 @@ class Placeholder(models.Model):
 
     def __unicode__(self):
         return self.slot
-    
+
     def get_add_url(self):
         return self._get_url('add_plugin')
-    
+
     def get_move_url(self):
         return self._get_url('move_plugin')
-        
+
     def get_remove_url(self):
         return self._get_url('remove_plugin')
-                
+
     def get_changelist_url(self):
         return self._get_url('changelist')
-        
+
     def _get_url(self, key):
         model = self._get_attached_model()
         if not model:
@@ -37,7 +38,7 @@ class Placeholder(models.Model):
             app_label = model._meta.app_label
             model_name = model.__name__.lower()
             return reverse('admin:%s_%s_%s' % (app_label, model_name, key))
-        
+
     def _get_permission(self, request, key):
         """
         Generic method to check the permissions for a request for a given key,
@@ -82,7 +83,7 @@ class Placeholder(models.Model):
         if media_classes:
             return reduce(operator.add, media_classes)
         return Media()
-    
+
     def _get_attached_fields(self):
         """
         Returns an ITERATOR of all non-cmsplugin reverse foreign key related fields.
@@ -94,7 +95,7 @@ class Placeholder(models.Model):
             field = getattr(self, rel.get_accessor_name())
             if field.count():
                 yield rel.field
-    
+
     def _get_attached_field(self):
         from cms.models import CMSPlugin
         if not hasattr(self, '_attached_field_cache'):
@@ -106,19 +107,19 @@ class Placeholder(models.Model):
                 if field.count():
                     self._attached_field_cache = rel.field
         return self._attached_field_cache
-    
+
     def _get_attached_field_name(self):
         field = self._get_attached_field()
         if field:
             return field.name
         return None
-    
+
     def _get_attached_model(self):
         field = self._get_attached_field()
         if field:
             return field.model
         return None
-    
+
     def _get_attached_models(self):
         """
         Returns a list of models of attached to this placeholder.
@@ -127,10 +128,10 @@ class Placeholder(models.Model):
 
     def get_plugins_list(self):
         return list(self.get_plugins())
-    
+
     def get_plugins(self):
         return self.cmsplugin_set.all().order_by('tree_id', '-rght')
-    
+
     @property
     def actions(self):
         if not hasattr(self, '_actions_cache'):
@@ -138,4 +139,4 @@ class Placeholder(models.Model):
             self._actions_cache = getattr(field, 'actions', PlaceholderNoAction())
         return self._actions_cache
 
-reversion_register(Placeholder) # follow=["cmsplugin_set"] not following plugins since they are a spechial case
+reversion_register(Placeholder)  # follow=["cmsplugin_set"] not following plugins since they are a spechial case

--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -37,14 +37,14 @@ class PluginModelBase(MPTTModelBase):
 
         # create a new class (using the super-metaclass)
         new_class = super(PluginModelBase, cls).__new__(cls, name, bases, attrs)
-        
+
         # if there is a RenderMeta in attrs, use this one
         if attr_meta:
             meta = attr_meta
         else:
             # else try to use the one from the superclass (if present)
             meta = getattr(new_class, '_render_meta', None)
-        
+
         # set a new BoundRenderMeta to prevent leaking of state
         new_class._render_meta = BoundRenderMeta(meta)
 
@@ -52,22 +52,22 @@ class PluginModelBase(MPTTModelBase):
         # 'myapp_' bit from the db_table name.
         if [base for base in bases if isinstance(base, PluginModelBase)]:
             splitter = '%s_' % new_class._meta.app_label
-            
+
             if splitter in new_class._meta.db_table:
                 splitted = new_class._meta.db_table.split(splitter, 1)
                 table_name = 'cmsplugin_%s' % splitted[1]
             else:
                 table_name = new_class._meta.db_table
             new_class._meta.db_table = table_name
-        
+
         return new_class
-         
-    
+
+
 class CMSPlugin(MPTTModel):
     '''
     The base class for a CMS plugin model. When defining a new custom plugin, you should
     store plugin-instance specific information on a subclass of this class.
-    
+
     An example for this would be to store the number of pictures to display in a galery.
 
     Two restrictions apply when subclassing this to use in your own models:
@@ -76,22 +76,22 @@ class CMSPlugin(MPTTModel):
 
     '''
     __metaclass__ = PluginModelBase
-    
+
     placeholder = models.ForeignKey(Placeholder, editable=False, null=True)
     parent = models.ForeignKey('self', blank=True, null=True, editable=False)
     position = models.PositiveSmallIntegerField(_("position"), blank=True, null=True, editable=False)
     language = models.CharField(_("language"), max_length=15, blank=False, db_index=True, editable=False)
     plugin_type = models.CharField(_("plugin_name"), max_length=50, db_index=True, editable=False)
     creation_date = models.DateTimeField(_("creation date"), editable=False, default=datetime.now)
-    
+
     level = models.PositiveIntegerField(db_index=True, editable=False)
     lft = models.PositiveIntegerField(db_index=True, editable=False)
     rght = models.PositiveIntegerField(db_index=True, editable=False)
     tree_id = models.PositiveIntegerField(db_index=True, editable=False)
-        
+
     class Meta:
         app_label = 'cms'
-        
+
     class RenderMeta:
         index = 0
         total = 1
@@ -135,23 +135,23 @@ class CMSPlugin(MPTTModel):
     def get_plugin_name(self):
         from cms.plugin_pool import plugin_pool
         return plugin_pool.get_plugin(self.plugin_type).name
-    
+
     def get_short_description(self):
         instance = self.get_plugin_instance()[0]
         if instance:
             return instance.__unicode__()
         else:
             return _("<Empty>")
-    
+
     def get_plugin_class(self):
         from cms.plugin_pool import plugin_pool
         return plugin_pool.get_plugin(self.plugin_type)
-        
+
     def get_plugin_instance(self, admin=None):
         from cms.plugin_pool import plugin_pool
         plugin_class = plugin_pool.get_plugin(self.plugin_type)
-        plugin = plugin_class(plugin_class.model, admin)# needed so we have the same signature as the original ModelAdmin
-        if plugin.model != self.__class__: # and self.__class__ == CMSPlugin:
+        plugin = plugin_class(plugin_class.model, admin)  # needed so we have the same signature as the original ModelAdmin
+        if plugin.model != self.__class__:  # and self.__class__ == CMSPlugin:
             # (if self is actually a subclass, getattr below would break)
             try:
                 instance = getattr(self, plugin.model.__name__.lower())
@@ -163,7 +163,7 @@ class CMSPlugin(MPTTModel):
         else:
             instance = self
         return instance, plugin
-    
+
     def render_plugin(self, context=None, placeholder=None, admin=False, processors=None):
         instance, plugin = self.get_plugin_instance()
         if instance and not (admin and not plugin.admin_preview):
@@ -182,12 +182,12 @@ class CMSPlugin(MPTTModel):
                 template = None
             return render_plugin(context, instance, placeholder, template, processors)
         return ""
-            
+
     def get_media_path(self, filename):
         pages = self.placeholder.page_set.all()
         if pages.count():
             return pages[0].get_media_path(filename)
-        else: # django 1.0.2 compatibility
+        else:  # django 1.0.2 compatibility
             today = date.today()
             return os.path.join(settings.CMS_PAGE_MEDIA_PATH,
                 str(today.year), str(today.month), str(today.day), filename)
@@ -199,7 +199,7 @@ class CMSPlugin(MPTTModel):
             "guaranteed to have a page associated with them!",
             DontUsePageAttributeWarning)
         return get_page_from_placeholder_if_exists(self.placeholder)
-    
+
     def get_instance_icon_src(self):
         """
         Get src URL for instance's icon
@@ -219,24 +219,24 @@ class CMSPlugin(MPTTModel):
             return unicode(plugin.icon_alt(instance))
         else:
             return u''
-        
+
     def save(self, no_signals=False, *args, **kwargs):
-        if no_signals:# ugly hack because of mptt
+        if no_signals:  # ugly hack because of mptt
             super(CMSPlugin, self).save_base(cls=self.__class__)
         else:
             super(CMSPlugin, self).save()
-                           
+
     def set_base_attr(self, plugin):
         for attr in ['parent_id', 'placeholder', 'language', 'plugin_type', 'creation_date', 'level', 'lft', 'rght', 'position', 'tree_id']:
             setattr(plugin, attr, getattr(self, attr))
-    
+
     def copy_plugin(self, target_placeholder, target_language, plugin_tree):
         """
         Copy this plugin and return the new plugin.
         """
         try:
             plugin_instance, cls = self.get_plugin_instance()
-        except KeyError: #plugin type not found anymore
+        except KeyError:  # plugin type not found anymore
             return
         new_plugin = CMSPlugin()
         new_plugin.placeholder = target_placeholder
@@ -247,7 +247,7 @@ class CMSPlugin(MPTTModel):
         if self.parent:
             pdif = self.level - plugin_tree[-1].level
             if pdif < 0:
-                plugin_tree[:] = plugin_tree[:pdif-1]
+                plugin_tree[:] = plugin_tree[:pdif - 1]
             new_plugin.parent = plugin_tree[-1]
             if pdif != 0:
                 plugin_tree.append(new_plugin)
@@ -269,26 +269,26 @@ class CMSPlugin(MPTTModel):
             plugin_instance.cmsplugin_ptr = new_plugin
             plugin_instance.language = target_language
             plugin_instance.parent = new_plugin.parent
-            plugin_instance.position = new_plugin.position # added to retain the position when creating a public copy of a plugin
+            plugin_instance.position = new_plugin.position  # added to retain the position when creating a public copy of a plugin
             plugin_instance.save()
             old_instance = plugin_instance.__class__.objects.get(pk=self.pk)
             plugin_instance.copy_relations(old_instance)
         return new_plugin
-        
+
     def post_copy(self, old_instance, new_old_ziplist):
         """
         Handle more advanced cases (eg Text Plugins) after the original is
         copied
         """
-        pass 
- 
+        pass
+
     def copy_relations(self, old_instance):
         """
         Handle copying of any relations attached to this plugin. Custom plugins
         have to do this themselves!
         """
         pass
-        
+
     def delete_with_public(self):
         """
             Delete the public copy of this plugin if it exists,
@@ -301,13 +301,13 @@ class CMSPlugin(MPTTModel):
             try:
                 placeholder = Placeholder.objects.get(page=page.publisher_public, slot=slot)
             except Placeholder.DoesNotExist:
-                pass                
+                pass
             else:
                 public_plugin = CMSPlugin.objects.filter(placeholder=placeholder, position=position)
                 public_plugin.delete()
         self.placeholder = None
         self.delete()
-        
+
     def has_change_permission(self, request):
         page = get_page_from_placeholder_if_exists(self.placeholder)
         if page:
@@ -317,16 +317,16 @@ class CMSPlugin(MPTTModel):
         elif self.parent:
             return self.parent.has_change_permission(request)
         return False
-        
+
     def is_first_in_placeholder(self):
         return self.position == 0
-    
+
     def is_last_in_placeholder(self):
         """
         WARNING: this is a rather expensive call compared to is_first_in_placeholder!
         """
         return self.placeholder.cmsplugin_set.all().order_by('-position')[0].pk == self.pk
-    
+
     def get_position_in_placeholder(self):
         """
         1 based position!
@@ -334,6 +334,7 @@ class CMSPlugin(MPTTModel):
         return self.position + 1
 
 reversion_register(CMSPlugin)
+
 
 def deferred_class_factory(model, attrs):
     """

--- a/cms/models/query.py
+++ b/cms/models/query.py
@@ -17,17 +17,17 @@ class PageQuerySet(PublisherQuerySet):
             except Site.DoesNotExist:
                 site = None
         return self.filter(site=site)
-        
+
     def root(self):
         """
         Return a queryset with pages that don't have parents, a.k.a. root. For
         current site - used in frontend
         """
         return self.on_site().filter(parent__isnull=True)
-    
+
     def all_root(self):
         """
-        Return a queryset with pages that don't have parents, a.k.a. root. For 
+        Return a queryset with pages that don't have parents, a.k.a. root. For
         all sites - used in frontend
         """
         return self.filter(parent__isnull=True)
@@ -56,7 +56,7 @@ class PageQuerySet(PublisherQuerySet):
                 Q(publication_date__lt=datetime.now()) |
                 Q(publication_date__isnull=True)
             )
-        
+
         if settings.CMS_SHOW_END_DATE:
             pub = pub.filter(
                 Q(publication_end_date__gte=datetime.now()) |
@@ -68,8 +68,8 @@ class PageQuerySet(PublisherQuerySet):
     def expired(self):
         return self.on_site().filter(
             publication_end_date__lte=datetime.now())
-            
-#    - seems this is not used anymore...  
+
+#    - seems this is not used anymore...
 #    def get_pages_with_application(self, path, language):
 #        """Returns all pages containing application for current path, or
 #        any parrent. Returned list is sorted by path length, longer path first.
@@ -83,17 +83,17 @@ class PageQuerySet(PublisherQuerySet):
 #        # add proper ordering
 #        app_pages.query.order_by.extend(('LENGTH(`cms_title`.`path`) DESC',))
 #        return app_pages
-    
+
     def get_all_pages_with_application(self):
         """Returns all pages containing applications for all sites.
-        
-        Doesn't cares about the application language. 
+
+        Doesn't cares about the application language.
         """
         return self.published().filter(title_set__application_urls__gt='').distinct()
-    
+
     def get_home(self, site=None):
         try:
             home = self.published(site).all_root().order_by("tree_id")[0]
         except IndexError:
-            raise  NoHomeFound('No Root page found. Publish at least one page!')
+            raise NoHomeFound('No Root page found. Publish at least one page!')
         return home

--- a/cms/models/titlemodels.py
+++ b/cms/models/titlemodels.py
@@ -6,6 +6,7 @@ from cms.models.managers import TitleManager
 from cms.models.pagemodel import Page
 from cms.utils.helpers import reversion_register
 
+
 class Title(models.Model):
     language = models.CharField(_("language"), max_length=15, db_index=True)
     title = models.CharField(_("title"), max_length=255)
@@ -20,21 +21,21 @@ class Title(models.Model):
     page_title = models.CharField(_("title"), max_length=255, blank=True, null=True, help_text=_("overwrite the title (html title tag)"))
     page = models.ForeignKey(Page, verbose_name=_("page"), related_name="title_set")
     creation_date = models.DateTimeField(_("creation date"), editable=False, default=datetime.now)
-    
+
     objects = TitleManager()
-    
+
     class Meta:
         unique_together = (('language', 'page'),)
         app_label = 'cms'
-    
+
     def __unicode__(self):
-        return "%s (%s)" % (self.title, self.slug) 
+        return "%s (%s)" % (self.title, self.slug)
 
     def save(self, *args, **kwargs):
         # Build path from parent page's path and slug
         current_path = self.path
         parent_page = self.page.parent
-        
+
         slug = u'%s' % self.slug
         if not self.has_url_overwrite:
             self.path = u'%s' % slug
@@ -51,8 +52,8 @@ class Title(models.Model):
         if self.has_url_overwrite:
             return self.path
         return None
-        
-        
+
+
 class EmptyTitle(object):
     """Empty title object, can be returned from Page.get_title_obj() if required
     title object doesn't exists.
@@ -67,10 +68,10 @@ class EmptyTitle(object):
     application_urls = ""
     menu_title = ""
     page_title = ""
-    
+
     @property
     def overwrite_url(self):
         return None
-    
-    
+
+
 reversion_register(Title)


### PR DESCRIPTION
Fixing specially:
- Trailing whitespaces
- Number of empty lines between classes/methods
- Comments
