### PR TITLE
Remove frontend tests from travis until #1979 is solved

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
 install:
     - export DISPLAY=:99.0
     - sh -e /etc/init.d/xvfb start
-    - if [ $TRAVIS_PYTHON_VERSION == '3.3' ]; then BASE='django'; else BASE='selenium'; fi && pip install -q -r "test_requirements/$BASE-$DJANGO.txt" --use-mirrors
+    - pip install -q -r "test_requirements/django-$DJANGO.txt" --use-mirrors
     - if [ $DB == 'mysql://root@127.0.0.1/djangocms_test' ]; then pip install -q mysql-python --use-mirrors; fi
 script:
     python runtests.py --db $DB


### PR DESCRIPTION
I guess at the moment the benefit of the single frontend test doesn't balance the issue of having random tests failing on travis.
This PR removes it from travis matrix waiting for #1979 to be solved
