### PR TITLE
bugfix: escape js string in a template

### DIFF
--- a/cms/templates/admin/cms/page/tree/base.html
+++ b/cms/templates/admin/cms/page/tree/base.html
@@ -51,10 +51,10 @@ $(document).ready(function () {
 			'filtered': {% if cl.is_filtered %}true{% else %}false{% endif %}
 		},
 		'lang': {
-			'success': '{% trans "Successfully moved" %}',
-			'changes': '{% trans "Changes within the tree might require a refresh." %}',
-			'error': '{% trans "An error occured. Please reload the page" %}',
-			'publish': '{% trans "Are you sure you want to %s this page?" %}'
+			'success': '{% trans "Successfully moved" as success_str %}{{ success_str|escapejs }}',
+			'changes': '{% trans "Changes within the tree might require a refresh." as changes_str %}{{ changes_str|escapejs }}',
+			'error': '{% trans "An error occured. Please reload the page" as error_str %}{{ error_str|escapejs }}',
+			'publish': '{% trans "Are you sure you want to %s this page?" as publish_str %}{{ publish_str|escapejs }}'
 		}
 	});
 });


### PR DESCRIPTION
Transtaled strings with quotes break javascript code in template `cms/templates/admin/cms/page/tree/base.html`.
