### PR TITLE
stop using mptt.register and deprecated/unused AlreadyRegistered exception in sample model

### DIFF
--- a/cms/test_utils/project/sampleapp/models.py
+++ b/cms/test_utils/project/sampleapp/models.py
@@ -2,28 +2,24 @@ from cms.models.fields import PlaceholderField
 from cms.utils.compat.dj import python_2_unicode_compatible
 from django.core.urlresolvers import reverse
 from django.db import models
-import mptt
+from mptt.models import MPTTModel
 
 
 @python_2_unicode_compatible
-class Category(models.Model):
+class Category(MPTTModel):
     parent = models.ForeignKey('self', blank=True, null=True)
     name = models.CharField(max_length=20)
     description = PlaceholderField('category_description', 600)
-    
+
     def __str__(self):
         return self.name
-    
+
     def get_absolute_url(self):
         return reverse('category_view', args=[self.pk])
-    
+
     class Meta:
         verbose_name_plural = 'categories'
-    
-try:
-    mptt.register(Category)
-except mptt.AlreadyRegistered:
-    pass
+
 
 class Picture(models.Model):
     image = models.ImageField(upload_to="pictures")


### PR DESCRIPTION
I'm about to release mptt 0.6. I almost removed mptt.AlreadyRegistered, but luckily I ack'd the django-cms codebase and it's still in the sample models file.

AlreadyRegistered hasn't been thrown since mptt 0.3, so not much point catching it. I took the liberty of switching to MPTTModel instead of mptt.register() too, since it's a bit prettier.
