### PR TITLE
live() is deprecated in jQuery since 2 years, replaced it with on()

### DIFF
--- a/cms/static/cms/js/plugins/cms.toolbar.js
+++ b/cms/static/cms/js/plugins/cms.toolbar.js
@@ -288,7 +288,7 @@ $(document).ready(function () {
 				e.preventDefault();
 				that._maximizeModal();
 			});
-			this.modal.find('.cms_modal-breadcrumb-items a').live('click', function (e) {
+			this.modal.on('click','.cms_modal-breadcrumb-items a', function (e) {
 				e.preventDefault();
 				that._changeModalContent($(this));
 			});


### PR DESCRIPTION
Please check and confirm/deny.
