### PR TITLE
If the language menu isn't present, don't change it.

### DIFF
--- a/cms/cms_toolbar.py
+++ b/cms/cms_toolbar.py
@@ -237,7 +237,10 @@ class PageToolbar(CMSToolbar):
                                            side=self.toolbar.RIGHT), len(self.toolbar.right_items))
 
     def change_language_menu(self):
-        language_menu = self.toolbar.get_or_create_menu(LANGUAGE_MENU_IDENTIFIER)
+        language_menu = self.toolbar.get_menu(LANGUAGE_MENU_IDENTIFIER)
+        if not language_menu:
+            return None
+
         add = []
         remove = self.page.get_languages()
         languages = get_language_objects(self.current_site.pk)

--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -96,6 +96,12 @@ class CMSToolbar(ToolbarAPIMixin):
 
     # Public API
 
+    def get_menu(self, key, verbose_name=None, side=LEFT, position=None):
+        self.populate()
+        if key in self.menus:
+            return self.menus[key]
+        return None
+
     def get_or_create_menu(self, key, verbose_name=None, side=LEFT, position=None):
         self.populate()
         if key in self.menus:

--- a/docs/extending_cms/toolbar.rst
+++ b/docs/extending_cms/toolbar.rst
@@ -79,7 +79,7 @@ exposed by the toolbar and its items.
 
 To add a :class:`cms.toolbar.items.Menu` to the toolbar, use
 :meth:`cms.toolbar.toolbar.CMSToolbar.get_or_create_menu` which will either add a menu if
-it doesn't exist, or create it. 
+it doesn't exist, or create it.
 
 Then, to add a link to your changelist that will open in the sideframe, use the
 :meth:`cms.toolbar.items.ToolbarMixin.add_sideframe_item` method on the menu
@@ -131,6 +131,11 @@ menus::
             url = reverse('admin:polls_poll_changelist')
             menu.add_sideframe_item(_('Poll overview'), url=url)
             admin_menu.add_break('poll-break', position=menu)
+
+
+If you wish to simply detect the presence of a menu without actually creating
+it, you can use :meth:`cms.toolbar.toolbar.CMSToolbar.get_menu`, which will
+return the menu if it is present, or, if not, will return `None`.
 
 
 ===========================


### PR DESCRIPTION
As per PR #2651, the language menu was disabled (not rendered) if the settings.USE_I18N is False. Previously, code would alter that menu, whether or not it was present, resulting in a mis-formed language menu.

This PR adds a new public API for the toolbar get_menu(), which operates like get_or_create_menu(), except that it will return None if the menu is not found.

Docs also updated.

Tests pass.
