### PR TITLE
check for django.jQuery existence before using it

### DIFF
--- a/cms/static/cms/js/modules/cms.base.js
+++ b/cms/static/cms/js/modules/cms.base.js
@@ -5,7 +5,7 @@
 window.django = window.django || undefined;
 
 // ensuring jQuery namespace is set correctly
-window.jQuery = (django) ? django.jQuery : window.jQuery || undefined;
+window.jQuery = (django && django.jQuery) ? django.jQuery : window.jQuery || undefined;
 
 // ensuring Class namespace is set correctly
 window.Class = window.Class || undefined;


### PR DESCRIPTION
This code seems to deal with the case of django global object coming from the admin:
https://github.com/django/django/blob/1.6.5/django/contrib/admin/static/admin/js/jquery.init.js#L7

But since Django 1.6, a global django object can also exist through the use of javascript_catalog view for instance, but this time without jQuery in it:
https://github.com/django/django/blob/1.6.5/django/views/i18n.py
