### PR TITLE
Cleanup & optimization for utils.page_resolver

### DIFF
--- a/cms/tests/admin.py
+++ b/cms/tests/admin.py
@@ -1393,7 +1393,7 @@ class AdminFormsTests(AdminTestsBase):
             self.assertIn('<b>Test</b>', output)
         with self.assertNumQueries(FuzzyInt(18, 34)):
             force_unicode(self.client.get('/en/?edit').content)
-        with self.assertNumQueries(FuzzyInt(13, 15)):
+        with self.assertNumQueries(FuzzyInt(12, 14)):
             force_unicode(self.client.get('/en/').content)
 
     def test_tree_view_queries(self):

--- a/cms/tests/cache.py
+++ b/cms/tests/cache.py
@@ -61,10 +61,10 @@ class CacheTestCase(CMSTestCase):
         with SettingsOverride(CMS_PAGE_CACHE=False, MIDDLEWARE_CLASSES=middleware):
             with self.assertNumQueries(FuzzyInt(14, 18)):
                 self.client.get('/en/')
-            with self.assertNumQueries(FuzzyInt(7, 11)):
+            with self.assertNumQueries(FuzzyInt(6, 10)):
                 self.client.get('/en/')
         with SettingsOverride(CMS_PAGE_CACHE=False, MIDDLEWARE_CLASSES=middleware, CMS_PLACEHOLDER_CACHE=False):
-            with self.assertNumQueries(FuzzyInt(9, 13)):
+            with self.assertNumQueries(FuzzyInt(8, 12)):
                 self.client.get('/en/')
 
     def test_no_cache_plugin(self):
@@ -112,7 +112,7 @@ class CacheTestCase(CMSTestCase):
         rctx = RequestContext(request)
         with self.assertNumQueries(4):
             render2 = template.render(rctx)
-        with self.assertNumQueries(FuzzyInt(10, 14)):
+        with self.assertNumQueries(FuzzyInt(9, 13)):
             response = self.client.get('/en/')
             resp2 = response.content.decode('utf8').split("$$$")[1]
         self.assertNotEqual(render, render2)

--- a/cms/tests/views.py
+++ b/cms/tests/views.py
@@ -214,8 +214,8 @@ class ContextTests(SettingsOverrideTestCase):
             # django applications
             with self.assertNumQueries(num_queries):
                 response = self.client.get("/en/admin/")
-            # 2 queries run when determining current page
-            with self.assertNumQueries(2):
+            # One query when determining current page
+            with self.assertNumQueries(1):
                 self.assertFalse(response.context['request'].current_page)
                 self.assertFalse(response.context['request']._current_page_cache)
             # Zero more queries when determining the current template
@@ -229,7 +229,7 @@ class ContextTests(SettingsOverrideTestCase):
         # Number of queries when context processors is not enabled
         with SettingsOverride(TEMPLATE_CONTEXT_PROCESSORS=new_context):
             # Baseline number of queries
-            with self.assertNumQueries(FuzzyInt(15, 19)) as context:
+            with self.assertNumQueries(FuzzyInt(13, 17)) as context:
                 response = self.client.get("/en/page-2/")
                 if DJANGO_1_5:
                     num_queries_page = len(context.connection.queries) - context.starting_queries

--- a/cms/utils/page_resolver.py
+++ b/cms/utils/page_resolver.py
@@ -52,9 +52,6 @@ def get_page_queryset_from_path(path, preview=False, draft=False, site=None):
     else:
         pages = Page.objects.public().published(site=site)
 
-    # Check if there are any pages
-    if not pages.all_root().exists():
-        return Page.objects.none()
     if not path:
         # if there is no path (slashes stripped) and we found a home, this is the
         # home page.


### PR DESCRIPTION
Saves 1 or 2 database queries from every page fetch. See individual commit messages for explanation.

@ojii, please scrutinize the 2nd commit -- you're the author of that original code. While I can't see any reasonable use for that condition, I might be missing something in my analysis.
