### PR TITLE
fix Multilingual middleware crash if request has no LANGUAGE_CODE

### DIFF
--- a/cms/middleware/multilingual.py
+++ b/cms/middleware/multilingual.py
@@ -133,7 +133,7 @@ class MultilingualURLMiddleware(object):
             response.content = patch_response(
                 decoded_response,
                 pages_root,
-                request.LANGUAGE_CODE
+                language
             )
 
         if response.status_code == 301 or response.status_code == 302:


### PR DESCRIPTION
fix Multilingual middleware crash if request has no LANGUAGE_CODE.
Fails when using non language aware urls (ex: /admin).
Seems a typo
