### PR TITLE
Ensure 'jQuery' is in the 'window' (global) namespace.

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -84,6 +84,7 @@ class PageAdmin(ModelAdmin):
             )]
         }
         js = ['%sjs/jquery.min.js' % admin_static_url()] + [cms_static_url(path) for path in [
+            'js/plugins/jquery.globaljquery.js',
             'js/plugins/jquery.query.js',
             'js/plugins/jquery.ui.custom.js',
         ]

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -37,6 +37,7 @@ class PlaceholderAdmin(ModelAdmin):
         }
         js = [cms_static_url(path) for path in [
             '%sjs/jquery.min.js' % admin_static_url(),
+            'js/plugins/jquery.globaljquery.js',
             'js/csrf.js',
             'js/plugins/jquery.query.js',
             'js/plugins/jquery.ui.custom.js',

--- a/cms/plugins/twitter/templates/cms/plugins/twitter_recent_entries.html
+++ b/cms/plugins/twitter/templates/cms/plugins/twitter_recent_entries.html
@@ -1,5 +1,6 @@
 {% load i18n sekizai_tags %}
 {% addtoblock "js" %}<script type="text/javascript" src="{{ STATIC_URL }}admin/js/jquery.min.js"></script>{% endaddtoblock %}
+{% addtoblock "js" %}<script type="text/javascript" src="{{ STATIC_URL }}cms/js/plugins/jquery.globaljquery.js"></script>{% endaddtoblock %}
 {% addtoblock "js" %}<script type="text/javascript" src="{{ STATIC_URL }}cms/js/plugins/jquery.tweet.js"></script>{% endaddtoblock %}
 {% addtoblock "js" %}
 <script type="text/javascript">

--- a/cms/static/cms/js/plugins/jquery.globaljquery.js
+++ b/cms/static/cms/js/plugins/jquery.globaljquery.js
@@ -1,0 +1,1 @@
+window.jQuery = window.jQuery || django.jQuery;


### PR DESCRIPTION
When running in DEBUG=False mode, a visit to `/admin/cms/page/add/` would load the following scripts in this order:
- ...
- `/static/admin/js/jquery.min.js` <-- creates window.jQuery
- `/static/admin/js/jquery.init.js` <-- replaces with django.jQuery
- ...
- `/static/cms/js/plugins/jquery.query.js` <-- cannot find window.jQuery
- ...

However in DEBUG=True mode, the following scripts would load:
- ...
- `/static/admin/js/jquery.js` <-- create window.jQuery
- `/static/admin/js/jquery.init.js` <-- replaces with django.jQuery
- ...
- `/static/admin/js/jquery.min.js` <-- creates window.jQuery again
- `/static/cms/js/plugins/jquery.query.js` <-- can find and use window.jQuery
- ...

From what I can tell this is a side-effect of having to support Django 1.3 through Django 1.5 as discussed in #1584

This patch introduces a `jquery.globaljquery.js` script in the three places in django-cms that load `jquery.min.js`; that way, if it's already loaded earlier and thus already moved to `django.jQuery`, it's available once again as `window.jQuery` for any plugins that are subsequently loaded.
