### PR TITLE
HTML classes added when cms_toolbar and switcher is ON

### DIFF
--- a/cms/static/cms/js/plugins/cms.toolbar.js
+++ b/cms/static/cms/js/plugins/cms.toolbar.js
@@ -248,6 +248,8 @@ CMS.$(document).ready(function ($) {
 				btn.data('state', false).css('backgroundPosition', '-40px -198px');
 			}
 
+			$('html').toggleClass('cms_toolbar-switcher', obj.state);
+
 			// add events
 			template.find('.cms_toolbar-item_switcher-link').bind('click', function (e) {
 				e.preventDefault();


### PR DESCRIPTION
These aide page CSS designers to prepare the page for editing using the on-page controls by expanding/revealing collapsed or hidden sections as appropriate.
