### PR TITLE
Fixes jsTree's relative URL construction for theme components

### DIFF
--- a/cms/static/cms/js/plugins/cms.changelist.js
+++ b/cms/static/cms/js/plugins/cms.changelist.js
@@ -55,17 +55,17 @@ $(document).ready(function () {
 	};
 
 	// For passing in to jsTree's settings.ui.theme_path in order to enable
- 	// it to construct a proper relative URL for its assets. If theme_path
- 	// remains false, jsTree will construct a path using the contents of the
- 	// location bar. In the case that static files (including jsTree's
- 	// javascript) are served from a location other than that of the HTML
- 	 // files, the URLs constructed will be incorrect.
+	// it to construct a proper relative URL for its assets. If theme_path
+	// remains false, jsTree will construct a path using the contents of the
+	// location bar. In the case that static files (including jsTree's
+	// javascript) are served from a location other than that of the HTML
+	// files, the URLs constructed will be incorrect.
 	function script_url_path() {
- 		// Find the URL that loaded this script (not sure if we can
- 		// programatically determine the name of the current script, so it is
- 		// hardcoded here)
-		full_url = $('script[src*="/cms.changelist.js?"]').attr('src');
- 		// Return everything but the filename
+		// Find the URL that loaded this script (not sure if we can
+		// programatically determine the name of the current script, so it is
+		// hardcoded here)
+		full_url = $('script[src*="/cms.changelist.js"]').attr('src');
+		// Return everything but the filename
 		return full_url.slice(0,full_url.lastIndexOf('/'));
 	}
 
@@ -94,7 +94,7 @@ $(document).ready(function () {
 				animation: 0,
 				hover_mode: true,
 				theme_path: script_url_path() + "/../jstree/themes/",
- 				theme_name: "default",
+				theme_name: "default",
 				a_class: "title"
 			},
 			cookies : {


### PR DESCRIPTION
I had some styling issues appear in the admin interface of django-cms after deploying my static files to a location other than '/static/...' (Screenshot: http://jonprindiville.net/django-cms-admin-styling.png )

Turns out that jsTree tries loading some theme components from paths relative to the URL in the browser's location bar. When initializing jsTree, here, I've written a function to find the path of the URL used to load this script and then set jsTree's theme_path appropriately.

(This file was already full of tabs, not spaces, so I have left them as-is)
