### PR TITLE
publisher_public_id added to attr for menu node.

### DIFF
--- a/cms/menu.py
+++ b/cms/menu.py
@@ -206,6 +206,7 @@ def page_to_node(page, home, cut):
     
     # Do we have a redirectURL?
     attr['redirect_url'] = page.get_redirect()  # save redirect URL if any
+    attr['publisher_public_id'] = page.publisher_public_id
     
     # Now finally, build the NavigationNode object and return it.
     ret_node = NavigationNode(


### PR DESCRIPTION
Added publisher_public_id to menu node attrs. Publisher_public_id is the only way I know to reference a cms page and that id is useful in menu rendering.
