### PR TITLE
Changing plugin delete template to fix error with django 1.7

### DIFF
--- a/cms/templates/admin/cms/page/plugin/delete_confirmation.html
+++ b/cms/templates/admin/cms/page/plugin/delete_confirmation.html
@@ -1,9 +1,4 @@
 {% extends "admin/delete_confirmation.html" %}
 {% load i18n admin_urls cms_tags %}
 
-{% block breadcrumbs %}
-<div class="breadcrumbs">
-	<a href="{% cms_admin_url 'index' %}">{% trans "Home" %}</a> &rsaquo;
-	{% trans "Delete" %}
-</div>
-{% endblock %}
+{% block breadcrumbs %}{% endblock %}


### PR DESCRIPTION
Breadcrumbs are not useful when deleting plugins and in django 1.7 only existing admins are registered and reversible.
Plugin application may not have any admin, so we'd better remove it
Fix #3466 
