### PR TITLE
Adds missing migration for Django 1.7

### DIFF
--- a/cms/migrations_django/0004_auto_20140929_1705.py
+++ b/cms/migrations_django/0004_auto_20140929_1705.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cms', '0003_auto_20140926_2347'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='page',
+            name='template',
+            field=models.CharField(default=b'INHERIT', help_text='The template used to render the content.', max_length=100, verbose_name='template', choices=[(b'fullwidth.html', 'Fullwidth'), (b'sidebar_left.html', 'Sidebar Left'), (b'sidebar_right.html', 'Sidebar Right'), (b'basepage.html', 'Base Page'), (b'homepage.html', 'Home Page'), (b'INHERIT', 'Inherit the template of the nearest ancestor')]),
+        ),
+        migrations.AlterField(
+            model_name='usersettings',
+            name='language',
+            field=models.CharField(help_text='The language for the admin interface and toolbar', max_length=10, verbose_name='Language', choices=[(b'en', b'en')]),
+        ),
+    ]


### PR DESCRIPTION
Working to test django-cms 3.0.5 against Django 1.7, and came across some missing migrations.  Found a couple others in the djangocms-inherit and djangocms-link repos and submitted PRs ([1](https://github.com/divio/djangocms-link/pull/22), [2](https://github.com/divio/djangocms-inherit/pull/6)) there also.

I'm going to deploy this to Heroku and play around a bit.  I'll let you know if any issues come up.  I've looked around for a milestone / roadmap to 1.7 final support, but couldn't get a good sense of status other than a few open issues referencing 1.7.  If you have a second, can you give me a brief update on where that stands, or better yet, point me to any documentation I may have overlooked.  Thanks!
