### PR TITLE
made runtests-isolated.py better

### DIFF
--- a/runtests-isolated.py
+++ b/runtests-isolated.py
@@ -15,6 +15,8 @@ def main(argv, failfast=False, test_labels=None):
         for clsname,cls in clsmembers.items():
             testlist.append(cls)
 
+    failures = []
+
     for cls in testlist:
         for method, line in cls.methods.items():
             if not method.startswith('test_'):
@@ -29,8 +31,15 @@ def main(argv, failfast=False, test_labels=None):
                     print(error)
                     if failfast:
                         sys.exit(p.returncode)
+                    else:
+                        failures.append(test)
                 else:
                     print()
+    print("Result: %s" % ('FAIL' if failures else 'OK'))
+    print("%s Failures:" % len(failures))
+    for failure in failures:
+        print("- %s" % failure)
+    sys.exit(len(failures))
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
Now shows you a neat summary at the end and exits with a non-zero exitcode on failure.

Example output:

```
Result: FAIL
19 Failures:
- CheckTests.test_no_sekizai
- ViewPermissionTests.test_unauthed_num_queries
- ViewPermissionTests.test_public_for_all
- ViewPermissionTests.test_page_permissions_view_groups
- ViewPermissionTests.test_page_permissions
- ViewPermissionTests.test_public_for_all_staff_assert_num_queries
- ViewPermissionTests.test_authed_basic_perm_num_queries
- ViewPermissionTests.test_unauthed_no_access
- ViewPermissionTests.test_global_permission
- ViewPermissionTests.test_unauthed
- ViewPermissionTests.test_public_for_all_num_queries
- ViewPermissionTests.test_authed_no_access
- ViewPermissionTests.test_public_for_all_staff
- ViewPermissionTests.test_unauthed_no_access_num_queries
- ViewPermissionTests.test_authed_basic_perm
- PlaceholderTestCase.test_placeholder_tag_language
- PlaceholderTestCase.test_placeholder_tag
- PublishingTests.test_publish_home
- StaticFilesTest.test_collectstatic_with_cached_static_files_storage
```
