### PR TITLE
Fix #3054, paste bin doesn't close unexpectedly anymore

### DIFF
--- a/cms/static/cms/js/modules/cms.clipboard.js
+++ b/cms/static/cms/js/modules/cms.clipboard.js
@@ -50,7 +50,7 @@ $(document).ready(function () {
 				// clear timeout
 				clearTimeout(that.timer);
 
-				if(e.type === 'mouseleave') hide();
+				if(e.type === 'mouseleave' && !that.containers.has(e.toElement).length) hide();
 
 				var index = that.clipboard.find('.cms_clipboard-triggers a').index(this);
 				var el = that.containers.eq(index);


### PR DESCRIPTION
This fixes #3054.

Basically by detecting if we are entering the paste bin panel after leaving the paste bin trigger.
