### PR TITLE
Re-add viewsitelink CSS class to page change_form template

### DIFF
--- a/cms/templates/admin/cms/page/change_form.html
+++ b/cms/templates/admin/cms/page/change_form.html
@@ -85,7 +85,7 @@
 	{% endif %}
 	{% if can_change and page.published and page.is_dirty %}<li><a href="revert/" class="revertlink">{% trans "Revert to public" %}</a></li>{% endif %}
 	<li><a href="history/" class="historylink">{% trans "History" %}</a></li>
-  	{% if page.publisher_public %}<li><a href="preview/?public=1&language={{ language }}">{% trans "View on site" %}</a></li>{% endif%}
+  	{% if page.publisher_public %}<li><a href="preview/?public=1&language={{ language }}" class="viewsitelink">{% trans "View on site" %}</a></li>{% endif%}
   </ul>
 {% endif %}{% endif %}
 {% endblock %}


### PR DESCRIPTION
This is needed for finer control over the link's styling (primarily for djangocms-admin-style).
