### PR TITLE
catch ValueError from log.get_edited_object in PageAdmin.resolve

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -1348,7 +1348,7 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
             log = LogEntry.objects.get(pk=request.session['cms_log_latest'])
             try:
                 obj = log.get_edited_object()
-            except ObjectDoesNotExist:
+            except (ObjectDoesNotExist, ValueError):
                 obj = None
             del request.session['cms_log_latest']
             if obj and obj.__class__ in toolbar_pool.get_watch_models() and hasattr(obj, 'get_absolute_url'):


### PR DESCRIPTION
When using django-siteprefs (https://github.com/idlesign/django-siteprefs) in the administration sidebar it is possible to have a LogEntry object with object_id = 'None'.  This causes a ValueError exception on line 1350 in PageAdmin.resolve().  Simplest solution is to catch ValueError and handle the same way as ObjectDoesNotExist.  Thanks!

```
(Pdb) p log.__dict__
{'action_flag': 2, 'action_time': datetime.datetime(2014, 5, 3, 2, 32, 50, 111000, tzinfo=<UTC>), 'user_id': 1, 'content_type_id': 124, 'object_repr': u'Preferences object', '_state': <django.db.models.base.ModelState object at 0x110b5ba90>, 'object_id': u'None', 'change_message': u'Changed shop_dashboard_url.', 'id': 162}
(Pdb) l
1347            if request.session.get('cms_log_latest', False):
1348                log = LogEntry.objects.get(pk=request.session['cms_log_latest'])
1349                try:
1350                    import pdb
1351                    pdb.set_trace()
1352 ->                 obj = log.get_edited_object()
1353                except ObjectDoesNotExist:
1354                    obj = None
1355                del request.session['cms_log_latest']
1356                if obj and obj.__class__ in toolbar_pool.get_watch_models() and hasattr(obj, 'get_absolute_url'):
1357                    try:
(Pdb) n
```

Here is the full traceback:

```
2014-05-02 22:44:28,431 ERROR Internal Server Error: /en/admin/cms/page/resolve/
Traceback (most recent call last):
  File "/Users/bschott/.virtualenvs/site-awesim/lib/python2.7/site-packages/django/core/handlers/base.py", line 114, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/Users/bschott/Source/django-cms/cms/admin/pageadmin.py", line 1350, in resolve
    obj = log.get_edited_object()
  File "/Users/bschott/.virtualenvs/site-awesim/lib/python2.7/site-packages/django/contrib/admin/models.py", line 68, in get_edited_object
    return self.content_type.get_object_for_this_type(pk=self.object_id)
  File "/Users/bschott/.virtualenvs/site-awesim/lib/python2.7/site-packages/django/contrib/contenttypes/models.py", line 168, in get_object_for_this_type
    return self.model_class()._base_manager.using(self._state.db).get(**kwargs)
  File "/Users/bschott/.virtualenvs/site-awesim/lib/python2.7/site-packages/django/db/models/query.py", line 298, in get
    clone = self.filter(*args, **kwargs)
  File "/Users/bschott/.virtualenvs/site-awesim/lib/python2.7/site-packages/django/db/models/query.py", line 590, in filter
    return self._filter_or_exclude(False, *args, **kwargs)
  File "/Users/bschott/.virtualenvs/site-awesim/lib/python2.7/site-packages/django/db/models/query.py", line 608, in _filter_or_exclude
    clone.query.add_q(Q(*args, **kwargs))
  File "/Users/bschott/.virtualenvs/site-awesim/lib/python2.7/site-packages/django/db/models/sql/query.py", line 1198, in add_q
    clause = self._add_q(where_part, used_aliases)
  File "/Users/bschott/.virtualenvs/site-awesim/lib/python2.7/site-packages/django/db/models/sql/query.py", line 1234, in _add_q
    current_negated=current_negated)
  File "/Users/bschott/.virtualenvs/site-awesim/lib/python2.7/site-packages/django/db/models/sql/query.py", line 1125, in build_filter
    clause.add(constraint, AND)
  File "/Users/bschott/.virtualenvs/site-awesim/lib/python2.7/site-packages/django/utils/tree.py", line 104, in add
    data = self._prepare_data(data)
  File "/Users/bschott/.virtualenvs/site-awesim/lib/python2.7/site-packages/django/db/models/sql/where.py", line 79, in _prepare_data
    value = obj.prepare(lookup_type, value)
  File "/Users/bschott/.virtualenvs/site-awesim/lib/python2.7/site-packages/django/db/models/sql/where.py", line 352, in prepare
    return self.field.get_prep_lookup(lookup_type, value)
  File "/Users/bschott/.virtualenvs/site-awesim/lib/python2.7/site-packages/django/db/models/fields/__init__.py", line 369, in get_prep_lookup
    return self.get_prep_value(value)
  File "/Users/bschott/.virtualenvs/site-awesim/lib/python2.7/site-packages/django/db/models/fields/__init__.py", line 613, in get_prep_value
    return int(value)
ValueError: invalid literal for int() with base 10: 'None'
Internal Server Error: /en/admin/cms/page/resolve/
```
