### PR TITLE
Small doc tweak

### DIFF
--- a/docs/getting_started/plugin_reference.rst
+++ b/docs/getting_started/plugin_reference.rst
@@ -150,7 +150,8 @@ You should take care that the directory defined by the configuration setting
 :setting:`django:MEDIA_ROOT`) is writable by the user under which django will be
 running.
 
-
+.. note:: In order to improve clarity, some Picture fields have been omitted in
+          the example template code.
 
 .. note:: For more advanced use cases where you would like to upload your media
           to a central location, consider using  `django-filer`_ with


### PR DESCRIPTION
Added note that the example template for the Picture plugin does not make use of all the Picture fields - can cause confusion for someone following the installation instructions.
