### PR TITLE
tools: updating PR template and contribution guideline

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,6 +25,6 @@ Use 'x' to check each item: [x] I have ...
 -->
 
 * [ ] I have opened this pull request against ``develop``
-* [ ] I have updated the **CHANGELOG.rst**
 * [ ] I have added or modified the tests when changing logic
+* [ ] I have followed [the conventionnal commits guidelines](http://conventionnalcommits.org/) to add meaningful information into the changelog
 * [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -34,6 +34,8 @@ Here’s what the pull request process looks like in brief:
 
 To learn more about basic requirements and standards of code contribution, please familiarize yourself with our comprehensive `documentation <https://docs.django-cms.org/en/latest/contributing/code.html#>`_. 
 
+django CMS commits follow the [Conventionnal Commits Guideline](http://conventionnalcommits.org/), please try to follow the Guidelines in your commit messages to ease our review&merge process.
+
 Receive rewards for submitting pull requests
 --------------------------------------------
 


### PR DESCRIPTION
As described on slack just now, let's remove the need to modify the CHANGELOG.rst (this forces every PR to be constantly rebased).

Instead let's use  conventionnalcommits.org guidelines.

@vinitkumar @NicolaiRidani @marksweb 