### PR TITLE
Simple, but important fix.

### DIFF
--- a/docs/extending_cms/custom_plugins.rst
+++ b/docs/extending_cms/custom_plugins.rst
@@ -712,8 +712,8 @@ added to this plugin.
 See also: `parent_classes`_
 
 
-disable_child_plugin
---------------------
+disable_child_plugins
+---------------------
 
 Default: ``False``
 


### PR DESCRIPTION
After trawling through the code base, I've discovered that this attribute name should be plural.
