### PR TITLE
Clarify the 'missing' text plugin

### DIFF
--- a/docs/getting_started/tutorial.rst
+++ b/docs/getting_started/tutorial.rst
@@ -493,7 +493,8 @@ The admin interfaces shows you theses placeholders as sub menus:
 
 Scroll down the "Available plugins" drop-down list. This displays the plugins you
 added to your :setting:`django:INSTALLED_APPS` settings. Choose the "text" plugin in the drop-down,
-then press the "Add" button.
+then press the "Add" button. If the "text" plugin is not listed, you need to add 
+'djangocms_text_ckeditor' to your :setting:`django:INSTALLED_APPS` settings.
 
 The right part of the plugin area displays a rich text editor (`TinyMCE`_).
 


### PR DESCRIPTION
Text plugin is not part of base installation and this change adds a hint for user to add plugin if not already installed. This should fix #3 on https://github.com/divio/django-cms/issues/2150 .
