### PR TITLE
No support for file permissions.

### DIFF
--- a/docs/advanced/permissions_reference.rst
+++ b/docs/advanced/permissions_reference.rst
@@ -78,3 +78,8 @@ Using the *Pages global permissions* model you can give a set of permissions to 
 .. note:: You always **must** set the sites managed py the global permissions, even if you only have one site.
 
 
+File Permissions
+================
+
+django CMS does not take care of and no responsibility for controlling access to files. Please make sure to use either
+a prebuilt solution (like `django-filer <https://github.com/stefanfoulis/django-filer>`_) or to roll your own.


### PR DESCRIPTION
When a file or other piece of uploaded media is added to a page/placeholder, there is no support for restricting access to the media.

I've implemented a view based on the use of Apache's mod-xsendfile, and while I wouldn't expect django-cms to deal with any of the header specifics, it'd be nice not to have to manually traverse through django-cms tables trying to work out whether a user is allowed to access a particular file...

At the moment I do something like this (assuming `path` is the url path component):

``` python
    try:
        f = CMSFile.objects.get(file=path)
        if f.placeholder_id:
            if f.placeholder.page:
                cms_page = f.placeholder.page
                if not cms_page.has_view_permission(request):
                   raise PermissionDenied
                return ... # some code to work with mod-xsendfile
    except CMSFile.DoesNotExist:
        raise Http404
```

I'm not sure if there are other valid ways to have access to a given file, but this works for me.
