### PR TITLE
Use AUTH_USER_MODEL in signals

### DIFF
--- a/cms/signals/__init__.py
+++ b/cms/signals/__init__.py
@@ -6,9 +6,9 @@ from cms.utils.conf import get_cms_setting
 from django.db.models import signals
 from django.dispatch import Signal
 
-from cms.models import PagePermission, GlobalPagePermission, PageUser, PageUserGroup
+from cms.models import PagePermission, GlobalPagePermission, User, PageUser, PageUserGroup
 from django.conf import settings
-from django.contrib.auth.models import User, Group
+from django.contrib.auth.models import Group
 
 #################### Our own signals ###################
 


### PR DESCRIPTION
## Description

The signals are currently registered to User model imported from django auth application. So the signals don't work when the user model is customized by AUTH_USER_MODEL settings.

This PR attaches the signals to model defined by AUTH_USER_MODEL.

