### PR TITLE
Inc. min. version of djangocms-text-ckeditor for recent builds of django-cms

### DIFF
--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -45,7 +45,7 @@ minimal additional configuration and are well-proven.
 Text Editors
 ------------
 
-* `Django CMS CKEditor`_ for a WYSIWYG editor 2.0.5 or higher
+* `Django CMS CKEditor`_ for a WYSIWYG editor 2.1.1 or higher
 
 .. _Django CMS CKEditor: https://github.com/divio/djangocms-text-ckeditor
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'Pygments==1.5',
         'dj-database-url==0.2.1',
         'django-hvad',
-        'djangocms-text-ckeditor',
+        'djangocms-text-ckeditor>=2.1.1',
         'djangocms-column',
         'djangocms-style',
     ],


### PR DESCRIPTION
Using the previously recommended version of 2.0.5 results in `ImportError: No module named utils` since cms.plugins.utils has been removed.

Upgrading djangocms-text-ckeditor to 2.1.1 resolves this.
