### PR TITLE
Only add cmsplugins to TinyMCE toolbar if absent

### DIFF
--- a/cms/plugins/text/widgets/tinymce_widget.py
+++ b/cms/plugins/text/widgets/tinymce_widget.py
@@ -68,7 +68,18 @@ class TinyMCEEditor(TinyMCE):
         mce_config['plugins'] = plugins
         if mce_config['theme'] == "simple":
             mce_config['theme'] = "advanced"
-        mce_config['theme_advanced_buttons1_add_before'] = "cmsplugins,cmspluginsedit"
+        # Add cmsplugin to first toolbar, if not already present
+        all_tools = []
+        idx = 0
+        while True:
+            idx += 1
+            buttons = mce_config.get('theme_advanced_buttons%d' % (idx,), None)
+            if buttons is None:
+                break
+            all_tools.extend(buttons.split(','))
+        if 'cmsplugins' not in all_tools and 'cmspluginsedit' not in all_tools:
+            mce_config['theme_advanced_buttons1_add_before'] = "cmsplugins,cmspluginsedit"
+        
         json = simplejson.dumps(mce_config)
         html = [u'<textarea%s>%s</textarea>' % (flatatt(final_attrs), escape(value))]
         if tinymce.settings.USE_COMPRESSOR:


### PR DESCRIPTION
Allows TINYMCE_DEFAULT_CONFIG to define where on the UI's button-bar/s the "cmsplugins" and "cmspluginsedit" tools should appear.
