### PR TITLE
Error when clicking a page link in the admin

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -462,7 +462,7 @@ class PageAdmin(ModelAdmin):
         return inlines
 
     def get_unihandecode_context(self, language):
-        if language[:2] in get_cms_setting('UNIHANDECODE_DECODERS'):
+        if language and language[:2] in get_cms_setting('UNIHANDECODE_DECODERS'):
             uhd_lang = language[:2]
         else:
             uhd_lang = get_cms_setting('UNIHANDECODE_DEFAULT_DECODER')


### PR DESCRIPTION
I have checked out the develop branch of the code, done a clean django CMS install and added a page in the admin. When I click on the link to the newly-created page in the admin, I get:

```
TypeError at /admin/cms/page/1/
'NoneType' object is unsubscriptable
cms/admin/pageadmin.py in get_unihandecode_context, line 465
```

If I instead click the "EN-GB" link to view the page, the error doesn't happen. Looking at the code, I think it's because the new `get_unihandecode_context()` method in 6f634e96dbdb7f21e480fa1e0d050178bfe55cf7 is always expecting a language to be specified in the querystring, but when you click the main link in the admin rather than the EN-GB link, there are no parameters in the querystring. So I have fixed this by first checking if the `language` parameter exists.
