### PR TITLE
Update __init__.py

### DIFF
--- a/cms/signals/__init__.py
+++ b/cms/signals/__init__.py
@@ -13,57 +13,27 @@ from django.contrib.auth.models import Group
 # ---------------- Our own signals ---------------- #
 
 # fired after page location is changed - is moved from one node to other
-page_moved = Signal(providing_args=["instance"])
+page_moved = Signal()
 
 # fired after page gets published - copied to public model - there may be more
 # than one instances published before this signal gets called
-post_publish = Signal(providing_args=["instance", "language"])
-post_unpublish = Signal(providing_args=["instance", "language"])
+post_publish = Signal()
+post_unpublish = Signal()
 
 # fired if a public page with an apphook is added or changed
-urls_need_reloading = Signal(providing_args=[])
+urls_need_reloading = Signal()
 
 # *disclaimer*
 # The generic object operation signals are very likely to change
 # as their usage evolves.
 # As a result, rely on these at your own risk
-pre_obj_operation = Signal(
-    providing_args=[
-        "operation",
-        "request",
-        "token",
-        "obj",
-    ]
-)
+pre_obj_operation = Signal()
 
-post_obj_operation = Signal(
-    providing_args=[
-        "operation",
-        "request",
-        "token",
-        "obj",
-    ]
-)
+post_obj_operation = Signal()
 
-pre_placeholder_operation = Signal(
-    providing_args=[
-        "operation",
-        "request",
-        "language",
-        "token",
-        "origin",
-    ]
-)
+pre_placeholder_operation = Signal()
 
-post_placeholder_operation = Signal(
-    providing_args=[
-        "operation",
-        "request",
-        "language",
-        "token",
-        "origin",
-    ]
-)
+post_placeholder_operation = Signal()
 
 
 # ---------------- apphook reloading ---------------- #


### PR DESCRIPTION
Proposed edit, so that it works with django 3.0+

## Description

When installing with django 3.0 or 4.0 it wouldn't start nor migrate because of a problem with the Signal calling.
This edit makes it work.

## Related resources

https://stackoverflow.com/questions/70364068/django-cms-unexpected-keyword-argument-providing-args/70367117#70367117

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x ] I have opened this pull request against ``develop``
* [x ] I have added or modified the tests when changing logic
* [x ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
