### PR TITLE
fixed url_redirects when USE_I18N=True, but no i18n_patterns is used

### DIFF
--- a/cms/tests/no_i18n.py
+++ b/cms/tests/no_i18n.py
@@ -77,3 +77,28 @@ class TestNoI18N(SettingsOverrideTestCase):
             tpl = Template("{%% load menu_tags %%}{%% page_language_url '%s' %%}" % "en-us")
             url = tpl.render(context)
             self.assertEqual(url, "%s" % path)
+
+    def test_url_redirect(self):
+        with SettingsOverride(
+                ROOT_URLCONF='cms.test_utils.project.urls_no18n',
+                USE_I18N=True,
+                MIDDLEWARE_CLASSES=[
+                    'django.contrib.sessions.middleware.SessionMiddleware',
+                    'django.contrib.auth.middleware.AuthenticationMiddleware',
+                    'django.contrib.messages.middleware.MessageMiddleware',
+                    'django.middleware.csrf.CsrfViewMiddleware',
+                    'django.middleware.locale.LocaleMiddleware',
+                    'django.middleware.doc.XViewMiddleware',
+                    'django.middleware.common.CommonMiddleware',
+                    'django.middleware.transaction.TransactionMiddleware',
+                    'django.middleware.cache.FetchFromCacheMiddleware',
+                    #'cms.middleware.language.LanguageCookieMiddleware',
+                    'cms.middleware.user.CurrentUserMiddleware',
+                    'cms.middleware.page.CurrentPageMiddleware',
+                    'cms.middleware.toolbar.ToolbarMiddleware',
+                ],
+                CMS_LANGUAGES={1: []},
+                LANGUAGES=(('en-us', 'English'),)):
+            create_page("home", template="col_two.html", language="en-us", published=True, redirect='/foobar/')
+            response = self.client.get('/', follow=False)
+            self.assertEqual(response['Location'], 'http://testserver/foobar/')

--- a/cms/utils/i18n.py
+++ b/cms/utils/i18n.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 from contextlib import contextmanager
-from cms.exceptions import LanguageError
-from cms.utils.conf import get_cms_setting
+
+from django.core.urlresolvers import get_resolver, LocaleRegexURLResolver
 from django.conf import settings
 from django.utils import translation
-from django.utils.translation import ugettext_lazy  as _
+from django.utils.translation import ugettext_lazy as _
+
+from cms.exceptions import LanguageError
+from cms.utils.conf import get_cms_setting
 
 
 @contextmanager
@@ -162,6 +165,7 @@ def get_fallback_languages(language, site_id=None):
     language = get_language_object(language, site_id)
     return language.get('fallbacks', [])
 
+
 def get_redirect_on_fallback(language, site_id=None):
     """
     returns if you should redirect on language fallback
@@ -172,6 +176,7 @@ def get_redirect_on_fallback(language, site_id=None):
     language = get_language_object(language, site_id)
     return language.get('redirect_on_fallback', True)
 
+
 def hide_untranslated(language, site_id=None):
     """
     Should untranslated pages in this language be hidden?
@@ -181,3 +186,14 @@ def hide_untranslated(language, site_id=None):
     """
     obj = get_language_object(language, site_id)
     return obj.get('hide_untranslated', True)
+
+
+def is_language_prefix_patterns_used():
+    """
+    Returns `True` if the `LocaleRegexURLResolver` is used
+    at root level of the urlpatterns, else it returns `False`.
+    """
+    for url_pattern in get_resolver(None).url_patterns:
+        if isinstance(url_pattern, LocaleRegexURLResolver):
+            return True
+    return False

--- a/cms/views.py
+++ b/cms/views.py
@@ -4,7 +4,7 @@ from cms.apphook_pool import apphook_pool
 from cms.appresolver import get_app_urls
 from cms.models import Title
 from cms.utils import get_template_from_request, get_language_from_request
-from cms.utils.i18n import get_fallback_languages, force_language, get_public_languages, get_redirect_on_fallback, get_language_list
+from cms.utils.i18n import get_fallback_languages, force_language, get_public_languages, get_redirect_on_fallback, get_language_list, is_language_prefix_patterns_used
 from cms.utils.page_resolver import get_page_from_request
 from cms.test_utils.util.context_managers import SettingsOverride
 from django.conf import settings
@@ -116,7 +116,7 @@ def details(request, slug):
         # Check if the page has a redirect url defined for this language.
     redirect_url = page.get_redirect(language=current_language)
     if redirect_url:
-        if (settings.USE_I18N and redirect_url[0] == "/"
+        if (is_language_prefix_patterns_used() and redirect_url[0] == "/"
             and not redirect_url.startswith('/%s/' % current_language)):
             # add language prefix to url
             redirect_url = "/%s/%s" % (current_language, redirect_url.lstrip("/"))


### PR DESCRIPTION
Currently, the code checks if `USE_I18N` is set to `False`. If it's `True`, a language prefix is added.

There are cases where one doesn't need language prefixes (only a single active language), but still wants `USE_I18N = True` (e.g. to make use of the django translation framework).

This PR includes a copy of django's `LocaleMiddleware.is_language_prefix_patterns_used()` to do a proper check if a language prefix is needed or not.
