### PR TITLE
Allow migrations to be ran backwards

### DIFF
--- a/cms/migrations/0018_create_pagenode.py
+++ b/cms/migrations/0018_create_pagenode.py
@@ -68,50 +68,24 @@ class Migration(IrreversibleMigration):
         migrations.CreateModel(
             name='TreeNode',
             fields=[
-                (
-                    'id',
-                    models.AutoField(
-                        auto_created=True,
-                        primary_key=True,
-                        serialize=False,
-                        verbose_name='ID',
-                    ),
-                ),
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('path', models.CharField(max_length=255, unique=True)),
                 ('depth', models.PositiveIntegerField()),
                 ('numchild', models.PositiveIntegerField(default=0)),
-                (
-                    'parent',
-                    models.ForeignKey(
-                        blank=True,
-                        null=True,
-                        on_delete=django.db.models.deletion.CASCADE,
-                        related_name='children',
-                        to='cms.TreeNode',
-                    ),
-                ),
-                (
-                    'site',
-                    models.ForeignKey(
-                        on_delete=django.db.models.deletion.CASCADE,
-                        related_name='djangocms_nodes',
-                        to='sites.Site',
-                        verbose_name='site',
-                    ),
-                ),
+                ('parent', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='children', to='cms.TreeNode')),
+                ('site', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='djangocms_nodes', to='sites.Site', verbose_name='site')),
             ],
-            options={'ordering': ('path',), 'default_permissions': []},
+            options={
+                'ordering': ('path',),
+                'default_permissions': [],
+            },
         ),
         migrations.RunPython(create_page_nodes, migrations.RunPython.noop),
         migrations.AddField(
             model_name='page',
             name='node',
-            field=models.ForeignKey(
-                null=True,
-                on_delete=django.db.models.deletion.CASCADE,
-                related_name='cms_pages',
-                to='cms.TreeNode',
-            ),
+            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, related_name='cms_pages',
+                                    to='cms.TreeNode'),
         ),
         migrations.AddField(
             model_name='page',
@@ -119,10 +93,13 @@ class Migration(IrreversibleMigration):
             field=models.PositiveIntegerField(null=True),
         ),
         migrations.AlterUniqueTogether(
-            name='page', unique_together=set([('node', 'publisher_is_draft')])
+            name='page',
+            unique_together=set([('node', 'publisher_is_draft')]),
         ),
         migrations.AlterModelManagers(
             name='pageusergroup',
-            managers=[('objects', django.contrib.auth.models.GroupManager())],
+            managers=[
+                ('objects', django.contrib.auth.models.GroupManager()),
+            ],
         ),
     ]

--- a/cms/migrations/0018_create_pagenode.py
+++ b/cms/migrations/0018_create_pagenode.py
@@ -68,24 +68,50 @@ class Migration(IrreversibleMigration):
         migrations.CreateModel(
             name='TreeNode',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
                 ('path', models.CharField(max_length=255, unique=True)),
                 ('depth', models.PositiveIntegerField()),
                 ('numchild', models.PositiveIntegerField(default=0)),
-                ('parent', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='children', to='cms.TreeNode')),
-                ('site', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='djangocms_nodes', to='sites.Site', verbose_name='site')),
+                (
+                    'parent',
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='children',
+                        to='cms.TreeNode',
+                    ),
+                ),
+                (
+                    'site',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='djangocms_nodes',
+                        to='sites.Site',
+                        verbose_name='site',
+                    ),
+                ),
             ],
-            options={
-                'ordering': ('path',),
-                'default_permissions': [],
-            },
+            options={'ordering': ('path',), 'default_permissions': []},
         ),
-        migrations.RunPython(create_page_nodes),
+        migrations.RunPython(create_page_nodes, migrations.RunPython.noop),
         migrations.AddField(
             model_name='page',
             name='node',
-            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, related_name='cms_pages',
-                                    to='cms.TreeNode'),
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='cms_pages',
+                to='cms.TreeNode',
+            ),
         ),
         migrations.AddField(
             model_name='page',
@@ -93,13 +119,10 @@ class Migration(IrreversibleMigration):
             field=models.PositiveIntegerField(null=True),
         ),
         migrations.AlterUniqueTogether(
-            name='page',
-            unique_together=set([('node', 'publisher_is_draft')]),
+            name='page', unique_together=set([('node', 'publisher_is_draft')])
         ),
         migrations.AlterModelManagers(
             name='pageusergroup',
-            managers=[
-                ('objects', django.contrib.auth.models.GroupManager()),
-            ],
+            managers=[('objects', django.contrib.auth.models.GroupManager())],
         ),
     ]

--- a/cms/migrations/0019_set_pagenode.py
+++ b/cms/migrations/0019_set_pagenode.py
@@ -53,8 +53,8 @@ class Migration(IrreversibleMigration):
     ]
 
     operations = [
-        migrations.RunPython(unpublish_never_published_pages),
-        migrations.RunPython(set_page_nodes),
+        migrations.RunPython(unpublish_never_published_pages, migrations.RunPython.noop),
+        migrations.RunPython(set_page_nodes, migrations.RunPython.noop),
     ]
 
     def apply(self, project_state, schema_editor, collect_sql=False):


### PR DESCRIPTION
currently django would raise exception if we tried to reverse the migrations because the data migration has no backwards. This avoids that problem [read more](https://django.doctor/advice/C8001)

I found this problem during auditing your codebase. [Read the full report](https://django.doctor/django-oscar/django-oscar)