### PR TITLE
Fix modal popup position when unmaximizing

### DIFF
--- a/cms/static/cms/js/plugins/cms.modal.js
+++ b/cms/static/cms/js/plugins/cms.modal.js
@@ -245,7 +245,8 @@ $(document).ready(function () {
 				this.modal.data('css', {
 					'left': this.modal.css('left'),
 					'top': this.modal.css('top'),
-					'margin': this.modal.css('margin')
+					'margin-left': this.modal.css('margin-left'),
+					'margin-top': this.modal.css('margin-top')
 				});
 				container.data('css', {
 					'width': container.width(),


### PR DESCRIPTION
At least on Firefox 25, when I maximize and unmaximize a modal popup, its position is badly restored.

Tested on Firefox 25 and WebKit 2.0.4.
