### PR TITLE
Use --noinput convention for delete_orphaned_plugins command

### DIFF
--- a/cms/management/commands/subcommands/delete_orphaned_plugins.py
+++ b/cms/management/commands/subcommands/delete_orphaned_plugins.py
@@ -1,4 +1,3 @@
-from cms.models import Page, CMSPlugin
 from django.core.management.base import NoArgsCommand
 from cms.management.commands.subcommands.list import plugin_report
 
@@ -16,23 +15,35 @@ class DeleteOrphanedPluginsCommand(NoArgsCommand):
         but not saved).
         """
         self.stdout.write("Obtaining plugin report\n")
-        report = plugin_report()
         uninstalled_instances = []
         unsaved_instances = []
 
-        # delete items whose plugin is uninstalled and items with unsaved instances
-        self.stdout.write("... deleting any instances of uninstalled plugins and unsaved plugin instances\n")        
-        
-        for plugin in report:
+        for plugin in plugin_report():
             if not plugin["model"]:
                 for instance in plugin["instances"]:
                     uninstalled_instances.append(instance)
-                    instance.delete()
-                    
+
             for instance in plugin["unsaved_instances"]:
                 unsaved_instances.append(instance)
+
+        if options.get('interactive'):
+            confirm = raw_input("""
+You have requested to delete any instances of uninstalled plugins and unsaved plugin instances.
+There are %d uninstalled plugins and %d unsaved_plugins.
+Are you sure you want to do this?
+Type 'yes' to continue, or 'no' to cancel: """ % (len(uninstalled_instances), len(unsaved_instances)))
+        else:
+            confirm = 'yes'
+
+        if confirm == 'yes':
+            # delete items whose plugin is uninstalled and items with unsaved instances
+            self.stdout.write("... deleting any instances of uninstalled plugins and unsaved plugin instances\n")
+
+            for instance in uninstalled_instances:
                 instance.delete()
 
-        self.stdout.write("Deleted instances of: \n    %s uninstalled plugins  \n    %s plugins with unsaved instances\n" % (len(uninstalled_instances), len(unsaved_instances)))
-        self.stdout.write("all done\n")
-                                    
+            for instance in unsaved_instances:
+                instance.delete()
+
+            self.stdout.write("Deleted instances of: \n    %s uninstalled plugins  \n    %s plugins with unsaved instances\n" % (len(uninstalled_instances), len(unsaved_instances)))
+            self.stdout.write("all done\n")

--- a/cms/tests/management.py
+++ b/cms/tests/management.py
@@ -61,14 +61,14 @@ class ManagementTestCase(CMSTestCase):
                 CMSPlugin.objects.filter(plugin_type=PLUGIN).count(),
                 2)
             self.assertEqual(
-                CMSPlugin.objects.filter(plugin_type="LinkPlugin").count(), 
-                1)            
+                CMSPlugin.objects.filter(plugin_type="LinkPlugin").count(),
+                1)
 
             # create a CMSPlugin with an unsaved instance
             instanceless_plugin = CMSPlugin(language="en", plugin_type="TextPlugin")
             instanceless_plugin.save()
 
-            # create a bogus CMSPlugin to simulate one which used to exist but 
+            # create a bogus CMSPlugin to simulate one which used to exist but
             # is no longer installed
             bogus_plugin = CMSPlugin(language="en", plugin_type="BogusPlugin")
             bogus_plugin.save()
@@ -77,60 +77,60 @@ class ManagementTestCase(CMSTestCase):
 
             # there should be reports for three plugin types
             self.assertEqual(
-                len(report), 
+                len(report),
                 3)
-                
-            # check the bogus plugin 
+
+            # check the bogus plugin
             bogus_plugins_report = report[0]
             self.assertEqual(
-                bogus_plugins_report["model"], 
-                None)            
+                bogus_plugins_report["model"],
+                None)
 
             self.assertEqual(
-                bogus_plugins_report["type"], 
-                u'BogusPlugin')            
-            
-            self.assertEqual(
-                bogus_plugins_report["instances"][0], 
-                bogus_plugin)            
+                bogus_plugins_report["type"],
+                u'BogusPlugin')
 
-            # check the link plugin 
+            self.assertEqual(
+                bogus_plugins_report["instances"][0],
+                bogus_plugin)
+
+            # check the link plugin
             link_plugins_report = report[1]
             self.assertEqual(
-                link_plugins_report["model"], 
-                link_plugin.__class__)            
+                link_plugins_report["model"],
+                link_plugin.__class__)
 
             self.assertEqual(
-                link_plugins_report["type"], 
-                u'LinkPlugin')            
-            
-            self.assertEqual(
-                link_plugins_report["instances"][0].get_plugin_instance()[0], 
-                link_plugin)            
+                link_plugins_report["type"],
+                u'LinkPlugin')
 
-            # check the text plugins 
+            self.assertEqual(
+                link_plugins_report["instances"][0].get_plugin_instance()[0],
+                link_plugin)
+
+            # check the text plugins
             text_plugins_report = report[2]
             self.assertEqual(
-                text_plugins_report["model"], 
-                TextPlugin.model)            
+                text_plugins_report["model"],
+                TextPlugin.model)
 
             self.assertEqual(
-                text_plugins_report["type"], 
-                u'TextPlugin')            
-            
+                text_plugins_report["type"],
+                u'TextPlugin')
+
             self.assertEqual(
-                len(text_plugins_report["instances"]), 
+                len(text_plugins_report["instances"]),
                 3)
-                
+
             self.assertEqual(
-                text_plugins_report["instances"][2], 
+                text_plugins_report["instances"][2],
                 instanceless_plugin)
-                            
+
             self.assertEqual(
-                text_plugins_report["unsaved_instances"], 
+                text_plugins_report["unsaved_instances"],
                 [instanceless_plugin])
-        
-                        
+
+
     def test_delete_orphaned_plugins(self):
         apps = ["cms", "menus", "sekizai", "cms.test_utils.project.sampleapp"]
         with SettingsOverride(INSTALLED_APPS=apps):
@@ -144,7 +144,7 @@ class ManagementTestCase(CMSTestCase):
                 language="en", plugin_type="TextPlugin")
             instanceless_plugin.save()
 
-            # create a bogus CMSPlugin to simulate one which used to exist but 
+            # create a bogus CMSPlugin to simulate one which used to exist but
             # is no longer installed
             bogus_plugin = CMSPlugin(language="en", plugin_type="BogusPlugin")
             bogus_plugin.save()
@@ -153,57 +153,58 @@ class ManagementTestCase(CMSTestCase):
 
             # there should be reports for three plugin types
             self.assertEqual(
-                len(report), 
+                len(report),
                 3)
-                
-            # check the bogus plugin 
+
+            # check the bogus plugin
             bogus_plugins_report = report[0]
             self.assertEqual(
-                len(bogus_plugins_report["instances"]), 
-                1)            
+                len(bogus_plugins_report["instances"]),
+                1)
 
-            # check the link plugin 
+            # check the link plugin
             link_plugins_report = report[1]
             self.assertEqual(
-                len(link_plugins_report["instances"]), 
-                1)                      
+                len(link_plugins_report["instances"]),
+                1)
 
-            # check the text plugins 
+            # check the text plugins
             text_plugins_report = report[2]
             self.assertEqual(
-                len(text_plugins_report["instances"]), 
-                3)            
+                len(text_plugins_report["instances"]),
+                3)
 
             self.assertEqual(
-                len(text_plugins_report["unsaved_instances"]), 
+                len(text_plugins_report["unsaved_instances"]),
                 1)
-                
 
-            management.call_command('cms', 'delete_orphaned_plugins', stdout=StringIO())
+            management.call_command(
+                'cms', 'delete_orphaned_plugins',
+                stdout=StringIO(), interactive=False)
             report = plugin_report()
 
             # there should be reports for two plugin types (one should have been deleted)
             self.assertEqual(
-                len(report), 
+                len(report),
                 2)
-                
-            # check the link plugin 
+
+            # check the link plugin
             link_plugins_report = report[0]
             self.assertEqual(
-                len(link_plugins_report["instances"]), 
-                1)                      
+                len(link_plugins_report["instances"]),
+                1)
 
-            # check the text plugins 
+            # check the text plugins
             text_plugins_report = report[1]
             self.assertEqual(
-                len(text_plugins_report["instances"]), 
-                2)            
+                len(text_plugins_report["instances"]),
+                2)
 
             self.assertEqual(
-                len(text_plugins_report["unsaved_instances"]), 
+                len(text_plugins_report["unsaved_instances"]),
                 0)
-                
-            
+
+
     def test_uninstall_plugins_without_plugin(self):
         out = StringIO()
         command = cms.Command()


### PR DESCRIPTION
delete_orphaned_plugins is a destructive command.  So by default report
how many things would be deleted and then ask for confirmation before
deleting them.  But if --noinput argument is used then don't ask for
confirmation and just go ahead.

Fixes issue #1591
