### PR TITLE
Fix for Publish Changes on non-cms pages containing static_placeholders

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -938,7 +938,7 @@ class PageAdmin(PlaceholderAdmin, ModelAdmin):
                 published = static_placeholder.publish(request)
                 if not published:
                     all_published = False
-        if all_published:
+        if page and all_published:
             messages.info(request, _('The content was successfully published.'))
             LogEntry.objects.log_action(
                 user_id=request.user.id,


### PR DESCRIPTION
Before this fix user receives:
AttributeError: 'NoneType' object has no attribute 'get_title'

When attempting to "Publish Changes" on a non-CMS page with static placeholders.
