### PR TITLE
removed extra slash in CMS_ADMIN_ICON_BASE

### DIFF
--- a/cms/templatetags/cms_admin.py
+++ b/cms/templatetags/cms_admin.py
@@ -16,9 +16,9 @@ register = template.Library()
 
 
 if LooseVersion(django.get_version()) < LooseVersion('1.4'):
-    CMS_ADMIN_ICON_BASE = "%s/admin/img/admin/" % settings.STATIC_URL
+    CMS_ADMIN_ICON_BASE = "%sadmin/img/admin/" % settings.STATIC_URL
 else:
-    CMS_ADMIN_ICON_BASE = "%s/admin/img/" % settings.STATIC_URL
+    CMS_ADMIN_ICON_BASE = "%sadmin/img/" % settings.STATIC_URL
 
 class ShowAdminMenu(InclusionTag):
     name = 'show_admin_menu'


### PR DESCRIPTION
as Django documentation dictates that STATIC_URL must include the trailing slash, therefore the url being built contained a double slash where it shouldn't which causes the development server to return error 500 rather than the images.
