### PR TITLE
Fixed #3326: Plugin pool initialises incorrectly if database is down during first request

### DIFF
--- a/cms/plugin_pool.py
+++ b/cms/plugin_pool.py
@@ -31,10 +31,10 @@ class PluginPool(object):
     def discover_plugins(self):
         if self.discovered:
             return
-        self.discovered = True
         from cms.views import invalidate_cms_page_cache
         invalidate_cms_page_cache()
         load('cms_plugins')
+        self.discovered = True
 
     def clear(self):
         self.discovered = False


### PR DESCRIPTION
This should fix #3326 by reporting job done (`discover_plugins`) after it's done, not before.
