### PR TITLE
fix toolbar position over placeholder

### DIFF
--- a/cms/static/cms/js/plugins/cms.toolbar.js
+++ b/cms/static/cms/js/plugins/cms.toolbar.js
@@ -584,6 +584,7 @@ $(document).ready(function () {
 
 		// private methods
 		_showToolbar: function (speed, init) {
+		    this.body.css('margin-top', '1.75em');
 			this.toolbarTrigger.addClass('cms_toolbar-trigger-expanded');
 			this.toolbar.slideDown(speed);
 			// set messages top to toolbar height
@@ -604,6 +605,7 @@ $(document).ready(function () {
 			// set new settings
 			this.settings.toolbar = 'collapsed';
 			if(!init) this.setSettings();
+			this.body.css('margin-top', '0em');
 		},
 
 		_enableEditMode: function (speed, init) {


### PR DESCRIPTION
On the frontend editing, when the toolbar is active, it is shown over the first plugin. This pull request adds a martin-top to the body when the toolbar is toggled to prevent this.
