### PR TITLE
bug fix for pages admin

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -676,7 +676,10 @@ class PageAdmin(ModelAdmin):
         # been opened already and extracts the page ID
         djangocms_nodes_open = request.COOKIES.get('djangocms_nodes_open', '')
         raw_nodes = unquote(djangocms_nodes_open).split(',')
-        open_menu_trees = [int(c.split('page_', 1)[1]) for c in raw_nodes]
+        try:
+            open_menu_trees = [int(c.split('page_', 1)[1]) for c in raw_nodes]
+        except IndexError:
+            open_menu_trees = []
 
         context = {
             'title': cl.title,


### PR DESCRIPTION
Having a single page in the admin > pages changeview produces an index error -- wrapped in try / except to prevent
