### PR TITLE
Added support for unihandecode.js

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -461,18 +461,30 @@ class PageAdmin(ModelAdmin):
             inlines = filtered_inlines
         return inlines
 
+    def get_unihandecode_context(self, language):
+        if language[:2] in get_cms_setting('UNIHANDECODE_DECODERS'):
+            uhd_lang = language[:2]
+        else:
+            uhd_lang = get_cms_setting('UNIHANDECODE_DEFAULT_DECODER')
+        uhd_host = get_cms_setting('UNIHANDECODE_HOST')
+        uhd_version = get_cms_setting('UNIHANDECODE_VERSION')
+        if uhd_lang and uhd_host and uhd_version:
+            uhd_urls = [
+                '%sunihandecode-%s.core.min.js' % (uhd_host, uhd_version),
+                '%sunihandecode-%s.%s.min.js' % (uhd_host, uhd_version, uhd_lang),
+                ]
+        else:
+            uhd_urls = []
+        return {'unihandecode_lang': uhd_lang, 'unihandecode_urls': uhd_urls}
+
+
     def add_view(self, request, form_url='', extra_context=None):
         extra_context = extra_context or {}
         language = get_language_from_request(request)
-        if language[:2] in ['ja', 'zh', 'vn', 'kr']:
-            unihandecodelang = language[:2]
-        else:
-            unihandecodelang = 'diacritic'
         extra_context.update({
             'language': language,
-            'unihandecode_lang': unihandecodelang,
-            'unihandecode_url': get_cms_setting('UNIHANDECODE_URL')
         })
+        extra_context.update(self.get_unihandecode_context(language))
         return super(PageAdmin, self).add_view(request, form_url, extra_context=extra_context)
 
     def change_view(self, request, object_id, extra_context=None):
@@ -504,7 +516,10 @@ class PageAdmin(ModelAdmin):
             }
             context.update(extra_context or {})
             extra_context = self.update_language_tab_context(request, obj, context)
+
         tab_language = request.GET.get("language", None)
+
+        extra_context.update(self.get_unihandecode_context(tab_language))
 
         # get_inline_instances will need access to 'obj' so that it can
         # determine if current user has enough rights to see PagePermissionInlineAdmin

--- a/cms/static/cms/js/change_form.js
+++ b/cms/static/cms/js/change_form.js
@@ -57,7 +57,11 @@
 		$("#id_title").keyup(function() {
 			var e = $("#id_slug")[0];
 			if (!e._changed && new_slug) {
-				e.value = URLify(this.value, 64);
+				var value = this.value;
+				if (window.UNIHANDECODER){
+					value = UNIHANDECODER.decode(value);
+				}
+				e.value = URLify(value, 64);
 			}
 		});
 		// saveform event handler

--- a/cms/templates/admin/cms/page/change_form.html
+++ b/cms/templates/admin/cms/page/change_form.html
@@ -14,22 +14,21 @@
 <script type="text/javascript" src="{% admin_static_url %}js/urlify.js"></script>
 
 {% if add %}
-{% if unihandecode_url %}
-<script type="text/javascript" src="{{ unihandecode_url }}unihandecode.core.min.js"></script>
-<script type="text/javascript" src="{{ unihandecode_url }}unihandecode.{{ unihandecode_lang }}.min.js"></script>
-{% endif %}
 <script type="text/javascript">
 //<![CDATA[	
 
 	jQuery(document).ready(function (){
-		jQuery("#id_title").keyup(function () {
-			var e = jQuery("#id_slug")[0];
-			if(!e._changed) {
-                var value = this.value;
-                {% if unihandecode_url %}value = Unihandecoder('{{ unihandecode_lang }}').decode(value);{% endif %}
-                e.value = URLify(value, 64);
-			}
-	    });
+        var title= jQuery('#id_title');
+        var slug = jQuery('#id_slug');
+        var update = function(){
+            var value = title.val();
+            if (window.UNIHANDECODER){
+                value = UNIHANDECODER.decode(value);
+            }
+            slug.val(URLify(value, 64));
+        };
+		title.keyup(update);
+        update();
 	});
 
 //]]>
@@ -197,6 +196,15 @@
 
 {% if add %}
    <script type="text/javascript">document.getElementById("{{ adminform.first_field.auto_id }}").focus();</script>
+
+{% endif %}
+{% for url in unihandecode_urls %}
+<script type="text/javascript" src="{{ url }}"></script>
+{% endfor %}
+{% if unihandecode_urls %}
+<script type="text/javascript">
+    var UNIHANDECODER = unihandecode.Unihan('{{ unihandecode_lang }}');
+</script>
 {% endif %}
 
 {# JavaScript for prepopulated fields #}

--- a/cms/test_utils/cli.py
+++ b/cms/test_utils/cli.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import with_statement
 from distutils.version import LooseVersion
 import django
 import os
@@ -233,6 +234,15 @@ def configure(db_url, **extra):
         from django.utils.functional import empty
         settings._wrapped = empty
     defaults.update(extra)
+    # add data from env
+    extra_settings = os.environ.get("DJANGO_EXTRA_SETTINGS", None)
+    if extra_settings:
+        from django.utils.simplejson import load, loads
+        if os.path.exists(extra_settings):
+            with open(extra_settings) as fobj:
+                defaults.update(load(fobj))
+        else:
+            defaults.update(loads(extra_settings))
     settings.configure(**defaults)
     from south.management.commands import patch_for_test_db_setup
     patch_for_test_db_setup()

--- a/cms/utils/conf.py
+++ b/cms/utils/conf.py
@@ -50,7 +50,9 @@ DEFAULTS = {
     'CACHE_PREFIX': 'cms-',
     'PLUGIN_PROCESSORS': [],
     'PLUGIN_CONTEXT_PROCESSORS': [],
-    'UNIHANDECODE_URL': None,
+    'UNIHANDECODE_VERSION': None,
+    'UNIHANDECODE_DECODERS': ['ja', 'zh', 'kr', 'vn', 'diacritic'],
+    'UNIHANDECODE_DEFAULT_DECODER': 'diacritic',
 }
 
 def get_cache_durations():
@@ -189,6 +191,15 @@ def get_languages():
         return languages
     return _ensure_languages_settings(languages)
 
+def get_unihandecode_host():
+    host = getattr(settings, 'CMS_UNIHANDECODE_HOST', None)
+    if not host:
+        return host
+    if host.endswith('/'):
+        return host
+    else:
+        return host + '/'
+
 COMPLEX = {
     'CACHE_DURATIONS': get_cache_durations,
     'MEDIA_ROOT': get_media_root,
@@ -197,6 +208,7 @@ COMPLEX = {
     'PLACEHOLDER_FRONTEND_EDITING': get_placeholder_frontend_editing,
     'TEMPLATES': get_templates,
     'LANGUAGES': get_languages,
+    'UNIHANDECODE_HOST': get_unihandecode_host,
 }
 
 def get_cms_setting(name):

--- a/docs/advanced/i18n.rst
+++ b/docs/advanced/i18n.rst
@@ -77,10 +77,10 @@ and you are on a page that doesn't yet have an English translation and you view
 the German version then the language chooser will redirect to ``/``. The same
 goes for urls that are not handled by the cms and display a language chooser.
 
-*************************************************
-Automated slug generation for non-ASCII languages
-*************************************************
+********************************************
+Automated slug generation unicode characters
+********************************************
 
 If your site has languages which use non-ASCII character sets, you might want
-to enable :setting:`CMS_UNIHANDECODE_URL` to get automated slugs for those
-languages too.
+to enable :setting:`CMS_UNIHANDECODE_HOST` and :setting:`CMS_UNIHANDECODE_VERSION`
+to get automated slugs for those languages too.

--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -333,22 +333,26 @@ Type: Boolean
 Default:``True``
 
 
-.. setting:: CMS_UNIHANDECODE_URL
+Unicode support for automated slugs
+===================================
 
-CMS_UNIHANDECODE_URL
-====================
+The django CMS supports automated slug generation from page titles that contain unicode characters via the
+unihandecode.js project. To enable support for unihandecode.js, at least :setting:`CMS_UNIHANDECODE_HOST` and
+:setting:`CMS_UNIHANDECODE_VERSION` must be set.
+
+
+.. setting:: CMS_UNIHANDECODE_HOST
+
+CMS_UNIHANDECODE_HOST
+---------------------
 
 default: ``None``
 
-To enable automatic slugs in the page add form in the admin for Japanese,
-Chinese, Korean or Vietnamese, or to improve the existing slug generation
-for other languages that use diacritics, you may set this setting to a URL
-where `unihandecode.js`_ is hosted.
-
-Due to conflicting licenses, unihandecode.js is not included in the django CMS
-and you must optain a copy of it yourself.
+Must be set to the URL where you host your unihandecode.js files. For licensing reasons, the django CMS does not include
+unihandecode.js.
 
 If set to ``None``, the default, unihandecode.js is not used.
+
 
 .. note::
 
@@ -356,6 +360,41 @@ If set to ``None``, the default, unihandecode.js is not used.
     for Japanese. It is therefore very important that you serve it from a
     server that supports gzip compression. Further, make sure that those files
     can be cached by the browser for a very long period.
+
+
+.. setting:: CMS_UNIHANDECODE_VERSION
+
+CMS_UNIHANDECODE_VERSION
+------------------------
+
+default: ``None``
+
+Must be set to the version number (eg ``'1.0.0'``) you want to use. Together with :setting:`CMS_UNIHANDECODE_HOST` this
+setting is used to build the full URLs for the javascript files. URLs are built like this:
+``<CMS_UNIHANDECODE_HOST>-<CMS_UNIHANDECODE_VERSION>.<DECODER>.min.js``.
+
+
+.. setting:: CMS_UNIHANDECODE_DECODERS
+
+CMS_UNIHANDECODE_DECODERS
+-------------------------
+
+default: ``['ja', 'zh', 'vn', 'kr', 'diacritic']``
+
+If you add additional decoders to your :setting:`CMS_UNIHANDECODE_HOST``, you can add them to this setting.
+
+
+.. setting:: CMS_UNIHANDECODE_DEFAULT_DECODER
+
+CMS_UNIHANDECODE_DEFAULT_DECODER
+--------------------------------
+
+default: ``'diacritic'``
+
+The default decoder to use when unihandecode.js support is enabled, but the current language does not provide a specific
+decoder in :setting:`CMS_UNIHANDECODE_DECODERS`. If set to ``None``, failing to find a specific decoder will disable
+unihandecode.js for this language.
+
 
 **************
 Media Settings

--- a/runtestserver.py
+++ b/runtestserver.py
@@ -5,7 +5,6 @@ import argparse
 from django.utils import autoreload
 import os
 import sys
-import urlparse
 
 
 def main():


### PR DESCRIPTION
Added support for unihandecode.js on the add page form in the admin.
This support must be explicitly enabled by the user and the django CMS
will not ship a copy of unihandecode.js.

Possible fix for #1597
