### PR TITLE
More obvious failure if SITE_ID is non-int

### DIFF
--- a/cms/tests/check.py
+++ b/cms/tests/check.py
@@ -117,6 +117,11 @@ class CheckTests(unittest.TestCase, CheckAssertMixin):
         with SettingsOverride(TEMPLATE_DIRS=[alt_dir], CMS_TEMPLATES=[]):
             self.assertCheck(True, warnings=1, errors=0)
 
+    def test_non_numeric_site_id(self):
+        self.assertCheck(True, warnings=0, errors=0)
+        with SettingsOverride(SITE_ID='broken'):
+            self.assertCheck(False, warnings=0, errors=1)
+
 
 class CheckWithDatabaseTests(TestCase, CheckAssertMixin):
 

--- a/cms/tests/i18n.py
+++ b/cms/tests/i18n.py
@@ -1,6 +1,7 @@
 from cms.test_utils.testcases import SettingsOverrideTestCase
 from cms.utils import i18n
 
+
 class TestLanguages(SettingsOverrideTestCase):
 
     settings_overrides = {

--- a/cms/tests/settings.py
+++ b/cms/tests/settings.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import with_statement
-from cms import constants
 from cms.test_utils.testcases import CMSTestCase
 from cms.test_utils.util.context_managers import SettingsOverride
+from cms.utils import get_cms_setting
 from django.core.exceptions import ImproperlyConfigured
 from django.template.loader import render_to_string
+
 
 class SettingsTests(CMSTestCase):
     def test_cms_templates_with_pathsep(self):
@@ -12,3 +13,10 @@ class SettingsTests(CMSTestCase):
         with SettingsOverride(CMS_TEMPLATES=[('subdir/template.html', 'Subdir')], DEBUG=True, TEMPLATE_DEBUG=True):
             context = SekizaiContext()
             self.assertEqual(render_to_string('subdir/template.html', context).strip(), 'test')
+
+    def test_non_numeric_site_id(self):
+        with SettingsOverride(SITE_ID='broken'):
+            self.assertRaises(
+                ImproperlyConfigured,
+                get_cms_setting, 'LANGUAGES'
+            )

--- a/cms/utils/check.py
+++ b/cms/utils/check.py
@@ -195,11 +195,14 @@ def check_i18n(output):
         for lang in getattr(settings, 'LANGUAGES', ()):
             if lang[0].find('_') > -1:
                 section.warn("LANGUAGES must contain valid language codes, not locales (e.g.: 'en-us' instead of 'en_US'): '%s' provided" % lang[0])
-        for site, items in get_cms_setting('LANGUAGES').items():
-            if type(site) == int:
-                for lang in items:
-                    if lang['code'].find('_') > -1:
-                        section.warn("CMS_LANGUAGES entries must contain valid language codes, not locales (e.g.: 'en-us' instead of 'en_US'): '%s' provided" % lang['code'])
+        if isinstance(settings.SITE_ID, int):
+            for site, items in get_cms_setting('LANGUAGES').items():
+                if type(site) == int:
+                    for lang in items:
+                        if lang['code'].find('_') > -1:
+                            section.warn("CMS_LANGUAGES entries must contain valid language codes, not locales (e.g.: 'en-us' instead of 'en_US'): '%s' provided" % lang['code'])
+        else:
+            section.error("SITE_ID must be an integer, not %r" % settings.SITE_ID)
         for deprecated in ['CMS_HIDE_UNTRANSLATED', 'CMS_LANGUAGE_FALLBACK', 'CMS_LANGUAGE_CONF', 'CMS_SITE_LANGUAGES', 'CMS_FRONTEND_LANGUAGES']:
             if hasattr(settings, deprecated):
                 section.warn("Deprecated setting %s found. This setting is now handled in the new style CMS_LANGUAGES and can be removed" % deprecated)

--- a/cms/utils/conf.py
+++ b/cms/utils/conf.py
@@ -187,6 +187,10 @@ def _ensure_languages_settings(languages):
 
 
 def get_languages():
+    if not isinstance(settings.SITE_ID, int):
+        raise ImproperlyConfigured(
+            "SITE_ID must be an integer"
+        )
     if not settings.USE_I18N:
         return _ensure_languages_settings(
             {settings.SITE_ID: [{'code': settings.LANGUAGE_CODE, 'name': settings.LANGUAGE_CODE}]})


### PR DESCRIPTION
- get_cms_settings now raises an ImproperlyConfigured exception if
  SITE_ID is not an integer (when 'LANGUAGES' is accessed).
- `cms check` now shows an error if SITE_ID is not an integer
