### PR TITLE
Doc fix for #1420

### DIFF
--- a/docs/advanced/templatetags.rst
+++ b/docs/advanced/templatetags.rst
@@ -194,7 +194,7 @@ Example::
     {% page_attribute "page_title" request.current_page.parent_id %}
     {% page_attribute "slug" request.current_page.get_root %}
 
-.. versionadded:: 2.3.1
+.. versionadded:: 2.3.2
     This template tag supports the ``as`` argument. With this you can assign the result
     of the template tag to a new variable that you can use elsewhere in the template.
 


### PR DESCRIPTION
2.3.1 was released as a stop-gap measure to fix django-mptt 0.5.3 problem and didn't include any code change compared to 2.3
