### PR TITLE
Cache Versioning on Permissions Cache

### DIFF
--- a/cms/cache/permissions.py
+++ b/cms/cache/permissions.py
@@ -50,7 +50,7 @@ def clear_user_permission_cache(user):
     Cleans permission cache for given user.
     """
     for key in PERMISSION_KEYS:
-        cache.delete(get_cache_key(user, key))
+        cache.delete(get_cache_key(user, key), version=get_cache_version())
 
 
 def clear_permission_cache():


### PR DESCRIPTION
I've replaced the aggressive cache deletion with cache versioning of the permissions cache. It reduced saving/publishing times on my pages from about 1 minute to 2 seconds.
