### PR TITLE
Prevents console errors when that.showError doesn't exist.

### DIFF
--- a/cms/static/cms/js/modules/cms.base.js
+++ b/cms/static/cms/js/modules/cms.base.js
@@ -62,8 +62,11 @@ $(document).ready(function () {
 						}
 					},
 					'error': function (jqXHR) {
-						if (that && that.showError && that.showError instanceof Function) {
-							that.showError(jqXHR.response + ' | ' + jqXHR.status + ' ' + jqXHR.statusText);						
+						if(CMS && CMS.API.Toolbar) {
+							CMS.API.Toolbar.showError(jqXHR.response + ' | ' + jqXHR.status + ' ' + jqXHR.statusText);
+						} else {
+							$('.messagelist').remove();
+							$('.breadcrumbs').after('<ul class="messagelist"><li class="error">' + jqXHR.response + ' | ' + jqXHR.status + ' ' + jqXHR.statusText + '</li></ul>');
 						}
 					}
 				});


### PR DESCRIPTION
Sadly, this is **not** the cause of issue #2480, but should be fixed anyway.
