### PR TITLE
fixed typo that was not allowing placeholder toolbars to show in fronten...

### DIFF
--- a/cms/templates/cms/toolbar/placeholder.html
+++ b/cms/templates/cms/toolbar/placeholder.html
@@ -15,7 +15,7 @@ CMS.$(document).ready(function () {
 });
 </script>
 <style rel="stylesheet" media="screen, projector">
-    .cms_placeholder-bar { display: none; }
+    .cms_placeholder { display: none; }
 </style>
 {% endaddtoblock %}
 <div id="cms_placeholder-bar-{{ placeholder.pk }}" class="cms_placeholder-bar cms_reset cms_placeholder_slot::{{ placeholder.slot }}">


### PR DESCRIPTION
This fixes a typo introduced in this commit: https://github.com/divio/django-cms/commit/289ec41d00d

Without this fix the placeholder toolbars do not show when you go into edit mode.
