### PR TITLE
Pin reversion

### DIFF
--- a/test_requirements/django-1.6.txt
+++ b/test_requirements/django-1.6.txt
@@ -1,3 +1,3 @@
 -r requirements_base.txt
 django>=1.6
-django-reversion>=1.8
+django-reversion==1.8


### PR DESCRIPTION
Pin reversion in tests to 1.8 to let tests pass, waiting for a proper fix of issues with 1.8.1
