### PR TITLE
Fixed: Error importing module cms.middleware.toolbar: "cannot import name plugin_pool"

### DIFF
--- a/cms/middleware/toolbar.py
+++ b/cms/middleware/toolbar.py
@@ -2,7 +2,6 @@
 """
 Edit Toolbar middleware
 """
-from cms.plugin_pool import plugin_pool
 from cms.toolbar.toolbar import CMSToolbar
 from cms.utils.i18n import force_language
 from django.contrib.admin.models import LogEntry
@@ -13,6 +12,7 @@ from cms.utils.placeholder import get_toolbar_plugin_struct
 
 
 def toolbar_plugin_processor(instance, placeholder, rendered_content, original_context):
+    from cms.plugin_pool import plugin_pool
     original_context.push()
     child_plugin_classes = []
     plugin_class = instance.get_plugin_class()


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/user1/test_env1/lib/python2.6/site-packages/django/core/handlers/wsgi.py", line 187, in __call__
    self.load_middleware()
  File "/home/user1/test_env1/lib/python2.6/site-packages/django/core/handlers/base.py", line 47, in load_middleware
    mw_class = import_by_path(middleware_path)
  File "/home/user1/test_env1/lib/python2.6/site-packages/django/utils/module_loading.py", line 26, in import_by_path
    sys.exc_info()[2])
  File "/home/user1/test_env1/lib/python2.6/site-packages/django/utils/module_loading.py", line 21, in import_by_path
    module = import_module(module_path)
  File "/home/user1/test_env1/lib/python2.6/site-packages/django/utils/importlib.py", line 40, in import_module
    __import__(name)
  File "/home/user1/test_env1/lib/python2.6/site-packages/cms/middleware/toolbar.py", line 5, in <module>
    from cms.plugin_pool import plugin_pool
  File "/home/user1/test_env1/lib/python2.6/site-packages/cms/plugin_pool.py", line 18, in <module>
    from cms.plugin_base import CMSPluginBase
  File "/home/user1/test_env1/lib/python2.6/site-packages/cms/plugin_base.py", line 16, in <module>
    from cms.models import CMSPlugin
  File "/home/user1/test_env1/lib/python2.6/site-packages/cms/models/__init__.py", line 9, in <module>
    from .placeholderpluginmodel import *  # nopyflakes
  File "/home/user1/test_env1/lib/python2.6/site-packages/cms/models/placeholderpluginmodel.py", line 3, in <module>
    from cms.models.fields import PlaceholderField
  File "/home/user1/test_env1/lib/python2.6/site-packages/cms/models/fields.py", line 2, in <module>
    from cms.forms.fields import PageSelectFormField
  File "/home/user1/test_env1/lib/python2.6/site-packages/cms/forms/fields.py", line 7, in <module>
    from cms.forms.widgets import PageSelectWidget, PageSmartLinkWidget
  File "/home/user1/test_env1/lib/python2.6/site-packages/cms/forms/widgets.py", line 14, in <module>
    from cms.templatetags.cms_admin import CMS_ADMIN_ICON_BASE
  File "/home/user1/test_env1/lib/python2.6/site-packages/cms/templatetags/cms_admin.py", line 9, in <module>
    from cms.utils.admin import get_admin_menu_item_context
  File "/home/user1/test_env1/lib/python2.6/site-packages/cms/utils/admin.py", line 13, in <module>
    from cms.utils import permissions
  File "/home/user1/test_env1/lib/python2.6/site-packages/cms/utils/permissions.py", line 9, in <module>
    from cms.plugin_pool import plugin_pool
ImproperlyConfigured: Error importing module cms.middleware.toolbar: "cannot import name plugin_pool"
```
