### PR TITLE
Enable Python 3.4 classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 2.6",
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.3",
+    "Programming Language :: Python :: 3.4",
 ]
 
 setup(


### PR DESCRIPTION
Since #3168 was merged, we can enable the Python 3.4 setuptools classifier
