### PR TITLE
Fix hard-coded primary key of PageUser

### DIFF
--- a/cms/signals/permissions.py
+++ b/cms/signals/permissions.py
@@ -17,7 +17,7 @@ def post_save_user(instance, raw, created, **kwargs):
     if not creator or not created or creator.is_anonymous:
         return
 
-    page_user = PageUser(user_ptr_id=instance.pk, created_by=creator)
+    page_user = PageUser(pk=instance.pk, created_by=creator)
     page_user.__dict__.update(instance.__dict__)
     page_user.save()
 


### PR DESCRIPTION
## Description

This PR fixes the issue #7030 for cases where the user model is named other than User.

The `post_save_user` signal is using a hard-coded value of primary key `user_ptr_id` while creating `PageUser` instance. So if the user model is named anything other than User e.g Admin then the database column name becomes `admin_ptr_id` which raises an error while executing the signal.

This PR uses `pk` to assign primary key field.
