### PR TITLE
inheritance of placeholder configuration

### DIFF
--- a/cms/utils/placeholder.py
+++ b/cms/utils/placeholder.py
@@ -64,6 +64,15 @@ def get_placeholder_conf(setting, placeholder, template=None, default=None):
             value = conf.get(setting)
             if value is not None:
                 return value
+            inherit = conf.get('inherit')
+            if inherit :
+                if ' ' in inherit:
+                    inherit = inherit.split(' ')
+                else:
+                    inherit = (None, inherit,)
+                value = get_placeholder_conf(setting, inherit[1], inherit[0], default)
+                if value is not None:
+                    return value
     return default
 
 

--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -109,7 +109,8 @@ Example::
             }.
         },
         'base.html content': {
-            "plugins": ['TextPlugin', 'PicturePlugin', 'TeaserPlugin']
+            "plugins": ['TextPlugin', 'PicturePlugin', 'TeaserPlugin'],
+            'inherit': 'content',
         },
     }
 
@@ -168,7 +169,12 @@ plugins, as shown above with ``base.html content``.
     A dictionary of plugin names with lists describing which plugins may contain
     each plugin. If not supplied, all plugins can be selected.
 
-
+``inherit``
+    Placeholder name or template name + placeholder name which inherit. In the
+    exemple, the configuration for "base.html content" inherits from "content"
+    and just overwrite the "plugins" setting to allow TeaserPlugin, thus you
+    have not to duplicate your "content"'s configuration.
+    
 .. setting:: CMS_PLUGIN_CONTEXT_PROCESSORS
 
 CMS_PLUGIN_CONTEXT_PROCESSORS


### PR DESCRIPTION
Issue #2507 (sorry for wrong issue number in commit)
Exemple usage : 

``` python
CMS_PLACEHOLDER_CONF = {
    'main': {
        'name': 'main content',
        'plugins': ['TextPlugin', 'LinkPlugin'],
        'default_plugins':[
            {
                'plugin_type':'TextPlugin', 
                'values':{
                    'body':'<p>Some default text</p>'
                },
            },
        ],
    },
    'layout/home.html main': {
        'name': u'main content with FilerImagePlugin and limit',
        'inherit':'main',
        'plugins': ['TextPlugin', 'FilerImagePlugin', 'LinkPlugin',],
        'limits': {'global': 1,},
    },
    'layout/other.html main': {
        'name': u'main content with FilerImagePlugin and no limit',
        'inherit':'layout/home.html main',
        'limits': {},
    },
}
```
