### PR TITLE
Fixes AttributeError: [some plugin] object has no attribute 'cms_plugin_ptr'

### DIFF
--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -246,7 +246,7 @@ class Page(with_metaclass(PageMetaClass, MPTTModel)):
         plugin_pool.set_plugin_meta()
         for plugin in CMSPlugin.objects.filter(placeholder__page=target, language=language).order_by('-level'):
             inst, cls = plugin.get_plugin_instance()
-            if inst:
+            if inst and getattr(inst, 'cms_plugin_ptr', False):
                 inst.cmsplugin_ptr._no_reorder = True
                 inst.delete()
             else:


### PR DESCRIPTION
In my case, this apparently was triggered by upgrading the CMS whilst having unsaved plugin instances, but this seems like a very safe addition. I mean, if we're going to bother checking to see if inst is valid, shouldn't we also check that the object we're about to access is also valid?
