### PR TITLE
Split database packages so that tests can be run with sqlite (same changes as develop)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.6, 3.7, ]  # latest release minus two
+        python-version: [ 3.7, 3.8, 3.9]  # latest release minus two
         requirements-file: [
-          django-1.11.txt,
           django-2.2.txt,
+          django-3.1.txt,
+          django-3.2.txt,
         ]
         os: [
           ubuntu-20.04,
@@ -42,11 +43,14 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest
         pip install -r test_requirements/${{ matrix.requirements-file }}
+        pip install -r test_requirements/databases.txt
         python setup.py install
 
     - name: Test with django test runner
       run: |
         python manage.py test
+      env:
+        DATABASE_URL: postgres://postgres:postgres@127.0.0.1/postgres
 
 
   database-mysql:
@@ -54,10 +58,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.6, 3.7, ]  # latest release minus two
+        python-version: [ 3.7, 3.8, 3.9]  # latest release minus two
         requirements-file: [
-          django-1.11.txt,
           django-2.2.txt,
+          django-3.1.txt,
+          django-3.2.txt,
         ]
         os: [
           ubuntu-20.04,
@@ -87,6 +92,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest
         pip install -r test_requirements/${{ matrix.requirements-file }}
+        pip install -r test_requirements/databases.txt
         python setup.py install
 
 
@@ -101,10 +107,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.6, 3.7, ]  # latest release minus two
+        python-version: [ 3.7, 3.8, 3.9]  # latest release minus two
         requirements-file: [
-          django-1.11.txt,
           django-2.2.txt,
+          django-3.1.txt,
+          django-3.2.txt,
         ]
         os: [
           ubuntu-20.04,
@@ -126,7 +133,6 @@ jobs:
         python setup.py install
 
     - name: Test with django test runner
-      run: |
-        python manage.py test
+      run: python manage.py test
       env:
         DATABASE_URL: sqlite://localhost/testdb.sqlite

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
         python-version: [ 3.7, 3.8, 3.9]  # latest release minus two
         requirements-file: [
           django-2.2.txt,
-          django-3.1.txt,
+#          django-3.1.txt,
 #          django-3.2.txt,
         ]
         os: [

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.7, 3.8, 3.9]  # latest release minus two
+        python-version: [ 3.6, 3.7]  # latest release minus two
         requirements-file: [
           django-2.2.txt,
 #          django-3.1.txt,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,7 @@ jobs:
         requirements-file: [
           django-2.2.txt,
           django-3.1.txt,
-          django-3.2.txt,
+#          django-3.2.txt,
         ]
         os: [
           ubuntu-20.04,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ jobs:
         python-version: [ 3.7, 3.8, 3.9]  # latest release minus two
         requirements-file: [
           django-2.2.txt,
-          django-3.1.txt,
-          django-3.2.txt,
+#          django-3.1.txt,
+#          django-3.2.txt,
         ]
         os: [
           ubuntu-20.04,
@@ -61,8 +61,8 @@ jobs:
         python-version: [ 3.7, 3.8, 3.9]  # latest release minus two
         requirements-file: [
           django-2.2.txt,
-          django-3.1.txt,
-          django-3.2.txt,
+#          django-3.1.txt,
+#          django-3.2.txt,
         ]
         os: [
           ubuntu-20.04,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.7, 3.8, 3.9]  # latest release minus two
+        python-version: [ 3.6, 3.7]  # latest release minus two
         requirements-file: [
           django-2.2.txt,
 #          django-3.1.txt,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.7, 3.8, 3.9]  # latest release minus two
+        python-version: [ 3.6, 3.7]  # latest release minus two
         requirements-file: [
           django-2.2.txt,
 #          django-3.1.txt,

--- a/cms/test_utils/util/static_analysis.py
+++ b/cms/test_utils/util/static_analysis.py
@@ -1,5 +1,5 @@
 import os
-from django.utils import six
+import io
 
 from pyflakes import api
 from pyflakes.checker import Checker
@@ -13,11 +13,11 @@ def _pyflakes_report_with_nopyflakes(self, messageClass, node, *args, **kwargs):
     self.messages.append(messageClass(self.filename, node, *args, **kwargs))
 
 
-def _pyflakes_no_migrations(self, tree, filename='(none)', builtins=None):
+def _pyflakes_no_migrations(self, tree, filename='(none)', builtins=None, file_tokens=()):
     if os.path.basename(os.path.dirname(filename)) == 'migrations':
         self.messages = []
     else:
-        Checker.___init___(self, tree, filename, builtins)
+        Checker.___init___(self, tree, filename, builtins, file_tokens)
 
 
 def _check_recursive(paths, reporter):
@@ -41,7 +41,7 @@ def pyflakes(packages):
     Checker.___init___ = Checker.__init__
     Checker.__init__ = _pyflakes_no_migrations
     Checker.report = _pyflakes_report_with_nopyflakes
-    out = six.StringIO()
+    out = io.StringIO()
     reporter = Reporter(out, out)
     paths = [os.path.dirname(package.__file__) for package in packages]
     return _check_recursive(paths, reporter), out.getvalue()

--- a/cms/test_utils/util/static_analysis.py
+++ b/cms/test_utils/util/static_analysis.py
@@ -1,5 +1,5 @@
 import os
-import io
+from django.utils import six
 
 from pyflakes import api
 from pyflakes.checker import Checker
@@ -13,11 +13,11 @@ def _pyflakes_report_with_nopyflakes(self, messageClass, node, *args, **kwargs):
     self.messages.append(messageClass(self.filename, node, *args, **kwargs))
 
 
-def _pyflakes_no_migrations(self, tree, filename='(none)', builtins=None, file_tokens=()):
+def _pyflakes_no_migrations(self, tree, filename='(none)', builtins=None):
     if os.path.basename(os.path.dirname(filename)) == 'migrations':
         self.messages = []
     else:
-        Checker.___init___(self, tree, filename, builtins, file_tokens)
+        Checker.___init___(self, tree, filename, builtins)
 
 
 def _check_recursive(paths, reporter):
@@ -41,7 +41,7 @@ def pyflakes(packages):
     Checker.___init___ = Checker.__init__
     Checker.__init__ = _pyflakes_no_migrations
     Checker.report = _pyflakes_report_with_nopyflakes
-    out = io.StringIO()
+    out = six.StringIO()
     reporter = Reporter(out, out)
     paths = [os.path.dirname(package.__file__) for package in packages]
     return _check_recursive(paths, reporter), out.getvalue()

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -8,10 +8,8 @@ from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
 from django.test import RequestFactory
 from django.test.utils import override_settings
-from django.utils.encoding import force_text
 from django.utils.html import escape
 from django.utils.timezone import now
-from django.utils.translation import override as force_language
 from djangocms_text_ckeditor.cms_plugins import TextPlugin
 
 from mock import patch
@@ -19,18 +17,16 @@ from mock import patch
 import cms
 from cms.api import create_page, create_title, add_plugin
 from cms.middleware.toolbar import ToolbarMiddleware
-from cms.models import EmptyPageContent, Page, PageContent, Placeholder, PageUrl
+from cms.models import Page, Placeholder
 from cms.templatetags.cms_tags import (
     _get_page_by_untyped_arg,
     _show_placeholder_by_id,
     render_plugin,
 )
 from cms.templatetags.cms_js_tags import json_filter
-from cms.templatetags.cms_admin import get_page_display_name
 from cms.test_utils.fixtures.templatetags import TwoPagesFixture
 from cms.test_utils.testcases import CMSTestCase
 from cms.toolbar.toolbar import CMSToolbar
-from cms.toolbar.utils import get_object_edit_url
 from cms.utils import get_site_id
 from cms.utils.conf import get_cms_setting
 from cms.utils.placeholder import get_placeholders
@@ -38,39 +34,6 @@ from sekizai.context import SekizaiContext
 
 
 class TemplatetagTests(CMSTestCase):
-
-    def test_get_admin_tree_title(self):
-        page = create_page("page_a", "nav_playground.html", "en")
-        self.assertEqual(get_page_display_name(page), 'page_a')
-        languages = {
-            1: [
-                {
-                    'code': 'en',
-                    'name': 'English',
-                    'fallbacks': ['fr', 'de'],
-                    'public': True,
-                    'fallbacks': ['fr']
-                },
-                {
-                    'code': 'fr',
-                    'name': 'French',
-                    'public': True,
-                    'fallbacks': ['en']
-                },
-        ]}
-        with self.settings(CMS_LANGUAGES=languages):
-            with force_language('fr'):
-                page.title_cache = {'en': PageContent(page_title="test2", title="test2")}
-                self.assertEqual('test2', force_text(get_page_display_name(page)))
-                page.title_cache = {'en': PageContent(page_title="test2")}
-                self.assertEqual('test2', force_text(get_page_display_name(page)))
-                page.title_cache = {'en': PageContent(menu_title="test2")}
-                self.assertEqual('test2', force_text(get_page_display_name(page)))
-                page.title_cache = {'en': PageContent()}
-                page.urls_cache = {'en': PageUrl(slug='test2')}
-                self.assertEqual('test2', force_text(get_page_display_name(page)))
-                page.title_cache = {'en': PageContent(), 'fr': EmptyPageContent('fr')}
-                self.assertEqual('test2', force_text(get_page_display_name(page)))
 
     def test_get_site_id_from_nothing(self):
         with self.settings(SITE_ID=10):
@@ -97,11 +60,11 @@ class TemplatetagTests(CMSTestCase):
     def test_page_attribute_tag_escapes_content(self):
         script = '<script>alert("XSS");</script>'
 
-        class FakePage(object):
+        class FakePage:
             def get_page_title(self, *args, **kwargs):
                 return script
 
-        class FakeRequest(object):
+        class FakeRequest:
             current_page = FakePage()
             GET = {'language': 'en'}
 
@@ -145,7 +108,7 @@ class TemplatetagTests(CMSTestCase):
         mock_storage.url.side_effect = lambda x: '/static/' + x
 
         template = (
-            """{% load staticfiles cms_static %}<script src="{% static_with_version "cms/css/cms.base.css" %}" """
+            """{% load static cms_static %}<script src="{% static_with_version "cms/css/cms.base.css" %}" """
             """type="text/javascript"></script>"""
         )
 
@@ -163,10 +126,10 @@ class TemplatetagTests(CMSTestCase):
 
 class TemplatetagDatabaseTests(TwoPagesFixture, CMSTestCase):
     def _getfirst(self):
-        return Page.objects.get(pagecontent_set__title='first')
+        return Page.objects.public().get(title_set__title='first')
 
     def _getsecond(self):
-        return Page.objects.get(pagecontent_set__title='second')
+        return Page.objects.public().get(title_set__title='second')
 
     def test_get_page_by_untyped_arg_none(self):
         control = self._getfirst()
@@ -185,7 +148,7 @@ class TemplatetagDatabaseTests(TwoPagesFixture, CMSTestCase):
         middleware = ToolbarMiddleware()
         middleware.process_request(request)
         page = _get_page_by_untyped_arg(control.pk, request, 1)
-        self.assertEqual(page, control)
+        self.assertEqual(page, control.publisher_draft)
 
     def test_get_page_by_untyped_arg_page(self):
         control = self._getfirst()
@@ -256,13 +219,17 @@ class TemplatetagDatabaseTests(TwoPagesFixture, CMSTestCase):
            untranslated (PR #1125)
 
         """
-        page_1 = create_page('Page 1', 'nav_playground.html', 'en',
+        page_1 = create_page('Page 1', 'nav_playground.html', 'en', published=True,
                              in_navigation=True, reverse_id='page1')
         create_title("de", "Seite 1", page_1, slug="seite-1")
-        page_2 = create_page('Page 2', 'nav_playground.html', 'en', page_1,
+        page_1.publish('en')
+        page_1.publish('de')
+        page_2 = create_page('Page 2', 'nav_playground.html', 'en', page_1, published=True,
                              in_navigation=True, reverse_id='page2')
         create_title("de", "Seite 2", page_2, slug="seite-2")
-        page_3 = create_page('Page 3', 'nav_playground.html', 'en', page_2,
+        page_2.publish('en')
+        page_2.publish('de')
+        page_3 = create_page('Page 3', 'nav_playground.html', 'en', page_2, published=True,
                              in_navigation=True, reverse_id='page3')
         tpl = "{% load menu_tags %}{% page_language_url 'de' %}"
         lang_settings = deepcopy(get_cms_setting('LANGUAGES'))
@@ -273,20 +240,26 @@ class TemplatetagDatabaseTests(TwoPagesFixture, CMSTestCase):
             res = self.render_template_obj(tpl, context.__dict__, context['request'])
             self.assertEqual(res, "/de/seite-2/")
 
+            # Default configuration has CMS_HIDE_UNTRANSLATED=False
+            context = self.get_context(page_2.get_absolute_url())
+            context['request'].current_page = page_2.publisher_public
+            res = self.render_template_obj(tpl, context.__dict__, context['request'])
+            self.assertEqual(res, "/de/seite-2/")
+
             context = self.get_context(page_3.get_absolute_url())
-            context['request'].current_page = page_3
+            context['request'].current_page = page_3.publisher_public
             res = self.render_template_obj(tpl, context.__dict__, context['request'])
             self.assertEqual(res, "/en/page-3/")
         lang_settings[1][1]['hide_untranslated'] = True
 
         with self.settings(CMS_LANGUAGES=lang_settings):
             context = self.get_context(page_2.get_absolute_url())
-            context['request'].current_page = page_2
+            context['request'].current_page = page_2.publisher_public
             res = self.render_template_obj(tpl, context.__dict__, context['request'])
             self.assertEqual(res, "/de/seite-2/")
 
             context = self.get_context(page_3.get_absolute_url())
-            context['request'].current_page = page_3
+            context['request'].current_page = page_3.publisher_public
             res = self.render_template_obj(tpl, context.__dict__, context['request'])
             self.assertEqual(res, "/de/")
 
@@ -297,14 +270,13 @@ class TemplatetagDatabaseTests(TwoPagesFixture, CMSTestCase):
         """
         page = create_page('Test', 'col_two.html', 'en')
         # I need to make it seem like the user added another placeholder to the SAME template.
-        page.title_cache['en'] = page.get_title_obj('en')
-        page.title_cache['en']._template_cache = 'col_three.html'
+        page._template_cache = 'col_three.html'
 
         request = self.get_request(page=page)
         context = SekizaiContext()
         context['request'] = request
 
-        self.assertObjectDoesNotExist(page.get_placeholders('en'), slot='col_right')
+        self.assertObjectDoesNotExist(page.placeholders.all(), slot='col_right')
         context = self.get_context(page=page)
         renderer = self.get_content_renderer(request)
         renderer.render_page_placeholder(
@@ -313,7 +285,7 @@ class TemplatetagDatabaseTests(TwoPagesFixture, CMSTestCase):
             inherit=False,
             page=page,
         )
-        self.assertObjectExist(page.get_placeholders('en'), slot='col_right')
+        self.assertObjectExist(page.placeholders.all(), slot='col_right')
 
 
 class NoFixtureDatabaseTemplateTagTests(CMSTestCase):
@@ -327,7 +299,7 @@ class NoFixtureDatabaseTemplateTagTests(CMSTestCase):
         template_dir = os.path.join(os.path.dirname(project.__file__), 'templates', 'alt_plugin_templates',
                                     'show_placeholder')
         page = create_page('Test', 'col_two.html', 'en')
-        placeholder = page.get_placeholders('en')[0]
+        placeholder = page.placeholders.all()[0]
         add_plugin(placeholder, TextPlugin, 'en', body='HIDDEN')
         request = RequestFactory().get('/')
         request.user = self.get_staff_user_with_no_permissions()
@@ -345,30 +317,29 @@ class NoFixtureDatabaseTemplateTagTests(CMSTestCase):
         cache.clear()
         page = create_page('Test', 'col_two.html', 'en')
         create_title('fr', 'Fr Test', page)
-        placeholder_en = page.get_placeholders('en')[0]
-        placeholder_fr = page.get_placeholders('fr')[0]
-        add_plugin(placeholder_en, TextPlugin, 'en', body='<b>En Test</b>')
-        add_plugin(placeholder_fr, TextPlugin, 'fr', body='<b>Fr Test</b>')
+        placeholder = page.placeholders.all()[0]
+        add_plugin(placeholder, TextPlugin, 'en', body='<b>En Test</b>')
+        add_plugin(placeholder, TextPlugin, 'fr', body='<b>Fr Test</b>')
 
         request = RequestFactory().get('/')
         request.user = AnonymousUser()
         request.current_page = page
 
         template = "{% load cms_tags sekizai_tags %}{% show_placeholder slot page 'en' 1 %}{% render_block 'js' %}"
-        output = self.render_template_obj(template, {'page': page, 'slot': placeholder_en.slot}, request)
+        output = self.render_template_obj(template, {'page': page, 'slot': placeholder.slot}, request)
         self.assertIn('<b>En Test</b>', output)
 
         template = "{% load cms_tags sekizai_tags %}{% show_placeholder slot page 'fr' 1 %}{% render_block 'js' %}"
-        output = self.render_template_obj(template, {'page': page, 'slot': placeholder_fr.slot}, request)
+        output = self.render_template_obj(template, {'page': page, 'slot': placeholder.slot}, request)
         self.assertIn('<b>Fr Test</b>', output)
 
         # Cache is now primed for both languages
         template = "{% load cms_tags sekizai_tags %}{% show_placeholder slot page 'en' 1 %}{% render_block 'js' %}"
-        output = self.render_template_obj(template, {'page': page, 'slot': placeholder_en.slot}, request)
+        output = self.render_template_obj(template, {'page': page, 'slot': placeholder.slot}, request)
         self.assertIn('<b>En Test</b>', output)
 
         template = "{% load cms_tags sekizai_tags %}{% show_placeholder slot page 'fr' 1 %}{% render_block 'js' %}"
-        output = self.render_template_obj(template, {'page': page, 'slot': placeholder_fr.slot}, request)
+        output = self.render_template_obj(template, {'page': page, 'slot': placeholder.slot}, request)
         self.assertIn('<b>Fr Test</b>', output)
 
     def test_show_placeholder_for_page_marks_output_safe(self):
@@ -376,7 +347,7 @@ class NoFixtureDatabaseTemplateTagTests(CMSTestCase):
 
         cache.clear()
         page = create_page('Test', 'col_two.html', 'en')
-        placeholder = page.get_placeholders('en')[0]
+        placeholder = page.placeholders.all()[0]
         add_plugin(placeholder, TextPlugin, 'en', body='<b>Test</b>')
 
         request = RequestFactory().get('/')
@@ -384,41 +355,41 @@ class NoFixtureDatabaseTemplateTagTests(CMSTestCase):
         request.current_page = page
 
         template = "{% load cms_tags sekizai_tags %}{% show_placeholder slot page 'en' 1 %}{% render_block 'js' %}"
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(3):
             output = self.render_template_obj(template, {'page': page, 'slot': placeholder.slot}, request)
         self.assertIn('<b>Test</b>', output)
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             output = self.render_template_obj(template, {'page': page, 'slot': placeholder.slot}, request)
         self.assertIn('<b>Test</b>', output)
 
     def test_cached_show_placeholder_preview(self):
         from django.core.cache import cache
         cache.clear()
-        page = create_page('Test', 'col_two.html', 'en')
-        placeholder = page.get_placeholders('en')[0]
+        page = create_page('Test', 'col_two.html', 'en', published=True)
+        placeholder = page.placeholders.all()[0]
         add_plugin(placeholder, TextPlugin, 'en', body='<b>Test</b>')
         request = RequestFactory().get('/')
         user = self._create_user("admin", True, True)
-        request.current_page = page
+        request.current_page = page.publisher_public
         request.user = user
         template = "{% load cms_tags %}{% show_placeholder slot page 'en' 1 %}"
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(3):
             output = self.render_template_obj(template, {'page': page, 'slot': placeholder.slot}, request)
         self.assertIn('<b>Test</b>', output)
         add_plugin(placeholder, TextPlugin, 'en', body='<b>Test2</b>')
         request = RequestFactory().get('/?preview')
         request.current_page = page
         request.user = user
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             output = self.render_template_obj(template, {'page': page, 'slot': placeholder.slot}, request)
         self.assertIn('<b>Test2</b>', output)
 
     def test_render_plugin(self):
         from django.core.cache import cache
         cache.clear()
-        page = create_page('Test', 'col_two.html', 'en')
-        placeholder = page.get_placeholders('en')[0]
+        page = create_page('Test', 'col_two.html', 'en', published=True)
+        placeholder = page.placeholders.all()[0]
         plugin = add_plugin(placeholder, TextPlugin, 'en', body='<b>Test</b>')
         template = "{% load cms_tags %}{% render_plugin plugin %}"
         request = RequestFactory().get('/')
@@ -434,16 +405,15 @@ class NoFixtureDatabaseTemplateTagTests(CMSTestCase):
     def test_render_plugin_editable(self):
         from django.core.cache import cache
         cache.clear()
-        page = create_page('Test', 'col_two.html', 'en')
-        page_content = self.get_page_title_obj(page)
-        placeholder = page.get_placeholders('en')[0]
+        page = create_page('Test', 'col_two.html', 'en', published=True)
+        placeholder = page.placeholders.all()[0]
         plugin = add_plugin(placeholder, TextPlugin, 'en', body='<b>Test</b>')
         template = "{% load cms_tags %}{% render_plugin plugin %}"
-        request = RequestFactory().get(get_object_edit_url(page_content))
+        request = RequestFactory().get('/')
         user = self._create_user("admin", True, True)
         request.user = user
         request.current_page = page
-        request.session = {}
+        request.session = {'cms_edit': True}
         request.toolbar = CMSToolbar(request)
         request.toolbar.show_toolbar = True
         output = self.render_template_obj(template, {'plugin': plugin}, request)
@@ -457,8 +427,8 @@ class NoFixtureDatabaseTemplateTagTests(CMSTestCase):
     def test_render_plugin_not_editable(self):
         from django.core.cache import cache
         cache.clear()
-        page = create_page('Test', 'col_two.html', 'en')
-        placeholder = page.get_placeholders('en')[0]
+        page = create_page('Test', 'col_two.html', 'en', published=True)
+        placeholder = page.placeholders.all()[0]
         plugin = add_plugin(placeholder, TextPlugin, 'en', body='<b>Test</b>')
         template = "{% load cms_tags %}{% render_plugin plugin %}"
         request = RequestFactory().get('/')
@@ -472,15 +442,13 @@ class NoFixtureDatabaseTemplateTagTests(CMSTestCase):
         self.assertEqual('<b>Test</b>', output)
 
     def test_render_plugin_no_context(self):
-        page = create_page('Test', 'col_two.html', 'en')
-        page_content = self.get_page_title_obj(page)
         placeholder = Placeholder.objects.create(slot='test')
         plugin = add_plugin(placeholder, TextPlugin, 'en', body='Test')
         superuser = self.get_superuser()
-        request = RequestFactory().get(get_object_edit_url(page_content))
+        request = RequestFactory().get('/')
         request.current_page = None
         request.user = superuser
-        request.session = {}
+        request.session = {'cms_edit': True}
         request.toolbar = CMSToolbar(request)
         context = SekizaiContext({
             'request': request,
@@ -494,8 +462,7 @@ class NoFixtureDatabaseTemplateTagTests(CMSTestCase):
         )
 
     def test_render_placeholder_with_no_page(self):
-        page = create_page('Test', 'col_two.html', 'en')
-        page.title_cache['en'] = page.pagecontent_set.get(language='en')
+        page = create_page('Test', 'col_two.html', 'en', published=True)
         template = "{% load cms_tags %}{% placeholder test or %}< --- empty --->{% endplaceholder %}"
         request = RequestFactory().get('/asdadsaasd/')
         user = self.get_superuser()
@@ -509,8 +476,7 @@ class NoFixtureDatabaseTemplateTagTests(CMSTestCase):
             self.assertEqual(output, '< --- empty --->')
 
     def test_render_placeholder_as_var(self):
-        page = create_page('Test', 'col_two.html', 'en')
-        page.title_cache['en'] = page.pagecontent_set.get(language='en')
+        page = create_page('Test', 'col_two.html', 'en', published=True)
         template = "{% load cms_tags %}{% placeholder test or %}< --- empty --->{% endplaceholder %}"
         request = RequestFactory().get('/asdadsaasd/')
         user = self.get_superuser()
@@ -529,14 +495,13 @@ class NoFixtureDatabaseTemplateTagTests(CMSTestCase):
 
         Category.objects.create(name='foo', depth=1)
         cache.clear()
-        page = create_page('Test', 'col_two.html', 'en')
-        page_content = self.get_page_title_obj(page)
+        page = create_page('Test', 'col_two.html', 'en', published=True)
         template = "{% load cms_tags %}{% render_model category 'name' %}"
         user = self._create_user("admin", True, True)
-        request = RequestFactory().get(get_object_edit_url(page_content))
+        request = RequestFactory().get('/')
         request.user = user
         request.current_page = page
-        request.session = {}
+        request.session = {'cms_edit': True}
         request.toolbar = CMSToolbar(request)
         request.toolbar.is_staff = True
         category = Category.objects.only('name').get()
@@ -560,17 +525,16 @@ class NoFixtureDatabaseTemplateTagTests(CMSTestCase):
         from cms.test_utils.project.sampleapp.models import Category
 
         cache.clear()
-        page = create_page('Test', 'col_two.html', 'en')
-        page_content = self.get_page_title_obj(page)
+        page = create_page('Test', 'col_two.html', 'en', published=True)
         template = "{% load cms_tags %}{% render_model_add category %}"
         user = self._create_user("admin", True, True)
-        request = RequestFactory().get(get_object_edit_url(page_content))
+        request = RequestFactory().get(page.get_absolute_url())
         request.user = user
         request.current_page = page
         request.session = {'cms_edit': True}
         request.toolbar = CMSToolbar(request)
         request.toolbar.is_staff = True
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(0):
             output = self.render_template_obj(template, {'category': Category()}, request)
         expected_start = '<template class="cms-plugin cms-plugin-start cms-plugin-sampleapp-category-add-0 cms-render-model-add"></template>'
         expected_end = '<template class="cms-plugin cms-plugin-end cms-plugin-sampleapp-category-add-0 cms-render-model-add"></template>'
@@ -593,17 +557,16 @@ class NoFixtureDatabaseTemplateTagTests(CMSTestCase):
         from cms.test_utils.project.sampleapp.models import Category
 
         cache.clear()
-        page = create_page('Test', 'col_two.html', 'en')
-        page_content = self.get_page_title_obj(page)
+        page = create_page('Test', 'col_two.html', 'en', published=True)
         template = "{% load cms_tags %}{% render_model_add_block category %}wrapped{% endrender_model_add_block %}"
         user = self._create_user("admin", True, True)
-        request = RequestFactory().get(get_object_edit_url(page_content))
+        request = RequestFactory().get(page.get_absolute_url())
         request.user = user
         request.current_page = page
         request.session = {'cms_edit': True}
         request.toolbar = CMSToolbar(request)
         request.toolbar.is_staff = True
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(0):
             output = self.render_template_obj(template, {'category': Category()}, request)
         expected_start = '<template class="cms-plugin cms-plugin-start cms-plugin-sampleapp-category-add-0 '
         'cms-render-model-add"></template>'

--- a/test_requirements/databases.txt
+++ b/test_requirements/databases.txt
@@ -1,0 +1,2 @@
+psycopg2==2.8.6
+mysqlclient==2.0.3

--- a/test_requirements/django-2.0.txt
+++ b/test_requirements/django-2.0.txt
@@ -1,2 +1,0 @@
--r requirements_base.txt
-Django>=2.0,<2.1

--- a/test_requirements/django-2.2.txt
+++ b/test_requirements/django-2.2.txt
@@ -1,5 +1,4 @@
 -r requirements_base.txt
-pyflakes>=2.1
 Django>=2.2,<3.0
 pyenchant==3.0.1
 django-formtools==2.2

--- a/test_requirements/django-2.2.txt
+++ b/test_requirements/django-2.2.txt
@@ -1,2 +1,5 @@
 -r requirements_base.txt
+pyflakes>=2.1
 Django>=2.2,<3.0
+pyenchant==3.0.1
+django-formtools==2.2

--- a/test_requirements/django-3.1.txt
+++ b/test_requirements/django-3.1.txt
@@ -1,5 +1,3 @@
 -r requirements_base.txt
 Django>=3.1,<3.2
 django-formtools==2.2
-pyenchant==3.0.1
-pyflakes>=2.2

--- a/test_requirements/django-3.1.txt
+++ b/test_requirements/django-3.1.txt
@@ -1,2 +1,5 @@
 -r requirements_base.txt
 Django>=3.1,<3.2
+django-formtools==2.2
+pyenchant==3.0.1
+pyflakes>=2.2

--- a/test_requirements/django-3.1.txt
+++ b/test_requirements/django-3.1.txt
@@ -1,2 +1,2 @@
 -r requirements_base.txt
-Django>=2.1a1,<2.2
+Django>=3.1,<3.2

--- a/test_requirements/django-3.2.txt
+++ b/test_requirements/django-3.2.txt
@@ -1,5 +1,3 @@
 -r requirements_base.txt
 Django>=3.2,<3.4
 django-formtools==2.2
-pyenchant==3.0.1
-pyflakes>=2.2

--- a/test_requirements/django-3.2.txt
+++ b/test_requirements/django-3.2.txt
@@ -1,2 +1,2 @@
 -r requirements_base.txt
-Django>=1.11,<2.0
+Django>=3.2,<3.4

--- a/test_requirements/django-3.2.txt
+++ b/test_requirements/django-3.2.txt
@@ -1,2 +1,5 @@
 -r requirements_base.txt
 Django>=3.2,<3.4
+django-formtools==2.2
+pyenchant==3.0.1
+pyflakes>=2.2

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -14,7 +14,7 @@ https://github.com/ojii/django-app-manage/archive/65da18ef234a4e985710c2c0ec7600
 iptools
 sphinx==1.8.5
 sphinxcontrib-spelling<7.0.0 # restriction for py35 tests
-pyflakes==1.1.0
+pyflakes>2,<3
 pyenchant
 # required to run the server for integration tests
 djangocms-helper

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -20,4 +20,3 @@ pyenchant
 djangocms-helper
 mock>=2.0.0
 django-formtools
-mysqlclient==2.0.3

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -14,6 +14,8 @@ https://github.com/ojii/django-app-manage/archive/65da18ef234a4e985710c2c0ec7600
 iptools
 sphinx==1.8.5
 sphinxcontrib-spelling<7.0.0 # restriction for py35 tests
+pyflakes==1.1.0
+pyenchant
 # required to run the server for integration tests
 djangocms-helper
 mock>=2.0.0

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -1,11 +1,11 @@
 coverage<5
 python-coveralls>2.5.0
 unittest-xml-reporting==1.11.0
-Pillow==3.3
+Pillow==5.2.0
 django-treebeard>=4.3
 argparse
 dj-database-url
-djangocms-admin-style>=1.2
+djangocms-admin-style>=1.5
 django-sekizai>=0.7
 django-classy-tags>=0.7.2
 https://github.com/divio/djangocms-text-ckeditor/archive/support/4.0.x.zip
@@ -14,8 +14,6 @@ https://github.com/ojii/django-app-manage/archive/65da18ef234a4e985710c2c0ec7600
 iptools
 sphinx==1.8.5
 sphinxcontrib-spelling<7.0.0 # restriction for py35 tests
-pyflakes>2,<3
-pyenchant
 # required to run the server for integration tests
 djangocms-helper
 mock>=2.0.0


### PR DESCRIPTION
The intention here was to update the test suite so that there wasn't a dependency on postgres or mysql - a change recently made in develop.

Having made that change however, I've found a rabbit hole of issues starting with out of date test requirements & ending up with parts of the code in `release/4.0.x` being behind develop and therefore not passing tests.

Not sure where to go from here, but leaving this as a draft for now.
