### PR TITLE
Set the default_auto_field on the AppConfigs

### DIFF
--- a/cms/apps.py
+++ b/cms/apps.py
@@ -5,6 +5,7 @@ from django.utils.translation import gettext_lazy as _
 class CMSConfig(AppConfig):
     name = 'cms'
     verbose_name = _("django CMS")
+    default_auto_field = 'django.db.models.AutoField'
 
     def ready(self):
         from cms.utils.setup import setup

--- a/menus/apps.py
+++ b/menus/apps.py
@@ -5,3 +5,4 @@ from django.utils.translation import gettext_lazy as _
 class MenusConfig(AppConfig):
     name = 'menus'
     verbose_name = _("django CMS menus system")
+    default_auto_field = 'django.db.models.AutoField'


### PR DESCRIPTION
## Description

Set the default_auto_field on the AppConfigs

Otherwise when someone sets the DEFAULT_AUTO_FIELD setting in their project unwanted migrations are created in the cms and menu app.

Fixes #7167

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7167 

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
