### PR TITLE
Fix #6622 bad Title.path in ML sites if parent slug is created or mod…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,11 +2,17 @@
 Changelog
 =========
 
+fp-6622 (2021-01-19)
+====================
+
+* Fixed 66622 bad Title.path in multilingual sites when parent slug is created or modified
+
 
 Unreleased
 ==================
 
 * Fixed builds on RTD
+
 
 3.8.0 (2020-10-28)
 ==================

--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -472,8 +472,9 @@ class ChangePageForm(BasePageForm):
 
         if update_count == 0:
             api.create_title(language=self._language, page=cms_page, **translation_data)
-        else:
-            cms_page._update_title_path_recursive(self._language)
+        # _update_title_path_recursive should be called if the new page is the parent
+        # of already created children in multilingual sites.
+        cms_page._update_title_path_recursive(self._language, slug=self.data['slug'])
         cms_page.clear_cache(menu=True)
         return cms_page
 

--- a/cms/management/commands/subcommands/titlepaths.py
+++ b/cms/management/commands/subcommands/titlepaths.py
@@ -1,0 +1,64 @@
+from cms.models import CMSPlugin, TreeNode, Title, Page
+
+from .base import SubcommandsCommand
+
+class CheckTitlePathsCommand(SubcommandsCommand):
+    help_string = 'Check page title paths'
+    command_name = 'check-title-paths'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--fix-paths', action='store_true', required=False,
+                            help='Fix title paths (please, save database before doing this!)')
+
+    
+    def handle(self, *args, **options):
+        self.fix = options.get('fix-paths', False)
+        self.checked = not options.get('interactive', True)
+            
+        root_nodes = TreeNode.objects.filter(parent__isnull=True)
+
+        for node in root_nodes.order_by('site__pk', 'path'):
+            # print("node = ", ' ', node.path, ' ', node.site)
+            page = node.get_item()
+            domain = node.site.domain
+            self._check_title_path_recursive(domain, page)
+            
+    def _check_title_path_recursive(self, domain, page):
+        parent_page = page.get_parent_page()
+        for language in page.get_languages():
+            if parent_page:
+                base = parent_page.get_path(language, fallback=True)
+            else:
+                base = ''
+            title_obj = page.get_title_obj(language, fallback=False)
+            p1 = title_obj.path
+            p2 = title_obj.get_path_for_base(base)
+            if p1 != p2:
+                print()
+                print(domain + '/' + language + '/' + p1)
+                print(domain + '/' + language + '/' + p2)
+                if self.fix:
+                    if self.checked:
+                        ok = True
+                    else:
+                        confirm = input("""
+You have requested to change this title path.
+Are you sure you want to do this?
+Type 'yes' or to continue for this, 'all' to change all title paths, or 'none' to cancel: """)
+                        if confirm == 'all':
+                            self.checked = True
+                            ok = True
+                        elif confirm == 'yes':
+                            ok = True
+                        elif confirm == 'none':
+                            self.fix = False
+                            ok = False
+                        else:
+                            ok = False
+                    if ok:
+                        title_obj.path = p2
+                        title_obj.save()
+                        print('-> Fixed')
+        for p in page.get_child_pages():
+            self._check_title_path_recursive(domain, p)
+

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -340,7 +340,7 @@ class Page(models.Model):
         title_obj.path = title_obj.get_path_for_base(base)
         title_obj.save()
 
-    def _update_title_path_recursive(self, language):
+    def _update_title_path_recursive(self, language, slug=None):
         assert self.publisher_is_draft
         from cms.models import Title
 
@@ -348,7 +348,10 @@ class Page(models.Model):
             return
 
         pages = self.get_child_pages()
-        base = self.get_path(language, fallback=True)
+        if slug:
+            base = self.get_path_for_slug(slug, language)
+        else:
+            base = self.get_path(language, fallback=True)
 
         if base:
             new_path = Concat(models.Value(base), models.Value('/'), models.F('slug'))


### PR DESCRIPTION
…ified

## Description

Fix #6622 Bad Title.path in Multilanguage sites if parent slug is created or modified

## Related resources

### First bug:

In 'en','fr' site
1) Create /en/en-1/ page
2) Create from this page a subpage with slug "en-1-1"
3) Create "fr" translation with slug "fr-1-1"
4) Create "fr" translation of parent /en/en-1/ with slug "fr-1"

As a result, the path of subpage "fr-1-1" is not updated. Here the paths:

/en/en-1/
/en/en-1/en-1-1/
/fr/fr-1/
/fr/en-1/fr-1-1/   <-- Bad Title.path "en-1/fr-1-1" instead of "fr-1/fr-1-1"

### Second bug:

Change "en" slug of /en/en-1/ page to "en-1b",
As a result the path of subpage "en-1-1" is changed to "fr-1/en-1-1" instead of "en-1b/en-1-1". Here the paths:

/en/en-1b/
/en/fr-1/en-1-1/   <-- Bad Title.path "fr-1/en-1-1" instead of "en-1b/fr-1-1"
/fr/fr-1/
/fr/en-1/fr-1-1/   <-- Bad Title.path "en-1/fr-1-1" instead of "fr-1/fr-1-1"


## Checklist

* [x] I have opened this pull request against ``develop``
* [x] I have updated the **CHANGELOG.rst**
* [x] I have added or modified the tests when changing logic (no changed logic)
