### PR TITLE
Copying plugins from one language to another was broken

### DIFF
--- a/cms/static/cms/js/plugin_editor.js
+++ b/cms/static/cms/js/plugin_editor.js
@@ -49,7 +49,7 @@
 			var $me = $(this),
 				$select = $me.siblings("select[name=plugins]"),
 				copy_from_language = $me.siblings("select[name=copy-plugins]").val(),
-				placeholder = $me.parents('.plugin-list-holder').attr('id'),
+				placeholder = $me.parents('.plugin-list-holder').data('id'),
 				splits = window.location.href.split("/"),
 				page_id = splits[splits.length-2],
 				to_language = $select.attr('data-language');


### PR DESCRIPTION
This is the fix.  Specifically, a declaration for the variable 'select' seems to have been missing.
