### PR TITLE
cms_toolbar templatetag library is not in 2.4.x

### DIFF
--- a/docs/advanced/templatetags.rst
+++ b/docs/advanced/templatetags.rst
@@ -462,19 +462,10 @@ Toolbar Templatetags
 
 .. highlightlang:: html+django
 
-To use any of the following templatetags you first need to load them at the
-top of your template::
-
-    {% load cms_toolbar %}
-	
-.. templatetag:: cms_toolbar
-
-cms_toolbar
-===========
-
-The ``cms_toolbar`` templatetag will add the required css and javascript to the
-sekizai blocks in the base template. The templatetag has to be placed after the
-``<body>`` tag and before any ``{% cms_placeholder %}`` occurrences within your HTML.
+The ``cms_toolbar`` templatetag is included in the ``cms_tags`` library and will add the 
+required css and javascript to the sekizai blocks in the base template. The templatetag 
+has to be placed after the ``<body>`` tag and before any ``{% cms_placeholder %}`` occurrences 
+within your HTML.
 
 Example::
 


### PR DESCRIPTION
pull#1759

>  Could you open the same PR for 2.4.x branch as well?

YES! That was actually the intention as i forked that branch, but github automatically sent the pull request for the master branch... will note that for future pull requests :)

Thanks and have a nice day :)

Ben
