### PR TITLE
use >= 1.4 import path django.conf.urls

### DIFF
--- a/cms/urls.py
+++ b/cms/urls.py
@@ -2,7 +2,7 @@
 from cms.apphook_pool import apphook_pool
 from cms.views import details
 from django.conf import settings
-from django.conf.urls.defaults import url, patterns
+from django.conf.urls import url, patterns
 
 if settings.APPEND_SLASH:
     reg = url(r'^(?P<slug>[0-9A-Za-z-_.//]+)/$', details, name='pages-details-by-slug')


### PR DESCRIPTION
From 2.4 release notes:
"In django CMS 2.4 we dropped support for Django 1.3 and Python 2.5. Django 1.4 and Python 2.6 are now the minimum required versions."

From Django docs:
"Changed in Django 1.4: Starting with Django 1.4 functions patterns, url, include plus the handler\* symbols described below live in the django.conf.urls module." (https://docs.djangoproject.com/en/1.5/ref/urls/)

Seems to me it's safe to apply this patch and get rid of the DeprecationWarning.
