### PR TITLE
Move context assignment to only where it is required

### DIFF
--- a/cms/views.py
+++ b/cms/views.py
@@ -69,8 +69,6 @@ def details(request, slug):
             response._headers = headers
             return response
 
-    # get the right model
-    context = RequestContext(request)
     # Get a Page model object from the request
     page = get_page_from_request(request, use_path=slug)
     if not page:
@@ -180,7 +178,8 @@ def details(request, slug):
         request.toolbar.set_object(page)
 
     template_name = get_template_from_request(request, page, no_current_page=True)
-    # fill the context 
+    # fill the context
+    context = RequestContext(request)
     context['lang'] = current_language
     context['current_page'] = page
     context['has_change_permissions'] = page.has_change_permission(request)
@@ -245,7 +244,7 @@ def _cache_page(response):
         )
         # See note in invalidate_cms_page_cache()
         _set_cache_version(version)
-    
+
 
 def _get_cache_key(request):
     #md5 key of current path


### PR DESCRIPTION
Moved the line to just before context is required. Tests pass.

It probably wouldn't be a bad idea to have a fuller review of this bit of code, however, I know that @ojii, is already mucking about in this bit whilst working in this bit now for a larger, upcoming change.

This closes #3106.
