### PR TITLE
Update cms.modal.js

### DIFF
--- a/cms/static/cms/js/plugins/cms.modal.js
+++ b/cms/static/cms/js/plugins/cms.modal.js
@@ -115,8 +115,8 @@ $(document).ready(function () {
 			// lets set the modal width and height to the size of the browser
 			var widthOffset = 300;
 			var heightOffset = 350;
-			var width = ($(window).width() >= this.options.minWidth + widthOffset) ? $(window).width() - widthOffset : this.options.minWidth;
-			var height = ($(window).height() >= this.options.minHeight + heightOffset) ? $(window).height() - heightOffset : this.options.minHeight;
+			var width = (screen.width >= this.options.minWidth + widthOffset) ? screen.width - widthOffset : this.options.minWidth;
+			var height = (screen.height >= this.options.minHeight + heightOffset) ? screen.height - heightOffset : this.options.minHeight;
 			this.modal.find('.cms_modal-body').css({
 				'width': width,
 				'height': height


### PR DESCRIPTION
The CMS modal was not displaying correctly in Firefox or Chrome. $(window).height() posed a problem when the height of the content in the CMS modal was greater than the screen height. Replacing $(window).height() with screen.height fixed the problem. This problem could also present itself when the content width is greater than screen width - thus $(window).width() was changed to screen.width.
