### PR TITLE
use new (as in Django 1.3) url tag which will be the default in Django 1.5

### DIFF
--- a/cms/templates/admin/cms/page/change_form.html
+++ b/cms/templates/admin/cms/page/change_form.html
@@ -1,11 +1,12 @@
 {% extends "admin/change_form.html" %}
 {% load i18n admin_modify adminmedia cms_tags cms_admin %}
+{% load url from future %}
 {% block title %}{% trans "Change a page" %}{% endblock %}
 
 {% block extrahead %}
 {{ block.super }}
 <script type="text/javascript" src="{{ STATIC_URL }}cms/js/csrf.js"></script>
-<script type="text/javascript" src="{% url admin:jsi18n %}"></script>
+<script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>
 
 {% if not add %}
 <script type="text/javascript" src="{{ STATIC_URL }}cms/js/change_form.js"></script>

--- a/cms/templates/admin/cms/page/plugin_change_form.html
+++ b/cms/templates/admin/cms/page/plugin_change_form.html
@@ -1,10 +1,10 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_modify adminmedia cms_admin %}
-
+{% load url from future %}
 {% block extrahead %}{{ block.super }}
 <script type="text/javascript" src="{% admin_static_url %}js/jquery.min.js"></script>
 <script type="text/javascript" src="{{ STATIC_URL }}cms/js/csrf.js"></script>
-<script type="text/javascript" src="{% url admin:jsi18n %}"></script>
+<script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>
 {{ media }}
 
 <script type="text/javascript">

--- a/cms/templates/admin/cms/page/recover_form.html
+++ b/cms/templates/admin/cms/page/recover_form.html
@@ -1,10 +1,10 @@
 {% extends "admin/cms/page/revision_form.html" %}
 {% load i18n %}
-
+{% load url from future %}
 
 {% block extrahead %}
     {{block.super}}
-    <script type="text/javascript" src="{% url admin:jsi18n %}"></script>
+    <script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>
     {{media}}
 {% endblock %}
 

--- a/cms/templates/cms/new.html
+++ b/cms/templates/cms/new.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+{% load url from future %}<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" dir="ltr" lang="en" xml:lang="en">
 <head>
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -48,7 +48,7 @@
 		<div class="box-right">
 			<h1>Welcome to the django CMS!<br />Here is what to do next:</h1>
 			<p>&nbsp;</p>
-			<h2>Log into the <a href="{% url admin:index %}">admin</a> interface and start <a href="{% url admin:cms_page_add %}">adding</a> some pages!</h2>
+			<h2>Log into the <a href="{% url 'admin:index' %}">admin</a> interface and start <a href="{% url 'admin:cms_page_add' %}">adding</a> some pages!</h2>
 			<p class="info">Make sure you publish them.</p>
 			<p>&nbsp;</p>
 			<p class="padding-top">

--- a/cms/test_utils/project/sampleapp/templates/sampleapp/home.html
+++ b/cms/test_utils/project/sampleapp/templates/sampleapp/home.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load cms_tags %}
+{% load url from future %}
 
 {% block content %}
 	<h2>Sample application home page - on page {% page_attribute page_title %}</h2>
@@ -7,13 +8,13 @@
 	{{ block.super }}
 	<ul>
 		<li>
-			<a href="{% url sample-root %}">Sample app root reverse test</a>
+			<a href="{% url 'sample-root' %}">Sample app root reverse test</a>
 		</li>
 		<li>
-			<a href="{% url de:sample-account %}">Sample app account reverse test german</a>
+			<a href="{% url 'de:sample-account' %}">Sample app account reverse test german</a>
 		</li>
 		<li>
-			<a href="{% url en:sample-account %}">Sample app account reverse test english</a>
+			<a href="{% url 'en:sample-account' %}">Sample app account reverse test english</a>
 		</li>
 	</ul>
 	<h4>Sample image  - appmedia works?</h4>


### PR DESCRIPTION
This kills a lot of DeprecationWarnings when running the testsuite with -Wall

Of course, this breaks Django 1.2 support completely, but I think we passed that bridge already.
