### PR TITLE
Sideframe is not shown (Google Chrome, Mac)

### DIFF
--- a/cms/static/cms/js/plugins/cms.toolbar.js
+++ b/cms/static/cms/js/plugins/cms.toolbar.js
@@ -730,6 +730,7 @@ $(document).ready(function () {
 			if(this.settings.sideframe.maximized) this._maximizeSideframe();
 			// otherwise do normal behaviour
 			if(!this.settings.sideframe.hidden && !this.settings.sideframe.maximized) {
+				this.sideframe.show();
 				if(animate) {
 					this.sideframe.animate({ 'width': width }, this.options.sideframeDuration);
 					this.body.animate({ 'margin-left': width }, this.options.sideframeDuration);


### PR DESCRIPTION
Display: block and no one changes it.

Hi, I'm not sure whether it's a bug or some kind of feature, but in my case I coulndt make the sideframe appear, but as soon as I added this little show() method everything was working as it should.

Can you please take a look at it?

Kind Regards
