### PR TITLE
Pin Sphinx version to avoid bogus test failure

### DIFF
--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -1,6 +1,6 @@
 coverage==3.4
 unittest-xml-reporting==1.0.3
-sphinx
+sphinx==1.1.3
 Pillow==2.0
 django-classy-tags>=0.3.4.1
 South>=0.7.2


### PR DESCRIPTION
Sphinx 1.2b2 release on Pypi causes a regression in the doc test.
Pinning version to latest stable for let testsuite works while finding a proper fix.
