### PR TITLE
Adds (removes) class 'cms_toolbar' to HTML when CMS Toolbar is shown (hi...

### DIFF
--- a/cms/static/cms/js/plugins/cms.toolbar.js
+++ b/cms/static/cms/js/plugins/cms.toolbar.js
@@ -248,6 +248,8 @@ CMS.$(document).ready(function ($) {
 				btn.data('state', false).css('backgroundPosition', '-40px -198px');
 			}
 
+			$('html').toggleClass('cms_toolbar-switcher', obj.state);
+
 			// add events
 			template.find('.cms_toolbar-item_switcher-link').bind('click', function (e) {
 				e.preventDefault();


### PR DESCRIPTION
...dden)

This allows CSS designers to expand collapsed sections of the page as appropriate for using the on-screen CMS controls.

Also, added radix parameter to Math.parseInt() usage.
