### PR TITLE
Docs guidelines, and clean up "app-hook" nomenclature

### DIFF
--- a/docs/contributing/contributing.rst
+++ b/docs/contributing/contributing.rst
@@ -95,7 +95,9 @@ We try to conform to `PEP8`_ as much as possible. A few highlights:
 HTML, CSS and JavaScript
 ------------------------
 
-As of django CMS 3.0.7, we use spaces within frontend code, not tabs as previously.
+As of django CMS 3.1, we will use spaces within frontend code, not tabs as previously. In the
+meantime, please continue using tabs - all tabs will be converted to spaces in a single commit
+for 3.1.
 
 Frontend code should be formatted for readability. If in doubt, follow existing examples, or ask.
 

--- a/docs/how_to/apphooks.rst
+++ b/docs/how_to/apphooks.rst
@@ -1,12 +1,13 @@
 #########
-App-Hooks
+Apphooks
 #########
 
-With App-Hooks you can attach whole Django applications to pages. For example
-you have a news app and you want it attached to your news page.
+An **Apphook** allows you to attach a Django application to a page. For example, you might have
+a news application that you'd like integrated with django CMS. In this case, you can create a
+normal django CMS page without any content of its own, and attach the news application to the page;
+the news application's content will be delivered at the page's URL.
 
-To create an apphook create a ``cms_app.py`` in your application. And in it
-write the following::
+To create an apphook place a ``cms_app.py`` in your application. And in it write the following::
 
     from cms.app_base import CMSApp
     from cms.apphook_pool import apphook_pool
@@ -19,7 +20,6 @@ write the following::
     apphook_pool.register(MyApphook)
 
 Replace ``myapp.urls`` with the path to your applications ``urls.py``.
-
 Now edit a page and open the advanced settings tab. Select your new apphook
 under "Application". Save the page.
 
@@ -66,9 +66,9 @@ The ``main_view`` should now be available at ``/hello/world/`` and the
     default :class:`~django.template.Context` instance.
 
 
-*************
-Apphook Menus
-*************
+**************
+Apphook menus
+**************
 
 If you want to add a menu to that page as well that may represent some views
 in your app add it to your apphook like this::
@@ -132,7 +132,7 @@ We would now create a menu out of these categories::
 
     menu_pool.register_menu(CategoryMenu)
 
-If you add this menu now to your app-hook::
+If you add this menu now to your apphook::
 
     from myapp.menus import CategoryMenu
 
@@ -147,7 +147,7 @@ You get the static entries of :class:`MyAppMenu` and the dynamic entries of
 .. _multi_apphook:
 
 ***************************************
-Attaching an Application multiple times
+Attaching an application multiple times
 ***************************************
 
 If you want to attach an application multiple times to different pages you have 2 possibilities.
@@ -246,7 +246,7 @@ Or, if you are rendering a plugin, of the context instance::
 .. _apphook_permissions:
 
 *******************
-Apphook Permissions
+Apphook permissions
 *******************
 
 By default all apphooks have the same permissions set as the page they are assigned to.
@@ -285,8 +285,9 @@ with CMS permission decorator, then use ``exclude_permissions`` property of apph
         exclude_permissions = ["some_nested_app"]
 
 
-For example, django-oscar_ apphook integration needs to be used with exclude permissions of dashboard app,
-because it use `customizable access function`__. So, your apphook in this case will looks like this::
+For example, django-oscar_ apphook integration needs to be used with exclude permissions of
+dashboard app, because it use `customizable access function`__. So, your apphook in this case will
+looks like this::
 
     class OscarApp(CMSApp):
         name = _("Oscar")
@@ -298,9 +299,9 @@ because it use `customizable access function`__. So, your apphook in this case w
 .. _django-oscar: https://github.com/tangentlabs/django-oscar
 .. __: https://github.com/tangentlabs/django-oscar/blob/0.7.2/oscar/apps/dashboard/nav.py#L57
 
-***********************************************
+************************************************
 Automatically restart server on apphook changes
-***********************************************
+************************************************
 
 As mentioned above, whenever you add or remove an apphook, change the slug of a
 page containing an apphook or the slug if a page which has a descendant with an

--- a/docs/introduction/apphooks.rst
+++ b/docs/introduction/apphooks.rst
@@ -1,15 +1,15 @@
-########
-AppHooks
-########
+#########
+Apphooks
+#########
 
 Right now, our django Polls app is statically hooked into the project's
 ``urls.py``. This is allright, but we can do more, by attaching applications to
 django CMS pages.
 
-We do this with an **AppHook**, created using a :class:`CMSApp
+We do this with an **Apphook**, created using a :class:`CMSApp
 <cms.app_base.CMSApp>` subclass, which tells the CMS how to include that app.
 
-AppHooks live in a file called ``cms_app.py``, so create one in your Poll
+Apphooks live in a file called ``cms_app.py``, so create one in your Poll
 application.
 
 This is the most basic example for a django CMS app::
@@ -25,7 +25,7 @@ This is the most basic example for a django CMS app::
 
     apphook_pool.register(PollsApp)  # register your app
 
-You'll need to restart the runserver to allow the new AppHook to become
+You'll need to restart the runserver to allow the new apphook to become
 available.
 
 In the admin, create a new child page of the Home page. In its *Advanced
@@ -36,7 +36,7 @@ settings*, choose "Polls App" from the *Application* menu, and Save.
 .. |apphooks| image:: ../images/cmsapphook.png
 
 Refresh the page, and you'll find that the Polls application is now available
-directly from the new django CMS page. (AppHooks won't take effect until the
+directly from the new django CMS page. (Apphooks won't take effect until the
 server has restarted, though this is not generally an issue on the runserver,
 which can handle this automatically.)
 

--- a/docs/introduction/menu.rst
+++ b/docs/introduction/menu.rst
@@ -52,7 +52,7 @@ What's happening here:
 * ... and then create a ``NavigationNode`` object from each one
 * ... and return a list of these ``NavigationNodes``
 
-This menu class is not active until attached to the AppHook we created earlier.
+This menu class is not active until attached to the apphook we created earlier.
 So open your ``cms_app.py`` and add::
 
     menus = [PollsMenu]

--- a/docs/introduction/third_party.rst
+++ b/docs/introduction/third_party.rst
@@ -48,7 +48,7 @@ Since we added a new app, we need to update our database::
 
 Start the server again.
 
-The weblog application comes with a django CMS AppHook, so add a new django CMS
+The weblog application comes with a django CMS apphook, so add a new django CMS
 page, and add the weblog application to it as you did for Polls in the previous
 tutorial. *You may need to restart your server at this point.*
 

--- a/docs/upgrade/2.4.rst
+++ b/docs/upgrade/2.4.rst
@@ -128,7 +128,7 @@ Removed the MultilingualMiddleware
 
 We removed the MultilingualMiddleware. This removed rather some unattractive
 monkey-patching of the ``reverse()`` function as well. As a benefit we now
-support localisation of urls and Apphook urls with standard Django helpers.
+support localisation of URLs and apphook URLs with standard Django helpers.
 
 
 For django 1.4 more infos can be found here:

--- a/docs/upgrade/3.0.3.rst
+++ b/docs/upgrade/3.0.3.rst
@@ -26,7 +26,7 @@ For more details have a look at the docs:
 
 
 Apphook Permissions
-===================
+====================
 
 Apphooks have now by default the same permissions as the page they are attached to.
 This means if a page has for example a login required enabled all views in the apphook

--- a/docs/upgrade/3.0.rst
+++ b/docs/upgrade/3.0.rst
@@ -240,7 +240,7 @@ processors you will need to change their function signature to add the extra
 argument.
 
 Apphooks
-========
+=========
 
 Apphooks have moved from the title to the page model. This means you can no
 longer have separate apphooks for each language. A new ``application instance name``


### PR DESCRIPTION
Existing examples included: AppHook, App-Hook, Apphook, apphook, app-hook
