### PR TITLE
Pin selenium version

### DIFF
--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -11,7 +11,7 @@ django-mptt>=0.6
 django-sekizai>=0.7
 argparse
 dj-database-url
-selenium
+selenium==2.41
 django-debug-toolbar
 https://github.com/KristianOellegaard/django-hvad/archive/master.zip#egg=hvad
 -e git+git://github.com/divio/djangocms-admin-style.git#egg=djangocms-admin-style


### PR DESCRIPTION
We need to pin selenium version as 2.42 is not compatible with python 3 (WAT?)
