### PR TITLE
If USE_I18N is False, do not create a 'Language' menu in the toolbar

### DIFF
--- a/cms/cms_toolbar.py
+++ b/cms/cms_toolbar.py
@@ -82,7 +82,8 @@ class BasicToolbar(CMSToolbar):
 
     def populate(self):
         self.add_admin_menu()
-        self.add_language_menu()
+        if settings.USE_I18N:
+            self.add_language_menu()
 
     def add_admin_menu(self):
         admin_menu = self.toolbar.get_or_create_menu(ADMIN_MENU_IDENTIFIER, self.current_site.name)


### PR DESCRIPTION
When USE_I18N is set to False, the menu is pointless and is confusing to clients.
