### PR TITLE
revert: changes in the cms user permission

### DIFF
--- a/cms/signals/permissions.py
+++ b/cms/signals/permissions.py
@@ -17,7 +17,7 @@ def post_save_user(instance, raw, created, **kwargs):
     if not creator or not created or creator.is_anonymous:
         return
 
-    page_user = PageUser(pk=instance.pk, created_by=creator)
+    page_user = PageUser(user_ptr_id=instance.pk, created_by=creator)
     page_user.__dict__.update(instance.__dict__)
     page_user.save()
 


### PR DESCRIPTION
Reverting the patch from this PR, since it is causing crash in some
websites with this error:

```python
django.db.utils.IntegrityError: 
(1452, 'Cannot add or update a child row: a foreign key constraint fails (`test_museumday`.`cms_pageuser`, CONSTRAINT `cms_pageuser_created_by_id_8e9fbf83_fk_users_user_id` FOREIGN KEY (`created_by_id`) REFERENCES `users_user` (`id`))')
```



Authored-by: Vinit Kumar <vinit.kumar@socialschools.nl>
Signed-off-by: Vinit Kumar <vinit.kumar@socialschools.nl>

## Related resources

- https://django-cmsworkspace.slack.com/archives/C01J7H87KFC/p1621333264008900

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventionnal commits guidelines](http://conventionnalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
