### PR TITLE
Adds a class (cms_toolbar-expanded) to body when the toolbar is expanded

### DIFF
--- a/cms/static/cms/js/plugins/cms.toolbar.js
+++ b/cms/static/cms/js/plugins/cms.toolbar.js
@@ -333,7 +333,7 @@ $(document).ready(function () {
 			this.toolbarTrigger.addClass('cms_toolbar-trigger-expanded');
 			this.toolbar.slideDown(speed);
 			// animate html
-			this.body.animate({ 'margin-top': (this.config.debug) ? 35 : 30 }, (init) ? 0 : speed);
+			this.body.addClass('cms_toolbar-expanded').animate({ 'margin-top': (this.config.debug) ? 35 : 30 }, (init) ? 0 : speed);
 			// set messages top to toolbar height
 			this.messages.css('top', 31);
 			// set new settings
@@ -348,7 +348,7 @@ $(document).ready(function () {
 			this.toolbarTrigger.removeClass('cms_toolbar-trigger-expanded');
 			this.toolbar.slideUp(speed);
 			// animate html
-			this.body.animate({ 'margin-top': (this.config.debug) ? 5 : 0 }, speed);
+			this.body.removeClass('cms_toolbar-expanded').animate({ 'margin-top': (this.config.debug) ? 5 : 0 }, speed);
 			// set messages top to 0
 			this.messages.css('top', 0);
 			// set new settings


### PR DESCRIPTION
Simply adds the class .cms_toolbar-expanded to body when the toolbar is expanded, removed when it is collapsed.

I've submitted a change like this in the past for some version 2 of the CMS. Looks like that change didn't get pulled into the new FE code base.

The reason this is important is because if the design of the website involves using "position: fixed" for a page header or another element, the toolbar will break the design when the toolbar adds a margin to the body. At least when there is a CSS class present, we can accommodate and re-position the elements with an additional 30px in our css class.

Also, in case anyone is doing this, if you want to also approximate the transition, use something like this in your CSS:

```
YOUR_ELEMENT {
    position: fixed;
    top: 0;
    transition: top 0.2s linear; // use prefixes as required!
    ...
}
body.cms_toolbar-expanded YOUR_ELEMENT {
    top: 30px;
}
```
