### PR TITLE
Fix broken tests:

### DIFF
--- a/cms/tests/placeholder.py
+++ b/cms/tests/placeholder.py
@@ -345,9 +345,9 @@ class PlaceholderActionTests(FakemlngFixtures, CMSTestCase):
         )
         EN = ('en', 'English')
         FR = ('fr', 'French')
-        self.assertEqual(fr_copy_languages, [EN])
-        self.assertEqual(de_copy_languages, [EN, FR])
-        self.assertEqual(en_copy_languages, [FR])
+        self.assertEqual(set(fr_copy_languages), set([EN]))
+        self.assertEqual(set(de_copy_languages), set([EN, FR]))
+        self.assertEqual(set(en_copy_languages), set([FR]))
 
     def test_mlng_placeholder_actions_copy(self):
         actions = MLNGPlaceholderActions()


### PR DESCRIPTION
since MLNGPlaceholderActions.de_copy_languages doesn't enforce order on the returned languages,
comparing lists in tests might give false positives
=> we need to assert sets are equal
