### PR TITLE
Fix for issue 2432

### DIFF
--- a/cms/static/cms/js/plugins/cms.plugins.js
+++ b/cms/static/cms/js/plugins/cms.plugins.js
@@ -204,6 +204,7 @@ $(document).ready(function () {
 			// adds double click to edit
 			this.container.bind('dblclick', function (e) {
 				e.preventDefault();
+				e.stopPropagation();
 				that.editPlugin(that.options.urls.edit_plugin, that.options.plugin_name, []);
 			});
 


### PR DESCRIPTION
This is to address the issue of not being able to edit models emitted by CMSPlugins. Because the event was being propagated, the double-click essentially triggers editing of both the model and of the plugin. The resulting mayhem made it impossible to do either. This fix seems to allow the editing of the model, without preventing edits to the plugin (by double-clicking on something other than the model).

Signed-off-by: Martin Koistinen mkoistinen@gmail.com
