### PR TITLE
_scan_placeholders shouldn't do any magic to get an ``include`` template...

### DIFF
--- a/cms/utils/plugins.py
+++ b/cms/utils/plugins.py
@@ -109,7 +109,7 @@ def _scan_placeholders(nodelist, current_block=None, ignore_blocks=None):
                 # Check if it quacks like a template object, if not
                 # presume is a template path and get the object out of it
                 if not callable(getattr(node.template, 'render', None)):
-                    template = get_template(force_unicode(node.template).strip('"'))
+                    template = get_template(node.template.var)
                 else:
                     template = node.template
                 placeholders += _scan_placeholders(template.nodelist, current_block)


### PR DESCRIPTION
Hard-coded `.strip('"')` meant server exceptions when using single quotes for the include template name e.g. `{% include '_messages.html' %}`. Should use the already parsed `node.template.var` directly.
