### PR TITLE
Since request.LANGUAGE_CODE might not always be avialable use cms.utils get_language_from_request

### DIFF
--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -3,6 +3,7 @@ from cms.constants import LEFT
 from cms.models import UserSettings, Placeholder
 from cms.toolbar.items import Menu, ToolbarAPIMixin, ButtonList
 from cms.toolbar_pool import toolbar_pool
+from cms.utils import get_language_from_request
 from cms.utils.i18n import force_language
 
 from django.contrib.auth.forms import AuthenticationForm
@@ -43,7 +44,7 @@ class CMSToolbar(ToolbarAPIMixin):
         self.use_draft = self.is_staff and self.edit_mode or self.build_mode
         self.show_toolbar = self.is_staff or self.request.session.get('cms_edit', False)
         if settings.USE_I18N:
-            self.language = self.request.LANGUAGE_CODE
+            self.language = get_language_from_request(request)
         else:
             self.language = settings.LANGUAGE_CODE
 

--- a/menus/utils.py
+++ b/menus/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import with_statement
+from cms.utils import get_language_from_request
 from cms.utils.i18n import force_language, hide_untranslated
 from django.conf import settings
 import warnings
@@ -79,7 +80,7 @@ class DefaultLanguageChanger(object):
     def app_path(self):
         if self._app_path is None:
             if settings.USE_I18N:
-                page_path = self.get_page_path(self.request.LANGUAGE_CODE)
+                page_path = self.get_page_path(get_language_from_request(self.request))
             else:
                 page_path = self.get_page_path(settings.LANGUAGE_CODE)
             if page_path:


### PR DESCRIPTION
get_language_for_request has a fallback mechanism for django-cms setups that don't need any i18n features.
Not using get_language_for_request might cause the request to break.
