### PR TITLE
Fix DoesNotExist when loading initial_data

### DIFF
--- a/cms/signals/page.py
+++ b/cms/signals/page.py
@@ -32,11 +32,15 @@ def post_save_page(instance, **kwargs):
     if (instance.old_page is None and instance.application_urls) or (instance.old_page and (
                 instance.old_page.application_urls != instance.application_urls or instance.old_page.application_namespace != instance.application_namespace)):
         if instance.publisher_public_id and instance.publisher_is_draft:
-            public = instance.publisher_public
-            public._publisher_keep_state = True
-            public.application_urls = instance.application_urls
-            public.application_namespace = instance.application_namespace
-            public.save()
+            # this was breaking load data
+            try:
+                public = instance.publisher_public
+                public._publisher_keep_state = True
+                public.application_urls = instance.application_urls
+                public.application_namespace = instance.application_namespace
+                public.save()
+            except ObjectDoesNotExist:
+                pass
         elif not instance.publisher_is_draft:
             apphook_post_page_checker(instance)
 


### PR DESCRIPTION
This is the error I was getting:

DoesNotExist: Problem installing fixture '/Users/patrick91/Documents/Roll/roll-site/src/core/fixtures/initial_data.json': Page matching query does not exist.
