### PR TITLE
Honor browser-length cookies; SESSION_EXPIRE_AT_BROWSER_CLOSE setting.

### DIFF
--- a/cms/middleware/language.py
+++ b/cms/middleware/language.py
@@ -11,10 +11,12 @@ class LanguageCookieMiddleware(object):
         if settings.LANGUAGE_COOKIE_NAME in request.COOKIES and \
                 request.COOKIES[settings.LANGUAGE_COOKIE_NAME] == language:
             return response
-        max_age = 365 * 24 * 60 * 60  # 10 years
-        expires = datetime.datetime.now() + datetime.timedelta(seconds=max_age)
-        response.set_cookie(settings.LANGUAGE_COOKIE_NAME, language, expires=expires.utctimetuple(),
-                            max_age=max_age)
+        if not settings.SESSION_EXPIRE_AT_BROWSER_CLOSE:
+            max_age = 365 * 24 * 60 * 60  # 10 years
+            expires = datetime.datetime.now() + datetime.timedelta(seconds=max_age)
+            response.set_cookie(settings.LANGUAGE_COOKIE_NAME, language, expires=expires.utctimetuple(),
+                                max_age=max_age)
+        else:
+            response.set_cookie(settings.LANGUAGE_COOKIE_NAME, language)
         return response
-
 


### PR DESCRIPTION
Apparently, the language middleware does write an expiry into the cookie regardless of django's configuration option for browser-length cookies. This patch makes the language middleware honor the setting.

Nothing big, but I have done it, and am willing to contribute.

Addendum: There is EU legislature, especially in the Netherlands, which requires explicit permission from users to set any cookies that are not browser-length cookies: http://www.cookiepedia.co.uk/cookie-laws-across-europe 

While the purpose and fitness to achieve anything of that law is certainly debatable, it does require us (meaning, the company I work for) to make sure no permanent cookies get set without permissions. I just spent some time to find out where that cookie is set, and fixed it so the configuration setting takes effect. 

The language cookie is by no means tracking anything to achieve behavioral advertising, I know. 
