### PR TITLE
Fixed flat URLs for app hooks.

### DIFF
--- a/cms/appresolver.py
+++ b/cms/appresolver.py
@@ -171,7 +171,10 @@ def get_app_patterns():
     
     # Loop over all titles with an application hooked to them
     for title in title_qs.exclude(application_urls=None).exclude(application_urls='').select_related():
-        path = title.path
+        if settings.CMS_FLAT_URLS:
+            path = title.slug
+        else:
+            path = title.path
         if use_namespaces:
             mixid = "%s:%s:%s" % (path + "/", title.application_urls, title.language)
         else:


### PR DESCRIPTION
Even if flat URLs will be deprecated in 2.4, they should still work in 2.3. This little change fixes them to again work correctly. As changes to support CMS_FLAT_URLS are really small, I would argue that they could be kept in also in future versions.
