### PR TITLE
Fix a broken link to djangocms-text-ckeditor in the upgrade notes.

### DIFF
--- a/docs/upgrade/3.0.rst
+++ b/docs/upgrade/3.0.rst
@@ -125,9 +125,9 @@ choices about what to install upon its adopters.
 The most significant of these removals is ``cms.plugins.text``.
 
 We provide ``djangocms-text-ckeditor``, a CKEditor-based Text Plugin. It's
-available from https://github.com/djangocms-text-ckeditor. You may of course
-use your preferred editor; others are available.  
-                        
+available from https://github.com/divio/djangocms-text-ckeditor. You may of
+course use your preferred editor; others are available.
+
 
 Plugin Context Processors take a new argument
 =============================================


### PR DESCRIPTION
The current upgrade notes for 3.0 contain a broken link to djangocms-text-ckeditor. This patch fixes that.
