### PR TITLE
FIx for issue 1487

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -443,23 +443,22 @@ class PageAdmin(ModelAdmin):
 
         return form
 
-    # remove permission inlines, if user isn't allowed to change them
-    def get_formsets(self, request, obj=None):
-        if obj:
-            inlines = self.get_inline_instances(request) if hasattr(self, 'get_inline_instances') \
-                      else self.inline_instances
+    def get_inline_instances(self, request):
+        inlines = super(PageAdmin, self).get_inline_instances(request)
+        if settings.CMS_PERMISSION and hasattr(self, '_current_page')\
+                and self._current_page:
+            filtered_inlines = []
             for inline in inlines:
-                if settings.CMS_PERMISSION and isinstance(inline, PagePermissionInlineAdmin) and not isinstance(inline, ViewRestrictionInlineAdmin):
-                    if "recover" in request.path or "history" in request.path: #do not display permissions in recover mode
+                if isinstance(inline, PagePermissionInlineAdmin)\
+                        and not isinstance(inline, ViewRestrictionInlineAdmin):
+                    if "recover" in request.path or "history" in request.path:
+                        # do not display permissions in recover mode
                         continue
-                    if obj and not obj.has_change_permissions_permission(request):
+                    if not self._current_page.has_change_permissions_permission(request):
                         continue
-                    elif not obj:
-                        try:
-                            permissions.get_user_permission_level(request.user)
-                        except NoPermissionsException:
-                            continue
-                yield inline.get_formset(request, obj)
+                filtered_inlines.append(inline)
+            inlines = filtered_inlines
+        return inlines
 
     def add_view(self, request, form_url='', extra_context=None):
         extra_context = extra_context or {}
@@ -499,8 +498,13 @@ class PageAdmin(ModelAdmin):
             context.update(extra_context or {})
             extra_context = self.update_language_tab_context(request, obj, context)
         tab_language = request.GET.get("language", None)
-        response = super(PageAdmin, self).change_view(request, object_id, extra_context=extra_context)
 
+        # get_inline_instances will need access to 'obj' so that it can
+        # determine if current user has enough rights to see PagePermissionInlineAdmin
+        # because get_inline_instances doesn't receive 'obj' as a parameter,
+        # the workaround is to set it as an attribute...
+        self._current_page = obj
+        response = super(PageAdmin, self).change_view(request, object_id, extra_context=extra_context)
         if tab_language and response.status_code == 302 and response._headers['location'][1] == request.path :
             location = response._headers['location']
             response._headers['location'] = (location[0], "%s?language=%s" % (location[1], tab_language))

--- a/cms/tests/admin.py
+++ b/cms/tests/admin.py
@@ -2,12 +2,13 @@
 from __future__ import with_statement
 from cms.admin.change_list import CMSChangeList
 from cms.admin.forms import PageForm
-from cms.admin.pageadmin import contribute_fieldsets, contribute_list_filter
+from cms.admin.pageadmin import contribute_fieldsets, contribute_list_filter, PageAdmin
+from cms.admin.permissionadmin import PagePermissionInlineAdmin
 from cms.api import create_page, create_title, add_plugin
 from cms.apphook_pool import apphook_pool, ApphookPool
 from cms.models.moderatormodels import PageModeratorState
 from cms.models.pagemodel import Page
-from cms.models.permissionmodels import GlobalPagePermission
+from cms.models.permissionmodels import GlobalPagePermission, PagePermission
 from cms.models.placeholdermodel import Placeholder
 from cms.models.titlemodels import Title
 from cms.plugins.text.models import Text
@@ -822,7 +823,18 @@ class PluginPermissionTests(AdminTestsBase):
     def _give_permission(self, user, model, permission_type, save=True):
         codename = '%s_%s' % (permission_type, model._meta.object_name.lower())
         user.user_permissions.add(Permission.objects.get(codename=codename))
-    
+
+    def _give_page_permssion_rights(self, user):
+        self._give_permission(user, PagePermission, 'add')
+        self._give_permission(user, PagePermission, 'change')
+        self._give_permission(user, PagePermission, 'delete')
+
+    def _get_change_page_request(self, user, page):
+        return type('Request', (object,), {
+                'user': user,
+                'path': base.URL_CMS_PAGE_CHANGE % page.pk
+                })
+
     def _give_cms_permissions(self, user, save=True):
         for perm_type in ['add', 'change', 'delete']:
             for model in [Page, Title]:
@@ -919,6 +931,35 @@ class PluginPermissionTests(AdminTestsBase):
         self._give_permission(normal_guy, Text, 'add')
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, HttpResponse.status_code)
+
+    def test_page_permission_inline_visibility(self):
+        user =User(username='user', email='user@domain.com', password='user',
+                   is_staff=True)
+        user.save()
+        self._give_page_permssion_rights(user)
+        page = create_page('A', 'nav_playground.html', 'en')
+        page_permission = PagePermission.objects.create(
+            can_change_permissions=True, user=user, page=page)
+        request = self._get_change_page_request(user, page)
+        page_admin = PageAdmin(Page, None)
+        page_admin._current_page = page
+        # user has can_change_permission 
+        # => must see the PagePermissionInline
+        self.assertTrue(
+            any(type(inline) is PagePermissionInlineAdmin
+                for inline in page_admin.get_inline_instances(request)))
+
+        page = Page.objects.get(pk=page.pk)
+        # remove can_change_permission
+        page_permission.can_change_permissions = False
+        page_permission.save()
+        request = self._get_change_page_request(user, page)
+        page_admin = PageAdmin(Page, None)
+        page_admin._current_page = page
+        # => PagePermissionInline is no longer visible
+        self.assertFalse(
+            any(type(inline) is PagePermissionInlineAdmin
+                for inline in page_admin.get_inline_instances(request)))
 
 
 class AdminFormsTests(AdminTestsBase):


### PR DESCRIPTION
For excluding inline admins for which the user doesn't have permissions, do the filtering on inline instances rather than on the generated formsets.
This ensures proper behaviour even if multiple inlines would be added in the future.

Also added a test for the filtering of the page permissions inline
