### PR TITLE
Fixed incorrect fuzzy translations

### DIFF
--- a/cms/locale/en/LC_MESSAGES/django.po
+++ b/cms/locale/en/LC_MESSAGES/django.po
@@ -33,9 +33,8 @@ msgid "Publish"
 msgstr ""
 
 #: cms_toolbar.py:112
-#, fuzzy
 msgid "Request Approval"
-msgstr "Request approval"
+msgstr ""
 
 #: cms_toolbar.py:127 cms_toolbar.py:136
 msgid "Logout"
@@ -58,9 +57,8 @@ msgid "Add sibling page"
 msgstr ""
 
 #: cms_toolbar.py:177
-#, fuzzy
 msgid "Delete Page"
-msgstr "deletion request"
+msgstr ""
 
 #: cms_toolbar.py:180 models/moderatormodels.py:45
 #: templates/admin/cms/page/permissions.html:5
@@ -1237,18 +1235,16 @@ msgid "Color Settings"
 msgstr ""
 
 #: plugins/video/models.py:9
-#, fuzzy
 msgid "movie file"
-msgstr "move request"
+msgstr ""
 
 #: plugins/video/models.py:9
 msgid "use .flv file or h264 encoded video file"
 msgstr ""
 
 #: plugins/video/models.py:10
-#, fuzzy
 msgid "movie url"
-msgstr "move request"
+msgstr ""
 
 #: plugins/video/models.py:10
 msgid ""
@@ -1277,9 +1273,8 @@ msgid "loop"
 msgstr ""
 
 #: plugins/video/models.py:22
-#, fuzzy
 msgid "background color"
-msgstr "background color"
+msgstr ""
 
 #: plugins/video/models.py:22 plugins/video/models.py:23
 #: plugins/video/models.py:24 plugins/video/models.py:25
@@ -1293,14 +1288,12 @@ msgid "text color"
 msgstr ""
 
 #: plugins/video/models.py:24
-#, fuzzy
 msgid "seekbar color"
-msgstr "background color"
+msgstr ""
 
 #: plugins/video/models.py:25
-#, fuzzy
 msgid "seekbar bg color"
-msgstr "background color"
+msgstr ""
 
 #: plugins/video/models.py:26
 msgid "loadingbar color"


### PR DESCRIPTION
Some translations in the english locale are incorrect and marked fuzzy. In transifex, the wrong source strings are shown, resulting in bad translations.
