### PR TITLE
Upgrade Docs now say django.contrib.auth is required in INSTALLED_APPS for 3.0

### DIFF
--- a/docs/upgrade/3.0.rst
+++ b/docs/upgrade/3.0.rst
@@ -431,6 +431,7 @@ Next, you need to make the following changes in your ``settings.py``
 
     * Remove ``cms.plugin.twitter``. This package has been deprecated, see :ref:`cmsplugin-twitter-removed`.
     * Rename all the other ``cms.plugins.X`` to ``djangocms_X``, see :ref:`ex-core-plugins`.
+    * Add ``django.contrib.auth`` if it is not yet listed.
 
 * settings.CONTEXT_PROCESSORS
 


### PR DESCRIPTION
My 2.4.3 version worked **without** django.contrib.auth in settings.INSTALLED_APPS. After upgrading to 3.0 it became necessary to list this module. I wrote this into the upgrade docs for the 3.0 version.
