### PR TITLE
Fix for #1484

### DIFF
--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -92,10 +92,7 @@ class PageAddForm(forms.ModelForm):
         
     def clean(self):
         cleaned_data = self.cleaned_data
-        if 'slug' in cleaned_data:
-            slug = cleaned_data['slug']
-        else:
-            slug = ""
+        slug = cleaned_data.get('slug', '')
         
         page = self.instance
         lang = cleaned_data.get('language', None)


### PR DESCRIPTION
Added checks for 'slug' key in cleaned_data to avoid errors during page validation
Reworked error messages to be raised against slug field instead of published.

Fixes #1484
