### PR TITLE
Handle custom auth user model name

### DIFF
--- a/cms/signals/permissions.py
+++ b/cms/signals/permissions.py
@@ -18,7 +18,12 @@ def post_save_user(instance, raw, created, **kwargs):
     if not creator or not created or creator.is_anonymous:
         return
 
-    page_user = PageUser(user_ptr_id=instance.pk, created_by=creator)
+    options = {
+        # handle custom auth user model with a different model name
+        instance._meta.model_name + "_ptr_id": instance.pk,
+        "created_by": creator
+    }
+    page_user = PageUser(**options)
     page_user.__dict__.update(instance.__dict__)
     page_user.save()
 


### PR DESCRIPTION
## Description

Handle custom auth user model name when `CMS_PERMISSION=True`.

When running the tests suit with `python manage.py test --auth-user-model=emailuserapp.EmailUser`, some tests are failing with the following error:
```
TypeError: PageUser() got an unexpected keyword argument 'user_ptr_id'
```
It is caused by the hard coded `user_ptr_id` in [this file](https://github.com/django-cms/django-cms/blob/develop/cms/signals/permissions.py#L20), which does not take into account the real AUTH_USER_MODEL name.

Someone has already tried to correct this issue, but it introduced another issue and so the fix has been reverted (see Related resources below).

## Related resources

- [Commit](https://github.com/django-cms/django-cms/commit/c38fde3bd084f29dd5762b40ab406c8a367b5262) that fixed the issue (but introduced another issue)
- [Commit](https://github.com/django-cms/django-cms/commit/ede01176a979dbf71a84c28248868e04eeeafa3a) that reverted the previous fix

## Checklist

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
