### PR TITLE
Fixes issue with template specific static placeholder configuration.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Unreleased
 * Fixed 66622 bad Title.path in multilingual sites when parent slug is created or modified
 * Added django-treebeard 4.5.1 support, previously pinned django-treebeard<4.5 to avoid breaking changes introduced
 * Updated documentation links
+* Fixes issue with template specific static placeholder configuration
 
 3.8.0 (2020-10-28)
 ==================

--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -401,6 +401,7 @@ class ContentRenderer(BaseRenderer):
             editable=editable,
             use_cache=use_cache,
             nodelist=nodelist,
+            page=self.current_page,
         )
 
         if static_placeholder.pk not in self._rendered_static_placeholders:
@@ -617,7 +618,7 @@ class StructureRenderer(BaseRenderer):
         # I really don't like these impromptu flags...
         placeholder.is_static = True
 
-        content = self.render_placeholder(placeholder, language=language)
+        content = self.render_placeholder(placeholder, language=language, page=self.current_page)
 
         if static_placeholder.pk not in self._rendered_static_placeholders:
             # First time this static placeholder is rendered


### PR DESCRIPTION
## Description

When configuring `CMS_PLACEHOLDER_CONF`. A combination of the template name can be used to create a specific placeholder configuration for a specific page. This works as intended for regular placeholder and allow the CMS to, for instance create default placeholders when creating a new page.

This behaviour is also useful for static placeholders (for instance: a navigation bar which should be present on all pages but has slightly different (default) settings for a specific template). However, this does not seem to work.

## Related resources

* https://github.com/django-cms/django-cms/issues/7001

## Checklist

* [x] I have opened this pull request against ``develop``
* [x] I have updated the **CHANGELOG.rst**
* [x] I have added or modified the tests when changing logic
