### PR TITLE
Fixes NoReverseMatch on new placeholder

### DIFF
--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -1097,6 +1097,7 @@ class Page(MPTTModel):
                 placeholder = Placeholder.objects.create(slot=placeholder_name)
                 self.placeholders.add(placeholder)
                 found[placeholder_name] = placeholder
+        return found
 
 
 def _reversion():

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -158,8 +158,7 @@ def _get_placeholder(current_page, page, context, name):
     if page.pk in placeholder_cache:
         return placeholder_cache[page.pk].get(name, None)
     placeholder_cache[page.pk] = {}
-    slots = get_placeholders(page.get_template())
-    placeholders = page.placeholders.filter(slot__in=slots)
+    placeholders = page.rescan_placeholders().values()
     assign_plugins(context['request'], placeholders, get_language())
     for placeholder in placeholders:
         placeholder_cache[page.pk][placeholder.slot] = placeholder


### PR DESCRIPTION
Made changes to templatetag code to always use the placeholders found in template. And if one is not found then create it. Fixed #1876
