### PR TITLE
Backport of #2365 to 2.3

### DIFF
--- a/cms/utils/placeholder.py
+++ b/cms/utils/placeholder.py
@@ -23,7 +23,7 @@ def get_placeholder_conf(setting, placeholder, template=None, default=None):
             if not conf:
                 continue
             value = conf.get(setting)
-            if value:
+            if value is not None:
                 return value
     return default
 


### PR DESCRIPTION
In get_placeholder_conf check value against None to allow '0' as a valid configuration value
