### PR TITLE
Open the settings overlay for the current page language.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -143,6 +143,7 @@ Contributors (in alphabetical order):
 * Marco Bonetti
 * Marco Rimoldi
 * Mark Rogers
+* Markus Holtermann
 * Martin Bommeli
 * Martin Brochhaus
 * Martin Koistinen

--- a/cms/cms_toolbar.py
+++ b/cms/cms_toolbar.py
@@ -108,7 +108,8 @@ class PageToolbar(CMSToolbar):
         menu_items = List(reverse("admin:cms_page_change", args=[page.pk]), _("Page"))
         menu_items.items.append(Item("?edit", _('Edit Page'), disabled=self.toolbar.edit_mode, load_modal=False))
         menu_items.items.append(Item(
-            reverse('admin:cms_page_change', args=[page.pk]),
+            '%s?language=%s' % (reverse('admin:cms_page_change', args=[page.pk]),
+            get_language_from_request(self.request)),
             _('Settings'),
             load_modal=True,
             close_url=reverse('admin:cms_page_changelist'),


### PR DESCRIPTION
When a user opens the page settings for a page in the front-end through the toolbar, the page settings will be opened for the requested language rather than the primary language.
