### PR TITLE
Optimize page permission checking

### DIFF
--- a/cms/tests/menu.py
+++ b/cms/tests/menu.py
@@ -1068,7 +1068,7 @@ class ViewPermissionMenuTests(SettingsOverrideTestCase):
             page = create_page('A', 'nav_playground.html', 'en')
             PagePermission.objects.create(can_view=True, user=user, page=page)
             pages = [page]
-            with self.assertNumQueries(2):
+            with self.assertNumQueries(3):
                 """
                 The queries are:
                 PagePermission query for affected pages
@@ -1097,7 +1097,7 @@ class ViewPermissionMenuTests(SettingsOverrideTestCase):
             page = create_page('A', 'nav_playground.html', 'en')
             PagePermission.objects.create(can_view=True, group=group, page=page)
             pages = [page]
-            with self.assertNumQueries(3):
+            with self.assertNumQueries(4):
                 """
                 The queries are:
                 PagePermission query for affected pages


### PR DESCRIPTION
Hi,

I discovered a bottleneck on my website. Generating the menu can take up to 50 seconds! After this fix, I can go down to 5 seconds. It's still not acceptable, but this is a quick fix.
