### PR TITLE
[Docs] plugin reference should cover provided contexts.

### DIFF
--- a/docs/extending_cms/custom_plugins.rst
+++ b/docs/extending_cms/custom_plugins.rst
@@ -454,6 +454,16 @@ A **bad** example:
 .. _plugin-context-processors:
 
 
+Plugin Context
+==============
+
+The plugin has access to the django template context. You can override variables using the ``with`` tag.
+
+Example::
+
+    {% with 320 as width %}{% placeholder "content" %}{% endwith %}
+
+
 Plugin Context Processors
 =========================
 


### PR DESCRIPTION
In light of [this thread on the google group](https://groups.google.com/forum/#!topic/django-cms/OxCeQYxK04Y), I think it would make sense for the [plugins reference](http://docs.django-cms.org/en/2.2/getting_started/plugin_reference.html) to document what values get passed from the plugin to the template, and expound on how to use the placeholder variable (and potentially the`{% with %}` tag) to change what's displayed. 

I'm fairly certain this is covered in minor ways in other parts of the documentation - the `{% with %}` usage, for example, [is here](http://readthedocs.org/docs/django-cms/en/latest/advanced/templatetags.html#placeholder); the `placeholder` usage [is here](http://docs.django-cms.org/en/2.2/getting_started/plugin_reference.html#picture) - but it would be good to have it a) all in one place, b) filling out the plugin reference docs, both in a clear way.

I'll start attacking it at some point, but I wanted a ticket in case I can't do so any time soon, for whatever reason.
