### PR TITLE
resolve django 1.5 error: get_inline_instances() takes exactly 2 arguments

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -444,7 +444,7 @@ class PageAdmin(ModelAdmin):
         return form
 
     def get_inline_instances(self, request, obj=None):
-        inlines = super(PageAdmin, self).get_inline_instances(request)
+        inlines = super(PageAdmin, self).get_inline_instances(request, obj)
         if settings.CMS_PERMISSION and hasattr(self, '_current_page')\
                 and self._current_page:
             filtered_inlines = []


### PR DESCRIPTION
I am doing an installation for the first time and using Django 1.5.

I haven't tested with versions less than 1.5 but this should not effect them.
