### PR TITLE
#1536 Refactor CMSToolbar to prevent unnecessary access to request user

### DIFF
--- a/cms/cms_toolbar.py
+++ b/cms/cms_toolbar.py
@@ -78,7 +78,7 @@ class CMSToolbar(Toolbar):
         self.init()
 
     def init(self):
-        """ Hook called whenever the user is reinitialised """
+        """ Hook called when the toolbar is reinitialised """
 
     @property
     def is_staff(self):

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -467,7 +467,7 @@ class CMSToolbar(InclusionTag):
             return ''
         return super(CMSToolbar, self).render(context)
 
-    def get_context(self, context, **kwargs):
+    def get_context(self, context):
         context['CMS_TOOLBAR_CONFIG'] = context['request'].toolbar.as_json(context)
         return context
 


### PR DESCRIPTION
- Login form processing moved to middleware
- CMSToolbar now built when needed by the template tag.
- Changed how get_items works to make it possible to modify toolbar components
