### PR TITLE
Modified the template to truncate the page's menu_title.

### DIFF
--- a/cms/templates/admin/cms/page/menu_item.html
+++ b/cms/templates/admin/cms/page/menu_item.html
@@ -2,7 +2,7 @@
 <div class="cont {{ css_class }}">
 	<div class="col1">
 		{% if has_change_permission %}
-			<a href="{{ url }}{{ page.id }}/" class="title" {% if cl.is_popup %}onclick="opener.dismissRelatedLookupPopup(window, {{ page.id }}); return false;" title="{% trans "select this page" %}"{% else %}title="{% trans "edit this page" %}"{% endif %}>{{ page.get_menu_title }}</a>
+			<a href="{{ url }}{{ page.id }}/" class="title" {% if cl.is_popup %}onclick="opener.dismissRelatedLookupPopup(window, {{ page.id }}); return false;" title="{% trans "select this page" %}"{% else %}title="{% trans "edit this page" %}"{% endif %}>{{ page.get_menu_title|truncatechars:100 }}</a>
 			<a href="{{ url }}{{ page.id }}/" class="changelink" title="{% trans "edit this page" %}">{% trans "edit" %}</a>
 		{% else %}
 			<span class="title">{{ page.get_slug }}</span>


### PR DESCRIPTION
The reason being that after the title reaches a certain point the UI breaks.
By default I chose to truncate after 100 characters, since it's a pretty reasonable amount.

![cms-admin-bug](https://f.cloud.github.com/assets/994951/48804/5909302c-5922-11e2-82f8-5f2e898afe97.png)
