### PR TITLE
Fixed metaclass support in Python 3

### DIFF
--- a/cms/toolbar/items.py
+++ b/cms/toolbar/items.py
@@ -1,11 +1,13 @@
-import abc
 import json
+from abc import ABCMeta
 from collections import defaultdict
-from cms.utils.compat.dj import force_unicode
-from cms.constants import RIGHT, LEFT, REFRESH_PAGE, URL_CHANGE
+
 from django.template.loader import render_to_string
 from django.utils import six
 from django.utils.functional import Promise
+
+from cms.utils.compat.dj import force_unicode
+from cms.constants import RIGHT, LEFT, REFRESH_PAGE, URL_CHANGE
 
 
 class ItemSearchResult(object):
@@ -30,7 +32,7 @@ def may_be_lazy(thing):
         return thing
 
 
-class ToolbarAPIMixin(six.with_metaclass(abc.ABCMeta)):
+class ToolbarAPIMixin(six.with_metaclass(ABCMeta)):
     REFRESH_PAGE = REFRESH_PAGE
     URL_CHANGE = URL_CHANGE
     LEFT = LEFT
@@ -171,7 +173,7 @@ class ToolbarAPIMixin(six.with_metaclass(abc.ABCMeta)):
         return item
 
 
-class BaseItem(six.with_metaclass(abc.ABCMeta)):
+class BaseItem(six.with_metaclass(ABCMeta)):
     template = None
 
     def __init__(self, side=LEFT):
@@ -346,8 +348,7 @@ class Break(BaseItem):
         self.identifier = identifier
 
 
-class BaseButton(object):
-    __metaclass__ = abc.ABCMeta
+class BaseButton(six.with_metaclass(ABCMeta)):
     template = None
 
     def render(self):


### PR DESCRIPTION
Use `django.utils.six` to allow metaclass support in Python 2 and Python 3.
