### PR TITLE
Multilanguage sitemaps

### DIFF
--- a/cms/sitemaps/cms_sitemap.py
+++ b/cms/sitemaps/cms_sitemap.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.contrib.sitemaps import Sitemap
-from cms.models import Title
 from django.utils import translation
+from cms.models import Title
 
 
 def from_iterable(iterables):

--- a/cms/tests/__init__.py
+++ b/cms/tests/__init__.py
@@ -26,6 +26,7 @@ from cms.tests.reversion_tests import *
 from cms.tests.security import *
 from cms.tests.settings import *
 from cms.tests.site import *
+from cms.tests.sitemap import *
 from cms.tests.static_placeholder import *
 from cms.tests.staticfiles import *
 from cms.tests.templatetags import *

--- a/cms/tests/page.py
+++ b/cms/tests/page.py
@@ -12,7 +12,7 @@ from django.core.urlresolvers import reverse
 from django.http import HttpRequest, HttpResponse, HttpResponseNotFound
 from django.utils import timezone
 
-from cms.admin.forms import PageForm, AdvancedSettingsForm
+from cms.admin.forms import AdvancedSettingsForm
 from cms.admin.pageadmin import PageAdmin
 from cms.api import create_page, add_plugin
 from cms.middleware.user import CurrentUserMiddleware
@@ -333,7 +333,6 @@ class PagesTestCase(CMSTestCase):
 
         self.assertEqual(Page.objects.drafts().count() - count, 3)
 
-
     def test_language_change(self):
         superuser = self.get_superuser()
         with self.login_user_context(superuser):
@@ -417,7 +416,6 @@ class PagesTestCase(CMSTestCase):
         child.move_page(parent, 'left')
         self.assertEqual(child.get_template(), parent.get_template())
 
-
     def test_add_placeholder(self):
         # create page
         page = create_page("Add Placeholder", "nav_playground.html", "en",
@@ -467,11 +465,12 @@ class PagesTestCase(CMSTestCase):
         now -= datetime.timedelta(microseconds=now.microsecond)
         one_day_ago = now - datetime.timedelta(days=1)
         page = create_page("page", "nav_playground.html", "en", published=True, publication_date=now)
+        title = page.get_title_obj('en')
         page.creation_date = one_day_ago
         page.changed_date = one_day_ago
         sitemap = CMSSitemap()
-        actual_last_modification_time = sitemap.lastmod(page)
-        self.assertEqual(actual_last_modification_time, now)
+        actual_last_modification_time = sitemap.lastmod(title)
+        self.assertEqual(actual_last_modification_time.date(), now.date())
 
     def test_edit_page_other_site_and_language(self):
         """

--- a/cms/tests/plugins.py
+++ b/cms/tests/plugins.py
@@ -740,16 +740,15 @@ class PluginsTestCase(PluginsTestBaseCase):
         now = timezone.now()
         one_day_ago = now - datetime.timedelta(days=1)
         page = create_page("page", "nav_playground.html", "en", published=True, publication_date=now)
+        title = page.get_title_obj('en')
         page.creation_date = one_day_ago
         page.changed_date = one_day_ago
-
         plugin_id = self._create_text_plugin_on_page(page)
         plugin = self._edit_text_plugin(plugin_id, "fnord")
 
-        actual_last_modification_time = CMSSitemap().lastmod(page)
-        self.assertEqual(plugin.changed_date - datetime.timedelta(microseconds=plugin.changed_date.microsecond),
-                         actual_last_modification_time - datetime.timedelta(
-                             microseconds=actual_last_modification_time.microsecond))
+        actual_last_modification_time = CMSSitemap().lastmod(title)
+        actual_last_modification_time -= datetime.timedelta(microseconds=actual_last_modification_time.microsecond)
+        self.assertEqual(plugin.changed_date.date(), actual_last_modification_time.date())
 
     def test_moving_plugin_to_different_placeholder(self):
         plugin_pool.register_plugin(DumbFixturePlugin)

--- a/cms/tests/sitemap.py
+++ b/cms/tests/sitemap.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+from django.utils.translation import ugettext_lazy as _
+from cms.models import Title, Page
+from cms.sitemaps import CMSSitemap
+from cms.test_utils.testcases import CMSTestCase
+from cms.api import create_page, create_title
+from cms.test_utils.util.context_managers import SettingsOverride
+
+
+class SitemapTestCase(CMSTestCase):
+    def create_fixtures(self):
+        """
+        Tree from fixture:
+
+            + P1 (de, en)
+            | + P2 (de, en)
+            |   + P3 (de, en)
+            | + P9 (de unpublished, en)
+            |   + P10 unpublished (de, en)
+            |   + P11 (en)
+            + P4 (de, en)
+            | + P5 (de, en)
+            + P6 (de, en) (not in menu)
+              + P7 (de, en)
+              + P8 (de, en)
+        """
+        defaults = {
+            'template': 'nav_playground.html',
+            'language': 'en',
+        }
+        with SettingsOverride(CMS_MODERATOR=False, CMS_PERMISSION=False):
+            p1 = create_page('P1', published=True, in_navigation=True, **defaults)
+            create_title(language='de', title="other title %s" % p1.get_title('en'), page=p1)
+            p4 = create_page('P4', published=True, in_navigation=True, **defaults)
+            create_title(language='de', title="other title %s" % p4.get_title('en'), page=p4)
+            p6 = create_page('P6', published=True, in_navigation=False, **defaults)
+            create_title(language='de', title="other title %s" % p6.get_title('en'), page=p6)
+            p2 = create_page('P2', published=True, in_navigation=True, parent=p1, **defaults)
+            create_title(language='de', title="other title %s" % p2.get_title('en'), page=p2)
+            p3 = create_page('P3', published=True, in_navigation=True, parent=p2, **defaults)
+            create_title(language='de', title="other title %s" % p3.get_title('en'), page=p3)
+            p5 = create_page('P5', published=True, in_navigation=True, parent=p4, **defaults)
+            create_title(language='de', title="other title %s" % p5.get_title('en'), page=p5)
+            p7 = create_page('P7', published=True, in_navigation=True, parent=p6, **defaults)
+            create_title(language='de', title="other title %s" % p7.get_title('en'), page=p7)
+            p8 = create_page('P8', published=True, in_navigation=True, parent=p6, **defaults)
+            create_title(language='de', title="other title %s" % p8.get_title('en'), page=p8)
+            p9 = create_page('P9', published=True, in_navigation=True, parent=p1, **defaults)
+            create_title(language='de', title="other title %s" % p9.get_title('en'), page=p9)
+            p10 = create_page('P10', published=False, in_navigation=True, parent=p9, **defaults)
+            create_title(language='de', title="other title %s" % p10.get_title('en'), page=p10)
+            p11 = create_page('P11', published=True, in_navigation=True, parent=p9, **defaults)
+            p8.publish()
+            p7.publish()
+            p5.publish()
+            p3.publish()
+            p2.publish()
+            p6.publish()
+            p4.publish()
+            p1.publish()
+
+    def test_sitemap_count(self):
+        """
+        Has the sitemap the correct number of elements?
+        """
+        sitemap = CMSSitemap()
+        # 8 pages with en and de titles published
+        # 1 page published only in english(with existsing de title)
+        # 1 page with both titles but unpublished
+        # 1 page with only english title
+        self.assertEqual(sitemap.items().count(), 18)
+
+    def test_sitemap_items_location(self):
+        """
+        Check the correct URL in location, recreating it according to the title
+        attributes (instead of using Page.get_absolute_url) for a lower level
+        check
+        """
+        sitemap = CMSSitemap()
+        urlset = sitemap.get_urls()
+        for item in urlset:
+            if item['item'].path:
+                url = 'http://example.com/%s/%s/' % (item['item'].language, item['item'].path)
+            else:
+                url = 'http://example.com/%s/%s' % (item['item'].language, item['item'].path)
+            self.assertEqual(item['location'], url)
+
+    def test_sitemap_published_titles(self):
+        """
+        Check that published titles are in the urls
+        """
+        sitemap = CMSSitemap()
+        locations = []
+        urlset = sitemap.get_urls()
+        for item in urlset:
+            locations.append(item['location'])
+        for title in Title.objects.public():
+            page = title.page.get_public_object()
+            if title.path:
+                url = 'http://example.com/%s/%s/' % (title.language, title.path)
+            else:
+                url = 'http://example.com/%s/%s' % (title.language, title.path)
+            if page.published and not page.publisher_is_draft:
+                self.assertTrue(url in locations)
+            else:
+                self.assertFalse(url in locations)
+
+    def test_sitemap_unpublished_titles(self):
+        """
+        Check that titles attached to unpublished pages are not in the urlset.
+        As titles are 'published' depending on their attached page, we create a
+        set of unpublished titles by checking titles attached to the draft and
+        public version of each page
+        """
+        sitemap = CMSSitemap()
+        locations = []
+        urlset = sitemap.get_urls()
+        unpublished_titles = set()
+        for item in urlset:
+            locations.append(item['location'])
+        for page in Page.objects.drafts():
+            if page.get_public_object():
+                set1 = set(page.get_public_object().title_set.values_list('path', flat=True))
+                set2 = set(page.title_set.values_list('path', flat=True))
+                unpublished_titles.update(set2.difference(set1))
+            else:
+                unpublished_titles.update(page.title_set.values_list('path', flat=True))
+
+        for path in unpublished_titles:
+            title = Title.objects.get(path=path)
+            if title.path:
+                url = 'http://example.com/%s/%s/' % (title.language, title.path)
+            else:
+                url = 'http://example.com/%s/%s' % (title.language, title.path)
+            self.assertFalse(url in locations)


### PR DESCRIPTION
This implementation of multilanguage Sitemap brings to CMSSitemap all the (published) language entries in the same sitemap.
This is achieved by using `Title` as the base item for the sitemap.
Do we need to have language-specific sitemaps too?

I had to use `.date()` in tests because of subtle time skewes in Travis

Fix #1557
