### PR TITLE
Fix last django-reversion update... master

### DIFF
--- a/cms/tests/reversion_tests.py
+++ b/cms/tests/reversion_tests.py
@@ -16,7 +16,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from os.path import join
 import reversion
 from reversion.models import Revision, Version
-if reversion.__version__ < (1,8,0):
+if hasattr(reversion.models, 'VERSION_CHANGE'):
     from reversion.models import VERSION_CHANGE
 
 
@@ -193,7 +193,7 @@ class ReversionFileFieldTests(CMSTestCase):
             # manually add a revision because we use the explicit way
             # django-cms uses too.
             adapter = reversion.get_adapter(FileModel)
-            if reversion.__version__ < (1,8,0):
+            if hasattr(reversion.models, 'VERSION_CHANGE'):
                 reversion.revision_context_manager.add_to_context(
                     reversion.default_revision_manager, file1,
                     adapter.get_version_data(file1, VERSION_CHANGE))

--- a/cms/utils/helpers.py
+++ b/cms/utils/helpers.py
@@ -37,7 +37,7 @@ def make_revision_with_plugins(obj, user=None, message=None):
     # we can safely import reversion - calls here always check for 
     # reversion in installed_applications first
     import reversion
-    if reversion.__version__ < (1,8,0):
+    if hasattr(reversion.models, 'VERSION_CHANGE'):
         from reversion.models import VERSION_CHANGE
     """
     Only add to revision if it is a draft.
@@ -58,7 +58,7 @@ def make_revision_with_plugins(obj, user=None, message=None):
                 revision_context.set_comment(message)
             # add toplevel object to the revision
             adapter = revision_manager.get_adapter(obj.__class__)
-            if reversion.__version__ < (1,8,0):
+            if hasattr(reversion.models, 'VERSION_CHANGE'):
                 revision_context.add_to_context(revision_manager, obj, adapter.get_version_data(obj, VERSION_CHANGE))
             else:
                 revision_context.add_to_context(revision_manager, obj, adapter.get_version_data(obj))
@@ -68,12 +68,12 @@ def make_revision_with_plugins(obj, user=None, message=None):
                 plugin_instance, admin = plugin.get_plugin_instance()
                 if plugin_instance:
                     padapter = revision_manager.get_adapter(plugin_instance.__class__)
-                    if reversion.__version__ < (1,8,0):
+                    if hasattr(reversion.models, 'VERSION_CHANGE'):
                         revision_context.add_to_context(revision_manager, plugin_instance, padapter.get_version_data(plugin_instance, VERSION_CHANGE))
                     else:
                         revision_context.add_to_context(revision_manager, plugin_instance, padapter.get_version_data(plugin_instance))
                 bpadapter = revision_manager.get_adapter(plugin.__class__)
-                if reversion.__version__ < (1,8,0):
+                if hasattr(reversion.models, 'VERSION_CHANGE'):
                     revision_context.add_to_context(revision_manager, plugin, bpadapter.get_version_data(plugin, VERSION_CHANGE))
                 else:
                     revision_context.add_to_context(revision_manager, plugin, bpadapter.get_version_data(plugin))


### PR DESCRIPTION
With the update of django-reversion to v1.8, its API has changed. get_version_data() does not accept VERSION_CHANGE anymore, and actually VERSION_CHANGE has been removed from reversion.models
