### PR TITLE
Added suffix to version (pkg_resources compatibility)

### DIFF
--- a/cms/__init__.py
+++ b/cms/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '2.4.3'
+__version__ = '2.4.3-support'


### PR DESCRIPTION
This is a minor change with major effects on automation with `setuptools` (when using entry_points).

If someone installs `django-cms` from your Git repository they must use a version identifier in the `#egg=` part of the URL other than `2.4.3` to avoid easy_install picking the official release from the PyPI server, e.g.

``` python
from setuptools import setup
setup(
    # ...
    install_requires=[
        'django-cms==2.4.3-support',  # support branch fixes reversion>=1.8 incompatibility
    ],
    dependency_links=[
        'git+https://github.com/bittner/django-cms.git@support/2.4.x#egg=django-cms-2.4.3-support',
    ],
    entry_points="""
        [console_scripts]
        mypackage-setup=mypackage.bin.mypackage_setup:anymethod
    """,
)
```

Appending a suffix is good practice, which is compatible with SemVer, though other ways also work (e.g. using `2.4.x` or `setup2.4.x`). (Using a scheme such as `support/2.4.x` or `support_2.4.x` won't work due to the inner workings of setuptools, see for example http://stackoverflow.com/questions/19097057/pip-e-no-magic-underscore-to-dash-replacement). A manual installation, e.g. using `pip`, will work fine, and even setuptools won't complains, as long as the `entry_points` feature is not used (e.g. for custom setup scripts).

However, `pkg_resources` will complain with a `DistributionNotFound` error as soon as you try to execute an entry_point script. (`pkg_resources.py:626` with Python 2.7.5+)
I suspect this is because django-cms is installed using the `#egg=` supplied version scheme, but the `cms` module still yields the regular version number `2.4.3`. Using a matching version numbering scheme for module and installation fixes the issue.

NOTE: I have appended `-support` instead of the usual `-dev` suffix to match the affected support branch.
