### PR TITLE
⬆️(coverage) enforce to use at least coverage version > 4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Unreleased
 ==================
 
 * Fixed builds on RTD
+* Enforce use of coverage > 4 for python 3.8 support
 
 3.8.0 (2020-10-28)
 ==================

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -1,5 +1,5 @@
-coverage<5
-python-coveralls==2.5.0
+coverage>=4
+python-coveralls>2.5.0
 unittest-xml-reporting==1.11.0
 Pillow==5.2.0
 django-treebeard>=4.3


### PR DESCRIPTION
## Description
Currently, PR merge is blocked because CI tests all failed.
It is due to an incompatibility of `coverage` version 3.7.1 with Python 3.8.

As the latest version of `coverage` (5.3.1) is compatible with python 2.7 and >= 3.5, we can safely update requirements to enforce the use of a `coverage` version greater than 4.0.

## Related resources

- https://pypi.org/project/coverage/
- [Raw logs of a failing CI Jobs with coverage 3.7.1 installed](https://api.travis-ci.org/v3/job/755690916/log.txt)

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have updated the **CHANGELOG.rst**
* N/A : I have added or modified the tests when changing logic
