### PR TITLE
Fix missing csrf_cookie_name in the cms toolbar

### DIFF
--- a/cms/templates/cms/toolbar/toolbar.html
+++ b/cms/templates/cms/toolbar/toolbar.html
@@ -3,6 +3,7 @@
 <script type="text/javascript">
 	var _jQuery = window.jQuery || null;
 	var _$ = window.$;
+	var csrf_cookie_name = "{{CSRF_COOKIE_NAME|default:'csrftoken'}}";
 </script>
 {% endaddtoblock %}
 {% addtoblock "js" %}<script type="text/javascript" src="{% admin_static_url %}js/jquery.min.js"></script>{% endaddtoblock %}


### PR DESCRIPTION
There was an issue with reordering plugins in the cms toolbar: 
 "Uncaught ReferenceError: csrf_cookie_name is not defined" was raised.
The cms.base.js needs csrf_cookie_name variable but it was not in the scope.
