### PR TITLE
Moved logic for determining the highest priority link into model itself

### DIFF
--- a/cms/plugins/link/cms_plugins.py
+++ b/cms/plugins/link/cms_plugins.py
@@ -12,28 +12,20 @@ class LinkPlugin(CMSPluginBase):
     name = _("Link")
     render_template = "cms/plugins/link.html"
     text_enabled = True
-    
+
     def render(self, context, instance, placeholder):
-        if instance.mailto:
-            link = u"mailto:%s" % instance.mailto
-        elif instance.url:
-            link = instance.url
-        elif instance.page_link:
-            link = instance.page_link.get_absolute_url()
-        else:
-            link = ""
         context.update({
             'name': instance.name,
-            'link': link, 
-            'target':instance.target,
+            'link': instance.link,
+            'target': instance.target,
             'placeholder': placeholder,
             'object': instance
         })
         return context
-    
+
     def get_form(self, request, obj=None, **kwargs):
         Form = super(LinkPlugin, self).get_form(request, obj, **kwargs)
-        
+
         # this is bit tricky, since i don't wont override add_view and 
         # change_view 
         class FakeForm(object):
@@ -45,7 +37,7 @@ class LinkPlugin(CMSPluginBase):
                 # do some troubles, with new versions of django, if there will
                 # be something more required
                 self.base_fields = Form.base_fields
-            
+
             def __call__(self, *args, **kwargs):
                 # instanciate the form on call
                 form = self.Form(*args, **kwargs)
@@ -61,8 +53,8 @@ class LinkPlugin(CMSPluginBase):
             # this might NOT give the result you expect
             site = Site.objects.get_current()
         return FakeForm(Form, site)
-        
+
     def icon_src(self, instance):
         return settings.STATIC_URL + u"cms/img/icons/plugins/link.png"
-    
+
 plugin_pool.register_plugin(LinkPlugin)

--- a/cms/plugins/link/models.py
+++ b/cms/plugins/link/models.py
@@ -21,6 +21,19 @@ class Link(CMSPlugin):
         ("_top", _("topmost frame")),
     )))
 
+    def link(self):
+        """
+        Returns the link with highest priority among the model fields
+        """
+        if self.mailto:
+            return u"mailto:%s" % self.mailto
+        elif self.url:
+            return self.url
+        elif self.page_link:
+            return self.page_link.get_absolute_url()
+        else:
+            return ""
+
     def __str__(self):
         return self.name
 


### PR DESCRIPTION
Currently the logic to determine the link for a cms.plugins.link.models.Link is in the render method.

Having it into the model instead allows to access the "link" from the Link instance directly.

The need comes from a custom plugin that has a foreign key for Link; this allows to directly to {{ link_instance.link }} in a template - otherwise impossible.

Also removed some whitespaces for PEP-8 (but left a typo as originally in comment)
