### PR TITLE
Accessing a page 404 on draft language

### DIFF
--- a/cms/page_rendering.py
+++ b/cms/page_rendering.py
@@ -24,7 +24,7 @@ def render_page(request, page, current_language, slug):
 
     cant_view_page = any([
         not context['has_view_permissions'],
-        isinstance(page.get_title_obj(current_language), EmptyPageContent)
+        isinstance(page.get_title_obj(current_language, fallback=False), EmptyPageContent)
     ])
     if cant_view_page:
         return _handle_no_page(request)

--- a/cms/utils/__init__.py
+++ b/cms/utils/__init__.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
 # TODO: this is just stuff from utils.py - should be splitted / moved
+from functools import lru_cache
+
 from django.conf import settings
 from django.core.files.storage import get_storage_class
 from django.utils.functional import LazyObject
+from django.urls import resolve
+from django.contrib.contenttypes.models import ContentType
+from django.urls.exceptions import Resolver404
 
 from cms.utils.conf import get_site_id  # nopyflakes
 from cms.utils.i18n import get_default_language
@@ -16,6 +21,34 @@ def get_current_site():
     return Site.objects.get_current()
 
 
+@lru_cache(512)
+def get_object_language(request):
+    """
+    We resolve the request and try to get content type if there is one.
+    If the content type has a language, it's the language we want to use.
+    """
+    try:
+        resolved = resolve(request.path)
+    except Resolver404:
+        return None
+
+    args = resolved.args
+    if len(args) != 2 or not all([a.isnumeric() for a in args]):
+        # if it is not a content type we can't get a language from it.
+        return None
+
+    content_type_id, object_id = args
+
+    try:
+        content_type = ContentType.objects.get_for_id(content_type_id)
+        content_type_obj = content_type.get_object_for_this_type(pk=object_id)
+        language = content_type_obj.language
+    except (ContentType.DoesNotExist, AttributeError):
+        return None
+
+    return language
+
+
 def get_language_from_request(request, current_page=None):
     """
     Return the most obvious language according the request
@@ -23,8 +56,14 @@ def get_language_from_request(request, current_page=None):
     language = None
     if hasattr(request, 'POST'):
         language = request.POST.get('language', None)
-    if hasattr(request, 'GET') and not language:
+    elif hasattr(request, 'GET'):
         language = request.GET.get('language', None)
+
+    if not language:
+        # if we still don't have language from get or post request
+        # we try to get it from the content object of the request.
+        language = get_object_language(request)
+
     site_id = current_page.node.site_id if current_page else None
     if language:
         language = get_language_code(language)

--- a/cms/views.py
+++ b/cms/views.py
@@ -164,7 +164,7 @@ def details(request, slug):
     if page.login_required and not request.user.is_authenticated:
         return redirect_to_login(urlquote(request.get_full_path()), settings.LOGIN_URL)
 
-    content = page.get_title_obj(language=request_language)
+    content = page.get_title_obj(language=request_language, fallback=False)
     # use the page object with populated cache
     content.page = page
     if hasattr(request, 'toolbar'):


### PR DESCRIPTION
## Description
When accessing a page in a specific language we can't use a fallback. If we do we'll show an english page even though we requested a french page.

We need to check that the page that we request is not EmptypageContent if it is the user should not see the page.

## Checklist

* [x] I have opened this pull request against ``release/4.0.x``
* [ ] I have updated the **CHANGELOG.rst**
* [x] I have added or modified the tests when changing logic

Since this logic only manifests itself when using djangocms-versioning the tests have been placed in that page. You can view the currently failing tests there. https://github.com/divio/djangocms-versioning/pull/217