### PR TITLE
Exception handling in management moderator command for 2.4.x

### DIFF
--- a/cms/management/commands/subcommands/moderator.py
+++ b/cms/management/commands/subcommands/moderator.py
@@ -1,13 +1,17 @@
 # -*- coding: utf-8 -*-
+from logging import getLogger
+
 from cms.management.commands.subcommands.base import SubcommandsCommand
 from cms.models import CMSPlugin
 from cms.models.pagemodel import Page
 from django.core.management.base import NoArgsCommand
 
 
+log = getLogger('cms.management.moderator')
+
 class ModeratorOnCommand(NoArgsCommand):
     help = 'Turn moderation on, run AFTER upgrading to 2.4'
-    
+
     def handle_noargs(self, **options):
         """
         Ensure that the public pages look the same as their draft versions.
@@ -21,11 +25,19 @@ class ModeratorOnCommand(NoArgsCommand):
         have the same plugins listed. If both versions exist and have content,
         the public page has precedence. Otherwise, the draft version is used.
         """
+        log.info('Reverting drafts to public versions')
         for page in Page.objects.public():
             if CMSPlugin.objects.filter(placeholder__page=page).count():
+                log.debug('Reverting page pk=%d' % (page.pk,))
                 page.publisher_draft.revert()
+
+        log.info('Publishing all published drafts')
         for page in Page.objects.drafts().filter(published=True):
-            page.publish()
+            try:
+                page.publish()
+                log.debug('Published page pk=%d' % (page.pk,))
+            except Exception, e:
+                log.exception('Error publishing page pk=%d' % (page.pk,))
 
 
 class ModeratorCommand(SubcommandsCommand):


### PR DESCRIPTION
Added some simple python logging and exception handling to the moderator on managment command.
