### PR TITLE
Move psycopg2 from requirements to travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,9 @@ before_script:
 install:
     - export DISPLAY=:99.0
     - sh -e /etc/init.d/xvfb start
-    - pip install -q -r "test_requirements/django-$DJANGO.txt" --use-mirrors
-    - if [ $DATABASE_URL == 'mysql://root@127.0.0.1/djangocms_test' ]; then pip install -q mysql-python --use-mirrors; fi
+    - pip install -q -r "test_requirements/django-$DJANGO.txt" 
+    - if [ $DATABASE_URL == 'postgres://postgres@127.0.0.1/djangocms_test' ]; then pip install -q psycopg2 ; fi
+    - if [ $DATABASE_URL == 'mysql://root@127.0.0.1/djangocms_test' ]; then pip install -q mysql-python ; fi
 script:
     python develop.py test --migrate
 notifications:

--- a/test_requirements/django-1.4.txt
+++ b/test_requirements/django-1.4.txt
@@ -1,4 +1,3 @@
 -r requirements_base.txt
 Django>=1.4.5,<1.5
 django-reversion>=1.6.6,<1.7
-psycopg2==2.4

--- a/test_requirements/django-1.5.txt
+++ b/test_requirements/django-1.5.txt
@@ -1,4 +1,3 @@
 -r requirements_base.txt
 Django>=1.5,<1.6
 django-reversion>=1.7,<1.8
-psycopg2==2.4


### PR DESCRIPTION
Should psycopg really stay in the requirements files?
Remove use-mirrors argument in travis, not required anymore with new PyPI infrastructure
