### PR TITLE
Fix menu_pool teardown after exception throwing another exception.

### DIFF
--- a/cms/test_utils/testcases.py
+++ b/cms/test_utils/testcases.py
@@ -95,7 +95,15 @@ class BaseCMSTestCase(object):
 
     def _post_teardown(self):
         # Needed to clean the menu keys cache, see menu.menu_pool.clear()
-        menu_pool.clear()
+        try:
+            from django.db.transaction import TransactionManagementError
+            try:
+                menu_pool.clear()
+            except TransactionManagementError:
+                pass # ignore this error if a previous DB command failed
+        except ImportError:
+            menu_pool.clear()
+
         cache.clear()
         super(BaseCMSTestCase, self)._post_teardown()
         set_current_user(None)

--- a/cms/test_utils/util/context_managers.py
+++ b/cms/test_utils/util/context_managers.py
@@ -138,7 +138,15 @@ class UserLoginContext(object):
         self.testcase.user = self.old_user
         if not self.testcase.user:
             delattr(self.testcase, 'user')
-        self.testcase.client.logout()
+
+        try:
+            from django.db.transaction import TransactionManagementError
+            try:
+                self.testcase.client.logout()
+            except TransactionManagementError:
+                pass # ignore this error if a previous DB command failed
+        except ImportError:
+            self.testcase.client.logout()
 
 
 class ChangeModel(object):


### PR DESCRIPTION
This conceals the original error that you actually want to fix:

```
ERROR at teardown of ResourceDetailAppTests.test_left_sidebar_contains_common_metadata
.ve/local/lib/python2.7/site-packages/django/test/testcases.py:187: in __call__
    self._post_teardown()
.ve/src/django-harness/django_harness/override_settings.py:48: in _post_teardown
    original_post_teardown(innerself)
.ve/src/django-cms/cms/test_utils/testcases.py:98: in _post_teardown
    menu_pool.clear()
.ve/src/django-cms/menus/menu_pool.py:97: in clear
    cache_keys.delete()
.ve/local/lib/python2.7/site-packages/django/db/models/query.py:467: in delete
    collector.collect(del_query)
.ve/local/lib/python2.7/site-packages/django/db/models/deletion.py:166: in collect
    reverse_dependency=reverse_dependency)
.ve/local/lib/python2.7/site-packages/django/db/models/deletion.py:77: in add
    if not objs:
.ve/local/lib/python2.7/site-packages/django/db/models/query.py:100: in __nonzero__
    self._fetch_all()
.ve/local/lib/python2.7/site-packages/django/db/models/query.py:857: in _fetch_all
    self._result_cache = list(self.iterator())
.ve/local/lib/python2.7/site-packages/django/db/models/query.py:220: in iterator
    for row in compiler.results_iter():
.ve/local/lib/python2.7/site-packages/django/db/models/sql/compiler.py:713: in results_iter
    for rows in self.execute_sql(MULTI):
.ve/local/lib/python2.7/site-packages/django/db/models/sql/compiler.py:786: in execute_sql
    cursor.execute(sql, params)
.ve/local/lib/python2.7/site-packages/django/db/backends/util.py:47: in execute
    self.db.validate_no_broken_transaction()
.ve/local/lib/python2.7/site-packages/django/db/backends/__init__.py:372: in validate_no_broken_transaction
    "An error occurred in the current transaction. You can't "
E   TransactionManagementError: An error occurred in the current transaction. You can't execute queries until the end of the 'atomic' block.
```
