### PR TITLE
Add CMSAppExtension.ready which is called after all cms app configs are loaded

### DIFF
--- a/cms/app_base.py
+++ b/cms/app_base.py
@@ -125,3 +125,11 @@ class CMSAppExtension(six.with_metaclass(ABCMeta)):
         :param cms_config: the cms config class of the app
         """
         pass
+
+    def ready(self):
+        """Override this method to run code after all CMS extensions
+        have been configured.
+
+        This method will be run once, even if no cms app config sets
+        its "<app_label>_enabled" attribute to True"""
+        pass

--- a/cms/app_registration.py
+++ b/cms/app_registration.py
@@ -140,6 +140,14 @@ def configure_cms_apps(apps_with_features):
                 configure_app(app_config.cms_config)
 
 
+def ready_cms_apps(apps_with_features):
+    """Run ready() methods on every registered cms extension,
+    so that final checks can happen after all apps have been configured
+    """
+    for app_with_feature in apps_with_features:
+        app_with_feature.cms_extension.ready()
+
+
 # TODO: Remove this function once backwards compatibility is deprecated
 def backwards_compatibility_config():
     """

--- a/cms/tests/test_app_registration.py
+++ b/cms/tests/test_app_registration.py
@@ -283,6 +283,18 @@ class ConfigureCmsAppsTestCase(CMSTestCase):
             feature_app_y.cms_extension.configure_app.call_args_list[1][0][0],
             config_app_y.cms_config)
 
+    @patch.object(apps, 'get_app_configs')
+    def test_runs_ready_for_all_extensions(self, mocked_apps):
+        feature_app = Mock(spec=AppConfig)
+        feature_app.label = 'djangocms_feature_x'
+        feature_app.cms_extension = Mock(spec=['ready'])
+
+        mocked_apps.return_value = [feature_app]
+
+        app_registration.ready_cms_apps([feature_app])
+
+        feature_app.cms_extension.ready.assert_called_once_with()
+
 
 class SetupCmsAppsTestCase(CMSTestCase):
 

--- a/cms/utils/setup.py
+++ b/cms/utils/setup.py
@@ -6,6 +6,7 @@ from cms.app_registration import (
     backwards_compatibility_config,
     configure_cms_apps,
     get_cms_extension_apps,
+    ready_cms_apps,
 )
 from cms.utils.compat.dj import is_installed as app_is_installed
 
@@ -56,3 +57,4 @@ def setup_cms_apps():
     cms_apps = get_cms_extension_apps()
     configure_cms_apps(cms_apps)
     backwards_compatibility_config()
+    ready_cms_apps(cms_apps)


### PR DESCRIPTION


<!--
    If this is a security-related patch stop immediately!

    See http://docs.django-cms.org/en/latest/contributing/development-policies.html
-->


### Summary

Fixes #



### Links to related discussion



### Proposed changes in this pull request


### Documentation checklist

* [ ] I have updated CHANGELOG.txt if appropriate
* [ ] I have updated the release notes document if appropriate, with:
    * [ ] general notes
    * [ ] bug-fixes
    * [ ] improvements/new features
    * [ ] backwards-incompatible changes
    * [ ] required upgrade steps
    * [ ] names of contributors
* [ ] I have updated other documentation
* [ ] I have added my name to the AUTHORS file
* [ ] This PR's documentation has been approved by Daniele Procida
