### PR TITLE
Fixes a typo in the default test configuration regarding the TEST_RUNNER

### DIFF
--- a/cms/test_utils/cli.py
+++ b/cms/test_utils/cli.py
@@ -173,7 +173,7 @@ def configure(**extra):
         CMS_NAVIGATION_EXTENDERS = (
             ('cms.test_utils.project.sampleapp.menu_extender.get_nodes', 'SampleApp Menu'),
         ),
-        TEST_RUNNER = 'cms.test_utils.runners.NormalTestRUnner',
+        TEST_RUNNER = 'cms.test_utils.runners.NormalTestRunner',
         JUNIT_OUTPUT_DIR = '.',
         TIME_TESTS = False,
         ROOT_URLCONF = 'cms.test_utils.cli',


### PR DESCRIPTION
The default configuration referenced a NormalTestRUnner class. From skimming through the source code a bit this seems not like a problem unless you want to use this configuration for your creating a test configuration for a plugin.
