### PR TITLE
Updated docs

### DIFF
--- a/docs/extending_cms/custom_plugins.rst
+++ b/docs/extending_cms/custom_plugins.rst
@@ -268,6 +268,14 @@ clause.
     field, as it is declared as a property of :class:`cms.models.pluginmodel.CMSPlugin`,
     and your plugin will not work as intended in the administration without
     further work.
+    
+.. warning::
+
+    If you are using Python 2.x and overriding the ``__unicode__`` method of the 
+    model file, make sure to return its results as UTF8-string. Otherwise 
+    saving an instance of your plugin might fail with the frontend editor showing 
+    an <Empty> plugin instance. To return in unicode use a return statement like
+    ``return u'{}'.format(self.guest_name)``.
 
 .. _handling-relations:
 


### PR DESCRIPTION
I added a warning about returning non-utf8-encoded strings from within `def __unicode__()`, as I found it resulting in a 500 response and a plugin instance marked as `<Empty>`. After returning as `UTF8` everything was working as expected. If you can't confirm these issues to be related, feel that the addition is not accurate enough or doesn't make sense for documentation readers, feel free to drop it.
