### PR TITLE
tests: adding test to ensure no migration can collide with 4.x upgrad…

### DIFF
--- a/cms/tests/test_compatibility_with_4x_branch.py
+++ b/cms/tests/test_compatibility_with_4x_branch.py
@@ -1,0 +1,24 @@
+import cms
+import os
+from django.test import testcases
+
+class Compatibility4xTestCase(testcases.TestCase):
+
+
+    def test_ensure_no_migration_is_added(self):
+        """
+        to ensure the next version is compatible with the 4.x branch, we need to make sure
+        no new migration is added (otherwise, this will thnn conflicts with what is present in the 4.x
+        branch
+        """
+
+        migration = os.path.join("cms", "migrations")
+        MAX = 22
+
+        for root, _, files in os.walk(migration):
+            for name in files:
+                if name == "__init__.py":
+                    continue
+
+                mid = int(name.split("_")[0])
+                self.assertTrue(mid <= MAX, "migration %s conflicts with 4.x upgrade!" % name)

--- a/cms/tests/test_compatibility_with_4x_branch.py
+++ b/cms/tests/test_compatibility_with_4x_branch.py
@@ -1,4 +1,3 @@
-import cms
 import os
 from django.test import testcases
 

--- a/cms/tests/test_compatibility_with_4x_branch.py
+++ b/cms/tests/test_compatibility_with_4x_branch.py
@@ -8,7 +8,7 @@ class Compatibility4xTestCase(testcases.TestCase):
     def test_ensure_no_migration_is_added(self):
         """
         to ensure the next version is compatible with the 4.x branch, we need to make sure
-        no new migration is added (otherwise, this will thnn conflicts with what is present in the 4.x
+        no new migration is added (otherwise, this will then conflicts with what is present in the 4.x
         branch
         """
 

--- a/cms/tests/test_compatibility_with_4x_branch.py
+++ b/cms/tests/test_compatibility_with_4x_branch.py
@@ -6,9 +6,8 @@ class Compatibility4xTestCase(testcases.TestCase):
 
     def test_ensure_no_migration_is_added(self):
         """
-        to ensure the next version is compatible with the 4.x branch, we need to make sure
-        no new migration is added (otherwise, this will then conflicts with what is present in the 4.x
-        branch
+        to ensure the next version is compatible with the 4.x branch, we need to make sure no new migration is added
+        (otherwise, this will then conflicts with what is present in the 4.x branch
         """
 
         migration = os.path.join("cms", "migrations")
@@ -16,7 +15,7 @@ class Compatibility4xTestCase(testcases.TestCase):
 
         for root, _, files in os.walk(migration):
             for name in files:
-                if name == "__init__.py":
+                if name == "__init__.py" or not name.endswith(".py"):
                     continue
 
                 mid = int(name.split("_")[0])


### PR DESCRIPTION
## Description

Following conversation on slack, Adding a test here to ensure no new migration can be added to the application (as this would make problems on 4.x migration path).

@marksweb  @Aiky30  @vinitkumar 