### PR TITLE
Pinned django-treebeard below 4.5 for tests due to introduced breaking changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,9 @@
 Changelog
 =========
 
+Unreleased (2021-02-18)
+=======================
+* Pinned django-treebeard to avoid breaking changes in django-treebeard 4.5
 
 3.7.4 (2020-07-21)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased (2021-02-18)
 =======================
 * Pinned django-treebeard to avoid breaking changes in django-treebeard 4.5
+* Enforce use of coverage > 4 for python 3.8 support
+* Set sphinxcontrib-spelling requirement to be <7.0.0
 
 3.7.4 (2020-07-21)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,11 +2,12 @@
 Changelog
 =========
 
-Unreleased (2021-02-18)
-=======================
+Unreleased
+==========
 * Pinned django-treebeard to avoid breaking changes in django-treebeard 4.5
 * Enforce use of coverage > 4 for python 3.8 support
 * Set sphinxcontrib-spelling requirement to be <7.0.0
+* Enforce use of django-classy-tags >=0.7.2,<2 for python 2.7 support
 
 3.7.4 (2020-07-21)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Unreleased
 * Enforce use of coverage > 4 for python 3.8 support
 * Set sphinxcontrib-spelling requirement to be <7.0.0
 * Enforce use of django-classy-tags >=0.7.2,<2 for python 2.7 support
+* Enforce use of django-sekizai >=0.7,<=1.10 for python 2.7 support
 
 3.7.4 (2020-07-21)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+
 * Pinned django-treebeard to avoid breaking changes in django-treebeard 4.5
 
 * Enforce use of coverage > 4 for python 3.8 support

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Unreleased
 * Set sphinxcontrib-spelling requirement to be <7.0.0
 * Enforce use of django-classy-tags >=0.7.2,<2 for python 2.7 support
 * Enforce use of django-sekizai >=0.7,<=1.10 for python 2.7 support
+* Enforced use of django-app-helper < 3.0.0
 
 3.7.4 (2020-07-21)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ INSTALL_REQUIREMENTS = [
     'Django>=1.11,<4',
     'django-classy-tags>=0.7.2',
     'django-formtools>=2.1',
-    'django-treebeard>=4.3',
+    'django-treebeard>=4.3,<4.5',
     'django-sekizai>=0.7',
     'djangocms-admin-style>=1.2',
     'six',

--- a/test_requirements/django-1.11.txt
+++ b/test_requirements/django-1.11.txt
@@ -9,4 +9,3 @@ djangocms-text-ckeditor<4
 sphinxcontrib-spelling<7.0.0 # restriction for py35 tests
 # required to run the server for integration tests
 django-app-helper<3.0.0
-

--- a/test_requirements/django-1.11.txt
+++ b/test_requirements/django-1.11.txt
@@ -3,3 +3,10 @@ pyflakes>=2.1
 Django>=1.11,<2.0
 pyenchant
 django-formtools>=2.1,<2.2
+django-sekizai>=0.7,<=1.10
+django-classy-tags>=0.7.2,<2
+djangocms-text-ckeditor<4
+sphinxcontrib-spelling<7.0.0 # restriction for py35 tests
+# required to run the server for integration tests
+django-app-helper<3.0.0
+

--- a/test_requirements/django-2.2.txt
+++ b/test_requirements/django-2.2.txt
@@ -3,3 +3,9 @@ pyflakes>=2.1
 Django>=2.2,<3.0
 pyenchant==3.0.1
 django-formtools==2.2
+django-sekizai>=0.7
+django-classy-tags>=0.7.2,<2
+djangocms-text-ckeditor<4
+sphinxcontrib-spelling<7.0.0 # restriction for py35 tests
+# required to run the server for integration tests
+django-app-helper<3.0.0

--- a/test_requirements/django-2.2.txt
+++ b/test_requirements/django-2.2.txt
@@ -9,3 +9,4 @@ djangocms-text-ckeditor<4
 sphinxcontrib-spelling<7.0.0 # restriction for py35 tests
 # required to run the server for integration tests
 django-app-helper<3.0.0
+

--- a/test_requirements/django-3.0.txt
+++ b/test_requirements/django-3.0.txt
@@ -10,3 +10,4 @@ https://github.com/divio/djangocms-text-ckeditor/archive/master.zip
 sphinxcontrib-spelling
 # required to run the server for integration tests
 django-app-helper
+

--- a/test_requirements/django-3.0.txt
+++ b/test_requirements/django-3.0.txt
@@ -4,3 +4,9 @@ https://github.com/PyCQA/pyflakes/archive/master.zip#egg=pyflakes
 Django>=3.0,<3.1
 pyenchant==3.0.1
 django-formtools==2.2
+django-sekizai>=0.7
+django-classy-tags>=0.7.2
+https://github.com/divio/djangocms-text-ckeditor/archive/master.zip
+sphinxcontrib-spelling
+# required to run the server for integration tests
+django-app-helper

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -8,7 +8,7 @@ dj-database-url
 djangocms-admin-style>=1.5
 django-sekizai>=0.7
 django-classy-tags>=0.7.2
-https://github.com/divio/djangocms-text-ckeditor/archive/master.zip
+djangocms-text-ckeditor<4
 https://github.com/ojii/django-better-test/archive/8aa2407d097fe3789b74682f0e6bd7d15d449416.zip#egg=django-better-test
 https://github.com/ojii/django-app-manage/archive/65da18ef234a4e985710c2c0ec760023695b40fe.zip#egg=django-app-manage
 iptools

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -7,7 +7,7 @@ argparse
 dj-database-url
 djangocms-admin-style>=1.5
 django-sekizai>=0.7
-django-classy-tags>=0.7.2
+django-classy-tags>=0.7.2,<2
 djangocms-text-ckeditor<4
 https://github.com/ojii/django-better-test/archive/8aa2407d097fe3789b74682f0e6bd7d15d449416.zip#egg=django-better-test
 https://github.com/ojii/django-app-manage/archive/65da18ef234a4e985710c2c0ec760023695b40fe.zip#egg=django-app-manage

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -6,7 +6,7 @@ django-treebeard>=4.3,<4.5
 argparse
 dj-database-url
 djangocms-admin-style>=1.5
-django-sekizai>=0.7
+django-sekizai>=0.7,<=1.10
 django-classy-tags>=0.7.2,<2
 djangocms-text-ckeditor<4
 https://github.com/ojii/django-better-test/archive/8aa2407d097fe3789b74682f0e6bd7d15d449416.zip#egg=django-better-test

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -6,14 +6,9 @@ django-treebeard>=4.3,<4.5
 argparse
 dj-database-url
 djangocms-admin-style>=1.5
-django-sekizai>=0.7,<=1.10
-django-classy-tags>=0.7.2,<2
-djangocms-text-ckeditor<4
 https://github.com/ojii/django-better-test/archive/8aa2407d097fe3789b74682f0e6bd7d15d449416.zip#egg=django-better-test
 https://github.com/ojii/django-app-manage/archive/65da18ef234a4e985710c2c0ec760023695b40fe.zip#egg=django-app-manage
 iptools
 sphinx==1.8.5
-sphinxcontrib-spelling<7.0.0 # restriction for py35 tests
 # required to run the server for integration tests
-django-app-helper<3.0.0
 mock>=2.0.0

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -15,5 +15,5 @@ iptools
 sphinx==1.8.5
 sphinxcontrib-spelling<7.0.0 # restriction for py35 tests
 # required to run the server for integration tests
-django-app-helper
+django-app-helper<3.0.0
 mock>=2.0.0

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -1,5 +1,5 @@
-coverage<5
-python-coveralls==2.5.0
+coverage>=4
+python-coveralls>2.5.0
 unittest-xml-reporting==1.11.0
 Pillow==5.2.0
 django-treebeard>=4.3,<4.5
@@ -13,7 +13,7 @@ https://github.com/ojii/django-better-test/archive/8aa2407d097fe3789b74682f0e6bd
 https://github.com/ojii/django-app-manage/archive/65da18ef234a4e985710c2c0ec760023695b40fe.zip#egg=django-app-manage
 iptools
 sphinx==1.8.5
-sphinxcontrib-spelling
+sphinxcontrib-spelling<7.0.0 # restriction for py35 tests
 # required to run the server for integration tests
 django-app-helper
 mock>=2.0.0

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -2,7 +2,7 @@ coverage<5
 python-coveralls==2.5.0
 unittest-xml-reporting==1.11.0
 Pillow==5.2.0
-django-treebeard>=4.3
+django-treebeard>=4.3,<4.5
 argparse
 dj-database-url
 djangocms-admin-style>=1.5


### PR DESCRIPTION
## Description

This PR contains temporary changes for an issue where an upgrade to django-treebeard contains breaking changes.

The following changes broke django-cms compatibility: https://github.com/django-treebeard/django-treebeard/pull/192/files

An issue has been raised with django-treebeard to help us decide on the right direction to fix the issue in the longer term: django-treebeard/django-treebeard#210

**For tests to pass we also needed to backport the following changes:**

- Set sphinxcontrib-spelling requirement to be <7.0.0 (https://github.com/django-cms/django-cms/commit/6766150a0df9697408cd7778d53f3395e73070d7)
- Fix failing CI tests: Enforce to use at least coverage version > 4 (https://github.com/django-cms/django-cms/commit/1df448b7593cca8d5f25b1a2ff002805355899db)
- Pin classy tags to a Python 2.7 compatible version (https://github.com/django-cms/django-classy-tags/blob/master/CHANGELOG.rst#200-2020-08-26)
- Pin django-sekizai to a django 2.2 compatible version (https://github.com/django-cms/django-sekizai/blob/master/CHANGELOG.rst)
- Pin django-app-helper to CASPER JS compatible version 

## Checklist


* [x] I have opened this pull request against ``develop``
* [x] I have updated the **CHANGELOG.rst**
* [ ] I have added or modified the tests when changing logic
