### PR TITLE
honour fallback languages regardless of default lang

### DIFF
--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -116,7 +116,6 @@ def render_placeholder(placeholder, context_to_copy, name_fallback="Placeholder"
     fallbacks = get_fallback_languages(lang)
     if (len(plugins) == 0 and placeholder and fallbacks and
             get_placeholder_conf("language_fallback", placeholder.slot, template, False)):
-        fallbacks = get_fallback_languages(lang)
         for fallback_language in fallbacks:
             plugins = [plugin for plugin in get_plugins(request, placeholder, fallback_language)]
             if plugins:


### PR DESCRIPTION
I encountered a problem where render_placeholder ignored fallback placeholders if the placeholder locale was the same as the default locale, here is the fix to make render_placeholder honour fallback languages if present regardless of default language setting.

Kegan
