### PR TITLE
Fix: django treebeard 4.5.1 compatibility

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Unreleased
 * Remove debug print from apphook_reload
 * Enforce use of coverage > 4 for python 3.8 support
 * Fixed 66622 bad Title.path in multilingual sites when parent slug is created or modified
-* Temporarily pinned django-treebeard to < 4.5, this avoids breaking changes introduced
+* Added django-treebeard 4.5.1 support, previously pinned django-treebeard<4.5 to avoid breaking changes introduced
 * Updated documentation links
 
 3.8.0 (2020-10-28)

--- a/cms/utils/plugins.py
+++ b/cms/utils/plugins.py
@@ -194,6 +194,7 @@ def copy_plugins_to_placeholder(plugins, placeholder, language=None, root_plugin
             new_plugin = deepcopy(source_plugin)
             new_plugin.pk = None
             new_plugin.id = None
+            new_plugin._state.adding = True
             new_plugin.language = language or new_plugin.language
             new_plugin.placeholder = placeholder
             new_plugin.parent = parent

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ REQUIREMENTS = [
     'Django>=2.2',
     'django-classy-tags>=0.7.2',
     'django-formtools>=2.1',
-    'django-treebeard>=4.3,<4.5',
+    'django-treebeard>=4.3',
     'django-sekizai>=0.7',
     'djangocms-admin-style>=1.2',
 ]

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -2,7 +2,7 @@ coverage>=4
 python-coveralls>2.5.0
 unittest-xml-reporting==1.11.0
 Pillow==5.2.0
-django-treebeard>=4.3,<4.5
+django-treebeard>=4.3
 argparse
 dj-database-url
 djangocms-admin-style>=1.5


### PR DESCRIPTION
## Description

django treebeard 4.5 introduced breaking changes that changed the check for if a model is being created or not. It appears that the django documentation does not cover the situation seen where the model _state needed to be manually updated.

This fix is now compatible with django-treebeard 4.5.1, 4.5 contained additional breaking changes that 4.5.1 resolves.

## Related resources

* https://github.com/django-treebeard/django-treebeard/issues/210
* Fixes: #6980 


## Checklist

* [x] I have opened this pull request against ``develop``
* [x] I have updated the **CHANGELOG.rst**
* [ ] I have added or modified the tests when changing logic
