### PR TITLE
bugfix: run GitHub Action workflows on pull requests and fix failing tests

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,6 +1,6 @@
 name: django CMS frontend.yml
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   frontend:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,6 +1,6 @@
 name: django CMS linters.yml
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   flake8:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: django CMS test.yml
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   database-postgres:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ Unreleased
 * Added support for Github Actions based CI.
 * Added Support for testing frontend, docs, test and linting in different/parallel CI pipelines.
 * Remove travis integration from the project as the project has moved to Github Actions.
-
+* Fix all GitHub actions tests run on pull requests
 
 3.8.0 (2020-10-28)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Unreleased
 * Added Support for testing frontend, docs, test and linting in different/parallel CI pipelines.
 * Remove travis integration from the project as the project has moved to Github Actions.
 * Fix all GitHub actions tests run on pull requests
+* Repair broken docs link to users/index.rst
 
 3.8.0 (2020-10-28)
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -198,3 +198,4 @@ project.
     topics/index
     contributing/index
     upgrade/index
+    user/index

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -35,7 +35,6 @@ your site may have.
 
     tutorial/index
     reference/index
-    user/index
 
 
 .. _django-cms-developers: https://groups.google.com/group/django-cms-developers

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -35,6 +35,7 @@ your site may have.
 
     tutorial/index
     reference/index
+    user/index
 
 
 .. _django-cms-developers: https://groups.google.com/group/django-cms-developers


### PR DESCRIPTION
## Description

All tests are not currently running on Pull Requests. Fix all GitHub actions tests run on pull requests

## Checklist


* [x] I have opened this pull request against ``develop``
* [x] I have updated the **CHANGELOG.rst**
* [ ] I have added or modified the tests when changing logic
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
