### PR TITLE
fixed readme quickstart section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ You can use the `django CMS installer <https://djangocms-installer.readthedocs.i
     (env) $ pip install djangocms-installer
     (env) $ mkdir myproject && cd myproject
     (env) $ djangocms -f -p . my_demo
-    (env) $ python manage.py
+    (env) $ python manage.py runserver
 
 ****
 Demo


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->
### Incomplete command reported

On the [Readme file](https://github.com/django-cms/django-cms/blob/develop/README.rst), Quick start section, the current, and incomplete, command reported is :
> **(env) $ python manage.py**

The right command is:
> **(env) $ python manage.py runserver**

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7008

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [ ] I have updated the **CHANGELOG.rst**
* [ ] I have added or modified the tests when changing logic
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
