### PR TITLE
Activate first language in publisher_publish command

### DIFF
--- a/cms/management/commands/publisher_publish.py
+++ b/cms/management/commands/publisher_publish.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from django.core.management.base import NoArgsCommand, CommandError
+from django.utils.translation import activate
 from cms.utils.compat.dj import force_unicode
 
 class Command(NoArgsCommand):
@@ -28,13 +29,17 @@ class Command(NoArgsCommand):
         pages_total, pages_published = qs.count(), 0
         
         print(u"\nPublishing public drafts....\n")
-        
+        output_language = None
         for i, page in enumerate(qs):
             m = " "
             add = True
             for lang in page.title_set.filter(published=True).values_list("language", flat=True):
+                if not output_language:
+                    output_language = lang
                 if not page.publish(lang):
                     add = False
+            # we may need to activate the first (main) language for proper page title rendering
+            activate(output_language)
             if add:
                 pages_published += 1
                 m = "*"


### PR DESCRIPTION
First (default) language should be activated to allow for proper menu title to be printed, otherwise the `en_us` language code is used to get it (even if `en` / `en_us` is not in `LANGUAGES`)
