### PR TITLE
fix problem when having different filename

### DIFF
--- a/cms/plugins/text/templates/cms/plugins/widgets/wymeditor.html
+++ b/cms/plugins/text/templates/cms/plugins/widgets/wymeditor.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n staticfiles %}
 <script type="text/javascript">
 //<![CDATA]
 
@@ -20,6 +20,7 @@ var editPluginPopupCallbacks = {};
 			updateSelector: 'input[type=submit],',
 			updateEvent: 'click',
 			logoHtml: '',
+            wymPath: '{% static 'cms/wymeditor/jquery.wymeditor.js' %}',
 			toolsItems: [
 					{{ WYM_TOOLS }}
 				],


### PR DESCRIPTION
jquery.wymeditor.js uses a regex to calculate the wymeditor files path.

If `django.contrib.staticfiles.storage.CachedFilesStorage` is used, then the unique generated filename (e.g.: "jquery.wymeditor.3fbe6a76dd28.js") doesn't match the regex.

While this patch fixes it, I don't know what happens if the user decides they're not using django.contrib.staticfiles (well, I do know, it fails).

I don't know if staticfiles is required by django-cms and if there's a safer, more internally-sound way of doing this, but the bottom line is that the `wymPath`, or possibly the `basePath` option should be passed to the `.wymeditor` call
