### PR TITLE
Store page status code into cache.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,6 @@
 === 3.8.0 (unreleased) ===
 
-* ...
+* Store page status code into the cache.
 
 
 === 3.7.0 (2019-09-25) ===

--- a/cms/cache/page.py
+++ b/cms/cache/page.py
@@ -15,6 +15,8 @@ from cms.toolbar.utils import get_toolbar_from_request
 from cms.utils.conf import get_cms_setting
 from cms.utils.helpers import get_timezone_name
 
+STATUS_CODE_CACHE_KEY = ".status_code"
+
 
 def _page_cache_key(request):
     #sha1 key of current path
@@ -88,6 +90,7 @@ def set_page_cache(response):
                 ttl,
                 version=version
             )
+            cache.set(_page_cache_key(request) + STATUS_CODE_CACHE_KEY, response.status_code, ttl, version=version)
             # See note in invalidate_cms_page_cache()
             _set_cache_version(version)
     return response
@@ -96,6 +99,11 @@ def set_page_cache(response):
 def get_page_cache(request):
     from django.core.cache import cache
     return cache.get(_page_cache_key(request), version=_get_cache_version())
+
+
+def get_page_cache_status_code(request, default_code):
+    from django.core.cache import cache
+    return cache.get(_page_cache_key(request) + STATUS_CODE_CACHE_KEY, default_code, version=_get_cache_version())
 
 
 def get_xframe_cache(page):

--- a/cms/views.py
+++ b/cms/views.py
@@ -11,7 +11,7 @@ from django.utils.timezone import now
 from django.utils.translation import get_language_from_request
 from django.views.decorators.http import require_POST
 
-from cms.cache.page import get_page_cache
+from cms.cache.page import get_page_cache, get_page_cache_status_code
 from cms.exceptions import LanguageError
 from cms.forms.login import CMSToolbarLoginForm
 from cms.models.pagemodel import TreeNode
@@ -54,6 +54,7 @@ def details(request, slug):
             response = HttpResponse(content)
             response.xframe_options_exempt = True
             response._headers = headers
+            response.status_code = get_page_cache_status_code(request, response.status_code)
             # Recalculate the max-age header for this cached response
             max_age = int(
                 (expires_datetime - response_timestamp).total_seconds() + 0.5)


### PR DESCRIPTION
### Proposed changes in this pull request

(Reopen #6732 - Branch rebased to `develop`.)

Some extensions can have error pages directly in cms administration. Such pages are cached. For this purpose, it is also necessary to save the status code of the corresponding error, otherwise HTTP 200 is set.