### PR TITLE
Fix migrations on multiple databases

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@
 
 * Introduced Django 2.2 support.
 * Fixed test suite.
+* Fixed migrations fail on multiple databases
 
 
 === 3.6.0 (2019-01-29) ===

--- a/cms/migrations/0019_set_pagenode.py
+++ b/cms/migrations/0019_set_pagenode.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations
+from django.db import router
 
 from . import IrreversibleMigration
 
@@ -63,6 +64,8 @@ class Migration(IrreversibleMigration):
 
     def apply(self, project_state, schema_editor, collect_sql=False):
         connection = schema_editor.connection
+        if not router.allow_migrate(connection.alias, self.app_label):
+            return project_state
         column_names = [
             column.name for column in
             connection.introspection.get_table_description(connection.cursor(), 'cms_page')

--- a/cms/migrations/0020_old_tree_cleanup.py
+++ b/cms/migrations/0020_old_tree_cleanup.py
@@ -6,6 +6,7 @@ import django
 import django.contrib.auth.models
 from django.db import migrations, models
 import django.db.models.deletion
+from django.db import router
 
 from . import IrreversibleMigration
 
@@ -61,6 +62,8 @@ class Migration(IrreversibleMigration):
 
     def apply(self, project_state, schema_editor, collect_sql=False):
         connection = schema_editor.connection
+        if not router.allow_migrate(connection.alias, self.app_label):
+            return project_state
         column_names = [
             column.name for column in
             connection.introspection.get_table_description(connection.cursor(), 'cms_page')


### PR DESCRIPTION
## Description

Fix migrations in case django-cms is used on a different database from the default and defines allow_migrate in the router.
Migrations with problems:
- 0019_set_pagenode.py
- 0020_old_tree_cleanup.py

## Related resources

### myproject/settings.py

```python
DATABASES = {
    'default': {
        'ENGINE': 'django.contrib.gis.db.backends.postgis',
        'OPTIONS': {
            'options': '-c search_path=public,cms'
        },
        'NAME': '<my_database>',
        'USER': '<my_user>',
        'PASSWORD': '<my_password>',
        'HOST': '127.0.0.1',
        'PORT': '5432',
        'TEST': {
            'DEPENDENCIES': [],
        },
    },
    'cms': {
        'ENGINE': 'django.contrib.gis.db.backends.postgis',
        'OPTIONS': {
            'options': '-c search_path=cms,public'
        },
        'NAME': '<my_database>',
        'USER': '<my_user>',
        'PASSWORD': '<my_password>',
        'HOST': '127.0.0.1',
        'PORT': '5432',
        'TEST': {
            'DEPENDENCIES': [ 'default'],
        },
    }
}

DATABASE_ROUTERS = [
    'myproject.routers.PrimaryRouter'
]
```

### myproject/routers.py

```python
class PrimaryRouter:
    def db_for_read(self, model, **hints):
        if model._meta.app_label == 'cms' or model._meta.app_label.startswith('djangocms_'):
            return 'cms'
        return 'default'

    def db_for_write(self, model, **hints):
        if model._meta.app_label == 'cms' or model._meta.app_label.startswith('djangocms_'):
            return 'cms'
        return 'default'

    def allow_relation(self, obj1, obj2, **hints):
        return True

    def allow_migrate(self, db, app_label, model_name=None, **hints):
        if app_label == 'cms' or app_label.startswith('djangocms_'):
            return 'cms'
        return db == 'default'
```

```bash
python manage.py migrate
python manage.py migrate --database=cms
```

## Checklist

* [x] I have opened this pull request against ``develop``
* [x] I have updated the **CHANGELOG.rst**
* [x] I have added or modified the tests when changing logic
