### PR TITLE
Fixed {% render_plugin %} example

### DIFF
--- a/docs/advanced/templatetags.rst
+++ b/docs/advanced/templatetags.rst
@@ -236,7 +236,7 @@ Example::
 
 	{% load cms_tags %}
 	<div class="multicolumn">
-	{% for plugin in instance.child_plugins %}
+	{% for plugin in instance.child_plugin_instances %}
 		<div style="width: {{ plugin.width }}00px;">
      		{% render_plugin plugin %}
 		</div>


### PR DESCRIPTION
The instance.child_plugins reference is not correct, it should be instance.child_plugin_instances. As this is the only example for this feature, it needs to show a valid implementation.
