### PR TITLE
optional clean_html from settings

### DIFF
--- a/cms/utils/html.py
+++ b/cms/utils/html.py
@@ -1,17 +1,21 @@
 # -*- coding: utf-8 -*-
+from django.conf import settings
 from html5lib import sanitizer, serializer, treebuilders, treewalkers
 import html5lib
 
 DEFAULT_PARSER = html5lib.HTMLParser(tokenizer=sanitizer.HTMLSanitizer,
                                      tree=treebuilders.getTreeBuilder("dom"))
 
-def clean_html(data, full=True, parser=DEFAULT_PARSER):
+def clean_html(data, **kwargs):
     """
     Cleans HTML from XSS vulnerabilities using html5lib
     
     If full is False, only the contents inside <body> will be returned (without
     the <body> tags).
     """
+    full = getattr(settings, 'full', True)
+    parser = getattr(kwargs, 'parser', DEFAULT_PARSER)
+    
     if full:
         dom_tree = parser.parse(data)
     else:
@@ -21,3 +25,5 @@ def clean_html(data, full=True, parser=DEFAULT_PARSER):
     s = serializer.htmlserializer.HTMLSerializer(omit_optional_tags=False,
                                                  quote_attr_values=True)
     return u''.join(s.serialize(stream))
+
+clean_html = getattr(settings, "CMS_CLEAN_HTML", clean_html)


### PR DESCRIPTION
settings.CMS_CLEAN_HTML let you change the default html sanitizer

Now i can do this

```
# settings.py
...
from lxml.html.clean import Cleaner
def clean_html(data, **kwargs):
    full = getattr(kwargs, 'full', True)
    options = {"safe_attrs_only": False,
               "page_structure": full}
    return Cleaner(**options).clean_html(data)

CMS_CLEAN_HTML = clean_html
```
