### PR TITLE
Simplified urls file.

### DIFF
--- a/cms/urls.py
+++ b/cms/urls.py
@@ -1,25 +1,25 @@
 # -*- coding: utf-8 -*-
-from cms.apphook_pool import apphook_pool
-from cms.views import details
 from django.conf import settings
-from django.conf.urls import url, patterns
+from django.conf.urls import url
+
+from cms.apphook_pool import apphook_pool
+from cms.appresolver import get_app_patterns
+from cms.views import details
+
 
 if settings.APPEND_SLASH:
-    reg = url(r'^(?P<slug>[0-9A-Za-z-_.//]+)/$', details, name='pages-details-by-slug')
+    regex = r'^(?P<slug>[0-9A-Za-z-_.//]+)/$'
 else:
-    reg = url(r'^(?P<slug>[0-9A-Za-z-_.//]+)$', details, name='pages-details-by-slug')
-
-urlpatterns = [
-    # Public pages
-    url(r'^$', details, {'slug':''}, name='pages-root'),
-    reg,
-]
+    regex = r'^(?P<slug>[0-9A-Za-z-_.//]+)$'
 
 if apphook_pool.get_apphooks():
-    """If there are some application urls, add special resolver, so we will
-    have standard reverse support.
-    """
-    from cms.appresolver import get_app_patterns
-    urlpatterns = get_app_patterns() + urlpatterns
-    
-urlpatterns = patterns('', *urlpatterns)
+    # If there are some application urls, use special resolver,
+    # so we will have standard reverse support.
+    urlpatterns = get_app_patterns()
+else:
+    urlpatterns = []
+
+urlpatterns.extend([
+    url(regex, details, name='pages-details-by-slug'),
+    url(r'^$', details, {'slug': ''}, name='pages-root'),
+])


### PR DESCRIPTION
Below is brief description of changes:
1. Only `regex` pattern needs to be assigned inside `if` clause.
2. New order of assignments to `urlpatterns` makes it easier to understand and not to mess it accidentally.
3. There is no need to use `patterns` function to create `urlpatterns`. No `prefix` is used by `django CMS` and thus plain list is sufficient. By the way `patterns` function is depreciated in django 1.8 and will be removed in 2.0. 
