### PR TITLE
Fix BaseCMSTestCase.get_staff_user_with_std_permissions

### DIFF
--- a/cms/test_utils/testcases.py
+++ b/cms/test_utils/testcases.py
@@ -167,7 +167,7 @@ class BaseCMSTestCase(object):
         This is a non superuser staff
         """
         staff = self._create_user("staff", is_staff=True, is_superuser=False,
-                                  add_permissions=True)
+                                  add_default_permissions=True)
         return staff
 
     def get_new_page_data(self, parent_id=''):


### PR DESCRIPTION
Wrong parameter in BaseCMSTestCase.get_staff_user_with_std_permissions, use add_default_permissions
