### PR TITLE
settings.CSRF_COOKIE_NAME changes are acknowledged 

### DIFF
--- a/cms/context_processors.py
+++ b/cms/context_processors.py
@@ -7,3 +7,6 @@ def media(request):
     Adds media-related context variables to the context.
     """
     return {'CMS_MEDIA_URL': get_cms_setting('MEDIA_URL')}
+
+def csrf_cookie_name(request):
+	return {'CSRF_COOKIE_NAME': settings.CSRF_COOKIE_NAME}

--- a/cms/static/cms/js/csrf.js
+++ b/cms/static/cms/js/csrf.js
@@ -34,7 +34,7 @@ $.ajaxSetup({
 					}
 					if(!(/^http:.*/.test(settings.url) || /^https:.*/.test(settings.url)) || base_doc_url == base_settings_url) {
 						// Only send the token to relative URLs i.e. locally.
-						xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+						xhr.setRequestHeader("X-CSRFToken", getCookie(csrf_cookie_name));
 						settings.csrfTokenSet = true;
 					}
 				}
@@ -81,7 +81,7 @@ base_settings_url = base_settings_url[0];
 }
 if (!(/^http:.*/.test(settings.url) || /^https:.*/.test(settings.url)) || base_doc_url == base_settings_url) {
 // Only send the token to relative URLs i.e. locally.
-xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+xhr.setRequestHeader("X-CSRFToken", getCookie(csrf_cookie_name));
 settings.csrfTokenSet = true;
 }
 }

--- a/cms/static/cms/js/plugins/cms.base.js
+++ b/cms/static/cms/js/plugins/cms.base.js
@@ -58,7 +58,7 @@
 						}
 						if(!(/^http:.*/.test(settings.url) || /^https:.*/.test(settings.url)) || base_doc_url == base_settings_url) {
 							// Only send the token to relative URLs i.e. locally.
-							xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+							xhr.setRequestHeader("X-CSRFToken", getCookie(csrf_cookie_name));
 							settings.csrfTokenSet = true;
 						}
 					}

--- a/cms/templates/admin/cms/page/change_form.html
+++ b/cms/templates/admin/cms/page/change_form.html
@@ -5,6 +5,9 @@
 
 {% block extrahead %}
 {{ block.super }}
+<script type="text/javascript">
+  var csrf_cookie_name = "{{CSRF_COOKIE_NAME|default:'csrftoken'}}";
+</script>
 <script type="text/javascript" src="{{ STATIC_URL }}cms/js/csrf.js"></script>
 <script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>
 

--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -506,6 +506,17 @@ If you have a huge site you can easily partition the menu with this.
 Advanced Settings
 *****************
 
+CSRF_COOKIE_NAME
+=================
+
+In case you've overwritten the default Django `CSRF_COOKIE_NAME` setting, then you should 
+inform Django-CMS about this by using a context processor dedicated for this. Extend the list
+of `TEMPLATE_CONTEXT_PROCESSORS` with
+
+.. code-block:: python
+
+    'cms.context_processors.csrf_cookie_name',
+
 .. setting:: CMS_PERMISSION
 
 CMS_PERMISSION


### PR DESCRIPTION
with the use of a new middleware that is optional

can we get this out into 2.4.4 ASAP, please?!
