### PR TITLE
Fixed a bug in the language menu.

### DIFF
--- a/cms/cms_toolbar.py
+++ b/cms/cms_toolbar.py
@@ -96,7 +96,8 @@ class BasicToolbar(CMSToolbar):
         language_changer = getattr(self.request, '_language_changer', DefaultLanguageChanger(self.request))
         for language in get_language_objects(self.current_site.pk):
             url = language_changer(language['code'])
-            language_menu.add_link_item(language['name'], url=url, active=current_lang['code'] == language['code'])
+            active = current_lang is not None and current_lang['code'] == language['code']
+            language_menu.add_link_item(language['name'], url=url, active=active)
 
 
 @toolbar_pool.register


### PR DESCRIPTION
If `current_lang` is `None`, then `current_lang['code']` fails of course.
