### PR TITLE
A workaround for a bug that breaks page slugs in a multi-language configuration (#6622)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,13 @@ Changelog
 =========
 
 
+3.7.2
+==================
+* Fix a bug about the slugs of child pages being built incorrectly and
+  returning a 404 error when a user was adding a custom slug
+  for another language of the parent page.
+
+
 3.7.1 (2019-11-26)
 ==================
 

--- a/cms/signals/slug_update_fix.py
+++ b/cms/signals/slug_update_fix.py
@@ -1,0 +1,32 @@
+"""
+This is a temporary fix that should be replaced with an adequate bug fix to the Page logic.
+"""
+
+from django.dispatch import receiver
+from django.db.models.signals import post_save
+from fieldsignals import post_save_changed
+
+from cms.models import Title, Page
+
+
+@receiver(post_save, sender=Page)
+def fix_page_slugs(sender, instance, **kwargs):
+    _update_child_pages(instance)
+
+
+@receiver(post_save_changed, sender=Title, fields=['slug', 'path'])
+def fix_title_path(sender, instance, **kwargs):
+    _update_child_pages(instance.page)
+
+
+def _update_child_pages(page):
+    for language in page.get_languages():
+        _update_title_path(page, language)
+        for child_page in page.get_child_pages():
+            _update_title_path(child_page, language)
+
+
+def _update_title_path(page, language):
+    if hasattr(page.get_title_obj(language, fallback=False), 'get_path_for_base'):
+        # noinspection PyProtectedMember
+        page._update_title_path(language)

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ INSTALL_REQUIREMENTS = [
     'django-treebeard>=4.3',
     'django-sekizai>=0.7',
     'djangocms-admin-style>=1.2',
+    'django-fieldsignals>=0.5.0',
 ]
 
 setup(


### PR DESCRIPTION
## Description

This is a temporary fix for #6622 that simply calls `page._update_title_path(language)` method one more time when a user changes the page slug.

By the way as far as I remember that issue is also solvable by calling `page.save()` method one more time, but this workaround is better targeted at the source of the problem.

## Related resources

https://github.com/divio/django-cms/issues/6622

## Checklist

* [x] I have opened this pull request against ``develop``
* [x] I have updated the **CHANGELOG.rst**
* [ ] I have added or modified the tests when changing logic - again alas I haven't had the time for it. In short this patch is in use on 3-4 projects in live at the moment, with django-cms from 3.5 to 3.7.1. I'm using it as part of [djangocms-helpers](https://pypi.org/project/djangocms-helpers/) package.
