### PR TITLE
Added django CMS Association/Slack to documentation

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -19,10 +19,7 @@ Issues and pull requests
 ========================
 
 * Please report **any bugs** through `GitHub issues <https://github.com/divio/django-cms/issues>`_.
-* For *help with django CMS*, please use our `users' email list <https://groups.google.com/forum/#!forum/django-cms>`_
-  or `StackOverflow <https://stackoverflow.com/questions/tagged/django-cms>`_.
-* For *feature requests*, please use our
-  `developers' email list <https://groups.google.com/forum/#!forum/django-cms-developers>`_.
+* Use our `Discourse forum <https://discourse.django-cms.org>`_ to discuss pull requests
 * For *security issues* please see further below.
 
 
@@ -39,15 +36,8 @@ Security issues
 Please have a look at our security policy for
 `how to deal with security issues <http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues>`_.
 
-If you think you have discovered a security issue in our code, please do not raise it on
-
-* GitHub
-* StackOverflow
-* IRC
-* Twitter
-* either of our email lists
-
-or in any other public forum until we have had a chance to deal with it.
+If you think you have discovered a security issue in our code, please do not raise it in any public
+forum until we have had a chance to deal with it.
 
 
 Community
@@ -55,15 +45,9 @@ Community
 
 You can join us online:
 
-* on `StackOverflow <https://stackoverflow.com/questions/tagged/django-cms>`_.
-* in our IRC channel, #django-cms, on ``irc.freenode.net``. If you don't have an IRC client, you can
-  `join our IRC channel using the KiwiIRC web client
-  <https://kiwiirc.com/client/irc.freenode.net/django-cms>`_, which works pretty well.
-* on our `django CMS users email list <https://groups.google.com/forum/#!forum/django-cms>`_ for
-  **general** django CMS questions and discussion
-* on our `django CMS developers email list
-  <https://groups.google.com/forum/#!forum/django-cms-developers>`_ for discussions about the
-  **development of django CMS**
+* in our `django CMS Slack channel <https://www.django-cms.org/slack>`_
+* on our `Discourse forum <https://discourse.django-cms.org>`_
+* on `StackOverflow <https://stackoverflow.com/questions/tagged/django-cms>`_
 
 You can also follow:
 

--- a/SECURITY.rst
+++ b/SECURITY.rst
@@ -8,7 +8,7 @@ Supported Versions
 Security updates are provided to the latest 2 django CMS versions released. Exceptions apply to the LTS releases.
 
 ======= =========
-Version Supported         
+Version Supported
 ------- ---------
 3.7.x   yes (LTS)
 3.6.x   yes
@@ -21,4 +21,4 @@ Reporting a Vulnerability
 
 If you think you have discovered a security issue in our code, please report it **privately**, by emailing us at security@django-cms.org.
 
-Please **do not** raise it on IRC, GitHub, either of our email lists, StackOverflow or in any other public forum until we have had a chance to deal with it.
+Please **do not** raise it on any public forum until we have had a chance to deal with it.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -131,8 +131,21 @@ try:
     import divio_docs_theme
     html_theme = 'divio_docs_theme'
     html_theme_path = [divio_docs_theme.get_html_theme_path()]
+    html_theme_options = {
+        'show_cloud_banner': True,
+        'cloud_banner_markup': """
+            <div class="divio-cloud">
+                <span class="divio-cloud-caption">The django CMS Association</span>
+                <p>The django CMS Association is a non-profit organisation that funds and
+                steers the development of django CMS, and nurtures its world-wide
+                community of developers and users.</p>
+                <a class="btn-neutral divio-cloud-btn" target="_blank" href="https://www.django-cms.org/en/about-us/">Join us</a>
+            </div>
+        """,
+    }
 except:
     html_theme = 'default'
+
 
 show_cloud_banner = True
 

--- a/docs/contributing/code.rst
+++ b/docs/contributing/code.rst
@@ -26,7 +26,7 @@ Basic requirements and standards
 ********************************
 
 If you're interested in developing a new feature for the CMS, it is recommended
-that you first discuss it on the `django-cms-developers`_  mailing list so as
+that you first discuss it on the `Discourse forum <https://discourse.django-cms.org>`_ so as
 not to do any work that will not get merged in anyway.
 
 - Code will be reviewed and tested by at least one core developer, preferably
@@ -105,8 +105,8 @@ coverage will only be accepted with a very good reason; bug-fixing patches
 **must** demonstrate the bug with a test to avoid regressions and to check
 that the fix works.
 
-We have `a Slack group <https://www.django-cms.org/slack>`_, our `django-cms-developers`_
-email list, and of course the code reviews mechanism on GitHub - do use them.
+We have `a Slack group <https://www.django-cms.org/slack>`_, a `Discourse forum
+<https://discourse.django-cms.org>`_, and of course the code reviews mechanism on GitHub - do use them.
 
 
 .. _contributing_frontend:

--- a/docs/contributing/code.rst
+++ b/docs/contributing/code.rst
@@ -105,11 +105,9 @@ coverage will only be accepted with a very good reason; bug-fixing patches
 **must** demonstrate the bug with a test to avoid regressions and to check
 that the fix works.
 
-We have an IRC channel, our `django-cms-developers`_ email list,
-and of course the code reviews mechanism on GitHub - do use them.
+We have `a Slack group <https://www.django-cms.org/slack>`_, our `django-cms-developers`_
+email list, and of course the code reviews mechanism on GitHub - do use them.
 
-If you don't have an IRC client, you can `join our IRC channel using the KiwiIRC web client
-<https://kiwiirc.com/client/irc.freenode.net/django-cms>`_, which works pretty well.
 
 .. _contributing_frontend:
 

--- a/docs/contributing/code_of_conduct.rst
+++ b/docs/contributing/code_of_conduct.rst
@@ -13,7 +13,7 @@ We will not tolerate abusive behaviour or language or any form of harassment.
 
 Individuals whose behaviour is a cause for concern will be give a warning, and
 if necessary will be excluded from participation in official django CMS
-channels (email lists, IRC channels, etc) and events. The `Django Software
+channels (email lists, Slack/IRC channels, etc) and events. The `Django Software
 Foundation <http://djangoproject.com/foundation/>`_ will also be informed of
 the issue.
 

--- a/docs/contributing/code_of_conduct.rst
+++ b/docs/contributing/code_of_conduct.rst
@@ -13,9 +13,9 @@ We will not tolerate abusive behaviour or language or any form of harassment.
 
 Individuals whose behaviour is a cause for concern will be give a warning, and
 if necessary will be excluded from participation in official django CMS
-channels (email lists, Slack/IRC channels, etc) and events. The `Django Software
-Foundation <http://djangoproject.com/foundation/>`_ will also be informed of
-the issue.
+channels (Slack group, Discourse forum, email lists, IRC channels, etc) and
+events. The `Django Software Foundation
+<http://djangoproject.com/foundation/>`_ will also be informed of the issue.
 
 *****************
 Raising a concern

--- a/docs/contributing/development-community.rst
+++ b/docs/contributing/development-community.rst
@@ -6,7 +6,7 @@ django CMS's development community
 
 You can join us online:
 
-* in our `django CMS Slack channel <www.django-cms.org/slack>`_
+* in our `django CMS Slack channel <https://www.django-cms.org/slack>`_
 * on our `django CMS users email list <https://groups.google.com/forum/#!forum/django-cms>`_ for
   **general discussion** of django CMS
 * on our `django CMS developers email list

--- a/docs/contributing/development-community.rst
+++ b/docs/contributing/development-community.rst
@@ -7,13 +7,8 @@ django CMS's development community
 You can join us online:
 
 * in our `django CMS Slack channel <https://www.django-cms.org/slack>`_
-* on our `django CMS users email list <https://groups.google.com/forum/#!forum/django-cms>`_ for
-  **general discussion** of django CMS
-* on our `django CMS developers email list
-  <https://groups.google.com/forum/#!forum/django-cms-developers>`_ for discussions about the
-  **development of django CMS**
-* on our `StackOverflow <https://stackoverflow.com/questions/tagged/django-cms>`_ for
-  general **questions** around django CMS and it's plugin ecosystem
+* on our `Discourse forum <https://discourse.django-cms.org>`_
+* on `StackOverflow <https://stackoverflow.com/questions/tagged/django-cms>`_
 
 You can also follow:
 

--- a/docs/contributing/development-policies.rst
+++ b/docs/contributing/development-policies.rst
@@ -15,8 +15,9 @@ Reporting security issues
     If you think you have discovered a security issue in our code, please report
     it **privately**, by emailing us at `security@divio.com <security@divio.com>`_.
 
-        Please **do not** raise it on IRC, GitHub, either of our email lists, StackOverflow
-        or in any other public forum until we have had a chance to deal with it.
+    Please **do not** raise it on Slack, IRC, GitHub, either of our email
+    lists, StackOverflow or in any other public forum until we have had a
+    chance to deal with it.
 
 
 ******

--- a/docs/contributing/development-policies.rst
+++ b/docs/contributing/development-policies.rst
@@ -15,8 +15,7 @@ Reporting security issues
     If you think you have discovered a security issue in our code, please report
     it **privately**, by emailing us at `security@divio.com <security@divio.com>`_.
 
-    Please **do not** raise it on Slack, IRC, GitHub, either of our email
-    lists, StackOverflow or in any other public forum until we have had a
+    Please **do not** raise it in any public forum until we have had a
     chance to deal with it.
 
 
@@ -48,8 +47,7 @@ the author of the pull request.
 Proposal and discussion of significant changes
 **********************************************
 
-New features and backward-incompatible changes should be proposed using the `django CMS developers email list
-<https://groups.google.com/group/django-cms-developers>`_. Discussion should take place there before any pull requests
+New features and backward-incompatible changes should be proposed using the `Discourse forum <https://discourse.django-cms.org>`_. Discussion should take place there before any pull requests
 are made.
 
 This is in the interests of openness and transparency, and to give the community a chance to participate in and
@@ -69,7 +67,7 @@ The `roadmap <https://www.django-cms.org/en/roadmap/>`_ can be found on our webs
 We are planning releases according to **key principles and aims**. Issues within milestones are
 therefore subject to change.
 
-The `django CMS developers email list <https://groups.google.com/group/django-cms-developers>`_ serves as gathering
+The `django CMS Discourse forum <https://discourse.django-cms.org>`_ serves as gathering
 point for developers. We submit ideas and proposals prior to the roadmap goals.
 
 django CMS 3.4, surpassed by 3.7, was the first "LTS" ("Long-Term Support")
@@ -216,5 +214,4 @@ New lines should be added to the top of the list.
 
 
 .. _security@django-cms.org: mailto:security@django-cms.org
-.. _django-cms-developers: https://groups.google.com/group/django-cms-developers
 .. _freenode: http://freenode.net/

--- a/docs/contributing/management.rst
+++ b/docs/contributing/management.rst
@@ -19,18 +19,17 @@ Raising an issue
 
 .. ATTENTION::
 
-    If you think you have discovered a security issue in our code, please
-    report it **privately**, by emailing us at `security@divio.com
-    <security@divio.com>`_.
+    If you think you have discovered a security issue in our code, please report
+    it **privately**, by emailing us at `security@divio.com <security@divio.com>`_.
 
-    Please **do not** raise it on Slack, IRC, GitHub, either of our email
-    lists, StackOverflow or in any other public forum until we have had a
+    Please **do not** raise it in any public forum until we have had a
     chance to deal with it.
 
 
-Except in the case of security matters, of course, you're welcome to raise issues in any way that
-suits you - :ref:`on one of our email lists, or the Slack group <development-community>` or in person
-if you happen to meet another django CMS developer.
+Except in the case of security matters, of course, you're welcome to raise
+issues in any way that suits you - :ref:`using Discourse, or the Slack group
+<development-community>` or in person if you happen to meet another django CMS
+developer.
 
 It's very helpful though if you don't just raise an issue by mentioning it to people, but actually
 file it too, and that means creating a `new issue on GitHub

--- a/docs/contributing/management.rst
+++ b/docs/contributing/management.rst
@@ -19,15 +19,17 @@ Raising an issue
 
 .. ATTENTION::
 
-    If you think you have discovered a security issue in our code, please report
-    it **privately**, by emailing us at `security@divio.com <security@divio.com>`_.
+    If you think you have discovered a security issue in our code, please
+    report it **privately**, by emailing us at `security@divio.com
+    <security@divio.com>`_.
 
-        Please **do not** raise it on IRC, GitHub, either of our email lists, StackOverflow
-        or in any other public forum until we have had a chance to deal with it.
+    Please **do not** raise it on Slack, IRC, GitHub, either of our email
+    lists, StackOverflow or in any other public forum until we have had a
+    chance to deal with it.
 
 
 Except in the case of security matters, of course, you're welcome to raise issues in any way that
-suits you - :ref:`on one of our email lists, or the IRC channel <development-community>` or in person
+suits you - :ref:`on one of our email lists, or the Slack group <development-community>` or in person
 if you happen to meet another django CMS developer.
 
 It's very helpful though if you don't just raise an issue by mentioning it to people, but actually

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,15 +83,24 @@ Technical reference material, for classes, methods, APIs, commands.
 Join us online
 **************
 
-django CMS is supported by a friendly and very knowledgeable community.
+The `django CMS Association <https://www.django-cms.org/en/about-us/>`_ is a non-profit
+organisation that exists to support the development of django CMS and its community.
+
 
 .. rst-class:: column column3
 
-Our IRC channel, #django-cms, is on ``irc.freenode.net``. If you don't have an IRC client, you can
-`join our IRC channel using the KiwiIRC web client
-<https://kiwiirc.com/client/irc.freenode.net/django-cms>`_, which works pretty well.
+Slack
+=====
+
+Join `our friendly Slack group <https:/https://www.django-cms.org/slack>`_ for
+**support** and to **share ideas** and **discuss technical questions** with
+other members of the community.
+
 
 .. rst-class:: column column3
+
+Email
+=====
 
 Our `django CMS users email list <https://groups.google.com/forum/#!forum/django-cms>`_ is for
 **general discussions** and the `django CMS developers email list
@@ -100,8 +109,11 @@ Our `django CMS users email list <https://groups.google.com/forum/#!forum/django
 
 .. rst-class:: column column3
 
-Our `StackOverflow <https://stackoverflow.com/questions/tagged/django-cms>`_ is for
-**questions** around django CMS and it's plugin ecosystem.
+StackOverflow
+=============
+
+`StackOverflow <https://stackoverflow.com/questions/tagged/django-cms>`_ is also a good place
+for questions around django CMS and its plugin ecosystem.
 
 
 ***************

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -99,13 +99,12 @@ other members of the community.
 
 .. rst-class:: column column3
 
-Email
-=====
+Discourse
+=========
 
-Our `django CMS users email list <https://groups.google.com/forum/#!forum/django-cms>`_ is for
-**general discussions** and the `django CMS developers email list
-<https://groups.google.com/forum/#!forum/django-cms-developers>`_ for the
-**development of django CMS**.
+Our `Discourse forum <https://discourse.django-cms.org>`_ is also used for
+discussion of django CMS, particularly to manage its technical development process.
+
 
 .. rst-class:: column column3
 

--- a/docs/introduction/index.rst
+++ b/docs/introduction/index.rst
@@ -41,7 +41,6 @@ If you want to install django CMS into an existing project, or prefer to configu
 hand, rather than using the automated installer, see :doc:`/how_to/install` and then follow the
 rest of the tutorials.
 
-Either way, you'll be able to find support and help from the numerous friendly members of the django CMS community, either on our
-`mailinglist`_ or `our friendly Slack group <https://www.django-cms.org/slack>`_.
-
-.. _mailinglist: https://groups.google.com/forum/#!forum/django-cms
+Either way, you'll be able to find support and help from the numerous friendly members of the
+django CMS community, either on our `Discourse forum <https://discourse.django-cms.org>`_ or `our
+Slack group <https://www.django-cms.org/slack>`_.

--- a/docs/introduction/index.rst
+++ b/docs/introduction/index.rst
@@ -41,11 +41,7 @@ If you want to install django CMS into an existing project, or prefer to configu
 hand, rather than using the automated installer, see :doc:`/how_to/install` and then follow the
 rest of the tutorials.
 
-Either way, you'll be able to find support and help from the numerous friendly
-members of the django CMS community, either on our `mailinglist`_ or IRC
-channel ``#django-cms`` on the ``irc.freenode.net`` network.
-
-If you don't have an IRC client, you can `join our IRC channel using the KiwiIRC web client
-<https://kiwiirc.com/client/irc.freenode.net/django-cms>`_, which works pretty well.
+Either way, you'll be able to find support and help from the numerous friendly members of the django CMS community, either on our
+`mailinglist`_ or `our friendly Slack group <https://www.django-cms.org/slack>`_.
 
 .. _mailinglist: https://groups.google.com/forum/#!forum/django-cms

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -2,13 +2,13 @@
 Using django CMS
 ################
 
-.. note:: This is a new section in the django CMS documentation, and a priority
-          for the project. If you'd like to contribute to it, we'd love to hear
-          from you - join us on the #django-cms IRC channel on `freenode`_ or
-          the `django-cms-developers`_ email list.
+.. note::
 
-          If you don't have an IRC client, you can `join our IRC channel using the KiwiIRC web client
-          <https://kiwiirc.com/client/irc.freenode.net/django-cms>`_, which works pretty well.
+          This is a new section in the django CMS documentation, and a priority
+          for the project. If you'd like to contribute to it, we'd love to hear
+          from you - join us on `our friendly Slack group
+          <https://www.django-cms.org/slack>`_.
+
 
 The **Using django CMS** documentation is divided into two parts.
 
@@ -38,4 +38,3 @@ your site may have.
 
 
 .. _django-cms-developers: https://groups.google.com/group/django-cms-developers
-.. _freenode : http://freenode.net/

--- a/docs/user/reference/index.rst
+++ b/docs/user/reference/index.rst
@@ -4,13 +4,12 @@
 Reference for content editors
 #############################
 
-.. note:: This is a new section in the django CMS documentation, and a priority
-          for the project. If you'd like to contribute to it, we'd love to hear
-          from you - join us on the #django-cms IRC channel on `freenode`_ or
-          the `django-cms-developers`_ email list.
+.. note::
 
-          If you don't have an IRC client, you can `join our IRC channel using the KiwiIRC web client
-          <https://kiwiirc.com/client/irc.freenode.net/django-cms>`_, which works pretty well.
+          This is a new section in the django CMS documentation, and a priority
+          for the project. If you'd like to contribute to it, we'd love to hear
+          from you - join us on `our friendly Slack group
+          <https://www.django-cms.org/slack>`_.
 
 .. toctree::
     :maxdepth: 2

--- a/docs/user/tutorial/index.rst
+++ b/docs/user/tutorial/index.rst
@@ -4,13 +4,12 @@
 Tutorial
 ########
 
-.. note:: This is a new section in the django CMS documentation, and a priority
-          for the project. If you'd like to contribute to it, we'd love to hear
-          from you - join us on the #django-cms IRC channel on `freenode`_ or
-          the `django-cms-developers`_ email list.
+.. note::
 
-          If you don't have an IRC client, you can `join our IRC channel using the KiwiIRC web client
-          <https://kiwiirc.com/client/irc.freenode.net/django-cms>`_, which works pretty well.
+          This is a new section in the django CMS documentation, and a priority
+          for the project. If you'd like to contribute to it, we'd love to hear
+          from you - join us on `our friendly Slack group
+          <https://www.django-cms.org/slack>`_.
 
 It's strongly recommended that you follow this tutorial step-by-step. It has
 been designed to introduce you to the system in a methodical way, and each


### PR DESCRIPTION
Documentation updates:

* added links to django CMS Association
* replaced link to IRC <wipes away a tear> with link to Slack group