### PR TITLE
Update tree_component.js

### DIFF
--- a/cms/static/cms/js/jstree/tree_component.js
+++ b/cms/static/cms/js/jstree/tree_component.js
@@ -361,8 +361,8 @@ function tree_component () {
 			if(this.settings.path == false) {
 				this.path = "";
 				jQuery("script").each( function () { 
-					if(this.src.toString().match(/tree_component.*?js$/)) {
-						_this.path = this.src.toString().replace(/tree_component.*?js$/, "");
+					if(this.src.toString().match(/tree_component.*?js.*$/)) {
+						_this.path = this.src.toString().replace(/tree_component.*?js.*$/, "");
 					}
 				});
 			}


### PR DESCRIPTION
Actually the path for the static files, loaded in js depends on the tree_component, but when the js file is delivered be a CDN, it get a query.

Changed regex for the path, to work with CDN's that attach a query to static files like tree_component.js?Signature=Pte%2BCS0PEtQDOSS%2
