### PR TITLE
Add test_alias_plugins_no_recursion_across_page_translation and fix not rendering alias plugins in edit-mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,10 +6,11 @@ Changelog
 3.8.0 (unreleased)
 ==================
 
+* Added ``test_alias_plugins_no_recursion_across_page_translation``
 * Introduced support for Django 3.1
 * Dropped support for Python 2.7 and Python 3.4
 * Dropped support for Django < 2.2
-* Added ``test_alias_recursion_across_page_translation``
+
 
 3.7.4 (2020-07-21)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Changelog
 * Introduced support for Django 3.1
 * Dropped support for Python 2.7 and Python 3.4
 * Dropped support for Django < 2.2
-
+* Added test_alias_recursion_across_page_translation
 
 3.7.4 (2020-07-21)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Changelog
 * Introduced support for Django 3.1
 * Dropped support for Python 2.7 and Python 3.4
 * Dropped support for Django < 2.2
-* Added test_alias_recursion_across_page_translation
+* Added ``test_alias_recursion_across_page_translation``
 
 3.7.4 (2020-07-21)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
 ==================
 
 * Added ``test_alias_plugins_no_recursion_across_page_translation``
+  and fix not rendering alias plugin in edit-mode across page translation
 * Introduced support for Django 3.1
 * Dropped support for Python 2.7 and Python 3.4
 * Dropped support for Django < 2.2

--- a/cms/models/aliaspluginmodel.py
+++ b/cms/models/aliaspluginmodel.py
@@ -58,4 +58,6 @@ class AliasPluginModel(CMSPlugin):
             Q(plugin__placeholder=self.placeholder_id) |
             Q(alias_placeholder=self.placeholder_id)
         )
+        if self.plugin and self.plugin.language != self.language:
+            return False
         return plugins.exists()

--- a/cms/tests/test_alias.py
+++ b/cms/tests/test_alias.py
@@ -109,10 +109,11 @@ class AliasTestCase(TransactionCMSTestCase):
         source_plugin = api.add_plugin(ph_2, 'StylePlugin', 'en', tag_type='div', class_name='info_2')
 
         api.create_title("fr", "page_1", page)
-        page.publish('fr')
 
         alias_placeholder = api.add_plugin(ph_1, 'AliasPlugin', 'fr', alias_placeholder=ph_1)
         alias_plugin = api.add_plugin(ph_2, 'AliasPlugin', 'fr', plugin=source_plugin)
+        
+        page.publish('fr')
 
         self.assertTrue(alias_placeholder.is_recursive())
         self.assertTrue(alias_plugin.is_recursive())

--- a/cms/tests/test_alias.py
+++ b/cms/tests/test_alias.py
@@ -118,6 +118,12 @@ class AliasTestCase(TransactionCMSTestCase):
         self.assertTrue(alias_plugin.is_recursive())
 
         with self.login_user_context(self.get_superuser()):
+            response = self.client.get(page.get_absolute_url(language='fr') + '?preview&edit_off')
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, '<div class="info_2">', html=True)
+            self.assertContains(response, '<div class="info_1">', html=True)
+        
+        with self.login_user_context(self.get_superuser()):
             response = self.client.get(page.get_absolute_url(language='fr') + '?edit')
             self.assertEqual(response.status_code, 200)
             self.assertContains(response, '<div class="info_1">', html=True)

--- a/cms/tests/test_alias.py
+++ b/cms/tests/test_alias.py
@@ -93,9 +93,11 @@ class AliasTestCase(TransactionCMSTestCase):
             self.assertContains(response, '<div class="info">', html=False)
 
     def test_alias_plugins_no_recursion_across_page_translation(self):
-        # Test only alias plugins across page translation, sample use case with a menu plugin
-        # in static_placeholder who use translation pages title) 
-        # Alias placeholder across across page translation is not implemented.
+        '''
+        Test only alias plugins across page translation, sample use case with a menu plugin
+        in static_placeholder who use translation pages title) 
+        Alias placeholder across page translation is not implemented.
+        '''
 
         page = api.create_page(
             "Alias plugin",


### PR DESCRIPTION
## Description
Across page language translation:
In edit_mode, Alias_​plugins  and  Alias_placeholders are not rendered.
In published mode, Alias_​plugins are rendered, but with Alias_placeholders they are not.

## Related resources
 
* #6819

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have updated the **CHANGELOG.rst**
* [x] I have added or modified the tests when changing logic
