### PR TITLE
Change confirmation message to reflect current CMS

### DIFF
--- a/cms/templates/cms/toolbar/toolbar_javascript.html
+++ b/cms/templates/cms/toolbar/toolbar_javascript.html
@@ -44,7 +44,7 @@ $(document).ready(function () {
 			'error': '<strong>{% trans "The following error occured:" %}</strong> ',
 			'success': '{% trans "Action successfull... reloading." %}',
 			'confirm': '{% trans "Are you sure you want to delete this plugin?" %}',
-			'publish': '{% trans "Publishing this page will activate it within the menu and set it live. Are you sure?" %}'
+			'publish': '{% trans "Are you sure you want to publish this page?" %}'
 		},
 		'urls': {
 			'settings': '{% url "admin:cms_usersettings_session_store" %}', // url to save settings


### PR DESCRIPTION
In my tests, publishing an unpublished page that is not active in the menu does _not_ set it active in the menu when you published (thankfully!), so this confirmation message appears out of date and is particularly unnerving if you do not want the page in the menu.

Does anyone know of a case where the old message "Publishing this page will activate it within the menu and set it live. Are you sure?" would be more accurate?
