### PR TITLE
Use Logger.warning instead of Logger.warn

### DIFF
--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -178,7 +178,7 @@ class Page(with_metaclass(PageMetaClass, MP_Node)):
                 if target.get_root().get_next_sibling().pk == public.get_root().pk:
                     target = target.publisher_public
                 else:
-                    Logger.warn('tree may need rebuilding: run manage.py cms fix-tree')
+                    Logger.warning('tree may need rebuilding: run manage.py cms fix-tree')
         if position == 'first-child' or position == 'last-child':
             self.parent_id = target.pk
         else:


### PR DESCRIPTION
`Logger.warn` is deprecated
https://docs.python.org/3/library/logging.html#logging.Logger.warning

In the Python 2.7 documentation it's not even mention https://docs.python.org/2.7/library/logging.html#logging.Logger.warning

In the Python 2.6 documentation this method is present as `logging.warn` but not as `logging.Logger.warn`
