### PR TITLE
Updated django.conf.urls.defaults -> django.conf.urls.

### DIFF
--- a/docs/advanced/i18n.rst
+++ b/docs/advanced/i18n.rst
@@ -14,7 +14,7 @@ official django `documentation`_.
 Main `urls.py` example::
 
     from django.conf import settings
-    from django.conf.urls.defaults import patterns, include, url
+    from django.conf.urls import patterns, include, url
     from django.contrib import admin
     from django.conf.urls.i18n import i18n_patterns
     from django.contrib.staticfiles.urls import staticfiles_urlpatterns

--- a/docs/extending_cms/app_integration.rst
+++ b/docs/extending_cms/app_integration.rst
@@ -202,7 +202,7 @@ under "Application". Save the page.
 If you attached the app to a page with the url ``/hello/world/`` and the app has
 a urls.py that looks like this::
 
-    from django.conf.urls.defaults import *
+    from django.conf.urls import *
 
     urlpatterns = patterns('sampleapp.views',
         url(r'^$', 'main_view', name='app_main'),

--- a/docs/extending_cms/extending_examples.rst
+++ b/docs/extending_cms/extending_examples.rst
@@ -10,7 +10,7 @@ Also, make sure the poll app is in your :setting:`django:INSTALLED_APPS`.
 
 We assume your main ``urls.py`` looks something like this::
 
-    from django.conf.urls.defaults import *
+    from django.conf.urls import *
 
     from django.contrib import admin
     admin.autodiscover()
@@ -165,7 +165,7 @@ In this file, write::
 Now remove the inclusion of the polls urls in your main ``urls.py`` so it looks
 like this::
 
-    from django.conf.urls.defaults import *
+    from django.conf.urls import *
 
     from django.contrib import admin
     admin.autodiscover()

--- a/docs/getting_started/tutorial.rst
+++ b/docs/getting_started/tutorial.rst
@@ -248,7 +248,7 @@ URL configuration
 You need to include the ``'cms.urls'`` urlpatterns **at the end** of your
 urlpatterns. We suggest starting with the following ``urls.py``::
 
-    from django.conf.urls.defaults import *
+    from django.conf.urls import *
     from django.conf.urls.i18n import i18n_patterns
     from django.contrib import admin
     from django.conf import settings

--- a/docs/upgrade/2.4.rst
+++ b/docs/upgrade/2.4.rst
@@ -149,7 +149,7 @@ What you need to do:
   and that it comes after the SessionMiddleware.
 - Be sure that the ``cms.urls`` is included in a ``i18n_patterns``::
 
-        from django.conf.urls.defaults import *
+        from django.conf.urls import *
         from django.conf.urls.i18n import i18n_patterns
         from django.contrib import admin
         from django.conf import settings


### PR DESCRIPTION
django.conf.urls.defaults was deprecated in Django 1.4.
