### PR TITLE
Create datetime with aware timezone, refs: #1396

### DIFF
--- a/cms/api.py
+++ b/cms/api.py
@@ -31,6 +31,11 @@ from cms.utils import moderator
 from cms.utils.permissions import _thread_locals
 
 
+try:
+    from django.utils import timezone
+except ImportError:
+    timezone = None
+
 #===============================================================================
 # Constants 
 #===============================================================================
@@ -236,6 +241,12 @@ def create_title(language, title, page, menu_title=None, slug=None,
     else:
         application_urls = None
     
+
+    if settings.USE_TZ and timezone:
+        now = timezone.now()
+    else:
+        now = datetime.now()
+
     title = Title.objects.create(
         language=language,
         title=title,
@@ -245,7 +256,8 @@ def create_title(language, title, page, menu_title=None, slug=None,
         redirect=redirect,
         meta_description=meta_description,
         meta_keywords=meta_keywords,
-        page=page
+        page=page,
+        creation_date=now
     )
 
     if overwrite_url:

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -23,6 +23,13 @@ from os.path import join
 import copy
 
 
+try:
+    from django.utils import timezone
+except ImportError:
+    timezone = None
+
+
+
 class Page(MPTTModel):
     """
     A simple hierarchical page model
@@ -344,7 +351,10 @@ class Page(MPTTModel):
 
         # if the page is published we set the publish date if not set yet.
         if self.publication_date is None and self.published:
-            self.publication_date = datetime.now()
+            if settings.USE_TZ and timezone:
+                self.publication_date = timezone.now()
+            else:
+                self.publication_date = datetime.now()
 
         if self.reverse_id == "":
             self.reverse_id = None

--- a/cms/models/query.py
+++ b/cms/models/query.py
@@ -6,6 +6,11 @@ from cms.publisher.query import PublisherQuerySet
 from django.conf import settings
 from cms.exceptions import NoHomeFound
 
+try:
+    from django.utils import timezone
+except ImportError:
+    timezone = None
+
 #from cms.utils.urlutils import levelize_path
 
 
@@ -50,24 +55,34 @@ class PageQuerySet(PublisherQuerySet):
 
     def published(self, site=None):
         pub = self.on_site(site).filter(published=True)
+        if timezone:
+            now = timezone.now()
+        else:
+            now = datetime.now()
+
 
         if settings.CMS_SHOW_START_DATE:
             pub = pub.filter(
-                Q(publication_date__lt=datetime.now()) |
+                Q(publication_date__lt=now) |
                 Q(publication_date__isnull=True)
             )
 
         if settings.CMS_SHOW_END_DATE:
             pub = pub.filter(
-                Q(publication_end_date__gte=datetime.now()) |
+                Q(publication_end_date__gte=now) |
                 Q(publication_end_date__isnull=True)
             )
 
         return pub
 
     def expired(self):
+        if timezone:
+            now = timezone.now()
+        else:
+            now = datetime.now()
+
         return self.on_site().filter(
-            publication_end_date__lte=datetime.now())
+            publication_end_date__lte=now)
 
 #    - seems this is not used anymore...
 #    def get_pages_with_application(self, path, language):

--- a/cms/tests/page.py
+++ b/cms/tests/page.py
@@ -30,6 +30,11 @@ import os.path
 from cms.utils.page import is_valid_page_slug
 
 
+try:
+    from django.utils import timezone
+except ImportError:
+    timezone = None
+
 class PagesTestCase(CMSTestCase):
     
     def test_add_page(self):
@@ -367,7 +372,11 @@ class PagesTestCase(CMSTestCase):
         self.assertEqual(CMSSitemap().items().count(),0)
 
     def test_sitemap_includes_last_modification_date(self):
-        one_day_ago = datetime.datetime.now() - datetime.timedelta(days=1)
+        if timezone:
+            now = timezone.now()
+        else:
+            now = datetime.datetime.now()
+        one_day_ago = now - datetime.timedelta(days=1)
         page = create_page("page", "nav_playground.html", "en", published=True, publication_date=one_day_ago)
         page.creation_date = one_day_ago
         page.save()
@@ -377,7 +386,10 @@ class PagesTestCase(CMSTestCase):
         self.assertTrue(actual_last_modification_time > one_day_ago)
 
     def test_sitemap_uses_publication_date_when_later_than_modification(self):
-        now = datetime.datetime.now()
+        if timezone:
+            now = timezone.now()
+        else:
+            now = datetime.datetime.now()
         one_day_ago = now - datetime.timedelta(days=1)
         page = create_page("page", "nav_playground.html", "en", published=True, publication_date=now)
         page.creation_date = one_day_ago

--- a/cms/tests/plugins.py
+++ b/cms/tests/plugins.py
@@ -35,6 +35,11 @@ from django.test.testcases import TestCase
 import os
 import datetime
 
+try:
+    from django.utils import timezone
+except ImportError:
+    timezone = None
+
 
 class DumbFixturePlugin(CMSPluginBase):
     model = CMSPlugin
@@ -653,7 +658,10 @@ class PluginsTestCase(PluginsTestBaseCase):
         self.assertFalse(len(placeholder._en_plugins_cache))
 
     def test_editing_plugin_changes_page_modification_time_in_sitemap(self):
-        now = datetime.datetime.now()
+        if timezone:
+            now = timezone.now()
+        else:
+            now = datetime.now()
         one_day_ago = now - datetime.timedelta(days=1)
         page = create_page("page", "nav_playground.html", "en", published=True, publication_date=now)
         page.creation_date = one_day_ago


### PR DESCRIPTION
This is a first PR to implement timezone on django-cms using django.utils.timezone.

It refers the issue #1396.

Note: there is still a problem with default value in models fields as in:

models/pluginmodel.py
84:    creation_date = models.DateTimeField(_("creation date"), editable=False, default=datetime.now)

and : 

models/titlemodels.py
23:    creation_date = models.DateTimeField(_("creation date"), editable=False, default=datetime.now)

thanks for reviewing this.
