### PR TITLE
modal popup: jquery hide function breaks ckeditor on firefox

### DIFF
--- a/cms/static/cms/js/plugins/cms.toolbar.js
+++ b/cms/static/cms/js/plugins/cms.toolbar.js
@@ -1188,7 +1188,7 @@ $(document).ready(function () {
 
 			// now refresh the content
 			var iframe = $('<iframe src="'+url+'" class="" frameborder="0" />');
-				iframe.hide();
+				iframe.css('visibility', 'hidden');
 			var holder = this.modal.find('.cms_modal-frame');
 
 			// set correct title
@@ -1196,7 +1196,7 @@ $(document).ready(function () {
 				title.html(name || '&nbsp;');
 
 			// insure previous iframe is hidden
-			holder.find('iframe').hide();
+			holder.find('iframe').css('visibility', 'hidden');
 
 			// attach load event for iframe to prevent flicker effects
 			iframe.bind('load', function () {
@@ -1224,7 +1224,7 @@ $(document).ready(function () {
 				that._setModalButtons($(this));
 
 				// than show
-				iframe.show();
+				iframe.css('visibility','visible');
 
 				// append ready state
 				iframe.data('ready', true);


### PR DESCRIPTION
On firefox, when using hide jquery function, ckeditor button icons are not displayed, only label are displayed.

As a workaround, we can use `visibilitity:hidden` instead of `display:none` (cf [ckeditor bug 10374](http://dev.ckeditor.com/ticket/10374)).

This is also related to #2257.
