### PR TITLE
perf: Don't count users when CMS_RAW_ID_USERS=True

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 unreleased
 ==========
 
+* Improved performance when using CMS_RAW_ID_USERS=True on a Postgres DB with many users
+
 3.11.0 (2022-08-02)
 ===================
 

--- a/cms/admin/permissionadmin.py
+++ b/cms/admin/permissionadmin.py
@@ -31,6 +31,29 @@ class TabularInline(admin.TabularInline):
     pass
 
 
+def users_exceed_threshold():
+    """
+    Check if the number of users exceed the configured threshold. Only bother
+    counting the users when using an integer threshold, otherwise return the
+    value of the setting to avoid a potentially expensive DB query.
+    """
+    threshold = get_cms_setting('RAW_ID_USERS')
+
+    # Don't bother counting the users when not using an integer threshold
+    if threshold is True or threshold is False:
+        return threshold
+
+    # Given a fresh django-cms install and a django settings with the
+    # CMS_RAW_ID_USERS = CMS_PERMISSION = True
+    # django throws an OperationalError when running
+    # ./manage migrate
+    # because auth_user doesn't exists yet
+    try:
+        return get_user_model().objects.count() > threshold
+    except OperationalError:
+        return False
+
+
 class PagePermissionInlineAdmin(TabularInline):
     model = PagePermission
     # use special form, so we can override of user and group field
@@ -54,19 +77,7 @@ class PagePermissionInlineAdmin(TabularInline):
     @classproperty
     def raw_id_fields(cls):
         # Dynamically set raw_id_fields based on settings
-        threshold = get_cms_setting('RAW_ID_USERS')
-
-        # Given a fresh django-cms install and a django settings with the
-        # CMS_RAW_ID_USERS = CMS_PERMISSION = True
-        # django throws an OperationalError when running
-        # ./manage migrate
-        # because auth_user doesn't exists yet
-        try:
-            threshold = threshold and get_user_model().objects.count() > threshold
-        except OperationalError:
-            threshold = False
-
-        return ['user'] if threshold else []
+        return ['user'] if users_exceed_threshold() else []
 
     def get_queryset(self, request):
         """
@@ -135,13 +146,8 @@ class GlobalPagePermissionAdmin(admin.ModelAdmin):
     list_filter.append('can_change_advanced_settings')
 
     def get_list_filter(self, request):
-        threshold = get_cms_setting('RAW_ID_USERS')
-        try:
-            threshold = threshold and get_user_model().objects.count() > threshold
-        except OperationalError:
-            threshold = False
         filter_copy = deepcopy(self.list_filter)
-        if threshold:
+        if users_exceed_threshold():
             filter_copy.remove('user')
         return filter_copy
 
@@ -160,19 +166,7 @@ class GlobalPagePermissionAdmin(admin.ModelAdmin):
     @classproperty
     def raw_id_fields(cls):
         # Dynamically set raw_id_fields based on settings
-        threshold = get_cms_setting('RAW_ID_USERS')
-
-        # Given a fresh django-cms install and a django settings with the
-        # CMS_RAW_ID_USERS = CMS_PERMISSION = True
-        # django throws an OperationalError when running
-        # ./manage migrate
-        # because auth_user doesn't exists yet
-        try:
-            threshold = threshold and get_user_model().objects.count() > threshold
-        except OperationalError:
-            threshold = False
-
-        return ['user'] if threshold else []
+        return ['user'] if users_exceed_threshold() else []
 
 
 if get_cms_setting('PERMISSION'):

--- a/cms/tests/test_admin.py
+++ b/cms/tests/test_admin.py
@@ -16,6 +16,9 @@ from djangocms_text_ckeditor.models import Text
 
 from cms import api
 from cms.admin.pageadmin import PageAdmin
+from cms.admin.permissionadmin import (
+    GlobalPagePermissionAdmin, PagePermissionInlineAdmin,
+)
 from cms.api import add_plugin, create_page, create_title, publish_page
 from cms.constants import TEMPLATE_INHERITANCE_MAGIC
 from cms.models import StaticPlaceholder
@@ -1390,3 +1393,54 @@ class AdminPageTreeTests(AdminTestsBase):
         #       ⊢ Beta
         #   ⊢ Delta
         #       ⊢ Gamma
+
+
+class AdminPerformanceTests(AdminTestsBase):
+
+    def test_raw_id_threshold_page_permission_inline_admin(self):
+        """
+        Only count users when using an integer value as threshold for
+        CMS_RAW_ID_USERS.
+        """
+        with self.settings(CMS_RAW_ID_USERS=1):
+            with self.assertNumQueries(1):
+                self.assertEqual(PagePermissionInlineAdmin.raw_id_fields, [])
+
+        # Create users to check if threshold is honored
+        self._get_guys()
+
+        with self.settings(CMS_RAW_ID_USERS=False):
+            with self.assertNumQueries(0):
+                self.assertEqual(PagePermissionInlineAdmin.raw_id_fields, [])
+
+        with self.settings(CMS_RAW_ID_USERS=True):
+            with self.assertNumQueries(0):
+                self.assertEqual(PagePermissionInlineAdmin.raw_id_fields, ['user'])
+
+        with self.settings(CMS_RAW_ID_USERS=1):
+            with self.assertNumQueries(1):
+                self.assertEqual(PagePermissionInlineAdmin.raw_id_fields, ['user'])
+
+    def test_raw_id_threshold_global_page_permission_admin(self):
+        """
+        Only count users when using an integer value as threshold for
+        CMS_RAW_ID_USERS.
+        """
+        with self.settings(CMS_RAW_ID_USERS=1):
+            with self.assertNumQueries(1):
+                self.assertEqual(GlobalPagePermissionAdmin.raw_id_fields, [])
+
+        # Create users to check if threshold is honored
+        self._get_guys()
+
+        with self.settings(CMS_RAW_ID_USERS=False):
+            with self.assertNumQueries(0):
+                self.assertEqual(GlobalPagePermissionAdmin.raw_id_fields, [])
+
+        with self.settings(CMS_RAW_ID_USERS=True):
+            with self.assertNumQueries(0):
+                self.assertEqual(GlobalPagePermissionAdmin.raw_id_fields, ['user'])
+
+        with self.settings(CMS_RAW_ID_USERS=1):
+            with self.assertNumQueries(1):
+                self.assertEqual(GlobalPagePermissionAdmin.raw_id_fields, ['user'])


### PR DESCRIPTION
## Description

When using CMS_RAW_ID_USERS=True on a Postgres database with many users, counting the users is slow and will always yield the same result.

Only count users when using an integer value as a threshold and reuse the same logic for both `PagePermissionInlineAdmin` and
`GlobalPagePermissionAdmin`.

### Background

When looking into performance issues for one of our websites, we found that Django CMS would regularly count all users in our Postgres database. Unfortunately, `SELECT COUNT(*) FROM huge_table` is slow in Postgres and easily takes 500ms or more if you have more than a million records in your table (exact numbers depend on the DB host of course).

I first looked into [improving the speed of the count query](https://www.cybertec-postgresql.com/en/postgresql-count-made-fast/), but this is not easy to achieve in a way that is compatible with different DB backends.

The easiest option was to not run this query at all when using the documented and widely used (AFAICT) `CMS_RAW_ID_USERS = True`.

The change should be backward compatible with the following exceptions:

* `CMS_RAW_ID_USERS = True` will use raw IDs, even if you have just one or zero users in the DB (since `2 > True` but not `1 >  True` in Python). Since the current behavior could be considered a (rather academic) bug, I don't think this is a deal-breaker.
* `CMS_RAW_ID_USERS = 0` will trigger a count and use raw IDs when there's one user or more. If that's a problem, I could check if `threshold` is "truthy" like in the original implementation.

## Checklist

* [x] I have opened this pull request against ``develop``
* [x] I have updated the **CHANGELOG.rst**
* [x] I have added or modified the tests when changing logic