### PR TITLE
[Docs] Fixes incorrect default path for `CMSPluginBase.change_form_…

### DIFF
--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -70,7 +70,7 @@ CMSPluginBase Attributes and Methods Reference
 
     ..  attribute:: change_form_template
 
-        Default: ``admin/cms/page/plugin_change_form.html``
+        Default: ``admin/cms/page/plugin/change_form.html``
 
         The template used to render the form when you edit the plugin.
 
@@ -80,7 +80,7 @@ CMSPluginBase Attributes and Methods Reference
                 model = MyModel
                 name = _("My Plugin")
                 render_template = "cms/plugins/my_plugin.html"
-                change_form_template = "admin/cms/page/plugin_change_form.html"
+                change_form_template = "admin/cms/page/plugin/change_form.html"
 
         See also: :attr:`frontend_edit_template`.
 


### PR DESCRIPTION

## Description

The default template path for `CMSPluginBase.change_form_template` in the [documentation](https://docs.django-cms.org/en/latest/reference/plugins.html#cms.plugin_base.CMSPluginBase.change_form_template) is wrong.  




## Checklist


* [x] I have opened this pull request against ``develop``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventionnal commits guidelines](http://conventionnalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
