### PR TITLE
fix #5831 - updated CMSPluginBase._get_render_template to raise Impro…

### DIFF
--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -9,7 +9,6 @@ from django.contrib import messages
 from django.core.exceptions import (
     ImproperlyConfigured,
     ObjectDoesNotExist,
-    ValidationError,
 )
 from django.utils.encoding import force_str
 from django.utils.html import escapejs
@@ -163,7 +162,7 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
             template = None
 
         if not template:
-            raise ValidationError("plugin has no render_template: %s" % self.__class__)
+            raise ImproperlyConfigured("plugin has no render_template: %s" % self.__class__)
         return template
 
     @classmethod


### PR DESCRIPTION
…perlyConfigured exception

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->
Method CMSPluginBase._get_render_template used to raise ValidationError, now it raises ImproperlyConfigured exception.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.

-->
https://github.com/django-cms/django-cms/issues/5831

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
