### PR TITLE
Fix equality condition on a lazy object.

### DIFF
--- a/cms/plugins/utils.py
+++ b/cms/plugins/utils.py
@@ -44,7 +44,8 @@ def assign_plugins(request, placeholders, lang=None):
         return
     lang = lang or get_language_from_request(request)
     request_lang = lang
-    if hasattr(request, "current_page") and request.current_page is not None:
+    if hasattr(request, "current_page") and not request.current_page == None:
+        # == is required since request.current_page may be a SimpleLazyObject
         languages = request.current_page.get_languages()
         if not lang in languages and not get_redirect_on_fallback(lang):
             fallbacks = get_fallback_languages(lang)


### PR DESCRIPTION
In `cms.plugins.utils.assign_plugins`, `request.current_page` seems to be, at least sometimes, a `SimpleLazyObject`. As a result, identity condition (`is None`) doesn't work and we need to use equality condition instead (`== None`).
