### PR TITLE
Fix invisible sideframe if maximized

### DIFF
--- a/cms/static/cms/js/plugins/cms.sideframe.js
+++ b/cms/static/cms/js/plugins/cms.sideframe.js
@@ -166,7 +166,10 @@ $(document).ready(function () {
 			// check if sideframe should be hidden
 			if(this.settings.sideframe.hidden) this._hide();
 			// check if sideframe should be maximized
-			if(this.settings.sideframe.maximized) this._maximize();
+			if(this.settings.sideframe.maximized) {
+				this.sideframe.show();
+				this._maximize();
+			}
 			// otherwise do normal behaviour
 			if(!this.settings.sideframe.hidden && !this.settings.sideframe.maximized) {
 				this.sideframe.show();


### PR DESCRIPTION
If the admin sideframe was maximized and you hit F5 or the page reloads it didn't show up anymore.
This fixes this.
