### PR TITLE
Avoid expensive permission checks if CMS_VIEW_PERMISSION is False

### DIFF
--- a/cms/menu.py
+++ b/cms/menu.py
@@ -71,7 +71,7 @@ def get_visible_pages(request, pages, site=None):
         site = current_site(request)
 
     # authenticated user and global permission
-    if is_auth_user:
+    if is_auth_user and get_cms_setting('VIEW_PERMISSION'):
         global_page_perm_q = Q(
             Q(user=request.user) | Q(group__user=request.user)
         ) & Q(can_view=True) & Q(Q(sites__in=[site.pk]) | Q(sites__isnull=True))
@@ -89,6 +89,8 @@ def get_visible_pages(request, pages, site=None):
             not restricted_pages and
             not global_view_perms):
             return []
+    else:
+        global_view_perms = False
 
 
     def has_global_perm():

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -778,6 +778,9 @@ class Page(MPTTModel):
 
         if not self.publisher_is_draft:
             return self.publisher_draft.has_view_permission(request)
+        
+        if not get_cms_setting('VIEW_PERMISSION'):
+            return True
             # does any restriction exist?
         # inherited and direct
         is_restricted = PagePermission.objects.for_page(page=self).filter(can_view=True).exists()

--- a/cms/utils/conf.py
+++ b/cms/utils/conf.py
@@ -34,6 +34,7 @@ DEFAULTS = {
     'TEMPLATE_INHERITANCE': True,
     'PLACEHOLDER_CONF': {},
     'PERMISSION': False,
+    'VIEW_PERMISSION': True,
     # Whether to use raw ID lookups for users when PERMISSION is True
     'RAW_ID_USERS': False,
     'PUBLIC_FOR': 'all',


### PR DESCRIPTION
Conflicts:

```
cms/models/pagemodel.py
cms/utils/conf.py
```
