### PR TITLE
`copy_plugins_to` should return copied plugins for additional post-processing to be possible

### DIFF
--- a/cms/utils/copy_plugins.py
+++ b/cms/utils/copy_plugins.py
@@ -19,3 +19,5 @@ def copy_plugins_to(plugin_list, to_placeholder, to_language = None):
         new_instance = new_plugin.get_plugin_instance()[0]
         if new_instance:
             new_instance.post_copy(old_plugin, plugins_ziplist)
+    # returns information about originals and copies
+    return plugins_ziplist


### PR DESCRIPTION
Change needed for [this bug](https://github.com/fivethreeo/cmsplugin-blog/issues/73) in cmsplugin-blog to be resolved.

Currently [simple-translation](https://github.com/fivethreeo/simple-translation/blob/develop/simple_translation/actions.py) uses its own (broken) plugin copying and it would be better if it would use `copy_plugins_to`, but its API is a bit different and it requires to know which plugins were copied and how. So this small change to `copy_plugins_to` would allow same API in simple-translation to use `copy_plugins_to` internally.
