### PR TITLE
Make it easier to use CMS Toolbar with custom admin site

### DIFF
--- a/cms/cms_toolbar.py
+++ b/cms/cms_toolbar.py
@@ -96,6 +96,7 @@ class BasicToolbar(CMSToolbar):
     """
     Basic Toolbar for site and languages menu
     """
+    admin_namespace = 'admin'
 
     def init_from_request(self):
         self.page = get_page_draft(self.request.current_page)
@@ -120,18 +121,31 @@ class BasicToolbar(CMSToolbar):
 
         if len(sites_queryset) > 1:
             sites_menu = admin_menu.get_or_create_menu('sites', _('Sites'))
-            sites_menu.add_sideframe_item(_('Admin Sites'), url=reverse('admin:sites_site_changelist'))
+            sites_menu.add_sideframe_item(
+                _('Admin Sites'),
+                url=reverse('{}:sites_site_changelist'.format(
+                    self.admin_namespace
+                ))
+            )
             sites_menu.add_break(ADMIN_SITES_BREAK)
             for site in sites_queryset:
                 sites_menu.add_link_item(site.name, url='http://%s' % site.domain,
                                          active=site.pk == self.current_site.pk)
 
         # admin
-        admin_menu.add_sideframe_item(_('Administration'), url=reverse('admin:index'))
+        admin_menu.add_sideframe_item(
+            _('Administration'),
+            url=reverse('{}:index'.format(self.admin_namespace))
+        )
         admin_menu.add_break(ADMINISTRATION_BREAK)
 
         # cms users
-        admin_menu.add_sideframe_item(_('User settings'), url=reverse('admin:cms_usersettings_change'))
+        admin_menu.add_sideframe_item(
+            _('User settings'),
+            url=reverse(
+                '{}:cms_usersettings_change'.format(self.admin_namespace)
+            )
+        )
         admin_menu.add_break(USER_SETTINGS_BREAK)
 
         # logout
@@ -144,7 +158,13 @@ class BasicToolbar(CMSToolbar):
             opts = User._meta
 
             if self.request.user.has_perm('%s.%s' % (opts.app_label, opts.get_change_permission())):
-                user_changelist_url = reverse('admin:%s_%s_changelist' % (opts.app_label, opts.module_name))
+                user_changelist_url = reverse(
+                    '{}:{}_{}_changelist'.format(
+                        self.admin_namespace,
+                        opts.app_label,
+                        opts.module_name
+                    )
+                )
                 parent.add_sideframe_item(_('Users'), url=user_changelist_url)
 
     def add_logout_button(self, parent):
@@ -166,7 +186,12 @@ class BasicToolbar(CMSToolbar):
         user_name = self.get_username()
         logout_menu_text = _('Logout %s') % user_name if user_name else _('Logout')
 
-        parent.add_ajax_item(logout_menu_text, action=reverse('admin:logout'), active=True, on_success=on_success)
+        parent.add_ajax_item(
+            logout_menu_text,
+            action=reverse('{}:logout'.format(self.admin_namespace)),
+            active=True,
+            on_success=on_success
+        )
 
     def add_language_menu(self):
         if settings.USE_I18N:
@@ -196,6 +221,7 @@ class BasicToolbar(CMSToolbar):
 @toolbar_pool.register
 class PageToolbar(CMSToolbar):
     watch_models = [Page]
+    admin_namespace = 'admin'
 
     # Helpers
 
@@ -313,7 +339,10 @@ class PageToolbar(CMSToolbar):
                 params['redirect'] = self.request.path
 
             with force_language(self.current_lang):
-                url = reverse('admin:cms_page_publish_page', args=(pk, self.current_lang))
+                url = reverse(
+                    '{}:cms_page_publish_page'.format(self.admin_namespace),
+                    args=(pk, self.current_lang)
+                )
 
             url = add_url_parameters(url, params)
 
@@ -342,7 +371,13 @@ class PageToolbar(CMSToolbar):
         self.toolbar.add_item(TemplateItem(template, extra_context=context, side=self.toolbar.RIGHT), position=pos)
 
     def add_page_settings_button(self, extra_classes=('cms_btn-action',)):
-        url = '%s?language=%s' % (reverse('admin:cms_page_change', args=[self.page.pk]), self.toolbar.language)
+        url = '{}?language={}'.format(
+            reverse(
+                '{}:cms_page_change'.format(self.admin_namespace),
+                args=[self.page.pk]
+            ),
+            self.toolbar.language
+        )
         self.toolbar.add_modal_button(_('Page settings'), url, side=self.toolbar.RIGHT, extra_classes=extra_classes)
 
     # Menus
@@ -362,7 +397,10 @@ class PageToolbar(CMSToolbar):
 
             if add:
                 language_menu.add_break(ADD_PAGE_LANGUAGE_BREAK)
-                page_change_url = reverse('admin:cms_page_change', args=(self.page.pk,))
+                page_change_url = reverse(
+                    '{}:cms_page_change'.format(self.admin_namespace),
+                    args=(self.page.pk,)
+                )
                 title = _('Add %(language)s Translation')
                 for code, name in add:
                     url = add_url_parameters(page_change_url, language=code)
@@ -370,7 +408,12 @@ class PageToolbar(CMSToolbar):
 
             if remove:
                 language_menu.add_break(REMOVE_PAGE_LANGUAGE_BREAK)
-                translation_delete_url = reverse('admin:cms_page_delete_translation', args=(self.page.pk,))
+                translation_delete_url = reverse(
+                    '{}:cms_page_delete_translation'.format(
+                        self.admin_namespace
+                    ),
+                    args=(self.page.pk,)
+                )
                 title = _('Delete %(language)s Translation')
                 disabled = len(remove) == 1
                 for code, name in remove:
@@ -379,7 +422,10 @@ class PageToolbar(CMSToolbar):
 
             if copy:
                 language_menu.add_break(COPY_PAGE_LANGUAGE_BREAK)
-                page_copy_url = reverse('admin:cms_page_copy_language', args=(self.page.pk,))
+                page_copy_url = reverse(
+                    '{}:cms_page_copy_language'.format(self.admin_namespace),
+                    args=(self.page.pk,)
+                )
                 title = _('Copy all plugins from %s')
                 question = _('Are you sure you want copy all plugins from %s?')
                 for code, name in copy:
@@ -390,7 +436,10 @@ class PageToolbar(CMSToolbar):
     def change_admin_menu(self):
         if self.has_page_change_permission():
             admin_menu = self.toolbar.get_or_create_menu(ADMIN_MENU_IDENTIFIER)
-            url = reverse('admin:cms_page_changelist')  # cms page admin
+            # cms page admin
+            url = reverse(
+                '{}:cms_page_changelist'.format(self.admin_namespace)
+            )
             params = {'language': self.toolbar.language}
             if self.page:
                 params['page_id'] = self.page.pk
@@ -407,7 +456,7 @@ class PageToolbar(CMSToolbar):
 
             # page operations menu
             add_page_menu = current_page_menu.get_or_create_menu(PAGE_MENU_ADD_IDENTIFIER, _('Add Page'))
-            app_page_url = reverse('admin:cms_page_add')
+            app_page_url = reverse('{}:cms_page_add'.format(self.admin_namespace))
             add_page_menu_sideframe_items = (
                 (_('New Page'), {'edit': 1, 'position': 'last-child', 'target': self.page.parent_id or ''}),
                 (_('New Sub Page'), {'edit': 1, 'position': 'last-child', 'target': self.page.pk}),
@@ -426,7 +475,10 @@ class PageToolbar(CMSToolbar):
             current_page_menu.add_link_item(_('Edit this Page'), disabled=edit_mode, url=page_edit_url)
 
             # page settings
-            page_settings_url = reverse('admin:cms_page_change', args=(self.page.pk,))
+            page_settings_url = reverse(
+                '{}:cms_page_change'.format(self.admin_namespace),
+                args=(self.page.pk,)
+            )
             page_settings_url = add_url_parameters(page_settings_url, language=self.toolbar.language)
             current_page_menu.add_modal_item(_('Page settings'), url=page_settings_url, disabled=not edit_mode,
                                              on_close=refresh)
@@ -434,7 +486,10 @@ class PageToolbar(CMSToolbar):
             # templates menu
             if self.toolbar.build_mode or edit_mode:
                 templates_menu = current_page_menu.get_or_create_menu('templates', _('Templates'))
-                action = reverse('admin:cms_page_change_template', args=(self.page.pk,))
+                action = reverse(
+                    '{}:cms_page_change_template'.format(self.admin_namespace),
+                    args=(self.page.pk,)
+                )
                 for path, name in get_cms_setting('TEMPLATES'):
                     active = self.page.template == path
                     if path == TEMPLATE_INHERITANCE_MAGIC:
@@ -446,19 +501,28 @@ class PageToolbar(CMSToolbar):
             current_page_menu.add_break(PAGE_MENU_SECOND_BREAK)
 
             # advanced settings
-            advanced_url = reverse('admin:cms_page_advanced', args=(self.page.pk,))
+            advanced_url = reverse(
+                '{}:cms_page_advanced'.format(self.admin_namespace),
+                args=(self.page.pk,)
+            )
             advanced_url = add_url_parameters(advanced_url, language=self.toolbar.language)
             advanced_disabled = not self.page.has_advanced_settings_permission(self.request) or not edit_mode
             current_page_menu.add_modal_item(_('Advanced settings'), url=advanced_url, disabled=advanced_disabled)
 
             # permissions
             if self.permissions_activated:
-                permissions_url = reverse('admin:cms_page_permissions', args=(self.page.pk,))
+                permissions_url = reverse(
+                    '{}:cms_page_permissions'.format(self.admin_namespace),
+                    args=(self.page.pk,)
+                )
                 permission_disabled = not edit_mode or not self.page.has_change_permissions_permission(self.request)
                 current_page_menu.add_modal_item(_('Permissions'), url=permissions_url, disabled=permission_disabled)
 
             # dates settings
-            dates_url = reverse('admin:cms_page_dates', args=(self.page.pk,))
+            dates_url = reverse(
+                '{}:cms_page_dates'.format(self.admin_namespace),
+                args=(self.page.pk,)
+            )
             current_page_menu.add_modal_item(_('Publishing dates'), url=dates_url, disabled=not edit_mode)
 
             # third break
@@ -466,17 +530,28 @@ class PageToolbar(CMSToolbar):
 
             # navigation toggle
             nav_title = _('Hide in navigation') if self.page.in_navigation else _('Display in navigation')
-            nav_action = reverse('admin:cms_page_change_innavigation', args=(self.page.pk,))
+            nav_action = reverse(
+                '{}:cms_page_change_innavigation'.format(self.admin_namespace),
+                args=(self.page.pk,)
+            )
             current_page_menu.add_ajax_item(nav_title, action=nav_action, disabled=not edit_mode, on_success=refresh)
 
             # publisher
             if self.title:
                 if self.title.published:
                     publish_title = _('Unpublish page')
-                    publish_url = reverse('admin:cms_page_unpublish', args=(self.page.pk, self.current_lang))
+                    publish_url = reverse(
+                        '{}:cms_page_unpublish'.format(self.admin_namespace),
+                        args=(self.page.pk, self.current_lang)
+                    )
                 else:
                     publish_title = _('Publish page')
-                    publish_url = reverse('admin:cms_page_publish_page', args=(self.page.pk, self.current_lang))
+                    publish_url = reverse(
+                        '{}:cms_page_publish_page'.format(
+                            self.admin_namespace
+                        ),
+                        args=(self.page.pk, self.current_lang)
+                    )
                 current_page_menu.add_ajax_item(publish_title, action=publish_url, disabled=not edit_mode,
                                                 on_success=refresh)
 
@@ -484,7 +559,10 @@ class PageToolbar(CMSToolbar):
             current_page_menu.add_break(PAGE_MENU_FOURTH_BREAK)
 
             # delete
-            delete_url = reverse('admin:cms_page_delete', args=(self.page.pk,))
+            delete_url = reverse(
+                '{}:cms_page_delete'.format(self.admin_namespace),
+                args=(self.page.pk,)
+            )
             on_delete_redirect_url = self.get_on_delete_redirect_url()
             current_page_menu.add_modal_item(_('Delete page'), url=delete_url, on_close=on_delete_redirect_url,
                                              disabled=not edit_mode)
@@ -493,7 +571,9 @@ class PageToolbar(CMSToolbar):
             current_page_menu.add_break(PAGE_MENU_LAST_BREAK)
 
             # page type
-            page_type_url = reverse('admin:cms_page_add_page_type')
+            page_type_url = reverse(
+                '{}:cms_page_add_page_type'.format(self.admin_namespace)
+            )
             page_type_url = add_url_parameters(page_type_url, copy_target=self.page.pk, language=self.toolbar.language)
             current_page_menu.add_modal_item(_('Save as Page Type'), page_type_url, disabled=not edit_mode)
 
@@ -515,16 +595,31 @@ class PageToolbar(CMSToolbar):
                     has_redo = False
                     has_undo = versions.count() > 1
 
-                undo_action = reverse('admin:cms_page_undo', args=(self.page.pk,))
-                redo_action = reverse('admin:cms_page_redo', args=(self.page.pk,))
+                undo_action = reverse(
+                    '{}:cms_page_undo'.format(self.admin_namespace),
+                    args=(self.page.pk,)
+                )
+                redo_action = reverse(
+                    '{}:cms_page_redo'.format(self.admin_namespace),
+                    args=(self.page.pk,)
+                )
 
                 history_menu.add_ajax_item(_('Undo'), action=undo_action, disabled=not has_undo, on_success=refresh)
                 history_menu.add_ajax_item(_('Redo'), action=redo_action, disabled=not has_redo, on_success=refresh)
 
                 history_menu.add_break(HISTORY_MENU_BREAK)
 
-            revert_action = reverse('admin:cms_page_revert_page', args=(self.page.pk, self.current_lang))
+            revert_action = reverse(
+                '{}:cms_page_revert_page'.format(self.admin_namespace),
+                args=(self.page.pk, self.current_lang)
+            )
             revert_question = _('Are you sure you want to revert to live?')
             history_menu.add_ajax_item(_('Revert to live'), action=revert_action, question=revert_question,
                                        disabled=not self.page.is_dirty(self.current_lang), on_success=refresh)
-            history_menu.add_modal_item(_('View history'), url=reverse('admin:cms_page_history', args=(self.page.pk,)))
+            history_menu.add_modal_item(
+                _('View history'),
+                url=reverse(
+                    '{}:cms_page_history'.format(self.admin_namespace),
+                    args=(self.page.pk,)
+                )
+            )


### PR DESCRIPTION
This pull request makes it easier to use the CMS Toolbar with a custom admin site by not hard-coding the `'admin'` namespace in the reverse calls. 

Instead of copy pasting all the toolbars, users can subclass them and overwrite `admin_namespace`.
