### PR TITLE
Fixing reference to django[cms]_admin_style package

### DIFF
--- a/docs/getting_started/tutorial.rst
+++ b/docs/getting_started/tutorial.rst
@@ -72,8 +72,8 @@ other highly recommended applications/libraries:
 * ``'menus'``, helper for model independent hierarchical website navigation
 * ``'south'``, intelligent schema and data migrations
 * ``'sekizai'``, for javascript and css management
-* ``'django_admin_style'``, for the admin skin. You **must** add
-  ``'django_admin_style'`` in the list before ``'django.contrib.admin'``.
+* ``'djangocms_admin_style'``, for the admin skin. You **must** add
+  ``'djangocms_admin_style'`` in the list before ``'django.contrib.admin'``.
 
 
 Also add any (or all) of the following plugins, depending on your needs:


### PR DESCRIPTION
I was going through the tutorial myself and this gave me an error. It only occurs twice in this file; not sure about other files. Didn't bother testing, because it's just a doc/text change.
