### PR TITLE
Fix corruption of cached template nodelist by placeholder scan.

### DIFF
--- a/cms/test_utils/project/templates/placeholder_tests/test_super_extends_1.html
+++ b/cms/test_utils/project/templates/placeholder_tests/test_super_extends_1.html
@@ -1,0 +1,11 @@
+{% extends "placeholder_tests/nested_super_level4.html" %}
+{% load cms_tags %}
+
+{% comment %}
+This template adds a line to "block one".
+{% endcomment %}
+
+{% block one %}
+Whee
+{{ block.super }}
+{% endblock %}

--- a/cms/test_utils/project/templates/placeholder_tests/test_super_extends_2.html
+++ b/cms/test_utils/project/templates/placeholder_tests/test_super_extends_2.html
@@ -1,0 +1,8 @@
+{% extends "placeholder_tests/test_super_extends_1.html" %}
+{% load cms_tags %}
+
+{% comment %}
+This template extends one that contains a block called "one", but doesn't itself
+define that block. The bug causes the block to be copied from the parent
+template when rendering this one, resulting in the word "whee" being added twice.
+{% endcomment %}

--- a/cms/tests/placeholder.py
+++ b/cms/tests/placeholder.py
@@ -14,7 +14,9 @@ from django.db import models
 from django.http import HttpResponseForbidden, HttpResponse
 from django.template import TemplateSyntaxError, Template
 from django.template.context import Context, RequestContext
+from django.template.loader import get_template
 from django.test import TestCase
+from django.test.utils import override_settings
 from django.utils.numberformat import format
 from djangocms_link.cms_plugins import LinkPlugin
 from djangocms_text_ckeditor.cms_plugins import TextPlugin
@@ -663,6 +665,56 @@ class PlaceholderTestCase(CMSTestCase, UnittestCompatMixin):
             self.assertTrue("PlaceholderAdminMixin with admin.ModelAdmin" in str(w[-1].message))
             self.assertIsInstance(pa, admin.ModelAdmin, 'PlaceholderAdmin not admin.ModelAdmin')
             self.assertIsInstance(pa, PlaceholderAdminMixin, 'PlaceholderAdmin not PlaceholderAdminMixin')
+
+    @override_settings(TEMPLATE_LOADERS=(
+        ('django.template.loaders.cached.Loader', (
+            'django.template.loaders.filesystem.Loader',
+            'django.template.loaders.app_directories.Loader',
+        )),))
+    def test_cached_template_not_corrupted_by_placeholder_scan(self):
+        """
+        This is the test for the low-level code that caused the bug:
+        the placeholder scan corrupts the nodelist of the extends node,
+        which is retained by the cached template loader, and future
+        renders of that template will render the super block twice.
+        """
+    
+        self.assertNotIn('one',
+            get_template("placeholder_tests/test_super_extends_2.html").nodelist[0].blocks.keys(),
+            "test_super_extends_1.html contains a block called 'one', "
+            "but _2.html does not.")
+
+        get_placeholders("placeholder_tests/test_super_extends_2.html")
+
+        self.assertNotIn('one',
+            get_template("placeholder_tests/test_super_extends_2.html").nodelist[0].blocks.keys(),
+            "test_super_extends_1.html still should not contain a block "
+            "called 'one' after rescanning placeholders.")
+
+    @override_settings(TEMPLATE_LOADERS=(
+        ('django.template.loaders.cached.Loader', (
+            'django.template.loaders.filesystem.Loader',
+            'django.template.loaders.app_directories.Loader',
+        )),))
+    def test_super_extends_not_corrupted_by_placeholder_scan(self):
+        """
+        This is the test for the symptom of the bug: because the block
+        context now contains two copies of the inherited block, that block
+        will be executed twice, and if it adds content to {{block.super}},
+        that content will be added twice.
+        """
+
+        template = get_template("placeholder_tests/test_super_extends_2.html")
+        output = template.render(Context({}))
+        self.assertEqual(['Whee'], [o for o in output.split('\n')
+            if 'Whee' in o])
+          
+        get_placeholders("placeholder_tests/test_super_extends_2.html")
+
+        template = get_template("placeholder_tests/test_super_extends_2.html")
+        output = template.render(Context({}))
+        self.assertEqual(['Whee'], [o for o in output.split('\n')
+            if 'Whee' in o])
 
 
 class PlaceholderActionTests(FakemlngFixtures, CMSTestCase):

--- a/cms/utils/plugins.py
+++ b/cms/utils/plugins.py
@@ -76,7 +76,7 @@ def _extend_nodelist(extend_node):
     if is_variable_extend_node(extend_node):
         return []
         # This is a dictionary mapping all BlockNode instances found in the template that contains extend_node
-    blocks = extend_node.blocks
+    blocks = dict(extend_node.blocks)
     _extend_blocks(extend_node, blocks)
     placeholders = []
 


### PR DESCRIPTION
get_placeholders() modifies the nodelist of a parsed template without
taking a copy. With non-caching template loaders this doesn't matter, but
with Django's caching template loader, the same template, with modified
nodelist, will be used next time the template is requested.

The main issue with this is that blocks inherited from a parent template,
and not overridden, appear as though they were copied literally into the
child template. Often this doesn't matter, but if the block uses block.super
and adds content, then because it's interpreted twice, the added content
will appear twice.
