### PR TITLE
Add 'last' class to items in lazy_child_menu.html

### DIFF
--- a/cms/templates/admin/cms/page/lazy_child_menu.html
+++ b/cms/templates/admin/cms/page/lazy_child_menu.html
@@ -1,4 +1,4 @@
-{% load cms_admin i18n adminmedia %}<li id="page_{{page.pk}}" class="{% if cl.is_filtered %}leaf{% endif %}{% if not page.get_next_sibling %} last{% endif %}{% if has_move_page_permission %} moveable{% endif %}{%if page.children.all %} closed{% endif %}"{% if metadata %} mdata="{{ metadata }}{% endif %}" rel="{% ifequal page.level 0 %}topnode{% else %}node{% endifequal %}">
+{% load cms_admin i18n adminmedia %}<li id="page_{{page.pk}}" class="{% if cl.is_filtered %}leaf{% endif %}{% if forloop.last %} last{% endif %}{% if has_move_page_permission %} moveable{% endif %}{%if page.children.all %} closed{% endif %}"{% if metadata %} mdata="{{ metadata }}{% endif %}" rel="{% ifequal page.level 0 %}topnode{% else %}node{% endifequal %}">
     {% include 'admin/cms/page/menu_item.html' %}
     
     {% with page.children as children %}


### PR DESCRIPTION
Refers to #1314
Is really page.get_next_sibling() the best approach to check last element in a level? Comments welcome.
