### PR TITLE
bugfix: bad tooltips and structure board areas positions

### DIFF
--- a/cms/static/cms/js/modules/cms.base.js
+++ b/cms/static/cms/js/modules/cms.base.js
@@ -116,12 +116,14 @@ $(document).ready(function () {
 			$('body').bind('mousemove.cms', function (e) {
 				// so lets figure out where we are
 				var offset = 20;
-				var bound = $(document).width();
-				var pos = e.pageX + tooltip.outerWidth(true) + offset;
+				var relX = e.pageX - $(tooltip).offsetParent().offset().left;
+				var relY = e.pageY - $(tooltip).offsetParent().offset().top;
+				var bound = $(tooltip).offsetParent().width();
+				var pos = relX + tooltip.outerWidth(true) + offset;
 
 				tooltip.css({
-					'left': (pos >= bound) ? e.pageX - tooltip.outerWidth(true) - offset : e.pageX + offset,
-					'top': e.pageY - 12
+					'left': (pos >= bound) ? relX - tooltip.outerWidth(true) - offset : relX + offset,
+					'top': relY - 12
 				});
 			});
 

--- a/cms/static/cms/js/modules/cms.structureboard.js
+++ b/cms/static/cms/js/modules/cms.structureboard.js
@@ -316,6 +316,7 @@ $(document).ready(function () {
 			var id = null;
 			var area = null;
 			var min = null;
+			var areaParentOffset = null;
 
 			// start calculating
 			this.placeholders.each(function (index, item) {
@@ -327,9 +328,13 @@ $(document).ready(function () {
 				item.height(area.outerHeight(true));
 				// set min width
 				min = (item.width()) ? 0 : 150;
+				// as area is "css positioned" and jquery offset function is relative to the
+				// document (not the first relative/absolute parent) we need to substract
+				// first relative/absolute parent offset.
+				areaParentOffset = $(area).offsetParent().offset();
 				area.css({
-					'top': item.offset().top - 5,
-					'left': item.offset().left - min,
+					'top': item.offset().top - areaParentOffset.top - 5,
+					'left': item.offset().left - areaParentOffset.left - min,
 					'width': item.width() + min
 				});
 			});


### PR DESCRIPTION
When the sideframe is opened, tooltips and structure board areas are
badly moved to the right.

As tooltips and area are "css positioned" and jquery offset function is
relative to the document (not the first relative/absolute parent), we
need to substract first relative/absolute parent offset.
