### PR TITLE
Fixed tooltip show/delete for generic popups

### DIFF
--- a/cms/static/cms/js/plugins/cms.plugins.js
+++ b/cms/static/cms/js/plugins/cms.plugins.js
@@ -170,7 +170,7 @@ $(document).ready(function () {
 				e.stopPropagation();
 				var name = $(this).data('settings').plugin_name;
 				var id = $(this).data('settings').plugin_id;
-				(e.type === 'mouseenter') ? CMS.API.Helpers.showTooltip(name, id) : CMS.API.Helpers.hideTooltip();
+				(e.type === 'mouseover') ? CMS.API.Helpers.showTooltip(name, id) : CMS.API.Helpers.hideTooltip();
 			});
 		},
 


### PR DESCRIPTION
Some leftover in https://github.com/divio/django-cms/blob/develop/cms/static/cms/js/plugins/cms.plugins.js#L173 does not trigger tooltip for generic popups
