### PR TITLE
fixed the inherit plugin so that it does not explode when trying to render an "empty" plugin

### DIFF
--- a/cms/plugins/inherit/cms_plugins.py
+++ b/cms/plugins/inherit/cms_plugins.py
@@ -51,6 +51,8 @@ class InheritPagePlaceholderPlugin(CMSPluginBase):
             tmpctx = copy.copy(context)
             tmpctx.update(template_vars)
             inst, name = plg.get_plugin_instance()
+            if inst is None:
+                continue
             outstr = inst.render_plugin(tmpctx, placeholder)
             plugin_output.append(outstr)
         template_vars['parent_output'] = plugin_output


### PR DESCRIPTION
"empty" means in this case a plugin that has a `CMSPlugin` instance, but no subclass instance, despite having a `plugin_type` other than `CMSPluginBase`. Such plugins can come into existence e.g. when the user starts creating a plugin, but cancels the creation of the plugin.

The test failure without this fix:

```
======================================================================
ERROR: test_inherit_plugin_with_empty_plugin (cms.tests.plugins.PluginsTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/benjamin/projects/django-cms/cms/tests/plugins.py", line 524, in test_inherit_plugin_with_empty_plugin
    rendered = inherited_body.render(context=self.get_context(other_page.get_absolute_url()), width=200)
  File "/home/benjamin/projects/django-cms/cms/models/placeholdermodel.py", line 78, in render
    return render_placeholder(self, context)
  File "/home/benjamin/projects/django-cms/cms/plugin_rendering.py", line 126, in render_placeholder
    content.extend(render_plugins(plugins, context, placeholder, processors))
  File "/home/benjamin/projects/django-cms/cms/plugin_rendering.py", line 80, in render_plugins
    out.append(plugin.render_plugin(context, placeholder, processors=processors))
  File "/home/benjamin/projects/django-cms/cms/models/pluginmodel.py", line 172, in render_plugin
    context = plugin.render(context, instance, placeholder_slot)
  File "/home/benjamin/projects/django-cms/cms/plugins/inherit/cms_plugins.py", line 54, in render
    outstr = inst.render_plugin(tmpctx, placeholder)
AttributeError: 'NoneType' object has no attribute 'render_plugin'
```
