### PR TITLE
Added code block formatting

### DIFF
--- a/docs/introduction/plugins.rst
+++ b/docs/introduction/plugins.rst
@@ -129,9 +129,7 @@ Now create a file ``cms_plugins.py`` in the same folder your models.py is in.
 The plugin class is responsible for providing django CMS with the necessary
 information to render your plugin.
 
-For our poll plugin, we're going to write the following plugin class:
-
-::
+For our poll plugin, we're going to write the following plugin class::
 
     from cms.plugin_base import CMSPluginBase
     from cms.plugin_pool import plugin_pool
@@ -172,9 +170,7 @@ the plugin which :attr:`render_template
 
 In this case the template needs to be at
 ``polls_plugin/templates/djangocms_polls/poll_plugin.html`` and should look
-something like this:
-
-::
+something like this::
 
     <h1>{{ instance.poll.question }}</h1>
 


### PR DESCRIPTION
Without the double colon (::), the indented text isn't viewed as a code block in html documentation. This change helps readability in my opinion. 
