### PR TITLE
Fix fails on not packaged single file modules

### DIFF
--- a/cms/utils/django_load.py
+++ b/cms/utils/django_load.py
@@ -25,7 +25,7 @@ def get_module(app, modname, verbose, failfast):
     # the module *should* exist - raise an error if it doesn't
     app_mod = import_module(app)
     try:
-        imp.find_module(modname, app_mod.__path__)
+        imp.find_module(modname, app_mod.__path__ if hasattr(app_mod, '__path__') else None)
     except ImportError:
         # this ImportError will be due to the module not existing
         # so here we can silently ignore it.  But an ImportError


### PR DESCRIPTION
On single file modules (without `__init__.py`) `./manage.py cms check` fails with AttributeError: 'module' object has no attribute '`__path__`'

How to reproduce:
1. pip install feedparser
2. Add in settings.py: INSTALLED_APPS = INSTALLED_APPS + ('feedparser', )
3. Run ./manage.py cms check
