### PR TITLE
Fixed incorrect docker commands

### DIFF
--- a/docs/introduction/01-install.rst
+++ b/docs/introduction/01-install.rst
@@ -47,11 +47,11 @@ Open the terminal application on your computer and go to a safe folder (i.e. cd 
 
       git clone git@github.com:django-cms/django-cms-quickstart.git
       cd django-cms-quickstart
-      docker compose build web
-      docker compose up -d database_default
-      docker compose run web python manage.py migrate
-      docker compose run web python manage.py createsuperuser
-      docker compose up -d
+      docker-compose build web
+      docker-compose up -d database_default
+      docker-compose run web python manage.py migrate
+      docker-compose run web python manage.py createsuperuser
+      docker-compose up -d
 
 During the installation process, you will be prompted to enter your email address and set a username and password.
 Open your browser and insert http://localhost:8000/; there you should be invited to login


### PR DESCRIPTION
Should be `docker-compose` not `docker compose`.

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
