### PR TITLE
Fixed missing builtin arguments on "cms" command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ Unreleased
 * Added support for Github Actions based CI.
 * Added Support for testing frontend, docs, test and linting in different/parallel CI pipelines.
 * Remove travis integration from the project as the project has moved to Github Actions.
+* Fixed missing builtin arguments on main ``cms`` management command causing it
+  to crash
 
 
 3.8.0 (2020-10-28)

--- a/cms/management/commands/subcommands/base.py
+++ b/cms/management/commands/subcommands/base.py
@@ -58,6 +58,7 @@ class SubcommandsCommand(BaseCommand):
             description=self.help or None,
             **kwargs
         )
+        add_builtin_arguments(parser)
         self.add_arguments(parser)
         return parser
 


### PR DESCRIPTION
## Description

When `./manage.py cms` is run, it currently crashes. This is because Django expects the `settings` attribute to be on the parsed arguments object: https://github.com/django/django/blob/42fea5d5b8e69ae2d72d1cd81fcb31a9b532c29d/django/core/management/base.py#L76

This PR adds the missing built-in arguments to the main "cms" command same as the other subcommands.

## Checklist

* [x] I have opened this pull request against ``develop``
* [x] I have updated the **CHANGELOG.rst**
* [x] I have added or modified the tests when changing logic
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
