### PR TITLE
Adds support for plugin action configuration.

### DIFF
--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -5,13 +5,14 @@ from django.db import transaction
 from django.utils import simplejson
 
 from django.views.decorators.clickjacking import xframe_options_sameorigin
+from cms.constants import PLUGIN_COPY_ACTION, PLUGIN_MOVE_ACTION
 from cms.exceptions import PluginLimitReached
 from cms.models.placeholdermodel import Placeholder
 from cms.models.pluginmodel import CMSPlugin
 from cms.plugin_pool import plugin_pool
 from cms.utils import cms_static_url, get_cms_setting
 from cms.utils.compat.dj import force_unicode
-from cms.plugins.utils import has_reached_plugin_limit
+from cms.plugins.utils import has_reached_plugin_limit, requires_reload
 from django.contrib.admin import ModelAdmin
 from django.http import HttpResponse, Http404, HttpResponseBadRequest, HttpResponseForbidden
 from django.shortcuts import render_to_response, get_object_or_404
@@ -208,12 +209,14 @@ class PlaceholderAdmin(ModelAdmin):
             return HttpResponseBadRequest(_("Language must be set to a supported language!"))
         if source_plugin_id:
             source_plugin = get_object_or_404(CMSPlugin, pk=source_plugin_id)
+            reload_required = requires_reload(PLUGIN_COPY_ACTION, [source_plugin])
             plugins = list(
                 source_placeholder.cmsplugin_set.filter(tree_id=source_plugin.tree_id, lft__gte=source_plugin.lft,
                                                         rght__lte=source_plugin.rght).order_by('tree_id', 'level', 'position'))
         else:
             plugins = list(
                 source_placeholder.cmsplugin_set.filter(language=source_language).order_by('tree_id', 'level', 'position'))
+            reload_required = requires_reload(PLUGIN_COPY_ACTION, plugins)
         if not self.has_copy_plugin_permission(request, source_placeholder, target_placeholder, plugins):
             return HttpResponseForbidden(_('You do not have permission to copy these plugins.'))
         copy_plugins.copy_plugins_to(plugins, target_placeholder, target_language, target_plugin_id)
@@ -225,7 +228,8 @@ class PlaceholderAdmin(ModelAdmin):
                 {'id': plugin.pk, 'type': plugin.plugin_type, 'parent': plugin.parent_id, 'position': plugin.position,
                     'desc': force_unicode(plugin.get_short_description())})
         self.post_copy_plugins(request, source_placeholder, target_placeholder, plugins)
-        return HttpResponse(simplejson.dumps({'plugin_list': reduced_list}), content_type='application/json')
+        json_response = {'plugin_list': reduced_list, 'reload': reload_required}
+        return HttpResponse(simplejson.dumps(json_response), content_type='application/json')
 
     @xframe_options_sameorigin
     def edit_plugin(self, request, plugin_id):
@@ -345,7 +349,8 @@ class PlaceholderAdmin(ModelAdmin):
                     break
                 x += 1
         self.post_move_plugin(request, plugin)
-        return HttpResponse(str("ok"))
+        json_response = {'reload': requires_reload(PLUGIN_MOVE_ACTION, [plugin])}
+        return HttpResponse(simplejson.dumps(json_response), content_type='application/json')
 
     @xframe_options_sameorigin
     def delete_plugin(self, request, plugin_id):

--- a/cms/constants.py
+++ b/cms/constants.py
@@ -6,3 +6,7 @@ REFRESH_PAGE = 'REFRESH_PAGE'
 URL_CHANGE = 'URL_CHANGE'
 RIGHT = object() # this is a trick so "foo is RIGHT" will only ever work for this, same goes for LEFT.
 LEFT = object()
+
+# Plugin actions
+PLUGIN_MOVE_ACTION = 'move'
+PLUGIN_COPY_ACTION = 'copy'

--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -151,16 +151,19 @@ class CMSPlugin(with_metaclass(PluginModelBase, MPTTModel)):
 
         return plugin_pool.get_plugin(self.plugin_type)
 
-    def get_plugin_instance(self, admin=None):
+    def get_plugin_class_instance(self, admin=None):
         plugin_class = self.get_plugin_class()
-        plugin = plugin_class(plugin_class.model,
-                              admin) # needed so we have the same signature as the original ModelAdmin
+        # needed so we have the same signature as the original ModelAdmin
+        return plugin_class(plugin_class.model, admin)
+
+    def get_plugin_instance(self, admin=None):
+        plugin = self.get_plugin_class_instance(admin)
         if hasattr(self, "_inst"):
             return self._inst, plugin
         if plugin.model != self.__class__: # and self.__class__ == CMSPlugin:
             # (if self is actually a subclass, getattr below would break)
             try:
-                instance = plugin_class.model.objects.get(cmsplugin_ptr=self)
+                instance = plugin.model.objects.get(cmsplugin_ptr=self)
                 instance._render_meta = self._render_meta
             except (AttributeError, ObjectDoesNotExist):
                 instance = None

--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from distutils.version import LooseVersion
+from cms.constants import PLUGIN_MOVE_ACTION, PLUGIN_COPY_ACTION
 from cms.utils.compat.metaclasses import with_metaclass
 import re
 
@@ -108,6 +109,16 @@ class CMSPluginBase(with_metaclass(CMSPluginBaseMetaclass, admin.ModelAdmin)):
 
     opts = {}
     module = None #track in which module/application belongs
+
+    action_options = {
+        PLUGIN_MOVE_ACTION: {
+            'requires_reload': True
+        },
+        PLUGIN_COPY_ACTION: {
+            'requires_reload': True
+        },
+    }
+
 
     def __init__(self, model=None, admin_site=None):
         if admin_site:
@@ -232,6 +243,17 @@ class CMSPluginBase(with_metaclass(CMSPluginBaseMetaclass, admin.ModelAdmin)):
         else:
             installed_plugins = plugin_pool.get_all_plugins(slot, page)
             return [cls.__name__ for cls in installed_plugins]
+
+    def get_action_options(self):
+        return self.action_options
+
+    def requires_reload(self, action):
+        actions = self.get_action_options()
+        reload_required = False
+        if action in actions:
+            options = actions[action]
+            reload_required = options.get('requires_reload', False)
+        return reload_required
 
     def __repr__(self):
         return smart_str(self.name)

--- a/cms/plugins/utils.py
+++ b/cms/plugins/utils.py
@@ -22,6 +22,17 @@ def get_plugins(request, placeholder, lang=None):
     return getattr(placeholder, '_%s_plugins_cache' % lang)
 
 
+def requires_reload(action, plugins):
+    """
+    Returns True if ANY of the plugins require a page reload when action is taking place.
+    """
+    for plugin in plugins:
+        plugin_class = plugin.get_plugin_class_instance()
+        if plugin_class.requires_reload(action):
+            return True
+    return False
+
+
 def assign_plugins(request, placeholders, lang=None):
     """
     Fetch all plugins for the given ``placeholders`` and

--- a/cms/tests/admin.py
+++ b/cms/tests/admin.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import with_statement
 from distutils.version import LooseVersion
+import json
 from cms.admin.change_list import CMSChangeList
 from cms.admin.forms import PageForm, AdvancedSettingsForm
 from cms.admin.pageadmin import PageAdmin
 from cms.admin.permissionadmin import PagePermissionInlineAdmin
 from cms.api import create_page, create_title, add_plugin, assign_user_to_page
+from cms.constants import PLUGIN_MOVE_ACTION
 from cms.models.pagemodel import Page
 from cms.models.permissionmodels import GlobalPagePermission, PagePermission
 from cms.models.placeholdermodel import Placeholder
@@ -511,6 +513,8 @@ class AdminTests(AdminTestsBase):
         page = self.get_page()
         source, target = list(page.placeholders.all())[:2]
         pageplugin = add_plugin(source, 'TextPlugin', 'en', body='test')
+        plugin_class = pageplugin.get_plugin_class_instance()
+        expected = {'reload': plugin_class.requires_reload(PLUGIN_MOVE_ACTION)}
         placeholder = Placeholder.objects.all()[0]
         permless = self.get_permless()
         admin = self.get_admin()
@@ -536,7 +540,7 @@ class AdminTests(AdminTestsBase):
                 'placeholder_id': placeholder.pk, 'plugin_parent': '', 'plugin_language': 'en'})
             response = self.admin_class.move_plugin(request)
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.content, b"ok")
+            self.assertEquals(json.loads(response.content.decode('utf8')), expected)
         with self.login_user_context(permless):
             request = self.get_request(post_data={'plugin_id': pageplugin.pk,
                 'placeholder_id': placeholder.id, 'plugin_parent': '', 'plugin_language': 'en'})
@@ -546,7 +550,7 @@ class AdminTests(AdminTestsBase):
                 'placeholder_id': placeholder.id, 'plugin_parent': '', 'plugin_language': 'en'})
             response = self.admin_class.move_plugin(request)
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.content, b"ok")
+            self.assertEquals(json.loads(response.content.decode('utf8')), expected)
 
     def test_move_language(self):
         page = self.get_page()

--- a/cms/tests/nested_plugins.py
+++ b/cms/tests/nested_plugins.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import with_statement
+import json
 
 from cms.api import create_page, add_plugin
+from cms.constants import PLUGIN_MOVE_ACTION
 from cms.models import Page
 from cms.models.placeholdermodel import Placeholder
 from cms.models.pluginmodel import CMSPlugin
@@ -770,10 +772,12 @@ class NestedPluginsTestCase(PluginsTestBaseCase, UnittestCompatMixin):
                     'plugin_language':'en',
                     'plugin_parent':'',
                 }
+                plugin_class = text_plugin_two.get_plugin_class_instance()
+                expected = {'reload': plugin_class.requires_reload(PLUGIN_MOVE_ACTION)}
                 edit_url = URL_CMS_MOVE_PLUGIN % page_one.id
                 response = self.client.post(edit_url, post_data)
                 self.assertEqual(response.status_code, 200)
-                self.assertEqual(response.content, b'ok')
+                self.assertEquals(json.loads(response.content.decode('utf8')), expected)
                 # check if the plugin got moved
                 page_one = self.reload(page_one)
                 text_plugin_two = self.reload(text_plugin_two)

--- a/cms/tests/plugins.py
+++ b/cms/tests/plugins.py
@@ -4,6 +4,7 @@ import datetime
 import json
 
 from cms.api import create_page, publish_page, add_plugin
+from cms.constants import PLUGIN_MOVE_ACTION, PLUGIN_COPY_ACTION
 from cms.exceptions import PluginAlreadyRegistered, PluginNotRegistered
 from cms.models import Page, Placeholder
 from cms.models.pluginmodel import CMSPlugin, PluginModelBase
@@ -769,6 +770,114 @@ class PluginsTestCase(PluginsTestBaseCase):
         inner_text_plugin_1 = add_plugin(ph_en, "TextPlugin", "en", body="I'm the first child of text_plugin_1")
         text_plugin_1.cmsplugin_set.add(inner_text_plugin_1)
         self.assertEquals(text_plugin_2.is_last_in_placeholder(), True)
+
+    def test_plugin_move_with_reload(self):
+        action_options = {
+            PLUGIN_MOVE_ACTION: {
+                'requires_reload': True
+            },
+            PLUGIN_COPY_ACTION: {
+                'requires_reload': True
+            },
+        }
+        non_reload_action_options = {
+            PLUGIN_MOVE_ACTION: {
+                'requires_reload': False
+            },
+            PLUGIN_COPY_ACTION: {
+                'requires_reload': False
+            },
+        }
+        ReloadDrivenPlugin = type('ReloadDrivenPlugin', (CMSPluginBase,), dict(action_options=action_options))
+        NonReloadDrivenPlugin = type('NonReloadDrivenPlugin', (CMSPluginBase,), dict(action_options=non_reload_action_options))
+        plugin_pool.register_plugin(ReloadDrivenPlugin)
+        plugin_pool.register_plugin(NonReloadDrivenPlugin)
+        page = create_page("page", "nav_playground.html", "en", published=True)
+        source_placeholder = page.placeholders.get(slot='body')
+        target_placeholder = page.placeholders.get(slot='right-column')
+        reload_expected = {'reload': True}
+        no_reload_expected = {'reload': False}
+        plugin_1 = add_plugin(source_placeholder, ReloadDrivenPlugin, settings.LANGUAGES[0][0])
+        plugin_2 = add_plugin(source_placeholder, NonReloadDrivenPlugin, settings.LANGUAGES[0][0])
+
+        # Test Plugin reload == True on Move
+        post = {
+            'plugin_id': plugin_1.pk,
+            'placeholder_id': target_placeholder.pk,
+            'plugin_parent': '',
+        }
+        response = self.client.post(URL_CMS_PLUGIN_MOVE, post)
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(json.loads(response.content.decode('utf8')), reload_expected)
+
+        # Test Plugin reload == False on Move
+        post = {
+            'plugin_id': plugin_2.pk,
+            'placeholder_id': target_placeholder.pk,
+            'plugin_parent': '',
+        }
+        response = self.client.post(URL_CMS_PLUGIN_MOVE, post)
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(json.loads(response.content.decode('utf8')), no_reload_expected)
+
+        plugin_pool.unregister_plugin(ReloadDrivenPlugin)
+        plugin_pool.unregister_plugin(NonReloadDrivenPlugin)
+
+    def test_plugin_copy_with_reload(self):
+        action_options = {
+            PLUGIN_MOVE_ACTION: {
+                'requires_reload': True
+            },
+            PLUGIN_COPY_ACTION: {
+                'requires_reload': True
+            },
+        }
+        non_reload_action_options = {
+            PLUGIN_MOVE_ACTION: {
+                'requires_reload': False
+            },
+            PLUGIN_COPY_ACTION: {
+                'requires_reload': False
+            },
+        }
+        ReloadDrivenPlugin = type('ReloadDrivenPlugin', (CMSPluginBase,), dict(action_options=action_options))
+        NonReloadDrivenPlugin = type('NonReloadDrivenPlugin', (CMSPluginBase,), dict(action_options=non_reload_action_options))
+        plugin_pool.register_plugin(ReloadDrivenPlugin)
+        plugin_pool.register_plugin(NonReloadDrivenPlugin)
+        page = create_page("page", "nav_playground.html", "en", published=True)
+        source_placeholder = page.placeholders.get(slot='body')
+        target_placeholder = page.placeholders.get(slot='right-column')
+        plugin_1 = add_plugin(source_placeholder, ReloadDrivenPlugin, settings.LANGUAGES[0][0])
+        plugin_2 = add_plugin(source_placeholder, NonReloadDrivenPlugin, settings.LANGUAGES[0][0])
+
+        # Test Plugin reload == True on Copy
+        copy_data = {
+            'source_placeholder_id': source_placeholder.pk,
+            'target_placeholder_id': target_placeholder.pk,
+            'target_language': settings.LANGUAGES[0][0],
+            'source_language': settings.LANGUAGES[0][0],
+        }
+        response = self.client.post(URL_CMS_PAGE + "copy-plugins/", copy_data)
+        self.assertEquals(response.status_code, 200)
+        json_response = json.loads(response.content.decode('utf8'))
+        self.assertEquals(json_response['reload'], True)
+
+        # Test Plugin reload == False on Copy
+        copy_data = {
+            'source_placeholder_id': source_placeholder.pk,
+            'source_plugin_id': plugin_2.pk,
+            'target_placeholder_id': target_placeholder.pk,
+            'target_language': settings.LANGUAGES[0][0],
+            'source_language': settings.LANGUAGES[0][0],
+        }
+        response = self.client.post(URL_CMS_PAGE + "copy-plugins/", copy_data)
+        self.assertEquals(response.status_code, 200)
+        json_response = json.loads(response.content.decode('utf8'))
+        self.assertEquals(json_response['reload'], False)
+
+        plugin_pool.unregister_plugin(ReloadDrivenPlugin)
+        plugin_pool.unregister_plugin(NonReloadDrivenPlugin)
+
 
 
 class FileSystemPluginTests(PluginsTestBaseCase):


### PR DESCRIPTION
Adds an extra layer of configuration to allow a plugin to configure the behavior of the cms frontend based on different actions. Right now the only option is `requires_reload` which when `True` tells the cms frontend to reload the page when the configured action is taken.
