### PR TITLE
Updated documentation links

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Unreleased
 * Fixed builds on RTD
 * Enforce use of coverage > 4 for python 3.8 support
 * Fixed 66622 bad Title.path in multilingual sites when parent slug is created or modified
+* Updated documentation links
 
 3.8.0 (2020-10-28)
 ==================

--- a/docs/contributing/code.rst
+++ b/docs/contributing/code.rst
@@ -14,7 +14,7 @@ In a nutshell
 
 Here's what the contribution process looks like in brief:
 
-#. Fork our `GitHub`_ repository, https://github.com/divio/django-cms
+#. Fork our `GitHub`_ repository, https://github.com/django-cms/django-cms
 #. Work locally and push your changes to your repository.
 #. When you feel your code is good enough for inclusion, send us a pull request.
 
@@ -192,7 +192,7 @@ CMS in external applications, you can only use bundles distributed by CMS, not
 the source modules.
 
 
-.. _fork: https://github.com/divio/django-cms
+.. _fork: https://github.com/django-cms/django-cms
 .. _PEP8: http://www.python.org/dev/peps/pep-0008/
 .. _Aldryn Boilerplate: https://aldryn-boilerplate-bootstrap3.readthedocs.io/en/latest/guidelines/index.html
 .. _django-cms-developers: https://groups.google.com/group/django-cms-developers

--- a/docs/contributing/development-community.rst
+++ b/docs/contributing/development-community.rst
@@ -12,7 +12,7 @@ You can join us online:
 
 You can also follow:
 
-* the `Travis Continuous Integration build reports <https://travis-ci.org/divio/django-cms>`_
+* the `Travis Continuous Integration build reports <https://travis-ci.com/django-cms/django-cms>`_
 * the `@djangocms <https://twitter.com/djangocms>`_ Twitter account for general announcements
 * the `django CMS Association LinkedIn <https://www.linkedin.com/company/django-cms-association>`_ account
 
@@ -48,7 +48,7 @@ The dCA’s role in steering the project’s development is formalised in the
 `django CMS technical comittee <https://github.com/django-cms/django-cms-mgmt/blob/master/tech-committee/about.md>`_,
 whose members are drawn from the django CMS community and the dCA.
 
-The dCA maintains overall control of the `django CMS repository <https://github.com/divio/django-cms>`_.
+The dCA maintains overall control of the `django CMS repository <https://github.com/django-cms/django-cms>`_.
 As the chief backer of django CMS, and in order to ensure a consistent and
 long-term approach to the project, the dCA reserves the right of final say in
 any decisions concerning its development.

--- a/docs/contributing/development-policies.rst
+++ b/docs/contributing/development-policies.rst
@@ -24,7 +24,7 @@ Review
 ******
 
 All patches should be made as pull requests **against develop** to
-`the GitHub repository <https://github.com/divio/django-cms>`_. Patches should
+`the GitHub repository <https://github.com/django-cms/django-cms>`_. Patches should
 never be pushed directly.
 
 **Nothing** may enter the code-base, *including the documentation*, without
@@ -98,7 +98,7 @@ Branches
     against ``develop``.
 
 We maintain a number of branches on
-`our GitHub repository <https://github.com/divio/django-cms>`_:
+`our GitHub repository <https://github.com/django-cms/django-cms>`_:
 
 ``develop``
     The default target branch for on-going development and new pull requests.
@@ -112,7 +112,7 @@ We maintain a number of branches on
     as the highest released version.
 
 ``releases`` hosts the `releases.json` file to indicate the availability of new
-    django CMS versions when using `djangocms-admin-style <https://github.com/divio/djangocms-admin-style#configuration>`_.
+    django CMS versions when using `djangocms-admin-style <https://github.com/django-cms/djangocms-admin-style#configuration>`_.
 
 Please always open PR's against develop and indicate that they should be
 backported to the latest LTS release when necessary. Older branches are not
@@ -198,7 +198,7 @@ Changelog
 .. versionadded:: 3.3
 
 **Every new feature, bugfix or other change of substance** must be represented in the `CHANGELOG
-<https://github.com/divio/django-cms/blob/develop/CHANGELOG.rst>`_. This includes documentation, but **doesn't** extend
+<https://github.com/django-cms/django-cms/blob/develop/CHANGELOG.rst>`_. This includes documentation, but **doesn't** extend
 to things like reformatting code, tidying-up, correcting typos and so on.
 
 Each line in the changelog should begin with a verb in the past tense, for example::

--- a/docs/contributing/documentation.rst
+++ b/docs/contributing/documentation.rst
@@ -138,7 +138,7 @@ caught by the spelling checker.
     You may well find that some words that pass the spelling test on one system but not on another.
     Dictionaries on different systems contain different words and even behave differently. The
     important thing is that the spelling tests pass on `Travis
-    <https://travis-ci.org/divio/django-cms>`_ when you submit a pull request.
+    <https://travis-ci.com/django-cms/django-cms>`_ when you submit a pull request.
 
 
 *********************

--- a/docs/contributing/management.rst
+++ b/docs/contributing/management.rst
@@ -4,7 +4,7 @@
 Code and project management
 ###########################
 
-We use our `GitHub project <https://github.com/divio/django-cms>`_ for managing both django CMS code
+We use our `GitHub project <https://github.com/django-cms/django-cms>`_ for managing both django CMS code
 and development activity.
 
 This document describes how we manage tickets on GitHub. By "tickets", we mean GitHub issues and
@@ -33,7 +33,7 @@ developer.
 
 It's very helpful though if you don't just raise an issue by mentioning it to people, but actually
 file it too, and that means creating a `new issue on GitHub
-<https://github.com/divio/django-cms/issues/new>`_.
+<https://github.com/django-cms/django-cms/issues/new>`_.
 
 There's an art to creating a good issue report.
 

--- a/docs/contributing/testing.rst
+++ b/docs/contributing/testing.rst
@@ -39,7 +39,7 @@ There's more than one way to do this, but here's one to help you get started::
     source bin/activate
 
     # get django CMS from GitHub
-    git clone git@github.com:divio/django-cms.git
+    git clone https://github.com/django-cms/django-cms.git
 
     # install the dependencies for testing
     # note that requirements files for other Django versions are also provided
@@ -65,7 +65,7 @@ We are working to improve the performance and reliability of our test suite. We'
 problems, but need feedback from people using a wide range of systems and configurations in order
 to benefit from their experience.
 
-Please report any issues on our `GitHub repository <https://github.com/divio/django-cms/issues>`_.
+Please report any issues on our `GitHub repository <https://github.com/django-cms/django-cms/issues>`_.
 
 If you can help *improve* the test suite, your input will be especially valuable.
 

--- a/docs/how_to/contributing.rst
+++ b/docs/how_to/contributing.rst
@@ -28,7 +28,7 @@ The basics
 
 The basic workflow for a code contribution will typically run as follows:
 
-#. Fork the `django CMS project <https://github.com/divio/django-cms>`_ GitHub repository to your
+#. Fork the `django CMS project <https://github.com/django-cms/django-cms>`_ GitHub repository to your
    own GitHub account
 #. Clone your fork locally::
 

--- a/docs/how_to/custom_plugins.rst
+++ b/docs/how_to/custom_plugins.rst
@@ -274,7 +274,7 @@ Relations *between* plugins
 It is much harder to manage the copying of relations when they are from one plugin to another.
 
 See the GitHub issue `copy_relations() does not work for relations between cmsplugins #4143
-<https://github.com/divio/django-cms/issues/4143>`_ for more details.
+<https://github.com/django-cms/django-cms/issues/4143>`_ for more details.
 
 ********
 Advanced

--- a/docs/how_to/install.rst
+++ b/docs/how_to/install.rst
@@ -99,7 +99,7 @@ You will need to add the following to its list of ``INSTALLED_APPS``::
 * `django-treebeard <http://django-treebeard.readthedocs.io>`_ is used to manage django CMS's page and plugin tree
   structures.
 
-django CMS installs `django CMS admin style <https://github.com/divio/djangocms-admin-style>`_.
+django CMS installs `django CMS admin style <https://github.com/django-cms/djangocms-admin-style>`_.
 This provides some styling that helps make django CMS administration components easier to work with.
 Technically it's an optional component and does not need to be enabled in your project,
 but it's strongly recommended.
@@ -454,7 +454,7 @@ Django CMS CKEditor
 
 `Django CMS CKEditor`_ is the default text editor for django CMS.
 
-.. _Django CMS CKEditor: https://github.com/divio/djangocms-text-ckeditor
+.. _Django CMS CKEditor: https://github.com/django-cms/djangocms-text-ckeditor
 
 Install: ``pip install djangocms-text-ckeditor``.
 
@@ -471,13 +471,13 @@ Miscellaneous plugins
 There are plugins for django CMS that cover a vast range of functionality. To get started, it's useful to be able to
 rely on a set of well-maintained plugins that cover some general content management needs.
 
-* `djangocms-link <https://github.com/divio/djangocms-link>`_
-* `djangocms-file <https://github.com/divio/djangocms-file>`_
-* `djangocms-picture <https://github.com/divio/djangocms-picture>`_
-* `djangocms-video <https://github.com/divio/djangocms-video>`_
-* `djangocms-googlemap <https://github.com/divio/djangocms-googlemap>`_
-* `djangocms-snippet <https://github.com/divio/djangocms-snippet>`_
-* `djangocms-style <https://github.com/divio/djangocms-style>`_
+* `djangocms-link <https://github.com/django-cms/djangocms-link>`_
+* `djangocms-file <https://github.com/django-cms/djangocms-file>`_
+* `djangocms-picture <https://github.com/django-cms/djangocms-picture>`_
+* `djangocms-video <https://github.com/django-cms/djangocms-video>`_
+* `djangocms-googlemap <https://github.com/django-cms/djangocms-googlemap>`_
+* `djangocms-snippet <https://github.com/django-cms/djangocms-snippet>`_
+* `djangocms-style <https://github.com/django-cms/djangocms-style>`_
 
 To install::
 

--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -435,7 +435,7 @@ CMSPluginBase Attributes and Methods Reference
         your text editor plugin.
 
         This requires support from the text plugin; support for this is currently planned
-        for `djangocms-text-ckeditor <https://github.com/divio/djangocms-text-ckeditor/>`_ 2.5.0.
+        for `djangocms-text-ckeditor <https://github.com/django-cms/djangocms-text-ckeditor/>`_ 2.5.0.
 
         See also: :attr:`text_enabled`.
 

--- a/docs/topics/commonly_used_plugins.rst
+++ b/docs/topics/commonly_used_plugins.rst
@@ -37,23 +37,23 @@ The django CMS Core Addons are:
 
 * `Django Filer <http://github.com/divio/django-filer>`_ - a file management application for
   images and other documents.
-* `django CMS Admin Style <https://github.com/divio/djangocms-admin-style>`_ - a CSS theme for the
+* `django CMS Admin Style <https://github.com/django-cms/djangocms-admin-style>`_ - a CSS theme for the
   Django admin
-* `django CMS Text CKEditor <https://github.com/divio/djangocms-text-ckeditor>`_ - our default rich
+* `django CMS Text CKEditor <https://github.com/django-cms/djangocms-text-ckeditor>`_ - our default rich
   text WYSIYG editor
-* `django CMS Link <https://github.com/divio/djangocms-link>`_ - add links to content
-* `django CMS Picture <https://github.com/divio/djangocms-picture>`_ - add images to your site
+* `django CMS Link <https://github.com/django-cms/djangocms-link>`_ - add links to content
+* `django CMS Picture <https://github.com/django-cms/djangocms-picture>`_ - add images to your site
   (Filer-compatible)
-* `django CMS File <https://github.com/divio/djangocms-file>`_ - add files or an entire folder to
+* `django CMS File <https://github.com/django-cms/djangocms-file>`_ - add files or an entire folder to
   your pages (Filer-compatible)
-* `django CMS Style <https://github.com/divio/djangocms-style>`_ - create HTML containers with
+* `django CMS Style <https://github.com/django-cms/djangocms-style>`_ - create HTML containers with
   classes, styles, ids and other attributes
-* `django CMS Snippet <https://github.com/divio/djangocms-snippet>`_ - insert arbitrary HTML content
-* `django CMS Audio <https://github.com/divio/djangocms-audio>`_ - publish audio files
+* `django CMS Snippet <https://github.com/django-cms/djangocms-snippet>`_ - insert arbitrary HTML content
+* `django CMS Audio <https://github.com/django-cms/djangocms-audio>`_ - publish audio files
   (Filer-compatible)
-* `django CMS Video <https://github.com/divio/djangocms-video>`_ - embed videos from YouTube, Vimeo
+* `django CMS Video <https://github.com/django-cms/djangocms-video>`_ - embed videos from YouTube, Vimeo
   and other services, or use uploaded videos (Filer-compatible)
-* `django CMS GoogleMap <http://github.com/divio/djangocms-googlemap>`_ - displays a map of an
+* `django CMS GoogleMap <http://github.com/django-cms/djangocms-googlemap>`_ - displays a map of an
   address on your page. Supports addresses and co-ordinates. Zoom level and route planner options
   can also be set.
 

--- a/docs/upgrade/3.0.rst
+++ b/docs/upgrade/3.0.rst
@@ -31,7 +31,7 @@ In addition, the system now offer two editing views:
 
 Page titles can also be modified directly from the frontend.
 
-.. _djangocms_admin_style: https://github.com/divio/djangocms-admin-style
+.. _djangocms_admin_style: https://github.com/django-cms/djangocms-admin-style
 
 New Toolbar
 ===========
@@ -117,7 +117,7 @@ choices about what to install upon its adopters.
 The most significant of these removals is ``cms.plugins.text``.
 
 We provide ``djangocms-text-ckeditor``, a CKEditor-based Text Plugin. It's
-available from https://github.com/divio/djangocms-text-ckeditor. You may of
+available from https://github.com/django-cms/djangocms-text-ckeditor. You may of
 course use your preferred editor; others are available.
 
 Furthermore, we removed the following plugins from the core and moved them into
@@ -135,7 +135,7 @@ File Plugin
 
 We removed the file plugin (``cms.plugins.file``). Its new location is at:
 
-* https://github.com/divio/djangocms-file
+* https://github.com/django-cms/djangocms-file
 
 As an alternative, you could also use the following (yet you will not be able
 to keep your existing files from the old ``cms.plugins.file``!)
@@ -157,7 +157,7 @@ Googlemap Plugin
 We removed the Googlemap plugin (``cms.plugins.googlemap``).
 Its new location is at:
 
-* https://github.com/divio/djangocms-googlemap
+* https://github.com/django-cms/djangocms-googlemap
 
 
 Inherit Plugin
@@ -175,7 +175,7 @@ Picture Plugin
 We removed the picture plugin (``cms.plugins.picture``).
 Its new location is at:
 
-* https://github.com/divio/djangocms-picture
+* https://github.com/django-cms/djangocms-picture
 
 
 Teaser Plugin
@@ -192,7 +192,7 @@ Video Plugin
 
 We removed the video plugin (``cms.plugins.video``). Its new location is at:
 
-* https://github.com/divio/djangocms-video
+* https://github.com/django-cms/djangocms-video
 
 
 Link Plugin
@@ -200,7 +200,7 @@ Link Plugin
 
 We removed the link plugin (``cms.plugins.link``). Its new location is at:
 
-* https://github.com/divio/djangocms-link
+* https://github.com/django-cms/djangocms-link
 
 
 Snippet Plugin
@@ -209,7 +209,7 @@ Snippet Plugin
 We removed the snippet plugin (``cms.plugins.snippet``).
 Its new location is at:
 
-* https://github.com/divio/djangocms-snippet
+* https://github.com/django-cms/djangocms-snippet
 
 As an alternative, you could also use the following (yet you will not be able
 to keep your existing files from the old ``cms.plugins.snippet``!)

--- a/docs/upgrade/3.2.rst
+++ b/docs/upgrade/3.2.rst
@@ -170,7 +170,7 @@ Automated spelling checks for documentation
 
 Documentation is now checked for spelling. A ``make spelling`` command is available now when
 working on documentation, and our `Travis Continuous Integration server
-<https://travis-ci.org/divio/django-cms>`_ also runs these checks.
+<https://travis-ci.com/django-cms/django-cms>`_ also runs these checks.
 
 See the :ref:`spelling` section in the documentation.
 
@@ -209,7 +209,7 @@ Known issues
 ************
 
 The `sub-pages of a page with an apphook will be unreachable
-<https://github.com/divio/django-cms/issues/4758>`_ (``404 page not found``), due to internal URL
+<https://github.com/django-cms/django-cms/issues/4758>`_ (``404 page not found``), due to internal URL
 resolution mechanisms in the CMS. Though it's unlikely that most users will need sub-pages of this
 kind (typically, an apphooked page will create its own sub-pages) this issue will be addressed in a
 forthcoming release.


### PR DESCRIPTION
Documentation updates:

- github.com://divio/django* -> github.com://django-cms/django*
  except djangocms-inherit, djangocms-column, djangocms-teaser, djangocms-flash
- travis-ci.org://divio/django* -> travis-ci.com://django-cms/django*
  transifex.org://divio/ unchanged
- git@github.com:django-cms/django-cms.git -> https://django-cms/django-cms.git


* [x ] I have opened this pull request against ``develop``
* [x ] I have updated the **CHANGELOG.rst**
