### PR TITLE
Fix issue 2435

### DIFF
--- a/cms/utils/django_load.py
+++ b/cms/utils/django_load.py
@@ -24,7 +24,7 @@ def get_module(app, modname, verbose, failfast):
         if failfast:
             raise
         elif verbose:
-            print(u"Could not load %r from %r: %s" % (modname, app)) # changed
+            print(u"Could not load %r from %r" % (modname, app)) # changed
             traceback.print_exc() # changed
         return None
     if verbose:


### PR DESCRIPTION
Apparently a bug was introduced in django_load.py. This code is not in sync with the source repo at: https://github.com/ojii/django-load where this issue has been fixed.

Ojii asked me (via IRC) to document this via this issue, and in my effort to clear out some of my old issues, I thought I'd simply post this fix. However, I suspect there's a deeper issue of why doesn't django-cms simply reference the source repo, instead of copy the code into the project?

The ill effects of this bug are only seen when debugging the loading of modules into django-cms, so this fix won't benefit most users (but won't hurt them either).

This PR should satisfy issue #2435.

Signed-off-by: Martin Koistinen mkoistinen@gmail.com
