### PR TITLE
Fix unique constraint violation and unicode error in publisher_publish command

### DIFF
--- a/cms/management/commands/publisher_publish.py
+++ b/cms/management/commands/publisher_publish.py
@@ -43,10 +43,9 @@ class Command(NoArgsCommand):
             if add:
                 pages_published += 1
                 m = "*"
-            self.stdout.write(u"%d.\t%s  %s [%d]" % (i + 1, m, force_unicode(page), page.id))
+            self.stdout.write(u"%d.\t%s  %s [%d]\n" % (i + 1, m, force_unicode(page), page.id))
 
         self.stdout.write(u"\n")
         self.stdout.write(u"=" * 40)
-        self.stdout.write(u"Total:     %s" % pages_total)
-        self.stdout.write(u"Published: %s" % pages_published)
-
+        self.stdout.write(u"\nTotal:     %s\n" % pages_total)
+        self.stdout.write(u"Published: %s\n" % pages_published)

--- a/cms/tests/publisher.py
+++ b/cms/tests/publisher.py
@@ -10,6 +10,7 @@ from django.core.urlresolvers import reverse
 
 from cms.api import create_page, add_plugin, create_title
 from cms.constants import PUBLISHER_STATE_PENDING, PUBLISHER_STATE_DEFAULT, PUBLISHER_STATE_DIRTY
+from cms.management.commands import publisher_publish
 from cms.models import CMSPlugin, Title
 from cms.models.pagemodel import Page
 from cms.plugin_pool import plugin_pool
@@ -27,12 +28,9 @@ class PublisherCommandTests(TestCase):
     """
 
     def test_command_line_should_raise_without_superuser(self):
-        raised = False
-        try:
-            call_command('publisher_publish')
-        except CommandError:
-            raised = True
-        self.assertTrue(raised)
+        with self.assertRaises(CommandError):
+            com = publisher_publish.Command()
+            com.handle_noargs()
 
     def test_command_line_publishes_zero_pages_on_empty_db(self):
         # we need to create a superuser (the db is empty)

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -12,16 +12,16 @@ argparse
 dj-database-url
 selenium==2.42.1
 django-debug-toolbar
--e git+https://github.com/divio/djangocms-admin-style.git#egg=djangocms-admin-style
--e git+https://github.com/divio/djangocms-text-ckeditor.git#egg=djangocms-text-ckeditor
--e git+https://github.com/divio/djangocms-column.git#egg=djangocms-column
--e git+https://github.com/divio/djangocms-style.git#egg=djangocms-style
--e git+https://github.com/divio/djangocms-file.git#egg=djangocms-file
--e git+https://github.com/divio/djangocms-flash.git#egg=djangocms-flash
--e git+https://github.com/divio/djangocms-googlemap.git#egg=djangocms-googlemap
--e git+https://github.com/divio/djangocms-inherit.git#egg=djangocms-inherit
--e git+https://github.com/divio/djangocms-picture.git#egg=djangocms-picture
--e git+https://github.com/divio/djangocms-teaser.git#egg=djangocms-teaser
--e git+https://github.com/divio/djangocms-video.git#egg=djangocms-video
--e git+https://github.com/divio/djangocms-link.git#egg=djangocms-link
+-e git+git://github.com/divio/djangocms-admin-style.git#egg=djangocms-admin-style
+-e git+git://github.com/divio/djangocms-text-ckeditor.git#egg=djangocms-text-ckeditor
+-e git+git://github.com/divio/djangocms-column.git#egg=djangocms-column
+-e git+git://github.com/divio/djangocms-style.git#egg=djangocms-style
+-e git+git://github.com/divio/djangocms-file.git#egg=djangocms-file
+-e git+git://github.com/divio/djangocms-flash.git#egg=djangocms-flash
+-e git+git://github.com/divio/djangocms-googlemap.git#egg=djangocms-googlemap
+-e git+git://github.com/divio/djangocms-inherit.git#egg=djangocms-inherit
+-e git+git://github.com/divio/djangocms-picture.git#egg=djangocms-picture
+-e git+git://github.com/divio/djangocms-teaser.git#egg=djangocms-teaser
+-e git+git://github.com/divio/djangocms-video.git#egg=djangocms-video
+-e git+git://github.com/divio/djangocms-link.git#egg=djangocms-link
 pyflakes


### PR DESCRIPTION
While migrating a Django CMS installation from 2.3.5 to 3.0.5 I have two errors running the `publisher_publish` command. 

The first problem is a unique constraint violation while trying to publish a page in multiple languages (see test or the stacktrace below). This can be avoided by returning a specific page only once in a queryset.

```
Traceback (most recent call last):
  File "bin/django-admin.py", line 5, in <module>
    management.execute_from_command_line()
  File "lib/python2.7/site-packages/django/core/management/__init__.py", line 399, in execute_from_command_line
    utility.execute()
  File "lib/python2.7/site-packages/django/core/management/__init__.py", line 392, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "lib/python2.7/site-packages/django/core/management/base.py", line 242, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "lib/python2.7/site-packages/django/core/management/base.py", line 285, in execute
    output = self.handle(*args, **options)
  File "lib/python2.7/site-packages/django/core/management/base.py", line 415, in handle
    return self.handle_noargs(**options)
  File "lib/python2.7/site-packages/cms/management/commands/publisher_publish.py", line 11, in handle_noargs
    self.publish_pages()
  File "lib/python2.7/site-packages/cms/management/commands/publisher_publish.py", line 39, in publish_pages
    if not page.publish(lang):
  File "lib/python2.7/site-packages/cms/models/pagemodel.py", line 573, in publish
    public_page.save()
  File "lib/python2.7/site-packages/cms/models/pagemodel.py", line 456, in save
    super(Page, self).save(**kwargs)
  File "lib/python2.7/site-packages/mptt/models.py", line 838, in save
    super(MPTTModel, self).save(*args, **kwargs)
  File "lib/python2.7/site-packages/django/db/models/base.py", line 545, in save
    force_update=force_update, update_fields=update_fields)
  File "lib/python2.7/site-packages/cms/models/pagemodel.py", line 474, in save_base
    ret = super(Page, self).save_base(*args, **kwargs)
  File "lib/python2.7/site-packages/django/db/models/base.py", line 573, in save_base
    updated = self._save_table(raw, cls, force_insert, force_update, using, update_fields)
  File "lib/python2.7/site-packages/django/db/models/base.py", line 654, in _save_table
    result = self._do_insert(cls._base_manager, using, fields, update_pk, raw)
  File "lib/python2.7/site-packages/django/db/models/base.py", line 687, in _do_insert
    using=using, raw=raw)
  File "lib/python2.7/site-packages/django/db/models/manager.py", line 232, in _insert
    return insert_query(self.model, objs, fields, **kwargs)
  File "lib/python2.7/site-packages/django/db/models/query.py", line 1514, in insert_query
    return query.get_compiler(using=using).execute_sql(return_id)
  File "lib/python2.7/site-packages/django/db/models/sql/compiler.py", line 903, in execute_sql
    cursor.execute(sql, params)
  File "lib/python2.7/site-packages/django/db/backends/util.py", line 53, in execute
    return self.cursor.execute(sql, params)
  File "lib/python2.7/site-packages/django/db/utils.py", line 99, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "lib/python2.7/site-packages/django/db/backends/util.py", line 53, in execute
    return self.cursor.execute(sql, params)
django.db.utils.IntegrityError: duplicate key value violates unique constraint "cms_page_publisher_public_id_key"
DETAIL:  Key (publisher_public_id)=(1613) already exists.
```

The second problem was trying to print unicode characters. I couldn't reproduce this one in a test but it vanished when I used standard command logging using `self.stdout.write` instead of print.

```
Traceback (most recent call last):
  File "bin/django-admin.py", line 5, in <module>
    management.execute_from_command_line()
  File "lib/python2.7/site-packages/django/core/management/__init__.py", line 399, in execute_from_command_line
    utility.execute()
  File "lib/python2.7/site-packages/django/core/management/__init__.py", line 392, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "lib/python2.7/site-packages/django/core/management/base.py", line 242, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "lib/python2.7/site-packages/django/core/management/base.py", line 285, in execute
    output = self.handle(*args, **options)
  File "lib/python2.7/site-packages/django/core/management/base.py", line 415, in handle
    return self.handle_noargs(**options)
  File "lib/python2.7/site-packages/cms/management/commands/publisher_publish.py", line 11, in handle_noargs
    self.publish_pages()
  File "lib/python2.7/site-packages/cms/management/commands/publisher_publish.py", line 46, in publish_pages
    print(u"%d.\t%s  %s [%d]" % (i + 1, m, force_unicode(page), page.id))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe3' in position 9: ordinal not in range(128)
```

I'm not sure if it's just my data that is in a corrupted state. Here are the commands I use to test-drive the migration:

```
django-admin.py syncdb --no-initial-data
django-admin.py migrate
django-admin.py cms delete_orphaned_plugins
django-admin.py cms check
django-admin.py cms moderator on
django-admin.py cms fix-mptt
django-admin.py publisher_publish
```
