### PR TITLE
Fixed bug in publisher_publish management command

### DIFF
--- a/cms/tests/publisher.py
+++ b/cms/tests/publisher.py
@@ -172,6 +172,38 @@ class PublisherCommandTests(TestCase):
         languages = sorted(public.title_set.values_list('language', flat=True))
         self.assertEqual(languages, ['de', 'fr'])
 
+    def test_command_line_publish_multiple_languages_check_count(self):
+        """
+        Publishing one page with multiple languages still counts
+        as one page. This test case checks whether it works
+        as expected.
+        """
+        # we need to create a superuser (the db is empty)
+        get_user_model().objects.create_superuser('djangocms', 'cms@example.com', '123456')
+
+        # Now, let's create a page with 2 languages.
+        page = create_page("en title", "nav_playground.html", "en", published=True)
+        create_title("de", "de title", page)
+        page.publish("de")
+
+        pages_from_output = 0
+        published_from_output = 0
+
+        with StdoutOverride() as buffer:
+            # Now we don't expect it to raise, but we need to redirect IO
+            com = publisher_publish.Command()
+            com.handle_noargs()
+            lines = buffer.getvalue().split('\n') #NB: readlines() doesn't work
+
+        for line in lines:
+            if 'Total' in line:
+                pages_from_output = int(line.split(':')[1])
+            elif 'Published' in line:
+                published_from_output = int(line.split(':')[1])
+
+        self.assertEqual(pages_from_output, 1)
+        self.assertEqual(published_from_output, 1)
+
     def tearDown(self):
         plugin_pool.patched = False
         plugin_pool.set_plugin_meta()


### PR DESCRIPTION
Added .distinct() on pages query (Page.objects.drafts().filter(title_set__published=True)), because .filter(title_set__published=True) can make duplicated page objects. This happens with multiple languages on one page - title_set__published causes Django to make a join, which in turn returns duplicated Page objects for a query. For this problem, pages with multiple languages were published multiple times (for each language).
