### PR TITLE
Fixes #7033: also check for Django 3.2, now that 3.9 supports it.

### DIFF
--- a/cms/management/commands/subcommands/base.py
+++ b/cms/management/commands/subcommands/base.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 from django.core.management.base import BaseCommand, CommandParser
 from django.core.management.color import no_style, color_style
 
-from cms.utils.compat import DJANGO_3_0, DJANGO_3_1
+from cms.utils.compat import DJANGO_3_0, DJANGO_3_1, DJANGO_3_2
 
 
 def add_builtin_arguments(parser):
@@ -37,7 +37,7 @@ def add_builtin_arguments(parser):
         help="Don't colorize the command output.")
     parser.add_argument('--force-color', action='store_true', dest='force_color', default=False,
         help="Colorize the command output.")
-    if DJANGO_3_0 or DJANGO_3_1:
+    if DJANGO_3_0 or DJANGO_3_1 or DJANGO_3_2:
         parser.add_argument('--skip-checks', action='store_true', dest='skip_checks', default=False,
             help="Skip the checks.")
 


### PR DESCRIPTION
## Description

Avoid a crash when running `python manage.py cms check` by checking against Django 3.2, as cms 3.9 supports it.
Fixes https://github.com/django-cms/django-cms/issues/7033  

## Related resources

* #7033 


## Checklist

* [x] I have opened this pull request against ``develop``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventionnal commits guidelines](http://conventionnalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
