### PR TITLE
page_url docs: explain handling of incorrect reverse IDs

### DIFF
--- a/docs/advanced/templatetags.rst
+++ b/docs/advanced/templatetags.rst
@@ -163,6 +163,13 @@ Example::
     <a href="{% page_url "help" %}">Help page</a>
     <a href="{% page_url request.current_page.parent %}">Parent page</a>
 
+If a matching page isn't found and :setting:`django:DEBUG` is ``True``, an
+exception will be raised. However, if :setting:`django:DEBUG` is ``False``, an
+exception will not be raised. Additionally, if
+:setting:`django:SEND_BROKEN_LINK_EMAILS` is ``True`` and you have specified
+some addresses in :setting:`django:MANAGERS`, an email will be sent to those
+addresses to inform them of the broken link.
+
 .. templatetag:: page_attribute
 
 page_attribute


### PR DESCRIPTION
In previous projects I have refused to use the `{% page_url %}` template tag because I was worried about 500 errors in production if an editor changed a page's reverse ID in the admin. It wasn't until I looked through the source code that I discovered an exception is only raised in debug mode, not production, and also it will optionally email people to inform them of a broken link, which is really useful!

However the docs don't mention this at all. If they had done, I would have used the tag a lot sooner. I think this information should be in the docs, so I have added it in this pull request.
