### PR TITLE
Fix two links to images in CSS files.

### DIFF
--- a/cms/static/cms/css/pages.css
+++ b/cms/static/cms/css/pages.css
@@ -131,7 +131,7 @@ a.collapsed span.collapsed{
 }
 
 .ac_loading {
-    background: white url('../indicator.gif') right center no-repeat;
+    background: white url('../images/indicator.gif') right center no-repeat;
 }
 
 .ac_odd {

--- a/cms/static/cms/js/wymeditor/skins/django/skin.css
+++ b/cms/static/cms/js/wymeditor/skins/django/skin.css
@@ -135,4 +135,4 @@
             /* End hide from IE-mac */                
             
 /*WYMEDITOR_LINK*/
-        a.wym_wymeditor_link        { text-indent: -9999px; float: right; display: block; width: 50px; height: 15px; background: url(../wymeditor_icon.png);  overflow: hidden; text-decoration: none;  }
+        a.wym_wymeditor_link        { text-indent: -9999px; float: right; display: block; width: 50px; height: 15px; background: url(../../../../wymeditor/skins/wymeditor_icon.png);  overflow: hidden; text-decoration: none;  }

--- a/cms/tests/__init__.py
+++ b/cms/tests/__init__.py
@@ -23,6 +23,7 @@ from cms.tests.reversion_tests import *
 from cms.tests.security import *
 from cms.tests.settings import *
 from cms.tests.site import *
+from cms.tests.staticfiles import *
 from cms.tests.templatetags import *
 from cms.tests.toolbar import *
 from cms.tests.urlutils import *

--- a/cms/tests/staticfiles.py
+++ b/cms/tests/staticfiles.py
@@ -1,0 +1,22 @@
+from __future__ import with_statement
+from cms.test_utils.compat import skipIf
+from cms.test_utils.util.context_managers import SettingsOverride, StdoutOverride, TemporaryDirectory
+import django
+from django.core import management
+from django.test import TestCase
+from distutils.version import LooseVersion
+
+
+class StaticFilesTest(TestCase):
+
+    @skipIf(LooseVersion(django.get_version()) < LooseVersion('1.4'),
+            "CachedStaticFilesStorage doesn't exist in Django < 1.4")
+    def test_collectstatic_with_cached_static_files_storage(self):
+        # CachedStaticFilesStorage requires that the CSS files
+        # don't contain any broken links.
+        with TemporaryDirectory() as tmpdir:
+            with SettingsOverride(STATIC_ROOT=tmpdir,
+                STATICFILES_STORAGE='django.contrib.staticfiles.storage.CachedStaticFilesStorage'):
+                with StdoutOverride() as output:
+                    management.call_command('collectstatic', interactive=False)
+


### PR DESCRIPTION
When the `CachedStaticFilesStorage` backend is used, `./manage.py
collectstatic` chokes on broken links in CSS. For more background on
this issue see https://code.djangoproject.com/ticket/18958.
