### PR TITLE
Fixes MultiValueDictKeyError when 'languages' does not exist.

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -1127,7 +1127,7 @@ class PageAdmin(ModelAdmin):
         # page add-plugin
         if page:
             # this only runs when both page and placeholder are not empty.
-            language = request.POST['language'] or get_language_from_request(request)
+            language = request.POST.get('language') or get_language_from_request(request)
             position = CMSPlugin.objects.filter(language=language, placeholder=placeholder).count()
             try:
                 has_reached_plugin_limit(placeholder, plugin_type, language, template=page.get_template())


### PR DESCRIPTION
Addresses [issues/2102](https://github.com/divio/django-cms/issues/2102)

When 'languages' is not present in the POST data, a MultiValueDictKeyError is raised.
