### PR TITLE
Relax url pk-regexes in FrontendEditableAdminMixin, PlaceholderAdminMixin

### DIFF
--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -49,7 +49,7 @@ class FrontendEditableAdminMixin(object):
 
         url_patterns = patterns(
             '',
-            pat(r'edit-field/([0-9]+)/([a-z\-]+)/$', self.edit_field),
+            pat(r'edit-field/([A-Za-z0-9_-]+)/([a-z\-]+)/$', self.edit_field),
         )
         return url_patterns + super(FrontendEditableAdminMixin, self).get_urls()
 
@@ -133,9 +133,9 @@ class PlaceholderAdminMixin(object):
             '',
             pat(r'copy-plugins/$', self.copy_plugins),
             pat(r'add-plugin/$', self.add_plugin),
-            pat(r'edit-plugin/([0-9]+)/$', self.edit_plugin),
-            pat(r'delete-plugin/([0-9]+)/$', self.delete_plugin),
-            pat(r'clear-placeholder/([0-9]+)/$', self.clear_placeholder),
+            pat(r'edit-plugin/([A-Za-z0-9_-]+)/$', self.edit_plugin),
+            pat(r'delete-plugin/([A-Za-z0-9_-]+)/$', self.delete_plugin),
+            pat(r'clear-placeholder/([A-Za-z0-9_-]+)/$', self.clear_placeholder),
             pat(r'move-plugin/$', self.move_plugin),
         )
         return url_patterns + super(PlaceholderAdminMixin, self).get_urls()


### PR DESCRIPTION
Currently frontend editing of models that have non-numeric primary keys is not possible.
`render_model` will throw NoReverseMatch in draft mode (see [1] for a post on the issue in Google Groups)

This PR fixes this for me. 

Unfortunately I'm too busy to setup the test machinery and add some tests just right now. 
Please tell me, if you'd be willing to merge this only if I add some tests.

[1] https://groups.google.com/forum/#!topic/django-cms/_Z_Lj_X4nCY
