### PR TITLE
clear the plugin list ul before re-adding the plugins returned by the copy action

### DIFF
--- a/cms/static/cms/js/plugin_editor.js
+++ b/cms/static/cms/js/plugin_editor.js
@@ -68,7 +68,7 @@
 					url: "copy-plugins/", dataType: "html", type: "POST",
 					data: { page_id: page_id, placeholder: placeholder, copy_from: copy_from_language, language: to_language },
 					success: function(data) {
-						ul_list.append(data);
+						ul_list.empty().append(data);
 						setclickfunctions();
 					},
 					error: function(xhr) {


### PR DESCRIPTION
fixes #1239
