### PR TITLE
Decode plugin name entities in edit tooltip

### DIFF
--- a/cms/static/cms/js/plugins/cms.placeholders.js
+++ b/cms/static/cms/js/plugins/cms.placeholders.js
@@ -68,7 +68,7 @@ $(document).ready(function () {
 
 				if(e.type === 'mouseover') {
 					var name = $(this).data('settings').plugin_name;
-					that.tooltip.show().find('span').text(name);
+					that.tooltip.show().find('span').html(name);
 				} else {
 					that.tooltip.hide();
 				}


### PR DESCRIPTION
For example when plugin name contains a single quote, `#$39;` was displayed instead.
