### PR TITLE
fix: missing tests of django3.2 for mysql and sqlite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,7 @@ jobs:
           django-2.2.txt,
           django-3.0.txt,
           django-3.1.txt,
+          django-3.2.txt,
         ]
         os: [
           ubuntu-20.04,
@@ -115,6 +116,7 @@ jobs:
           django-2.2.txt,
           django-3.0.txt,
           django-3.1.txt,
+          django-3.2.txt,
         ]
         os: [
           ubuntu-20.04,


### PR DESCRIPTION
- Add missing tests for django3.2. We somehow missed adding them to the CI when we added support for Django3.2. 