### PR TITLE
issue: 6934 - Adds overwrite_url validation and related test

### DIFF
--- a/cms/constants.py
+++ b/cms/constants.py
@@ -26,6 +26,7 @@ X_FRAME_OPTIONS_ALLOW = 3
 PAGE_USERNAME_MAX_LENGTH = 255
 
 SLUG_REGEXP = '[0-9A-Za-z-_.//]+'
+NEGATE_SLUG_REGEXP = '[^0-9A-Za-z-_.//]+'
 
 EXPIRE_NOW = 0
 # HTTP Specification says max caching should only be up to one year.

--- a/cms/forms/validators.py
+++ b/cms/forms/validators.py
@@ -4,6 +4,7 @@ from django.utils.encoding import force_str
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext
 
+from cms.constants import NEGATE_SLUG_REGEXP
 from cms.utils.page import get_all_pages_from_path
 from cms.utils.urlutils import admin_reverse, relative_url_regex
 
@@ -19,6 +20,14 @@ def validate_url(value):
     except ValidationError:
         # Fallback to absolute urls
         URLValidator()(value)
+
+
+def validate_overwrite_url(value):
+    try:
+        RegexValidator(regex=NEGATE_SLUG_REGEXP)(value)
+    except:
+        return True
+    return False
 
 
 def validate_url_uniqueness(site, path, language, exclude_page=None):

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -1340,6 +1340,25 @@ class PageTest(PageTestBase):
         page = get_page_from_request(request)
         self.assertEqual(page, mock_page)
 
+
+    @override_settings(CMS_PERMISSION=False)
+    def test_set_overwrite_url_with_invalid_value(self):
+        # User cannot add reserved characters in the "overwrite_url" input.
+        superuser = self.get_superuser()
+        cms_page = create_page('page', 'nav_playground.html', 'en', published=True)
+        expected_error_message = "You entered an invalid URL"
+
+        endpoint = self.get_admin_url(Page, 'advanced', cms_page.pk)
+
+        with self.login_user_context(superuser):
+            page_data = {
+                'overwrite_url': 'https://django-cms.org',
+                'template': cms_page.template,
+            }
+            response = self.client.post(endpoint, page_data)
+            self.assertContains(response, expected_error_message)
+
+
     @override_settings(CMS_PERMISSION=False)
     def test_set_overwrite_url(self):
         superuser = self.get_superuser()


### PR DESCRIPTION
## Description
`overwrite_url` field in advanced page settings accepts reserved characters for a URL such as `:$?` and does not validate it. The page is saved successfully but then when visited it gives NoReverseMatch exception.
Details in issue 6934
## Related resources
Issue: https://github.com/django-cms/django-cms/issues/6934

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [] I have followed [the conventionnal commits guidelines](http://conventionnalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
