### PR TITLE
fixed an error after publishing a page who's parent is not yet published

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -911,7 +911,7 @@ class PageAdmin(PlaceholderAdmin, ModelAdmin):
         # ensure user has permissions to publish this page
         if not page.has_publish_permission(request):
             return HttpResponseForbidden(_("You do not have permission to publish this page"))
-        page.publish()
+        published = page.publish()
         messages.info(request, _('The page "%s" was successfully published.') % page)
         if "reversion" in settings.INSTALLED_APPS:
             # delete revisions that are not publish revisions
@@ -943,8 +943,12 @@ class PageAdmin(PlaceholderAdmin, ModelAdmin):
         referrer = request.META.get('HTTP_REFERER', '')
         path = '../../'
         if 'admin' not in referrer:
-            public_page = Page.objects.get(publisher_public=page.pk)
-            path = '%s?edit_off' % public_page.get_absolute_url()
+            if published:
+                public_page = Page.objects.get(publisher_public=page.pk)
+                path = '%s?edit_off' % public_page.get_absolute_url()
+            else:
+                path = '/?edit_off'
+
         return HttpResponseRedirect(path)
 
     #TODO: Make the change form buttons use POST


### PR DESCRIPTION
If newly created page under a parent page gets published and the parent page was not yet published there is no publisher_public for the page. The result is an exeption DoesNotExist. This patch fixes the error and redirects to root instead.
