### PR TITLE
Removed links to now defunct crate.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,9 @@ django CMS
 .. image:: https://api.travis-ci.org/divio/django-cms.svg?branch=develop
     :target: http://travis-ci.org/divio/django-cms
 .. image:: https://pypip.in/v/django-cms/badge.svg
-    :target: https://crate.io/packages/django-cms/
+    :target: https://pypi.python.org/pypi/django-cms/
 .. image:: https://pypip.in/d/django-cms/badge.svg
-    :target: https://crate.io/packages/django-cms/
+    :target: https://pypi.python.org/pypi/django-cms/
 .. image:: https://pypip.in/wheel/django-cms/badge.svg
     :target: https://pypi.python.org/pypi/django-cms/
 .. image:: https://pypip.in/license/django-cms/badge.svg


### PR DESCRIPTION
Removed links to now defunct crate.io. Closes #3364 
