### PR TITLE
Fixed permission check for static placeholder

### DIFF
--- a/cms/models/static_placeholder.py
+++ b/cms/models/static_placeholder.py
@@ -84,11 +84,10 @@ class StaticPlaceholder(models.Model):
         if request.user.is_superuser:
             return True
         opts = self._meta
-        return request.user.has_perm(opts.app_label + '.' + "change")
+        return request.user.has_perm(opts.app_label + '.' + opts.get_change_permission())
 
     def has_publish_permission(self, request):
         if request.user.is_superuser:
             return True
         opts = self._meta
-        return request.user.has_perm(opts.app_label + '.' + "change") and \
-               self.has_generic_permission(request, "publish")
+        return request.user.has_perm(opts.app_label + '.' + opts.get_change_permission())


### PR DESCRIPTION
Permission codename was incorrect. Only superuser could publish changes to static placeholder. Other other users had this permission denied.
