### PR TITLE
Correct plugin testing docs

### DIFF
--- a/docs/extending_cms/testing.rst
+++ b/docs/extending_cms/testing.rst
@@ -73,7 +73,6 @@ So you could do::
 
         def setUp(self):
             self.plugin = MyPlugin()
-            self.plugin.save()
 
         def test_plugin(self):
             context = {'info': 'value'}


### PR DESCRIPTION
You shouldn't actually call `save()` on the plugin itself, as mentioned
in a comment to the original pull request, #1807
