### PR TITLE
Fix setup.py test dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'html5lib',
         'django-mptt>=0.5.1,<0.5.3',
         'django-sekizai>=0.7',
-	'djangocms-admin-style'
+        'djangocms-admin-style'
     ],
     tests_require=[
         'django-reversion==1.6.6',


### PR DESCRIPTION
While not the best way to run djangocms tests, it should be at least in runnable state
