### PR TITLE
keep going after plugin uninstallation

### DIFF
--- a/cms/plugin_pool.py
+++ b/cms/plugin_pool.py
@@ -117,7 +117,10 @@ class PluginPool(object):
         Retrieve a plugin from the cache.
         """
         self.discover_plugins()
-        return self.plugins[name]
+        if name in self.plugins:
+            return self.plugins[name]
+        else:
+            return type('Uninstalled%s' % str(name), (CMSPluginBase,), {'render_plugin': False})
     
     def get_patterns(self):
         self.discover_plugins()


### PR DESCRIPTION
Changes PluginPool.get_plugin not to raise a KeyError if the plugin is no longer available, but to return sort of dummy plugin with appropriate name.
This allows user to safely uninstall any plugin (remove it from INSTALLED_APPS).
If the plugin is still used somewhere in the web, it does not break the whole page, but silently renders nothing.
Such plugin instance may be easily removed in the editing mode.
