### PR TITLE
Simplejson replaced to json

### DIFF
--- a/cms/plugins/text/widgets/tinymce_widget.py
+++ b/cms/plugins/text/widgets/tinymce_widget.py
@@ -3,7 +3,7 @@ from cms.utils.conf import get_cms_setting
 from django.forms.widgets import flatatt
 from django.template.defaultfilters import escape
 from django.template.loader import render_to_string
-from django.utils import simplejson
+import json
 from django.utils.encoding import smart_unicode
 from django.utils.safestring import mark_safe
 from django.utils.translation import get_language
@@ -80,7 +80,7 @@ class TinyMCEEditor(TinyMCE):
         if 'cmsplugins' not in all_tools and 'cmspluginsedit' not in all_tools:
             mce_config['theme_advanced_buttons1_add_before'] = "cmsplugins,cmspluginsedit"
         
-        json = simplejson.dumps(mce_config)
+        json = json.dumps(mce_config)
         html = [u'<textarea%s>%s</textarea>' % (flatatt(final_attrs), escape(value))]
         if tinymce.settings.USE_COMPRESSOR:
             compressor_config = {
@@ -90,7 +90,7 @@ class TinyMCEEditor(TinyMCE):
                 'diskcache': True,
                 'debug': False,
             }
-            c_json = simplejson.dumps(compressor_config)
+            c_json = json.dumps(compressor_config)
             html.append(u'<script type="text/javascript">//<![CDATA[\ntinyMCE_GZ.init(%s);\n//]]></script>' % (c_json))
         html.append(u'<script type="text/javascript">//<![CDATA[\n%s;\ntinyMCE.init(%s);\n//]]></script>' % (self.render_additions(name, value, attrs), json))
         return mark_safe(u'\n'.join(html))

--- a/cms/templatetags/cms_js_tags.py
+++ b/cms/templatetags/cms_js_tags.py
@@ -2,14 +2,14 @@
 from classytags.core import Tag, Options
 from django import template
 from django.core.serializers.json import DjangoJSONEncoder
-from django.utils import simplejson
+import json
 from django.utils.text import javascript_quote
 
 register = template.Library()
 
 @register.filter
 def js(value):
-    return simplejson.dumps(value, cls=DjangoJSONEncoder)
+    return json.dumps(value, cls=DjangoJSONEncoder)
 
 @register.filter
 def bool(value):

--- a/cms/toolbar/base.py
+++ b/cms/toolbar/base.py
@@ -2,7 +2,7 @@
 from cms.toolbar.constants import ALIGNMENTS
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import simplejson
+import json
 from django.utils.encoding import force_unicode
 from django.utils.functional import Promise
 
@@ -22,7 +22,7 @@ class Serializable(object):
         Converts the (serialized) data to JSON
         """
         data = self.serialize(context, **kwargs)
-        return simplejson.dumps(data)
+        return json.dumps(data)
         
     def serialize(self, context, **kwargs):
         """

--- a/cms/utils/admin.py
+++ b/cms/utils/admin.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.http import HttpResponse
 from django.shortcuts import render_to_response
 from django.template.context import RequestContext
-from django.utils import simplejson
+import json
 from django.contrib.sites.models import Site
 
 from cms.models import Page
@@ -18,7 +18,7 @@ def jsonify_request(response):
          * status: original response status code
          * content: original response content
     """
-    return HttpResponse(simplejson.dumps({'status':response.status_code,'content':response.content}),
+    return HttpResponse(json.dumps({'status':response.status_code,'content':response.content}),
                                 content_type="application/json")
 
 publisher_classes = {


### PR DESCRIPTION
In django 1.5 simplejson is deprecated and incompatible with django JSONEncoder.
