### PR TITLE
Update URI of Wymeditor example page

### DIFF
--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -187,7 +187,7 @@ The Wymeditor from :mod:`cms.plugins.text` plugin can take the same
 configuration as vanilla Wymeditor. Therefore you will need to learn 
 how to configure that. The best thing to do is to head 
 over to the `Wymeditor examples page 
-<http://files.wymeditor.org/wymeditor-0.5/examples/>`_
+<http://files.wymeditor.org/wymeditor-1.0.0b2/examples/>`_
 in order to understand how Wymeditor works. 
 
 The :mod:`cms.plugins.text` plugin exposes several variables named


### PR DESCRIPTION
The existing URI, http://files.wymeditor.org/wymeditor/examples/, returns a 404 error. There are two possible sets of examples to view based on desired Wymeditor version:
1. 0.5 -- http://files.wymeditor.org/wymeditor-0.5/examples/
2. 1.0.0b2 -- http://files.wymeditor.org/wymeditor-1.0.0b2/examples/

I'm not entirely certain which version most closely matches that used by Django CMS so I've linked to the examples for version 0.5.
