### PR TITLE
Pinned django-treebeard below 4.5 for tests due to introduced breaking changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Unreleased
 * Remove debug print from apphook_reload
 * Enforce use of coverage > 4 for python 3.8 support
 * Fixed 66622 bad Title.path in multilingual sites when parent slug is created or modified
-* Pinned django-treebeard to avoid breaking changes in django-treebeard 4.5
+* Temporarily pinned django-treebeard to avoid breaking changes in django-treebeard 4.5
 
 3.8.0 (2020-10-28)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Unreleased
 * Remove debug print from apphook_reload
 * Enforce use of coverage > 4 for python 3.8 support
 * Fixed 66622 bad Title.path in multilingual sites when parent slug is created or modified
-* Temporarily pinned django-treebeard to avoid breaking changes in django-treebeard 4.5
+* Temporarily pinned django-treebeard to 4.5 in the tests to avoid breaking changes introduced
 
 3.8.0 (2020-10-28)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Unreleased
 * Remove debug print from apphook_reload
 * Enforce use of coverage > 4 for python 3.8 support
 * Fixed 66622 bad Title.path in multilingual sites when parent slug is created or modified
-* Temporarily pinned django-treebeard to 4.5 in the tests to avoid breaking changes introduced
+* Temporarily pinned django-treebeard to < 4.5, this avoids breaking changes introduced
 
 3.8.0 (2020-10-28)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Unreleased
 * Remove debug print from apphook_reload
 * Enforce use of coverage > 4 for python 3.8 support
 * Fixed 66622 bad Title.path in multilingual sites when parent slug is created or modified
+* Pinned django-treebeard to avoid breaking changes in django-treebeard 4.5
 
 3.8.0 (2020-10-28)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ REQUIREMENTS = [
     'Django>=2.2',
     'django-classy-tags>=0.7.2',
     'django-formtools>=2.1',
-    'django-treebeard>=4.3',
+    'django-treebeard<4.5',
     'django-sekizai>=0.7',
     'djangocms-admin-style>=1.2',
 ]

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ REQUIREMENTS = [
     'Django>=2.2',
     'django-classy-tags>=0.7.2',
     'django-formtools>=2.1',
-    'django-treebeard>=4.3',
+    'django-treebeard>=4.3,<4.5',
     'django-sekizai>=0.7',
     'djangocms-admin-style>=1.2',
 ]

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ REQUIREMENTS = [
     'Django>=2.2',
     'django-classy-tags>=0.7.2',
     'django-formtools>=2.1',
-    'django-treebeard>=4.3,<4.5',
+    'django-treebeard>=4.3',
     'django-sekizai>=0.7',
     'djangocms-admin-style>=1.2',
 ]

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ REQUIREMENTS = [
     'Django>=2.2',
     'django-classy-tags>=0.7.2',
     'django-formtools>=2.1',
-    'django-treebeard<4.5',
+    'django-treebeard>=4.3,<4.5',
     'django-sekizai>=0.7',
     'djangocms-admin-style>=1.2',
 ]

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -2,7 +2,7 @@ coverage>=4
 python-coveralls>2.5.0
 unittest-xml-reporting==1.11.0
 Pillow==5.2.0
-django-treebeard>=4.3
+django-treebeard<4.5
 argparse
 dj-database-url
 djangocms-admin-style>=1.5

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -2,7 +2,7 @@ coverage>=4
 python-coveralls>2.5.0
 unittest-xml-reporting==1.11.0
 Pillow==5.2.0
-django-treebeard<4.5
+django-treebeard>=4.3,<4.5
 argparse
 dj-database-url
 djangocms-admin-style>=1.5


### PR DESCRIPTION
## Description

This PR contains temporary changes for an issue where an upgrade to django-treebeard contains breaking changes.

The following changes broke django-cms compatibility: https://github.com/django-treebeard/django-treebeard/pull/192/files

An issue has been raised with django-treebeard to help us decide on the right direction to fix the issue in the longer term: https://github.com/django-treebeard/django-treebeard/issues/210

## Checklist

* [X] I have opened this pull request against ``develop``
* [X] I have updated the **CHANGELOG.rst**
* [ ] I have added or modified the tests when changing logic
