### PR TITLE
meta: Fixes two typos in PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,5 +26,5 @@ Use 'x' to check each item: [x] I have ...
 
 * [ ] I have opened this pull request against ``develop``
 * [ ] I have added or modified the tests when changing logic
-* [ ] I have followed [the conventionnal commits guidelines](http://conventionnalcommits.org/) to add meaningful information into the changelog
+* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
 * [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.


### PR DESCRIPTION
## Description

Fixes a typo in "conventional commits", as well as the URL describing them (the existing URL leads to a missing domain)


## Checklist
* [x] I have opened this pull request against ``develop``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventionnal commits guidelines](http://conventionnalcommits.org/) to add meaningful information into the changelog 
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
