### PR TITLE
Limits page_link pages to draft ones.

### DIFF
--- a/cms/plugins/picture/models.py
+++ b/cms/plugins/picture/models.py
@@ -23,6 +23,7 @@ class Picture(CMSPlugin):
     url = models.CharField(_("link"), max_length=255, blank=True, null=True,
         help_text=_("If present, clicking on image will take user to link."))
     page_link = models.ForeignKey(Page, verbose_name=_("page"), null=True,
+        limit_choices_to={'publisher_is_draft': True},
         blank=True, help_text=_("If present, clicking on image will take user \
         to specified page."))
     alt = models.CharField(_("alternate text"), max_length=255, blank=True,


### PR DESCRIPTION
`page_link` foreign key is filtered to show draft pages only: it looks the best choice as draft pages are always guaranteed to exists and this way it's possible to create  link to still unpublished pages.
issue may arise if the page containing the plugin is published before the referenced page

Tests needed

Fixes #1977 
