### PR TITLE
language_chooser fix and docs

### DIFF
--- a/docs/upgrade/2.4.rst
+++ b/docs/upgrade/2.4.rst
@@ -128,9 +128,11 @@ of the new functionality in django 1.4 and can be found here:
 
 What you need to do:
 
-- Remove the MultilingualMiddleware from your settings.
-- Be sure the LocaleMiddleware is in your settings and that it comes after the SessionMiddleware.
-- Be sure that the cms.urls is included in a i18n_patterns::
+- Remove ``cms.middleware.multilingual.MultilingualURLMiddleware`` from your
+  settings.
+- Be sure ``django.middleware.locale.LocaleMiddleware`` is in your settings,
+  and that it comes after the SessionMiddleware.
+- Be sure that the cms.urls is included in a ``i18n_patterns``::
 
         from django.conf.urls.defaults import *
         from django.conf.urls.i18n import i18n_patterns

--- a/menus/templates/menu/language_chooser.html
+++ b/menus/templates/menu/language_chooser.html
@@ -1,4 +1,4 @@
-{% load i18n_compat menu_tags %}
+{% load i18n menu_tags %}
 {% get_available_languages as languages %}
 {% for language in languages %}
     {% language language.0 %}


### PR DESCRIPTION
`{% language_chooser %}`'s template wanted `{% get_available_languages %}`, but instead of `{% load i18n %}` (from Django itself) used `{% load i18n_compat %}`, a django CMS library that can't help here.

Shouldn't templates be covered by tests?

Also: a tiny docs change.
