### PR TITLE
Removed optional approve argument to publish_page

### DIFF
--- a/docs/extending_cms/api_references.rst
+++ b/docs/extending_cms/api_references.rst
@@ -140,22 +140,13 @@ Functions and constants
 
 .. function:: publish_page(page, user)
 
-    Publishes a page and optionally approves that publication.
+    Publishes a page.
     
     :param page: The page to publish
     :type page: :class:`cms.models.pagemodel.Page` instance
     :param user: The user that performs this action
     :type user: :class:`django.contrib.auth.models.User` instance
-    
 
-.. function:: approve_page(page, user)
-
-    Approves a page.
-    
-    :param page: The page to approve
-    :type page: :class:`cms.models.pagemodel.Page` instance
-    :param user: The user that performs this action
-    :type user: :class:`django.contrib.auth.models.User` instance
 
 
 Example workflows


### PR DESCRIPTION
 (not use anymore on Django-CMS 2.4 and develop branch)
