### PR TITLE
Added basic support for Django apps registry

### DIFF
--- a/cms/__init__.py
+++ b/cms/__init__.py
@@ -1,2 +1,4 @@
 # -*- coding: utf-8 -*-
 __version__ = '3.0.1.dev1'
+
+default_app_config = 'cms.apps.CMSConfig'

--- a/cms/apps.py
+++ b/cms/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+
+class CMSConfig(AppConfig):
+    name = 'cms'
+    verbose_name = _("Django CMS")

--- a/menus/__init__.py
+++ b/menus/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'menus.apps.MenusConfig'

--- a/menus/apps.py
+++ b/menus/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+
+class MenusConfig(AppConfig):
+    name = 'menus'
+    verbose_name = _("Django CMS menus system")


### PR DESCRIPTION
There is a new feature added to Django in version 1.7 called _Applications_. It's a registry that keeps track of all applications from `INSTALLED_APPS` and their properties like name, model module, path etc. (please refer to documentation: https://docs.djangoproject.com/en/1.7/ref/applications/).

It might be beneficial for Django CMS to integrate this feature and it the future we can use it to obtain some info contained it the registry in cms code (see how it's done in `django.contrib.admin`). For now on I only propose to support `cms` and `menus` applications as a valid Django apps. More support would come later when Django 1.7 would become minimal required version for cms and menus.

Older versions of Django (< 1.7) are ignoring this and noting breaks.
