### PR TITLE
Update docs/upgrade/2.4.rst

### DIFF
--- a/docs/upgrade/2.4.rst
+++ b/docs/upgrade/2.4.rst
@@ -22,7 +22,7 @@ What's new in 2.4
 
 Migrations overhaul
 ===================
-In version 2.4 migrations have been completely rewritten to address issues with
+In version 2.4, migrations have been completely rewritten to address issues with
 newer South releases.
 
 To ease the upgrading process, all the migrations for the `cms` application have
@@ -76,7 +76,7 @@ Addded a check command
 
 Added a management command to check your configuration and environment.
 
-To use th command, simply run:
+To use this command, simply run:
 
     manage.py cms check
 
@@ -290,7 +290,7 @@ If you have code that needs to access django CMS settings (settings prefixed
 with ``CMS_`` or ``PLACEHOLDER_``) you would have used for example
 ``from django.conf import settings; settings.CMS_TEMPLATES``. This will no
 longer guarantee to return sane values, instead you should use
-``django.utils.conf.get_cms_setting`` which takes the name of the setting
+``cms.utils.conf.get_cms_setting`` which takes the name of the setting
 **without** the ``CMS_`` prefix as argument and returns the setting.
 
 Example of old, now deprecated style::


### PR DESCRIPTION
Changed typos and the path to get_cms_settings func (in cms, not in django)
