### PR TITLE
Typo - Extending the CMS 1.3

### DIFF
--- a/docs/extending_cms/extending_examples.rst
+++ b/docs/extending_cms/extending_examples.rst
@@ -242,7 +242,7 @@ In your ``menu.py`` write::
 At this point this menu alone doesn't do a whole lot. We have to attach it to the
 Apphook first.
 
-So open your ``cms_apps.py`` and write::
+So open your ``cms_app.py`` and write::
 
     from cms.app_base import CMSApp
     from cms.apphook_pool import apphook_pool


### PR DESCRIPTION
"At this point this menu alone doesn’t do a whole lot. We have to attach it to the Apphook first.

So open your cms_apps.py and write:"

In the second line, "cms_apps.py" should be "cms_app.py" for consistency.
