### PR TITLE
Point badge for BUILT to the new Travis-CI location

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 ##########
 django CMS
 ##########
-.. image:: https://travis-ci.org/divio/django-cms.svg?branch=develop
-    :target: https://travis-ci.org/divio/django-cms
+.. image:: https://travis-ci.org/django-cms/django-cms.svg?branch=develop
+    :target: https://travis-ci.org/django-cms/django-cms
 .. image:: https://img.shields.io/pypi/v/django-cms.svg
     :target: https://pypi.python.org/pypi/django-cms/
 .. image:: https://img.shields.io/badge/wheel-yes-green.svg


### PR DESCRIPTION
## Description

Since this repository moved from the `divio` organization to `django-cms` the badge for the building process
pointed onto the wrong location. This pull request fixes that.

## Related resources

## Checklist

* [X] I have opened this pull request against ``develop``
* [o] I have updated the **CHANGELOG.rst**
* [o] I have added or modified the tests when changing logic
