### PR TITLE
googlemap plugin: Bootstrap and Google Maps Info window styles problem

### DIFF
--- a/cms/plugins/googlemap/templates/cms/plugins/googlemap.html
+++ b/cms/plugins/googlemap/templates/cms/plugins/googlemap.html
@@ -1,5 +1,14 @@
 {% load i18n sekizai_tags %}
 
+{% addtoblock "css" %}                                                         
+  <style type="text/css">                                                        
+    /** FIX for Bootstrap and Google Maps Info window styes problem **/          
+    img[src*="gstatic.com/"], img[src*="googleapis.com/"] {                      
+      max-width: none;                                                           
+    }                                                                            
+  </style>                                                                       
+{% endaddtoblock %}   
+
 {% addtoblock "js" %}
   <script type="text/javascript" src="https://maps-api-ssl.google.com/maps/api/js?v=3&sensor=true"></script>
 {% endaddtoblock %}


### PR DESCRIPTION
Current bootstrap styles have an issue with google maps ones, affecting info window appearance. 

As this fix does not affect any other style, maybe would be a good idea to fix it at django-cms side. maybe not ;)

Issue is currently opened in bootstrap:
twitter/bootstrap#2410

The pull request is a quick fix got from referenced bootstrap issue

![gmap-bootstrap-infow-issue](https://f.cloud.github.com/assets/797664/431124/a4b9287a-ae80-11e2-92c5-e04c9749a243.jpg)
