### PR TITLE
Switch default language configuration in doc

### DIFF
--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -240,7 +240,7 @@ Example::
         'default': {
             'fallbacks': ['en', 'de', 'fr'],
             'redirect_on_fallback':True,
-            'public': False,
+            'public': True,
             'hide_untranslated': False,
         }
     }


### PR DESCRIPTION
Having default value of `public` to `False` can be confusing for new users.
See #1881
