### PR TITLE
Improve the Plugins documentation for referencability

### DIFF
--- a/docs/extending_cms/custom_plugins.rst
+++ b/docs/extending_cms/custom_plugins.rst
@@ -924,13 +924,14 @@ See also: `translatable_content_excluded_fields`_, `set_translatable_content`_
 post_copy
 ---------
 
-Can be overriden to handle more advanced cases (eg Text Plugins) after the
-original has been copied.
+Can (should) be overriden to handle the copying of plugins which contain
+children plugins after the original parent has been copied.
 
 ``post_copy`` takes 2 arguments:
 
 * ``old_instance``: The old plugin instance instance
-* ``new_old_ziplist``: [unclear at time of this edit]
+* ``new_old_ziplist``: A list of tuples containing new copies and the old
+                       existing child plugins.
 
 See also: `Handling Relations`_, `copy_relations`_
 


### PR DESCRIPTION
Updates the reference section of the plugin documentation as follows:
1. Split into two sub-sections: attributes and methods
2. Alphabetize the entries in each section
3. Cross-reference each entry with related via "See also:..."

Update icon_src() and icon_atl() with examples and rationale.

I'll leave this unmerged so that it can be reviewed by others for a few hours.
