### PR TITLE
Move to request.path_info to be more compatible

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -177,7 +177,7 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
         target = request.GET.get('target', None)
         position = request.GET.get('position', None)
 
-        if 'recover' in request.path:
+        if 'recover' in request.path_info:
             pk = obj.pk
             if obj.parent_id:
                 parent = Page.objects.get(pk=obj.parent_id)
@@ -193,7 +193,7 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
             obj.save(no_signals=True)
 
         else:
-            if 'history' in request.path:
+            if 'history' in request.path_info:
                 old_obj = Page.objects.get(pk=obj.pk)
                 obj.level = old_obj.level
                 obj.parent_id = old_obj.parent_id
@@ -205,7 +205,7 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
             new = True
         obj.save()
 
-        if 'recover' in request.path or 'history' in request.path:
+        if 'recover' in request.path_info or 'history' in request.path_info:
             revert_plugins(request, obj.version.pk, obj)
 
         if target is not None and position is not None:
@@ -228,7 +228,7 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
             obj.save()
             for lang in copy_target.languages.split(','):
                 copy_target._copy_contents(obj, lang)
-        if not 'permission' in request.path:
+        if not 'permission' in request.path_info:
             language = form.cleaned_data['language']
             Title.objects.set_or_create(
                 request,
@@ -249,16 +249,16 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
             return form.fieldsets
 
     def get_inline_classes(self, request, obj=None, **kwargs):
-        if obj and 'permission' in request.path:
+        if obj and 'permission' in request.path_info:
             return PERMISSION_ADMIN_INLINES
         return []
 
     def get_form_class(self, request, obj=None, **kwargs):
-        if 'advanced' in request.path:
+        if 'advanced' in request.path_info:
             return AdvancedSettingsForm
-        elif 'permission' in request.path:
+        elif 'permission' in request.path_info:
             return PagePermissionForm
-        elif 'dates' in request.path:
+        elif 'dates' in request.path_info:
             return PublicationDatesForm
         return self.form
 
@@ -293,8 +293,8 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
         self.inlines = self.get_inline_classes(request, obj, **kwargs)
 
         if obj:
-            if 'history' in request.path or 'recover' in request.path:
-                version_id = request.path.split('/')[-2]
+            if 'history' in request.path_info or 'recover' in request.path_info:
+                version_id = request.path_info.split('/')[-2]
             else:
                 version_id = None
 
@@ -443,7 +443,7 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
             self._current_page = obj
         response = super(PageAdmin, self).change_view(
             request, object_id, form_url=form_url, extra_context=extra_context)
-        if tab_language and response.status_code == 302 and response._headers['location'][1] == request.path:
+        if tab_language and response.status_code == 302 and response._headers['location'][1] == request.path_info:
             location = response._headers['location']
             response._headers['location'] = (location[0], "%s?language=%s" % (location[1], tab_language))
         return response
@@ -687,7 +687,7 @@ class PageAdmin(PlaceholderAdminMixin, ModelAdmin):
             # is screwed up with the database, so display an error page.
             if ERROR_FLAG in request.GET.keys():
                 return render_to_response('admin/invalid_setup.html', {'title': _('Database error')})
-            return HttpResponseRedirect(request.path + '?' + ERROR_FLAG + '=1')
+            return HttpResponseRedirect(request.path_info + '?' + ERROR_FLAG + '=1')
         cl.set_items(request)
 
         site_id = request.GET.get('site__exact', None)

--- a/cms/admin/useradmin.py
+++ b/cms/admin/useradmin.py
@@ -43,7 +43,7 @@ class PageUserAdmin(UserAdmin, GenericCmsPermissionAdmin):
     def get_fieldsets(self, request, obj=None):
         fieldsets = self.update_permission_fieldsets(request, obj)
         
-        if not '/add' in request.path:
+        if not '/add' in request.path_info:
             fieldsets[0] = (None, {'fields': (get_user_model().USERNAME_FIELD, 'notify_user')})
             fieldsets.append((_('Password'), {'fields': ('password1', 'password2'), 'classes': ('collapse',)}))
         return fieldsets

--- a/cms/appresolver.py
+++ b/cms/appresolver.py
@@ -33,7 +33,7 @@ def applications_page_check(request, current_page=None, path=None):
     if path is None:
         # We should get in this branch only if an apphook is active on /
         # This removes the non-CMS part of the URL.
-        path = request.path.replace(reverse('pages-root'), '', 1)
+        path = request.path_info.replace(reverse('pages-root'), '', 1)
         # check if application resolver can resolve this
     for lang in get_language_list():
         if path.startswith(lang + "/"):

--- a/cms/cms_toolbar.py
+++ b/cms/cms_toolbar.py
@@ -248,7 +248,7 @@ class PageToolbar(CMSToolbar):
     def in_apphook(self):
         with force_language(self.toolbar.language):
             try:
-                resolver = resolve(self.request.path)
+                resolver = resolve(self.request.path_info)
             except Resolver404:
                 return False
             else:
@@ -310,7 +310,7 @@ class PageToolbar(CMSToolbar):
                 params['statics'] = ','.join(str(sp.pk) for sp in self.dirty_statics)
 
             if self.in_apphook():
-                params['redirect'] = self.request.path
+                params['redirect'] = self.request.path_info
 
             with force_language(self.current_lang):
                 url = admin_reverse('cms_page_publish_page', args=(pk, self.current_lang))

--- a/cms/menu.py
+++ b/cms/menu.py
@@ -316,7 +316,7 @@ class NavExtender(Modifier):
         # if breadcrumb and home not in navigation add node
             if breadcrumb and home and not home.visible:
                 home.visible = True
-                if request.path == home.get_absolute_url():
+                if request.path_info == home.get_absolute_url():
                     home.selected = True
                 else:
                     home.selected = False

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -109,7 +109,7 @@ def _get_page_by_untyped_arg(page_lookup, request, site_id):
         subject = _('Page not found on %(domain)s') % {'domain': site.domain}
         body = _("A template tag couldn't find the page with lookup arguments `%(page_lookup)s\n`. "
                  "The URL of the request was: http://%(host)s%(path)s") \
-               % {'page_lookup': repr(page_lookup), 'host': site.domain, 'path': request.path}
+               % {'page_lookup': repr(page_lookup), 'host': site.domain, 'path': request.path_info}
         if settings.DEBUG:
             raise Page.DoesNotExist(body)
         else:

--- a/cms/test_utils/project/sampleapp/views.py
+++ b/cms/test_utils/project/sampleapp/views.py
@@ -10,7 +10,7 @@ from django.utils.translation import ugettext_lazy as _
 
 @csrf_exempt
 def exempt_view(request, **kw):
-    app = resolve(request.path).namespace
+    app = resolve(request.path_info).namespace
     kw['app'] = app
     response_kwargs = {'current_app': app, 'dict_': kw}
     context = RequestContext(request, **response_kwargs)
@@ -18,7 +18,7 @@ def exempt_view(request, **kw):
 
 
 def sample_view(request, **kw):
-    app = resolve(request.path).namespace
+    app = resolve(request.path_info).namespace
     kw['app'] = app
     response_kwargs = {'current_app': app, 'dict_': kw}
     context = RequestContext(request, **response_kwargs)
@@ -36,7 +36,7 @@ def category_view(request, id):
 
 
 def extra_view(request, **kw):
-    app = resolve(request.path).namespace
+    app = resolve(request.path_info).namespace
     kw['app'] = app
     response_kwargs = {'current_app': app, 'dict_': kw}
     context = RequestContext(request, **response_kwargs)
@@ -44,7 +44,7 @@ def extra_view(request, **kw):
 
 
 def current_app(request):
-    app = resolve(request.path).namespace
+    app = resolve(request.path_info).namespace
     context = RequestContext(request, {'app': app}, current_app=app)
     return render_to_response("sampleapp/app.html", context)
 

--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -77,7 +77,7 @@ class CMSToolbar(ToolbarAPIMixin):
             self.clipboard = user_settings.clipboard
         with force_language(self.language):
             try:
-                decorator = resolve(self.request.path).func
+                decorator = resolve(self.request.path_info).func
                 try:
                     # If the original view is decorated we try to extract the real function
                     # module instead of the decorator's one
@@ -258,7 +258,7 @@ class CMSToolbar(ToolbarAPIMixin):
     def _request_hook_get(self):
         if 'cms-toolbar-logout' in self.request.GET:
             logout(self.request)
-            return HttpResponseRedirect(self.request.path)
+            return HttpResponseRedirect(self.request.path_info)
 
     def _request_hook_post(self):
         # login hook
@@ -269,7 +269,7 @@ class CMSToolbar(ToolbarAPIMixin):
                 if REDIRECT_FIELD_NAME in self.request.GET:
                     return HttpResponseRedirect(self.request.GET[REDIRECT_FIELD_NAME])
                 else:
-                    return HttpResponseRedirect(self.request.path)
+                    return HttpResponseRedirect(self.request.path_info)
             else:
                 if REDIRECT_FIELD_NAME in self.request.GET:
                     return HttpResponseRedirect(self.request.GET[REDIRECT_FIELD_NAME]+"?cms-toolbar-login-error=1")

--- a/cms/utils/page_resolver.py
+++ b/cms/utils/page_resolver.py
@@ -100,7 +100,7 @@ def get_page_from_request(request, use_path=None):
     if use_path is not None:
         path = use_path
     else:
-        path = request.path
+        path = request.path_info
         pages_root = unquote(reverse("pages-root"))
         # otherwise strip off the non-cms part of the URL
         if is_installed('django.contrib.admin'):

--- a/cms/utils/urlutils.py
+++ b/cms/utils/urlutils.py
@@ -59,7 +59,7 @@ def is_media_request(request):
     Check if a request is a media request.
     """
     parsed_media_url = urlparse(settings.MEDIA_URL)
-    if request.path.startswith(parsed_media_url.path):
+    if request.path_info.startswith(parsed_media_url.path):
         if parsed_media_url.netloc:
             if request.get_host() == parsed_media_url.netloc:
                 return True

--- a/docs/concepts/menu_system.rst
+++ b/docs/concepts/menu_system.rst
@@ -100,7 +100,7 @@ Don't forget that show_menu recurses - so it will do *all* of the below for *eac
 				    * adds all nodes into a big list
             * :py:meth:`menus.menu_pool.MenuPool.apply_modifiers()` 
                 * :py:meth:`menus.menu_pool.MenuPool._mark_selected()`
-                * loops over each node, comparing its URL with the request.path, and marks the best match as ``selected``
+                * loops over each node, comparing its URL with the request.path_info, and marks the best match as ``selected``
                 * loops over the Modifiers in self.modifiers calling each one's :py:meth:`modify(post_cut=False)`. The default Modifiers are:
                     * :py:class:`cms.menu.NavExtender`
                     * :py:class:`cms.menu.SoftRootCutter` removes all nodes below the appropriate soft root 

--- a/docs/extending_cms/app_integration.rst
+++ b/docs/extending_cms/app_integration.rst
@@ -357,7 +357,7 @@ hook like this::
 If you use app namespace you will need to give all your view ``context`` a ``current_app``::
 
   def my_view(request):
-      current_app = resolve(request.path).namespace
+      current_app = resolve(request.path_info).namespace
       context = RequestContext(request, current_app=current_app)
       return render_to_response("my_templace.html", context_instance=context)
 
@@ -393,7 +393,7 @@ as an argument. You can do so by looking up the `current_app` attribute of
 the request instance::
 
     def myviews(request):
-        current_app = resolve(request.path).namespace
+        current_app = resolve(request.path_info).namespace
 
         reversed_url = reverse('myapp_namespace:app_main',
                 current_app=current_app)
@@ -404,7 +404,7 @@ Or, if you are rendering a plugin, of the context instance::
     class MyPlugin(CMSPluginBase):
         def render(self, context, instance, placeholder):
             # ...
-            current_app = resolve(request.path).namespace
+            current_app = resolve(request.path_info).namespace
             reversed_url = reverse('myapp_namespace:app_main',
                     current_app=current_app)
             # ...

--- a/docs/upgrade/3.0.rst
+++ b/docs/upgrade/3.0.rst
@@ -262,7 +262,7 @@ documentation on the subject at https://docs.djangoproject.com/en/dev/topics/htt
 following code instead in your views::
 
     def my_view(request):
-      current_app = resolve(request.path).namespace
+      current_app = resolve(request.path_info).namespace
       context = RequestContext(request, current_app=current_app)
       return render_to_response("my_templace.html", context_instance=context)
 

--- a/menus/utils.py
+++ b/menus/utils.py
@@ -93,9 +93,9 @@ class DefaultLanguageChanger(object):
             else:
                 page_path = self.get_page_path(settings.LANGUAGE_CODE)
             if page_path:
-                self._app_path = self.request.path[len(page_path):]
+                self._app_path = self.request.path_info[len(page_path):]
             else:
-                self._app_path = self.request.path
+                self._app_path = self.request.path_info
         return self._app_path
 
     def get_page_path(self, lang):
@@ -119,7 +119,7 @@ class DefaultLanguageChanger(object):
         page_language = get_language_from_request(self.request)
         with force_language(page_language):
             try:
-                view = resolve(self.request.path)
+                view = resolve(self.request.path_info)
             except:
                 view = None
         if hasattr(self.request, 'toolbar') and self.request.toolbar.obj:


### PR DESCRIPTION
Change `request.path` to `request.path_info` as suggested in #3255 (see https://docs.djangoproject.com/en/1.6/ref/request-response/#django.http.HttpRequest.path for more detail on the difference)
Fix #3255 
