### PR TITLE
don't fail when english is not available

### DIFF
--- a/cms/forms/utils.py
+++ b/cms/forms/utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from cms.exceptions import LanguageError
 from cms.models import Page
 from cms.models.titlemodels import Title
 from cms.utils import i18n
@@ -30,7 +31,11 @@ def update_site_and_page_choices(lang=None):
     site_choices = []
     page_choices = [('', '----')]
     
-    language_order = [lang] + i18n.get_fallback_languages(lang)
+    try:
+        fallbacks = i18n.get_fallback_languages(lang)
+    except LanguageError:
+        fallbacks = []
+    language_order = [lang] + fallbacks
     
     for sitepk, sitename in sites.items():
         site_choices.append((sitepk, sitename))

--- a/cms/tests/multilingual.py
+++ b/cms/tests/multilingual.py
@@ -2,6 +2,8 @@
 from __future__ import with_statement
 import copy
 from cms.api import create_page, create_title, publish_page, add_plugin
+from cms.exceptions import LanguageError
+from cms.forms.utils import update_site_and_page_choices
 from cms.models import Title
 from cms.test_utils.testcases import (CMSTestCase, SettingsOverrideTestCase,
                                       URL_CMS_PAGE_ADD, 
@@ -251,3 +253,15 @@ class MultilingualTestCase(SettingsOverrideTestCase):
         with SettingsOverride(CMS_LANGUAGES=lang_settings):
             response = self.client.get("/de/")
             self.assertEquals(response.status_code, 200)
+
+    def test_no_english_defined(self):
+        with SettingsOverride(TEMPLATE_CONTEXT_PROCESSORS=[],
+            CMS_LANGUAGES={
+                1:[
+                    {'code': 'de', 'name': 'German', 'public':True, 'fallbacks': []},
+                ]},
+            ):
+            try:
+                update_site_and_page_choices(lang='en-us')
+            except LanguageError:
+                self.fail("LanguageError raised")


### PR DESCRIPTION
Django runs all management commands with 'en-us' as the activated language.
If 'en' or one of the en-sublanguages is not defined in CMS_LANGUAGES,
`update_site_and_page_choices` fails.

I'm not 100% sure if this fixes the problem at the right level, though...
