### PR TITLE
Trivial fix for the egg_name of text plugin in requirements file

### DIFF
--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -10,7 +10,7 @@ django-sekizai>=0.7
 argparse
 dj-database-url
 djangocms-admin-style
--e git+git://github.com/divio/djangocms-text-ckeditor.git#egg=djangcms-text-ckeditor
+-e git+git://github.com/divio/djangocms-text-ckeditor.git#egg=djangocms-text-ckeditor
 -e git+git://github.com/KristianOellegaard/django-hvad.git#egg=hvad
 -e git+git://github.com/divio/djangocms-column.git#egg=djangocms-column
 -e git+git://github.com/divio/djangocms-style.git#egg=djangocms-style


### PR DESCRIPTION
Just a typo in the eggname
