### PR TITLE
Fix Python 3.5 tests on Travis

### DIFF
--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -13,7 +13,7 @@ https://github.com/ojii/django-better-test/archive/8aa2407d097fe3789b74682f0e6bd
 https://github.com/ojii/django-app-manage/archive/65da18ef234a4e985710c2c0ec760023695b40fe.zip#egg=django-app-manage
 iptools
 sphinx==1.8.5
-sphinxcontrib-spelling
+sphinxcontrib-spelling<7.0.0 # restriction for py35 tests
 # required to run the server for integration tests
 django-app-helper
 mock>=2.0.0


### PR DESCRIPTION
## Description

Currently, the [python 3.5 tests on Travis are failing](https://travis-ci.com/github/django-cms/django-cms/builds/197666022), since `sphinxcontrib-spelling` [dropped python 3.5 support with version 7.0.0](https://sphinxcontrib-spelling.readthedocs.io/en/latest/history.html#id2).
Thus, in order for the python 3.5 tests to pass the restriction `sphinxcontrib-spelling<7.0.0` needs to be set in `requirements_base.txt`.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* https://github.com/django-cms/django-cms/pull/6699#issuecomment-720988770

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [ ] I have updated the **CHANGELOG.rst**
* [ ] I have added or modified the tests when changing logic
