### PR TITLE
Fix migrations name

### DIFF
--- a/cms/migrations_django/0003_auto_20140926_2347.py
+++ b/cms/migrations_django/0003_auto_20140926_2347.py
@@ -7,7 +7,7 @@ from django.db import models, migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('cms', '0003_auto_20140924_1038'),
+        ('cms', '0002_auto_20140816_1918'),
     ]
 
     operations = [

--- a/cms/migrations_django/0004_auto_20140924_1038.py
+++ b/cms/migrations_django/0004_auto_20140924_1038.py
@@ -7,7 +7,7 @@ from django.db import models, migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('cms', '0002_auto_20140816_1918'),
+        ('cms', '0003_auto_20140926_2347'),
     ]
 
     operations = [

--- a/cms/migrations_django/0005_auto_20140924_1039.py
+++ b/cms/migrations_django/0005_auto_20140924_1039.py
@@ -166,7 +166,7 @@ def move_to_mp(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('cms', '0004_auto_20140926_2347'),
+        ('cms', '0004_auto_20140924_1038'),
     ]
 
     operations = [


### PR DESCRIPTION
Restore migration name to be compatible with  3.0.x release
