### PR TITLE
Fixed error when non-superuser tries to create a top-level page

### DIFF
--- a/cms/utils/permissions.py
+++ b/cms/utils/permissions.py
@@ -54,7 +54,7 @@ def has_page_add_permission(request):
     from cms.utils.plugins import current_site
     site = current_site(request)
 
-    if target is not None:
+    if target:
         try:
             page = Page.objects.get(pk=target)
         except Page.DoesNotExist:


### PR DESCRIPTION
When a non-superuser that had the correct page-level permissions tried to create a 'New Page' from the CMS toolbar, I was getting the error `invalid literal for int() with base 10: ''` appear in the sidebar. The user could, however, create a new top-level page from within the admin.

I tracked the problem down to 2 places in the `cms` codebase. `cms_toolbar.py` `add_page_menu()` method of `PageToolbar`. Where the URL is being generated for the 'New Page' link `target` is set to `self.page.parent_id or ''`, which at the top level means `''` empty string.

``` python
url="%s?language=%s&edit=1&target=%s&position=last-child" % (
    reverse("admin:cms_page_add"),
    self.toolbar.language,
    self.page.parent_id or ''
)
```

Then in `utils/permissions.py` `has_page_add_permission()` function, `target` gets extracted from `request.GET`

``` python
target = request.GET.get('target', None)
```

so `target` is an empty string. It's not `None` so passes the `if` statement test. Then it tries to get a `Page` object using empty string as the `pk`:

``` python
page = Page.objects.get(pk=target)
```

Which gives the error `invalid literal for int() with base 10: ''`. Being less strict about the checking of `target` means cms doesn't try to make it a sub-page.
