### PR TITLE
Make toolbar_pool.register a valid decorator

### DIFF
--- a/cms/toolbar_pool.py
+++ b/cms/toolbar_pool.py
@@ -44,6 +44,7 @@ class ToolbarPool(object):
         if name in self.toolbars.keys():
             raise ToolbarAlreadyRegistered("[%s] a toolbar with this name is already registered" % name)
         self.toolbars[name] = toolbar
+        return toolbar
 
     def get_toolbars(self):
         self.discover_toolbars()


### PR DESCRIPTION
In `cms_toolbar` you are using `toolbar_pool.register` as a decorator, but it returns `None` so the class you are decorating cannot be subclassed anymore.
Either do not use `register` as a decorator or make it return the toolbar as I did in this PR.
