### PR TITLE
Fix to allow javascript catch the right CSRF_COOKIE_NAME. Issue #1713

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -539,6 +539,7 @@ class PageAdmin(ModelAdmin):
                 'moderation_delete_request': moderation_delete_request,
                 'show_delete_translation': len(obj.get_languages()) > 1,
                 'current_site_id': settings.SITE_ID,
+                'CSRF_COOKIE_NAME': settings.CSRF_COOKIE_NAME,
             }
             extra_context = self.update_language_tab_context(request, obj, extra_context)
         tab_language = request.GET.get("language", None)
@@ -704,6 +705,7 @@ class PageAdmin(ModelAdmin):
             'DEBUG': settings.DEBUG,
             'site_languages': languages,
             'open_menu_trees': open_menu_trees,
+            'CSRF_COOKIE_NAME': settings.CSRF_COOKIE_NAME,
         }
         if 'reversion' in settings.INSTALLED_APPS:
             context['has_change_permission'] = self.has_change_permission(request)

--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -122,6 +122,7 @@ class CMSPluginBase(admin.ModelAdmin):
             'is_popup': True,
             'plugin': self.cms_plugin_instance,
             'CMS_MEDIA_URL': settings.CMS_MEDIA_URL,
+            'CSRF_COOKIE_NAME': settings.CSRF_COOKIE_NAME,
         })
         
         return super(CMSPluginBase, self).render_change_form(request, context, add, change, form_url, obj)

--- a/cms/static/cms/js/csrf.js
+++ b/cms/static/cms/js/csrf.js
@@ -34,7 +34,7 @@ $.ajaxSetup({
 					}
 					if(!(/^http:.*/.test(settings.url) || /^https:.*/.test(settings.url)) || base_doc_url == base_settings_url) {
 						// Only send the token to relative URLs i.e. locally.
-						xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+						xhr.setRequestHeader("X-CSRFToken", getCookie(window.__csrf_cookie_name__ || 'csrftoken'));
 						settings.csrfTokenSet = true;
 					}
 				}
@@ -81,7 +81,7 @@ base_settings_url = base_settings_url[0];
 }
 if (!(/^http:.*/.test(settings.url) || /^https:.*/.test(settings.url)) || base_doc_url == base_settings_url) {
 // Only send the token to relative URLs i.e. locally.
-xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+xhr.setRequestHeader("X-CSRFToken", getCookie(window.__csrf_cookie_name__ || 'csrftoken'));
 settings.csrfTokenSet = true;
 }
 }

--- a/cms/static/cms/js/plugins/cms.base.js
+++ b/cms/static/cms/js/plugins/cms.base.js
@@ -58,7 +58,7 @@
 						}
 						if(!(/^http:.*/.test(settings.url) || /^https:.*/.test(settings.url)) || base_doc_url == base_settings_url) {
 							// Only send the token to relative URLs i.e. locally.
-							xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+							xhr.setRequestHeader("X-CSRFToken", getCookie(window.__csrf_cookie_name__ || 'csrftoken'));
 							settings.csrfTokenSet = true;
 						}
 					}

--- a/cms/templates/admin/cms/page/change_form.html
+++ b/cms/templates/admin/cms/page/change_form.html
@@ -4,6 +4,7 @@
 {% block title %}{% trans "Change a page" %}{% endblock %}
 
 {% block extrahead %}
+<script type="text/javascript">window.__csrf_cookie_name__ = "{% filter escapejs %}{{CSRF_COOKIE_NAME}}{% endfilter %}";</script>
 {{ block.super }}
 <script type="text/javascript" src="{{ STATIC_URL }}cms/js/csrf.js"></script>
 <script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>

--- a/cms/templates/admin/cms/page/change_list.html
+++ b/cms/templates/admin/cms/page/change_list.html
@@ -12,6 +12,7 @@
 
 {% block coltype %}flex{% endblock %}
 {% block extrahead %}
+<script type="text/javascript">window.__csrf_cookie_name__ = "{% filter escapejs %}{{CSRF_COOKIE_NAME}}{% endfilter %}";</script>
 <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}cms/css/pages.css"/>
 <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}cms/jstree/tree_component.css" />
 <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}cms/css/jquery.dialog.css" />

--- a/cms/templates/admin/cms/page/plugin_change_form.html
+++ b/cms/templates/admin/cms/page/plugin_change_form.html
@@ -1,7 +1,9 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_modify adminmedia cms_admin %}
 {% load url from future %}
-{% block extrahead %}{{ block.super }}
+{% block extrahead %}
+<script type="text/javascript">window.__csrf_cookie_name__ = "{% filter escapejs %}{{CSRF_COOKIE_NAME}}{% endfilter %}";</script>
+{{ block.super }}
 <script type="text/javascript" src="{% admin_static_url %}js/jquery.min.js"></script>
 <script type="text/javascript" src="{{ STATIC_URL }}cms/js/csrf.js"></script>
 <script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>

--- a/cms/templates/cms/toolbar/toolbar.html
+++ b/cms/templates/cms/toolbar/toolbar.html
@@ -1,5 +1,6 @@
 {% load i18n adminmedia sekizai_tags cms_js_tags cms_admin %}
 {% addtoblock "js" %}
+<script type="text/javascript">window.__csrf_cookie_name__ = "{% filter escapejs %}{{CSRF_COOKIE_NAME}}{% endfilter %}";</script>
 <script type="text/javascript">
 	var _jQuery = window.jQuery || null;
 	var _$ = window.$;

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -431,5 +431,6 @@ class CMSToolbar(InclusionTag):
 
     def get_context(self, context):
         context['CMS_TOOLBAR_CONFIG'] = context['request'].toolbar.as_json(context)
+        context['CSRF_COOKIE_NAME'] = settings.CSRF_COOKIE_NAME
         return context
 register.tag(CMSToolbar)


### PR DESCRIPTION
- Added javascript global variable `__csrf_cookie_name__`, it will
  be displayed only in admin views and when the toolbar is available
  so it doesn't expose this variable in the public version of the pages
  - Fixed the javascript code where the 'csrftoken' string is hardcoded.
  - Modified views and templates to pass to the context the
    CSRF_COOKIE_NAME and use it to set the value of the global javascript
    variable `window.__csrf_cookie_name__` falling back to the default
    'csrftoken' value

The solution is not very clean, this is open to suggestions to improve the code and also how to test this functionality.

The commit in this PR can also be cherry picked on top of "develop" branch, as the same problem exists there.
