### PR TITLE
Unicode fix to make Sphinx 1.2b2 happy

### DIFF
--- a/cms/tests/docs.py
+++ b/cms/tests/docs.py
@@ -11,7 +11,7 @@ from cms.utils.compat.string_io import StringIO
 
 
 ROOT_DIR = os.path.dirname(cms.__file__)
-DOCS_DIR = os.path.abspath(os.path.join(ROOT_DIR, '..', 'docs'))
+DOCS_DIR = os.path.abspath(os.path.join(ROOT_DIR, u'..', u'docs'))
 
 
 def has_no_internet():


### PR DESCRIPTION
This makes `DOCS_DIR` proper unicode both on python 2 and python 3, Sphinx is happy now
