### PR TITLE
Added warning in docs for Twitter plugins

### DIFF
--- a/docs/basic_reference/plugin_reference.rst
+++ b/docs/basic_reference/plugin_reference.rst
@@ -281,6 +281,8 @@ We recommend one of the following plugins:
 * https://github.com/nephila/djangocms_twitter
 * https://github.com/changer/cmsplugin-twitter
 
+.. warning:: These plugins are not currently compatible with Django 1.7.
+
 .. :module:: djangocms_inherit
 
 .. :class:: djangocms_inherit.cms_plugins.InheritPagePlaceholderPlugin


### PR DESCRIPTION
They are not currently compatible with Django 1.7
