### PR TITLE
test for no placeholder

### DIFF
--- a/cms/templates/admin/cms/page/widgets/plugin_editor.html
+++ b/cms/templates/admin/cms/page/widgets/plugin_editor.html
@@ -18,10 +18,12 @@
 		{% endif %}
 	{% endif %}
 </div>
-<script type="text/javascript">
-cms_plugin_editor_jQuery(document).ready(function($){
-var placeholder_element = $('#placeholder-{{ placeholder.pk }}');
-placeholder_element.data('id', {{ placeholder.pk }});
-placeholder_element.data('name', '{{ placeholder.slot }}');
-});
-</script>
+{% if placeholder %}
+	<script type="text/javascript">
+	cms_plugin_editor_jQuery(document).ready(function($){
+	var placeholder_element = $('#placeholder-{{ placeholder.pk }}');
+	placeholder_element.data('id', {{ placeholder.pk }});
+	placeholder_element.data('name', '{{ placeholder.slot }}');
+	});
+	</script>
+{% endif %}


### PR DESCRIPTION
When you create a Page, you have to save it before you get to do anything with placeholders. Once you've saved it for the first time, an empty placeholder is created.

When using placeholders in a model outside the CMS, you can create a new one in the admin and start editing it, but if you have a placeholder field in it, it will say:

> You must save the page first to add plugins.

That's good, but it will also throw up some JavaScript errors. For each placeholder, you'll get a `SyntaxError: Unexpected token ')'`, because `cms/templates/admin/cms/page/widgets/plugin_editor.html` tries to populate some JavaScript using a missing `placeholder` variable.

It doesn't stop anything from working, but it's unsightly.

Simply adding `{% if placeholder %}` around the JavaScript solves the problem.
