### PR TITLE
better code: using _() in a template instead of trans

### DIFF
--- a/cms/templates/admin/cms/page/tree/base.html
+++ b/cms/templates/admin/cms/page/tree/base.html
@@ -51,10 +51,10 @@ $(document).ready(function () {
 			'filtered': {% if cl.is_filtered %}true{% else %}false{% endif %}
 		},
 		'lang': {
-			'success': '{% trans "Successfully moved" as success_str %}{{ success_str|escapejs }}',
-			'changes': '{% trans "Changes within the tree might require a refresh." as changes_str %}{{ changes_str|escapejs }}',
-			'error': '{% trans "An error occured. Please reload the page" as error_str %}{{ error_str|escapejs }}',
-			'publish': '{% trans "Are you sure you want to %s this page?" as publish_str %}{{ publish_str|escapejs }}'
+			'success': '{{ _("Successfully moved")|escapejs }}',
+			'changes': '{{ _("Changes within the tree might require a refresh.")|escapejs }}',
+			'error': '{{ _("An error occured. Please reload the page")|escapejs }}',
+			'publish': '{{ _("Are you sure you want to %s this page?")|escapejs }}'
 		}
 	});
 });


### PR DESCRIPTION
_() in templates is documented at least since django 1.4. I'm wondering
why it's not more emphasised in django doc. Give it a try.
