### PR TITLE
Fix 5930 page attribute as varname

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@ Changelog
 =========
 
 
+next
+====
+
+* Fixes templatetag ``page_attribute`` when extanding with ``as ...``.
+
+
 3.8.0 (2020-10-28)
 ==================
 

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -421,6 +421,12 @@ class PageAttribute(AsTag):
             return ret_val
         return ''
 
+    def get_value_for_context(self, context, **kwargs):
+        try:
+            return super().get_value_for_context(context, **kwargs)
+        except Page.DoesNotExist:
+            return ''
+
 
 class CMSToolbar(RenderBlock):
     name = 'cms_toolbar'

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -74,6 +74,21 @@ class TemplatetagTests(CMSTestCase):
         self.assertNotEqual(script, output)
         self.assertEqual(escape(script), output)
 
+    def test_page_attribute_tag_as_var(self):
+        class FakePage:
+            def get_page_title(self, *args, **kwargs):
+                return 'Fake Title'
+
+        class FakeRequest:
+            current_page = FakePage()
+            GET = {'language': 'en'}
+
+        request = FakeRequest()
+        template = '{% load cms_tags %}{% page_attribute page_title as my_title %}<title>{{ my_title }}</title>'
+        output = self.render_template_obj(template, {}, request)
+        expected = '<title>Fake Title</title>'
+        self.assertEqual(expected, output)
+
     def test_json_encoder(self):
         self.assertEqual(json_filter(True), 'true')
         self.assertEqual(json_filter(False), 'false')

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -57,16 +57,6 @@ class TemplatetagTests(CMSTestCase):
     def test_unicode_placeholder_name_fails_fast(self):
         self.assertRaises(ImproperlyConfigured, get_placeholders, 'unicode_placeholder.html')
 
-    def test_page_attribute_tag(self):
-        page = create_page('My Page', 'nav_playground.html', 'en', published=True)
-        request = RequestFactory().get('/')
-        request.user = AnonymousUser()
-        request.current_page = page
-
-        template = '{% load cms_tags %}{% page_attribute "page_title" %}<title>{{ my_title }}</title>'
-        output = self.render_template_obj(template, {}, request)
-        self.assertEqual(output, '<title>My Page</title>')
-
     def test_page_attribute_tag_escapes_content(self):
         script = '<script>alert("XSS");</script>'
 
@@ -84,16 +74,27 @@ class TemplatetagTests(CMSTestCase):
         self.assertNotEqual(script, output)
         self.assertEqual(escape(script), output)
 
-    def test_page_attribute_tag_with_lookup(self):
+    def test_page_attribute_tag(self):
         page = create_page('My Page', 'nav_playground.html', 'en', published=True)
         request = RequestFactory().get('/')
         request.user = AnonymousUser()
         request.current_page = page
 
-        template = '{% load cms_tags %}<title>{% page_attribute "page_title" page %}</title>'
-        output = self.render_template_obj(template, {'page': page}, request)
+        template = '{% load cms_tags %}<title>{% page_attribute "page_title" %}</title>'
+        output = self.render_template_obj(template, {}, request)
         self.assertEqual(output, '<title>My Page</title>')
-        output = self.render_template_obj(template, {'page': 'nopage'}, request)
+
+    def test_page_attribute_tag_with_lookup_page(self):
+        page = create_page('My Page', 'nav_playground.html', 'en', published=True)
+        request = RequestFactory().get('/')
+        request.user = AnonymousUser()
+        request.current_page = page
+        lookup_page = create_page('Lookup Page', 'nav_playground.html', 'en', published=True)
+
+        template = '{% load cms_tags %}<title>{% page_attribute "page_title" lookup_page %}</title>'
+        output = self.render_template_obj(template, {'lookup_page': lookup_page}, request)
+        self.assertEqual(output, '<title>Lookup Page</title>')
+        output = self.render_template_obj(template, {'lookup_page': 'nopage'}, request)
         self.assertEqual(output, '<title></title>')  # only for DEBUG=False
 
     def test_page_attribute_tag_as_var(self):

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -84,7 +84,7 @@ class TemplatetagTests(CMSTestCase):
         self.assertNotEqual(script, output)
         self.assertEqual(escape(script), output)
 
-    def test_page_attribute_tag(self):
+    def test_page_attribute_tag_with_lookup(self):
         page = create_page('My Page', 'nav_playground.html', 'en', published=True)
         request = RequestFactory().get('/')
         request.user = AnonymousUser()


### PR DESCRIPTION
## Description

It adds the same behaviour to templatetag `{% page_attribute 'field_name' 'page_lookup' as varname %}` as is already implemented in templatetag `{% page_url 'page_lookup' as varname %}`. If `settings.DEBUG = True` and the underlying page is missing, the templatetag fails silently instead of raising a template exception.


This pull request superseeds #6602 and has been rebased against version 3.8.0.


## Related resources

* #5930
* #6602


## Checklist

* [x] I have opened this pull request against ``releases/3.8``
* [x] I have updated the **CHANGELOG.rst**
* [x] I have added or modified the tests when changing logic
