### PR TITLE
useful debug info for DuplicatePlaceholderWarning

### DIFF
--- a/cms/tests/placeholder.py
+++ b/cms/tests/placeholder.py
@@ -74,8 +74,7 @@ class PlaceholderTestCase(CMSTestCase):
         self.assertEqual(sorted(placeholders), sorted([u'new_one', u'new_two', u'new_three']))
 
     def test_placeholder_scanning_duplicate(self):
-        placeholders = self.assertWarns(DuplicatePlaceholderWarning, "Duplicate placeholder found: `one`",
-                                        get_placeholders, 'placeholder_tests/test_seven.html')
+        placeholders = self.assertWarns(DuplicatePlaceholderWarning, 'Duplicate {% placeholder "one" %} in template placeholder_tests/test_seven.html.', get_placeholders, 'placeholder_tests/test_seven.html')
         self.assertEqual(sorted(placeholders), sorted([u'one']))
 
     def test_placeholder_scanning_extend_outside_block(self):

--- a/cms/utils/plugins.py
+++ b/cms/utils/plugins.py
@@ -125,7 +125,10 @@ def get_placeholders(template):
     clean_placeholders = []
     for placeholder in placeholders:
         if placeholder in clean_placeholders:
-            warnings.warn("Duplicate placeholder found: `%s`" % placeholder, DuplicatePlaceholderWarning)
+            warnings.warn("Duplicate {{% placeholder \"{0}\" %}} "
+                          "in template {1}."
+                          .format(placeholder, template, placeholder),
+                          DuplicatePlaceholderWarning)
         else:
             validate_placeholder_name(placeholder)
             clean_placeholders.append(placeholder)


### PR DESCRIPTION
before: 'Duplicate placeholder found: `one`'
after:  'Duplicate {% placeholder "one" %} in template placeholder_tests/test_seven.html.'

---

^ i always found/felt that the scan-template-for-placeholders mechanism django-cms does to be preeetty magic.  One example being, the admin UI-- things won't pop up there if you forget to put a {% placeholder ... %} in the template etc.

Soooo this patch just gives a developer an immediate place to look at to find a fix.  It's probably more of a problem on large projects where there are many many templates etc.
