### PR TITLE
Separate Language dependent and independent fields in Advanced Settings

### DIFF
--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -213,6 +213,16 @@ class AdvancedSettingsForm(forms.ModelForm):
     language = forms.ChoiceField(label=_("Language"), choices=get_language_tuple(),
                                  help_text=_('The current language of the content fields.'))
 
+    fieldsets = (
+        (None, {
+            'fields': ('overwrite_url','redirect'),
+        }),
+        ('Language independent options', {
+            'fields': ('site', 'template', 'reverse_id', 'soft_root', 'navigation_extenders',
+            'application_urls', 'application_namespace', "xframe_options",)
+        })
+    )
+
     def __init__(self, *args, **kwargs):
         super(AdvancedSettingsForm, self).__init__(*args, **kwargs)
         self.fields['language'].widget = HiddenInput()

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -238,6 +238,14 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
         if new and Page.objects.filter(site_id=obj.site_id).count() == 1:
             obj.publish(language)
 
+    def get_fieldsets(self, request, obj=None):
+        form = self.get_form(request, obj, fields=None)
+        if getattr(form, 'fieldsets', None) is None:
+            fields = list(form.base_fields) + list(self.get_readonly_fields(request, obj))
+            return [(None, {'fields': fields})]
+        else:
+            return form.fieldsets
+
     def get_form(self, request, obj=None, **kwargs):
         """
         Get PageForm for the Page model and modify its fields depending on


### PR DESCRIPTION
Since there are language dependent fields (redirect, overwrite_url) as well as language independent fields (all others)  within advanced settings of a page, I use the django admin fieldsets to separate those into 2 groups. 
