### PR TITLE
Extends PR #2156 with feedback to users

### DIFF
--- a/menus/menu_pool.py
+++ b/menus/menu_pool.py
@@ -147,7 +147,7 @@ class MenuPool(object):
                 nodes = []
                 toolbar = getattr(request, 'toolbar', None)
                 if toolbar and toolbar.is_staff:
-                    messages.error(request, _('Menu %s cannot be loaded. Please, make sure all its urls exist and can be resolved.' % menu_class_name))
+                    messages.error(request, _('Menu %s cannot be loaded. Please, make sure all its urls exist and can be resolved.') % menu_class_name)
                     logger.error("Menu %s could not be loaded." % menu_class_name, exc_info=True)
             # nodes is a list of navigation nodes (page tree in cms + others)
             final_nodes += _build_nodes_inner_for_one_menu(nodes, menu_class_name)


### PR DESCRIPTION
Adds user feedback via messages framework when a NoReverseMatch exception is raised due to missing apphook.
Message is visible only to staff users when toolbar is active.

Fix #2156
Fix #1649
