### PR TITLE
Fixed boolean expression that breaks the CMS toolbar on non-CMS pages with static placeholders.

### DIFF
--- a/cms/cms_toolbar.py
+++ b/cms/cms_toolbar.py
@@ -194,7 +194,7 @@ class PageToolbar(CMSToolbar):
                 classes = ["cms_btn-action", "cms_btn-publish"]
 
                 dirty = bool(self.page and self.page.is_dirty(self.current_lang)) or len(dirty_statics) > 0
-                dirty = bool(dirty or (self.page.publisher_public_id and self.page.publisher_public.get_publisher_state(
+                dirty = bool(dirty or (self.page and self.page.publisher_public_id and self.page.publisher_public.get_publisher_state(
                     self.current_lang) == PUBLISHER_STATE_PENDING))
                 if dirty:
                     classes.append("cms_btn-publish-active")


### PR DESCRIPTION
The boolean expression changed in this commit was breaking the CMS toolbar for me on non-CMS Page that happened to have a static placeholder, after attempting to login as the superuser using the CMS toolbar.

AttributeError at /en/shop/products/
'NoneType' object has no attribute 'publisher_public_id'
Request Method: GET
Request URL:    http://localhost:8000/en/shop/products/
Django Version: 1.6.2
Exception Type: AttributeError
Exception Value:  
'NoneType' object has no attribute 'publisher_public_id'
Exception Location: /Users/eric/.virtualenvs/site-awesim/lib/python2.7/site-packages/cms/cms_toolbar.py in post_template_populate, line 197
Python Executable:  /Users/eric/.virtualenvs/site-awesim/bin/python
Python Version: 2.7.6
Python Path:  
['/Users/eric/Nimbis/site-awesim',
 '/Users/eric/.virtualenvs/site-awesim/lib/python27.zip',
 '/Users/eric/.virtualenvs/site-awesim/lib/python2.7',
 '/Users/eric/.virtualenvs/site-awesim/lib/python2.7/plat-darwin',
 '/Users/eric/.virtualenvs/site-awesim/lib/python2.7/plat-mac',
 '/Users/eric/.virtualenvs/site-awesim/lib/python2.7/plat-mac/lib-scriptpackages',
 '/Users/eric/.virtualenvs/site-awesim/lib/python2.7/lib-tk',
 '/Users/eric/.virtualenvs/site-awesim/lib/python2.7/lib-old',
 '/Users/eric/.virtualenvs/site-awesim/lib/python2.7/lib-dynload',
 '/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7',
 '/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/plat-darwin',
 '/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/lib-tk',
 '/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/plat-mac',
 '/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/plat-mac/lib-scriptpackages',
 '/Users/eric/.virtualenvs/site-awesim/lib/python2.7/site-packages']
Server time:    Wed, 12 Mar 2014 12:15:35 -0400
