### PR TITLE
Fix for non-ASCII characters in LANGUAGES.name

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -984,7 +984,7 @@ class PageAdmin(ModelAdmin):
                 raise PermissionDenied
 
             message = _('Title and plugins with language %(language)s was deleted') % {
-                'language': get_language_object(language)['name']
+                'language': unicode(get_language_object(language)['name'], 'utf-8')
             }
             self.log_change(request, titleobj, message)
             messages.info(request, message)


### PR DESCRIPTION
https://github.com/divio/django-cms/issues/1803
Signed-off-by: Martin Koistinen mkoistinen@gmail.com
