### PR TITLE
Remove python 2.5 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-    - "2.5"
     - "2.6"
     - "2.7"
 env:


### PR DESCRIPTION
See http://about.travis-ci.org/blog/2013-11-18-upcoming-build-environment-updates/
