### PR TITLE
Fixes broken language cookie

### DIFF
--- a/cms/middleware/language.py
+++ b/cms/middleware/language.py
@@ -12,9 +12,6 @@ class LanguageCookieMiddleware(object):
                 request.COOKIES[settings.LANGUAGE_COOKIE_NAME] == language:
             return response
         max_age = 365 * 24 * 60 * 60  # 10 years
-        expires = datetime.datetime.now() + datetime.timedelta(seconds=max_age)
-        response.set_cookie(settings.LANGUAGE_COOKIE_NAME, language, expires=expires.utctimetuple(),
-                            max_age=max_age)
+        expires = datetime.datetime.strftime(datetime.datetime.utcnow() + datetime.timedelta(seconds=max_age), "%a, %d-%b-%Y %H:%M:%S GMT")
+        response.set_cookie(settings.LANGUAGE_COOKIE_NAME, language, expires=expires, max_age=max_age)
         return response
-
-


### PR DESCRIPTION
Header before:
`Set-Cookie: django_language=en-us; expires=time.struct_time(tm_year=2014, tm_mon=5, tm_mday=29, tm_hour=6, tm_min=56, tm_sec=54, tm_wday=3, tm_yday=149, tm_isdst=0); Max-Age=31536000; Path=/`

In addition to a language cookie, this would set cookies for each item in the struct_time tuple: tm_year, tm_mon, etc.

Header after:
`Set-Cookie: django_language=en-us; expires=Thu, 29-May-2014 14:40:53 GMT; Max-Age=31536000; Path=/`

I think this is what was intended in the first place and it sets only the language cookie.

Signed-off-by: Martin Koistinen mkoistinen@gmail.com
