### PR TITLE
Fix placeholder_conf when overriding with empty parent_classes or empty child_classes

### DIFF
--- a/docs/advanced/templatetags.rst
+++ b/docs/advanced/templatetags.rst
@@ -695,7 +695,7 @@ show_breadcrumb
 ===============
 
 Renders the breadcrumb navigation of the current page.
-The template for the HTML can be found at ``cms/breadcrumb.html``::
+The template for the HTML can be found at ``menu/breadcrumb.html``::
 
     {% show_breadcrumb %}
 
@@ -706,7 +706,7 @@ Or with a custom template and only display level 2 or higher::
 Usually, only pages visible in the navigation are shown in the
 breadcrumb. To include *all* pages in the breadcrumb, write::
 
-    {% show_breadcrumb 0 "cms/breadcrumb.html" 0 %}
+    {% show_breadcrumb 0 "menu/breadcrumb.html" 0 %}
 
 If the current URL is not handled by the CMS or by a navigation extender,
 the current menu node can not be determined.


### PR DESCRIPTION
This fixes the following issue:

In the app's `settings.py.CMS_PLACEHOLDER_CONF` override `child_classes` or `parent_classes` of a placeholder config. If the plugin defined those classes, but in the settings it shall be overridden by an empty list, this is not possible, because the expression is evaluated for truethness instead of checking for an empty list.
Changeset: 1964b1287393da4b99ce0bcd97de38d2563c6dda

Additionally I fixed many PEP8 issues in that file.
Changeset: 3b444a50b646f63e5fd03c298b6b32fa573e7b53
