### PR TITLE
Emptying a static placeholder will not be published

### DIFF
--- a/cms/static/cms/js/plugins/cms.plugins.js
+++ b/cms/static/cms/js/plugins/cms.plugins.js
@@ -25,7 +25,8 @@ $(document).ready(function () {
 				'add_plugin': '',
 				'edit_plugin': '',
 				'move_plugin': '',
-				'copy_plugin': ''
+				'copy_plugin': '',
+				'delete_plugin': ''
 			}
 		},
 
@@ -386,6 +387,16 @@ $(document).ready(function () {
 			$('.cms_btn-publish').addClass('cms_btn-publish-active').parent().show();
 		},
 
+		deletePlugin: function (url, name, breadcrumb) {
+			// trigger modal window
+			var modal = new CMS.Modal({
+				'newPlugin': this.newPlugin || false,
+				'onClose': this.options.onClose || false,
+				'redirectOnClose': this.options.redirectOnClose || false
+			});
+			modal.open(url, name, breadcrumb);
+		},
+
 		// private methods
 		_setSubnav: function (nav) {
 			var that = this;
@@ -419,6 +430,9 @@ $(document).ready(function () {
 						break;
 					case 'cut':
 						that.cutPlugin();
+						break;
+					case 'delete':
+						that.deletePlugin(that.options.urls.delete_plugin, that.options.plugin_name, that.options.plugin_breadcrumb);
 						break;
 					default:
 						CMS.API.Toolbar._loader(false);

--- a/cms/templates/cms/toolbar/dragitem.html
+++ b/cms/templates/cms/toolbar/dragitem.html
@@ -12,7 +12,7 @@
 				<div class="cms_submenu-item"><a data-rel="copy" href="#">{% trans "Copy" %}</a></div>
 				<div class="cms_submenu-item"><a data-rel="cut" href="#">{% trans "Cut" %}</a></div>
 				<div class="cms_submenu-item"><a data-rel="edit" href="#">{% trans "Edit" %}</a></div>
-				<div class="cms_submenu-item"><a data-rel="modal" href="{% url "admin:cms_page_delete_plugin" plugin.pk %}" data-name="{% trans "Delete" %} {{ plugin.get_plugin_name }}">{% trans "Delete" %}</a></div>
+				<div class="cms_submenu-item"><a data-rel="delete" href="#">{% trans "Delete" %}</a></div>
 				{% comment %}
 				// TODO this feature will be removed within RC1, use separate plugin "presets" instead
 				<div class="cms_submenu-item"><a data-rel="modal" href="{% url "admin:stacks_stack_create_stack_from_plugin" placeholder_id=plugin.placeholder_id plugin_id=plugin.pk %}">{% trans "Create stack" %}</a></div>


### PR DESCRIPTION
Steps:
- Create a page with a static placeholder and add a plugin to it
- Publish the page
- Edit the page again, remove the plugin from the static placeholder so that the placeholder is now empty
- The publish button doesn't appear. If you 'force' publish through the admin link, it won't update the live page either.

Check the live page - the plugin will still be there. This happens because of the way the publishing of static placeholders is handled. The call is (`cms/cms_toolbar.py:176`):

```
http://localhost/de/admin/cms/page/1/publish/?statics=2
```

where 2 is the static placeholder's primary key. But if it empty, it won't be published.

As far as I could find out, this method below at `cms.admin.static_placeholder.StaticPlaceholderAdmin.post_delete_plugin` is never called. 

```
def post_delete_plugin(self, request, plugin):
        self.mark_dirty(plugin.placeholder)
```

It uses the method from `cms.admin.pageadmin.PageAdmin.post_delete_plugin` instead.

```
    def post_delete_plugin(self, request, plugin):
        plugin_name = force_unicode(plugin_pool.get_plugin(plugin.plugin_type).name)
        page = plugin.placeholder.page
        if page:
            page.save()
            comment = _("%(plugin_name)s plugin at position %(position)s in %(placeholder)s was deleted.") % {
                'plugin_name': plugin_name,
                'position': plugin.position,
                'placeholder': plugin.placeholder,
            }
            moderator.page_changed(page, force_moderation_action=PageModeratorState.ACTION_CHANGED)
            if 'reversion' in settings.INSTALLED_APPS:
                helpers.make_revision_with_plugins(page, request.user, comment)
```

The call:

```
[18/Jan/2014 01:59:36] "GET /de/admin/cms/page/delete-plugin/32717/ HTTP/1.1" 200 2362
```

Instead of, like editing:

```
[18/Jan/2014 01:57:07] "GET /de/admin/cms/staticplaceholder/edit-plugin/32717/ HTTP/1.1" 200 6448
```
