### PR TITLE
Add class to modal window body

### DIFF
--- a/cms/static/cms/js/modules/cms.modal.js
+++ b/cms/static/cms/js/modules/cms.modal.js
@@ -565,6 +565,7 @@ $(document).ready(function () {
 					contents.find('body').bind('keydown.cms', function (e) {
 						if(e.keyCode === 27) that.close();
 					});
+					contents.find('body').addClass('cms_modal-window');
 
 					// figure out if .object-tools is available
 					if(contents.find('.object-tools').length) {


### PR DESCRIPTION
Adds a class to the body of the frontend editor iframe. This makes easier to customize the design of the admin views using CSS
