### PR TITLE
Fix errors in plugins migrations

### DIFF
--- a/cms/plugins/inherit/migrations/0002_fieldchanges.py
+++ b/cms/plugins/inherit/migrations/0002_fieldchanges.py
@@ -34,13 +34,12 @@ class Migration:
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'slot': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'})
         },
-        'flash.flash': {
-            'Meta': {'object_name': 'Flash', 'db_table': "'cmsplugin_flash'", '_ormbases': ['cms.CMSPlugin']},
+        'inherit.inheritpageplaceholder': {
+            'Meta': {'object_name': 'InheritPagePlaceholder', 'db_table': "'cmsplugin_inheritpageplaceholder'", '_ormbases': ['cms.CMSPlugin']},
             'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
-            'file': ('django.db.models.fields.files.FileField', [], {'max_length': '100'}),
-            'height': ('django.db.models.fields.CharField', [], {'max_length': '6'}),
-            'width': ('django.db.models.fields.CharField', [], {'max_length': '6'})
-        }
+            'from_language': ('django.db.models.fields.CharField', [], {'max_length': '5', 'null': 'True', 'blank': 'True'}),
+            'from_page': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Page']", 'null': 'True', 'blank': 'True'})
+        },
     }
 
-    complete_apps = ['flash']
+    complete_apps = ['inherit']

--- a/cms/plugins/picture/migrations/0002_link_rename.py
+++ b/cms/plugins/picture/migrations/0002_link_rename.py
@@ -63,14 +63,15 @@ class Migration:
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'slot': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'})
         },
-        'link.link': {
-            'Meta': {'object_name': 'Link', 'db_table': "'cmsplugin_link'", '_ormbases': ['cms.CMSPlugin']},
+        'picture.picture': {
+            'Meta': {'object_name': 'Picture', 'db_table': "'cmsplugin_picture'", '_ormbases': ['cms.CMSPlugin']},
+            'alt': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
             'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
-            'mailto': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
-            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'float': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'longdesc': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
             'page_link': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Page']", 'null': 'True', 'blank': 'True'}),
-            'target': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
-            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'})
         },
         'sites.site': {
             'Meta': {'ordering': "('domain',)", 'object_name': 'Site', 'db_table': "'django_site'"},
@@ -80,4 +81,4 @@ class Migration:
         }
     }
 
-    complete_apps = ['link']
+    complete_apps = ['picture']

--- a/cms/plugins/picture/migrations/0003_freeze.py
+++ b/cms/plugins/picture/migrations/0003_freeze.py
@@ -63,14 +63,15 @@ class Migration:
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'slot': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'})
         },
-        'link.link': {
-            'Meta': {'object_name': 'Link', 'db_table': "'cmsplugin_link'", '_ormbases': ['cms.CMSPlugin']},
+        'picture.picture': {
+            'Meta': {'object_name': 'Picture', 'db_table': "'cmsplugin_picture'", '_ormbases': ['cms.CMSPlugin']},
+            'alt': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
             'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
-            'mailto': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
-            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'float': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'longdesc': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
             'page_link': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Page']", 'null': 'True', 'blank': 'True'}),
-            'target': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
-            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'})
         },
         'sites.site': {
             'Meta': {'ordering': "('domain',)", 'object_name': 'Site', 'db_table': "'django_site'"},
@@ -80,4 +81,4 @@ class Migration:
         }
     }
 
-    complete_apps = ['link']
+    complete_apps = ['picture']

--- a/cms/plugins/picture/migrations/0004_publisher.py
+++ b/cms/plugins/picture/migrations/0004_publisher.py
@@ -63,14 +63,15 @@ class Migration:
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'slot': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'})
         },
-        'link.link': {
-            'Meta': {'object_name': 'Link', 'db_table': "'cmsplugin_link'", '_ormbases': ['cms.CMSPlugin']},
+        'picture.picture': {
+            'Meta': {'object_name': 'Picture', 'db_table': "'cmsplugin_picture'", '_ormbases': ['cms.CMSPlugin']},
+            'alt': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
             'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
-            'mailto': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
-            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'float': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'longdesc': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
             'page_link': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Page']", 'null': 'True', 'blank': 'True'}),
-            'target': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
-            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'})
         },
         'sites.site': {
             'Meta': {'ordering': "('domain',)", 'object_name': 'Site', 'db_table': "'django_site'"},
@@ -80,4 +81,4 @@ class Migration:
         }
     }
 
-    complete_apps = ['link']
+    complete_apps = ['picture']

--- a/cms/plugins/picture/migrations/0005_table_rename.py
+++ b/cms/plugins/picture/migrations/0005_table_rename.py
@@ -63,14 +63,15 @@ class Migration:
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'slot': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'})
         },
-        'link.link': {
-            'Meta': {'object_name': 'Link', 'db_table': "'cmsplugin_link'", '_ormbases': ['cms.CMSPlugin']},
+        'picture.picture': {
+            'Meta': {'object_name': 'Picture', 'db_table': "'cmsplugin_picture'", '_ormbases': ['cms.CMSPlugin']},
+            'alt': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
             'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
-            'mailto': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
-            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'float': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'longdesc': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
             'page_link': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Page']", 'null': 'True', 'blank': 'True'}),
-            'target': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
-            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'})
         },
         'sites.site': {
             'Meta': {'ordering': "('domain',)", 'object_name': 'Site', 'db_table': "'django_site'"},
@@ -80,4 +81,4 @@ class Migration:
         }
     }
 
-    complete_apps = ['link']
+    complete_apps = ['picture']

--- a/cms/plugins/picture/migrations/0006_float_added.py
+++ b/cms/plugins/picture/migrations/0006_float_added.py
@@ -63,14 +63,15 @@ class Migration:
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'slot': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'})
         },
-        'link.link': {
-            'Meta': {'object_name': 'Link', 'db_table': "'cmsplugin_link'", '_ormbases': ['cms.CMSPlugin']},
+        'picture.picture': {
+            'Meta': {'object_name': 'Picture', 'db_table': "'cmsplugin_picture'", '_ormbases': ['cms.CMSPlugin']},
+            'alt': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
             'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
-            'mailto': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
-            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'float': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'longdesc': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
             'page_link': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Page']", 'null': 'True', 'blank': 'True'}),
-            'target': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
-            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'})
         },
         'sites.site': {
             'Meta': {'ordering': "('domain',)", 'object_name': 'Site', 'db_table': "'django_site'"},
@@ -80,4 +81,4 @@ class Migration:
         }
     }
 
-    complete_apps = ['link']
+    complete_apps = ['picture']

--- a/cms/plugins/picture/migrations/0007_publisher2.py
+++ b/cms/plugins/picture/migrations/0007_publisher2.py
@@ -63,14 +63,15 @@ class Migration:
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'slot': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'})
         },
-        'link.link': {
-            'Meta': {'object_name': 'Link', 'db_table': "'cmsplugin_link'", '_ormbases': ['cms.CMSPlugin']},
+        'picture.picture': {
+            'Meta': {'object_name': 'Picture', 'db_table': "'cmsplugin_picture'", '_ormbases': ['cms.CMSPlugin']},
+            'alt': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
             'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
-            'mailto': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
-            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'float': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'longdesc': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
             'page_link': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Page']", 'null': 'True', 'blank': 'True'}),
-            'target': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
-            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'})
         },
         'sites.site': {
             'Meta': {'ordering': "('domain',)", 'object_name': 'Site', 'db_table': "'django_site'"},
@@ -80,4 +81,4 @@ class Migration:
         }
     }
 
-    complete_apps = ['link']
+    complete_apps = ['picture']

--- a/cms/plugins/picture/migrations/0008_longdesc_added.py
+++ b/cms/plugins/picture/migrations/0008_longdesc_added.py
@@ -63,14 +63,15 @@ class Migration:
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'slot': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'})
         },
-        'link.link': {
-            'Meta': {'object_name': 'Link', 'db_table': "'cmsplugin_link'", '_ormbases': ['cms.CMSPlugin']},
+        'picture.picture': {
+            'Meta': {'object_name': 'Picture', 'db_table': "'cmsplugin_picture'", '_ormbases': ['cms.CMSPlugin']},
+            'alt': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
             'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
-            'mailto': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
-            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'float': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'longdesc': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
             'page_link': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Page']", 'null': 'True', 'blank': 'True'}),
-            'target': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
-            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'})
         },
         'sites.site': {
             'Meta': {'ordering': "('domain',)", 'object_name': 'Site', 'db_table': "'django_site'"},
@@ -80,4 +81,4 @@ class Migration:
         }
     }
 
-    complete_apps = ['link']
+    complete_apps = ['picture']


### PR DESCRIPTION
When migrations was rewritten, some error slipped in the code.
Even if the plugins are going away, they should be sane for the time left.
Backport to 2.4 of #2037
