### PR TITLE
delete_orphaned_plugins command

### DIFF
--- a/cms/management/commands/cms.py
+++ b/cms/management/commands/cms.py
@@ -4,9 +4,10 @@ from cms.management.commands.subcommands.base import SubcommandsCommand
 from cms.management.commands.subcommands.list import ListCommand
 from cms.management.commands.subcommands.moderator import ModeratorCommand
 from cms.management.commands.subcommands.uninstall import UninstallCommand
+from cms.management.commands.subcommands.mptt import FixMPTTCommand
+from cms.management.commands.subcommands.delete_orphaned_plugins import DeleteOrphanedPluginsCommand
 from django.core.management.base import BaseCommand
 from optparse import make_option
-from cms.management.commands.subcommands.mptt import FixMPTTCommand
 
 
 class Command(SubcommandsCommand):
@@ -25,6 +26,7 @@ class Command(SubcommandsCommand):
         'list': ListCommand,
         'moderator': ModeratorCommand,
         'fix-mptt': FixMPTTCommand,
+        'delete_orphaned_plugins': DeleteOrphanedPluginsCommand,
     }
 
     @property

--- a/cms/management/commands/subcommands/delete_orphaned_plugins.py
+++ b/cms/management/commands/subcommands/delete_orphaned_plugins.py
@@ -1,0 +1,36 @@
+from cms.models import Page, CMSPlugin
+from django.core.management.base import NoArgsCommand
+from cms.management.commands.subcommands.list import plugin_report
+
+
+class DeleteOrphanedPluginsCommand(NoArgsCommand):
+    help = "Delete plugins from the CMSPlugins table that should have instances but don't, and ones for which a corresponding plugin model can no longer be found"
+
+    def handle_noargs(self, **options):
+        """
+        Obtains a plugin report -
+        cms.management.commands.subcommands.list.plugin_report - and uses it
+        to delete orphaned plugins from the database, i.e. ones that are no
+        longer installed, and ones that have no corresponding saved plugin
+        instances (as will happen if a plugin is inserted into a placeholder,
+        but not saved).
+        """
+        self.stdout.write("Obtaining plugin report\n")
+        report = plugin_report()
+        model_less_instances = []
+        unsaved_instances = []
+        self.stdout.write("... deleting orphaned plugins\n")        
+        for plugin in report:
+            # delete items with no model
+            if not plugin["model"]:
+                for instance in plugin["instances"]:
+                    model_less_instances.append(instance)
+                    instance.delete()
+                    
+            # delete items with unsaved instances
+            for instance in plugin["unsaved_instances"]:
+                unsaved_instances.append(instance)
+                instance.delete()
+        self.stdout.write("Deleted %s model-less plugins and %s plugins with unsaved instances\n" % (len(model_less_instances), len(unsaved_instances)))
+        self.stdout.write("all done\n")
+                                    

--- a/cms/management/commands/subcommands/list.py
+++ b/cms/management/commands/subcommands/list.py
@@ -16,9 +16,9 @@ class ListApphooksCommand(NoArgsCommand):
             
 def plugin_report():
     plugin_report = []
-    all_plugins = CMSPlugin.objects.order_by("-plugin_type")
-    plugin_types = set(all_plugins.values_list("plugin_type", flat=True))
-
+    all_plugins = CMSPlugin.objects.order_by("plugin_type")
+    plugin_types = list(set(all_plugins.values_list("plugin_type", flat=True)))
+    plugin_types.sort()
     #     self.stdout.write(plugin+'\n')
     uninstalled_plugins = []                
 
@@ -38,7 +38,7 @@ def plugin_report():
         except KeyError:
             uninstalled_plugins.append(plugin_type)
             plugin["model"] = None
-            plugin["instances"] = []
+            plugin["instances"] = plugins
             plugin["unsaved_instances"] = []
 
         plugin_report.append(plugin)
@@ -61,20 +61,19 @@ class ListPluginsCommand(NoArgsCommand):
             unsaved_instances = len(plugin["unsaved_instances"])
 
             if not plugin_model: 
-                self.stdout.write("* warning    : not installed \n")
-                self.stdout.write("  instance(s): unknown \n")
+                self.stdout.write(self.style.ERROR("  ERROR      : not installed \n"))
 
             elif plugin_model == CMSPlugin:
                 self.stdout.write("    model-less plugin \n")
                 self.stdout.write("    unsaved instance(s) : %s  \n" % unsaved_instances)
-                self.stdout.write("  instance(s): %s \n" % instances)
 
             else:
                 self.stdout.write("  model      : %s.%s  \n" % 
                     (plugin_model.__module__, plugin_model.__name__))
                 if unsaved_instances: 
-                    self.stdout.write("* warning    : %s unsaved instance(s) \n" % unsaved_instances)
-                self.stdout.write("  instance(s): %s \n" % instances)
+                    self.stdout.write(self.style.ERROR("  ERROR      : %s unsaved instance(s) \n" % unsaved_instances))
+            
+            self.stdout.write("  instance(s): %s \n" % instances)
 
                    
 class ListCommand(SubcommandsCommand):

--- a/cms/tests/management.py
+++ b/cms/tests/management.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import with_statement
 from StringIO import StringIO
+from django.core import management
+
 from cms.test_utils.testcases import CMSTestCase
 from cms.test_utils.util.context_managers import SettingsOverride
 from cms.api import create_page, add_plugin
@@ -53,16 +55,155 @@ class ManagementTestCase(CMSTestCase):
             placeholder = Placeholder.objects.create(slot="test")
             add_plugin(placeholder, TextPlugin, "en", body="en body")
             add_plugin(placeholder, TextPlugin, "en", body="en body")
-            add_plugin(placeholder, "LinkPlugin", "en",
+            link_plugin = add_plugin(placeholder, "LinkPlugin", "en",
                 name="A Link", url="https://www.django-cms.org")
             self.assertEqual(
                 CMSPlugin.objects.filter(plugin_type=PLUGIN).count(),
                 2)
             self.assertEqual(
-                CMSPlugin.objects.filter(plugin_type="LinkPlugin").count(),
+                CMSPlugin.objects.filter(plugin_type="LinkPlugin").count(), 
+                1)            
+
+            # create a CMSPlugin with an unsaved instance
+            instanceless_plugin = CMSPlugin(language="en", plugin_type="TextPlugin")
+            instanceless_plugin.save()
+
+            # create a bogus CMSPlugin to simulate one which used to exist but 
+            # is no longer installed
+            bogus_plugin = CMSPlugin(language="en", plugin_type="BogusPlugin")
+            bogus_plugin.save()
+
+            report = plugin_report()
+
+            # there should be reports for three plugin types
+            self.assertEqual(
+                len(report), 
+                3)
+                
+            # check the bogus plugin 
+            bogus_plugins_report = report[0]
+            self.assertEqual(
+                bogus_plugins_report["model"], 
+                None)            
+
+            self.assertEqual(
+                bogus_plugins_report["type"], 
+                u'BogusPlugin')            
+            
+            self.assertEqual(
+                bogus_plugins_report["instances"][0], 
+                bogus_plugin)            
+
+            # check the link plugin 
+            link_plugins_report = report[1]
+            self.assertEqual(
+                link_plugins_report["model"], 
+                link_plugin.__class__)            
+
+            self.assertEqual(
+                link_plugins_report["type"], 
+                u'LinkPlugin')            
+            
+            self.assertEqual(
+                link_plugins_report["instances"][0].get_plugin_instance()[0], 
+                link_plugin)            
+
+            # check the text plugins 
+            text_plugins_report = report[2]
+            self.assertEqual(
+                text_plugins_report["model"], 
+                TextPlugin.model)            
+
+            self.assertEqual(
+                text_plugins_report["type"], 
+                u'TextPlugin')            
+            
+            self.assertEqual(
+                len(text_plugins_report["instances"]), 
+                3)
+                
+            self.assertEqual(
+                text_plugins_report["instances"][2], 
+                instanceless_plugin)
+                            
+            self.assertEqual(
+                text_plugins_report["unsaved_instances"], 
+                [instanceless_plugin])
+        
+                        
+    def test_delete_orphaned_plugins(self):
+        apps = ["cms", "menus", "sekizai", "cms.test_utils.project.sampleapp"]
+        with SettingsOverride(INSTALLED_APPS=apps):
+            placeholder = Placeholder.objects.create(slot="test")
+            add_plugin(placeholder, TextPlugin, "en", body="en body")
+            add_plugin(placeholder, TextPlugin, "en", body="en body")
+            link_plugin = add_plugin(placeholder, "LinkPlugin", "en",
+                name="A Link", url="https://www.django-cms.org")
+
+            instanceless_plugin = CMSPlugin(
+                language="en", plugin_type="TextPlugin")
+            instanceless_plugin.save()
+
+            # create a bogus CMSPlugin to simulate one which used to exist but 
+            # is no longer installed
+            bogus_plugin = CMSPlugin(language="en", plugin_type="BogusPlugin")
+            bogus_plugin.save()
+
+            report = plugin_report()
+
+            # there should be reports for three plugin types
+            self.assertEqual(
+                len(report), 
+                3)
+                
+            # check the bogus plugin 
+            bogus_plugins_report = report[0]
+            self.assertEqual(
+                len(bogus_plugins_report["instances"]), 
+                1)            
+
+            # check the link plugin 
+            link_plugins_report = report[1]
+            self.assertEqual(
+                len(link_plugins_report["instances"]), 
+                1)                      
+
+            # check the text plugins 
+            text_plugins_report = report[2]
+            self.assertEqual(
+                len(text_plugins_report["instances"]), 
+                3)            
+
+            self.assertEqual(
+                len(text_plugins_report["unsaved_instances"]), 
                 1)
+                
 
+            management.call_command('cms', 'delete_orphaned_plugins')
+            report = plugin_report()
 
+            # there should be reports for two plugin types (one should have been deleted)
+            self.assertEqual(
+                len(report), 
+                2)
+                
+            # check the link plugin 
+            link_plugins_report = report[0]
+            self.assertEqual(
+                len(link_plugins_report["instances"]), 
+                1)                      
+
+            # check the text plugins 
+            text_plugins_report = report[1]
+            self.assertEqual(
+                len(text_plugins_report["instances"]), 
+                2)            
+
+            self.assertEqual(
+                len(text_plugins_report["unsaved_instances"]), 
+                0)
+                
+            
     def test_uninstall_plugins_without_plugin(self):
         out = StringIO()
         command = cms.Command()

--- a/docs/advanced/cli.rst
+++ b/docs/advanced/cli.rst
@@ -25,10 +25,37 @@ It has two subcommands:
 * ``cms list plugins`` lists all plugins that are used in your project.
 * ``cms list apphooks`` lists all apphooks that are used in your project.
 
+``cms list plugins`` will issue warnings when it finds orphaned plugins (see
+``cms delete_orphaned_plugins`` below).
+
 
 **************************************
 Plugin and apphook management commands
 **************************************
+
+.. _cms-delete-orphaned-plugins-command:
+
+``cms delete_orphaned_plugins``
+===============================
+
+.. warning::
+
+    The ``delete_orphaned_plugins`` command **permanently deletes** data from
+    your database. You should make a backup of your database before using it!
+    
+Identifies and deletes orphaned plugins.
+
+Orphaned plugins are ones that exist in the CMSPlugins table, but:
+
+* have a plugin_type that is no longer even installed
+* have no corresponding saved instance in that particular plugin type's table  
+
+Such plugins will cause problems when trying to use operations that need to copy
+pages (and thefore plugins), which includes ``cms moderator on`` as well as page
+copy operations in the admin.
+
+It is advised to run ``cms list plugins`` periodically, and ``cms
+delete_orphaned_plugins`` when required.
 
 ``cms uninstall``
 =================
@@ -51,7 +78,7 @@ It has two subcommands:
 
 .. warning::
 
-    The uninstall command **permanently deletes** data from your database.
+    The uninstall commands **permanently delete** data from your database.
     You should make a backup of your database before using them!
     
 
@@ -71,7 +98,10 @@ used moderation in the past.
 .. warning::
 
     This command **alters data** in your database. You should make a backup of
-    your database before using it!
+    your database before using it! **Never** run this command without first 
+    checking for orphaned plugins, using the ``cms list plugins`` command, and
+    if necessary ``delete_orphaned_plugins``. Running  ``cms moderator`` with
+    orphaned plugins will fail and leave bad data in your database.
 
 
 *******************

--- a/docs/upgrade/2.4.rst
+++ b/docs/upgrade/2.4.rst
@@ -58,9 +58,18 @@ For the two-step upgrade process do the following in your project main directory
     pip install django-cms==2.4
     python manage.py migrate
 
+Added delete orphaned plugins command
+=====================================
+
+Added a management command for deleting orphaned plugins from the database..
+
+The command can be run with:
+
+	manage.py cms delete_orphaned_plugins
+
+Please read :ref:`cms-delete-orphaned-plugins-command` before using.
 
 .. _cms-moderator-upgrade:
-
 
 CMS_MODERATOR
 =============
@@ -71,7 +80,12 @@ can publish changes to the public site.
 .. admonition:: Management command required
 
     To bring a previous version of your site's database up-to-date, you'll need
-    to run ``manage.py cms moderator on``.
+    to run ``manage.py cms moderator on``. **Never run this command without
+    first checking for orphaned plugins**, using the ``cms list plugins``
+    command, and if necessary ``delete_orphaned_plugins``. Running ``cms
+    moderator`` with orphaned plugins will fail and leave bad data in your
+    database. See :ref:`cms-list-command` and
+    :ref:`cms-delete-orphaned-plugins-command`.
 
 
 Added Fix MPTTT Management command


### PR DESCRIPTION
https://github.com/divio/django-cms/pull/1564 went a bit mad on one of the commits, so here's a new version of exactly the same thing.

Improves the cms list plugins command, and adds a new command to delete orphaned plugins.

Orphaned plugins are ones that exist in the CMSPlugins table, but:

have a plugin_type that is no longer even installed
have no corresponding saved instance in the table for that specific plugin
The second type is easy to create inadvertently: Insert a plugin in the admin, but don't save it. One of my databases had literally hundreds of these.

Includes tests and docs.
