### PR TITLE
feat: add django3.2 in the framework identifier for setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ CLASSIFIERS = [
     'Framework :: Django :: 2.2',
     'Framework :: Django :: 3.0',
     'Framework :: Django :: 3.1',
+    'Framework :: Django :: 3.2',
     'Topic :: Internet :: WWW/HTTP',
     'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     'Topic :: Software Development',


### PR DESCRIPTION
We support Django3.2, but we forgot to add it to the setup.py, If not
present, it will not show the support for django3.2 in PyPI.

Authored-by: Vinit Kumar <vinit.kumar@socialschools.nl>
