### PR TITLE
removed handling of iterables in plugin_pool.register_plugin

### DIFF
--- a/cms/plugin_pool.py
+++ b/cms/plugin_pool.py
@@ -25,11 +25,6 @@ class PluginPool(object):
 
         If a plugin is already registered, this will raise PluginAlreadyRegistered.
         """
-        if hasattr(plugin,'__iter__'):
-            warnings.warn("Registering more than one plugin at once will be deprecated in 2.3", DeprecationWarning)
-            for single_plugin in plugin:
-                self.register_plugin(single_plugin)
-            return
         if not issubclass(plugin, CMSPluginBase):
             raise ImproperlyConfigured(
                 "CMS Plugins must be subclasses of CMSPluginBase, %r is not."
@@ -60,11 +55,6 @@ class PluginPool(object):
 
         If a plugin isn't already registered, this will raise PluginNotRegistered.
         """
-        if hasattr(plugin,'__iter__'):
-            warnings.warn("Unregistering more than one plugin at once will be deprecated in 2.3", DeprecationWarning)
-            for single_plugin in plugin:
-                self.unregister_plugin(single_plugin)
-            return 
         plugin_name = plugin.__name__
         if plugin_name not in self.plugins:
             raise PluginNotRegistered(

--- a/docs/upgrade/2.3.rst
+++ b/docs/upgrade/2.3.rst
@@ -78,6 +78,18 @@ New minimum requirements for dependencies
 * ``django-reversion`` must now be at version 1.6
 * ``django-sekizai`` must be at least at version 0.6.1
 
+Registering a list of plugins in the plugin pool
+================================================
+This feature was deprecated in version 2.2 and removed in 2.3. Code like this
+will not work anymore::
+
+    plugin_pool.register_plugin([FooPlugin, BarPlugin])
+
+Instead, use multiple calls to ``register_plugin``::
+
+    plugin_pool.register_plugin(FooPlugin)
+    plugin_pool.register_plugin(BarPlugin)
+
 
 ********************
 Pending deprecations


### PR DESCRIPTION
A `DeprecationWarning` was issued in 2.2, hence the removal in 2.3
