### PR TITLE
fix: Unlocalize page and node ids when rendering the page tree in the admin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ unreleased
 
 * Make javascript dark mode functions available to popups as CMS.API.getColorScheme
   and CMS.API.setColorScheme
+* Unlocalize page and node ids when rendering the page tree in the admin (#7175)
 
 3.11.0 (2022-08-02)
 ===================

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import re
 import sys
 import uuid
 from collections import namedtuple
@@ -1401,8 +1402,12 @@ class BasePageAdmin(PlaceholderAdminMixin, admin.ModelAdmin):
         """
         site = self.get_site(request)
         pages = self.get_queryset(request)
-        node_id = request.GET.get('nodeId')
-        open_nodes = list(map(int, request.GET.getlist('openNodes[]')))
+        node_id = re.sub(r'[^\d]', '', request.GET.get('nodeId', '')) or None
+        open_nodes = list(map(
+            int,
+            [re.sub(r'[^\d]', '', node) for node in
+                request.GET.getlist('openNodes[]')]
+            ))
 
         if node_id:
             page = get_object_or_404(pages, node_id=int(node_id))

--- a/cms/templates/admin/cms/page/tree/actions_dropdown.html
+++ b/cms/templates/admin/cms/page/tree/actions_dropdown.html
@@ -1,12 +1,12 @@
-{% load i18n admin_urls %}
+{% load i18n l10n admin_urls %}
 {% spaceless %}
 <ul class="cms-pagetree-dropdown-menu-inner">
     {% block actions %}
         <li
             {% if has_copy_page_permission %}
                 class="js-cms-tree-item-copy"
-                data-id="{{ page.pk }}"
-                data-node-id="{{ node.pk }}"
+                data-id="{{ page.pk|unlocalize }}"
+                data-node-id="{{ node.pk|unlocalize }}"
                 data-apphook="{{ page.application_urls|default_if_none:"" }}"
             {% endif %}
         >
@@ -18,8 +18,8 @@
         <li
             {% if has_move_page_permission %}
                 class="js-cms-tree-item-cut"
-                data-id="{{ page.pk }}"
-                data-node-id="{{ node.pk }}"
+                data-id="{{ page.pk|unlocalize }}"
+                data-node-id="{{ node.pk|unlocalize }}"
             {% endif %}
         >
             <a{% if not has_move_page_permission %} class="cms-pagetree-dropdown-item-disabled"{% endif %}
@@ -29,8 +29,8 @@
             </a>
         </li>
         <li>
-            <a href="#" data-id="{{ page.pk }}"
-                data-node-id="{{ node.pk }}"
+            <a href="#" data-id="{{ page.pk|unlocalize }}"
+                data-node-id="{{ node.pk|unlocalize }}"
                 class="{% if has_add_permission %}js-cms-tree-item-paste{% endif %}
                 {% if not has_add_permission or not paste_enabled %} cms-pagetree-dropdown-item-disabled{% endif %}">
                 <span class="cms-icon cms-icon-alias"></span>

--- a/cms/templates/admin/cms/page/tree/base.html
+++ b/cms/templates/admin/cms/page/tree/base.html
@@ -107,7 +107,7 @@
                                     <span class="label">{% trans "Sites" %}</span>
                                 </li>
                                 {% for site in tree.sites %}
-                                    <li{% if site.pk|unlocalize == tree.site.pk|unlocalize %} class="active"{% endif %}>
+                                    <li{% if site.pk == tree.site.pk %} class="active"{% endif %}>
                                         <a href="#{{ site.pk|unlocalize }}" class="js-cms-pagetree-site-trigger" data-id="{{ site.pk|unlocalize }}">{{ site.name }}</a>
                                     </li>
                                 {% endfor %}

--- a/cms/templates/admin/cms/page/tree/base.html
+++ b/cms/templates/admin/cms/page/tree/base.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_list.html" %}
-{% load i18n admin_list static admin_urls cms_admin cms_js_tags cms_static cms_tags %}
+{% load i18n l10n admin_list static admin_urls cms_admin cms_js_tags cms_static cms_tags %}
 
 {# TODO might not need that #}
 {% block title %}{% trans "List of pages" %}{% endblock %}
@@ -107,8 +107,8 @@
                                     <span class="label">{% trans "Sites" %}</span>
                                 </li>
                                 {% for site in tree.sites %}
-                                    <li{% if site.pk == tree.site.pk %} class="active"{% endif %}>
-                                        <a href="#{{ site.pk }}" class="js-cms-pagetree-site-trigger" data-id="{{ site.pk }}">{{ site.name }}</a>
+                                    <li{% if site.pk|unlocalize == tree.site.pk|unlocalize %} class="active"{% endif %}>
+                                        <a href="#{{ site.pk|unlocalize }}" class="js-cms-pagetree-site-trigger" data-id="{{ site.pk|unlocalize }}">{{ site.name }}</a>
                                     </li>
                                 {% endfor %}
                                 {% if has_recover_permission %}
@@ -127,7 +127,7 @@
                         <form method="post" class="js-cms-pagetree-site-form cms-hidden">
                             <select name="site">
                                 {% for site in tree.sites %}
-                                    <option value="{{ site.pk }}">{{ site.name }}</option>
+                                    <option value="{{ site.pk|unlocalize }}">{{ site.name }}</option>
                                 {% endfor %}
                             </select>
                             {% csrf_token %}
@@ -186,7 +186,7 @@
                             "permission": {{ CMS_PERMISSION|bool }},
                             "debug": {{ DEBUG|bool }},
                             "filtered": {% if tree.is_filtered %}true{% else %}false{% endif %},
-                            "site": {{ tree.site.pk }},
+                            "site": {{ tree.site.pk|unlocalize }},
                             "hasAddRootPermission": {{ has_add_permission|yesno:"true,false" }},
                             "lang": {
                                 "code": "{{ preview_language|lower }}",
@@ -250,7 +250,7 @@
                         "permission": {{ CMS_PERMISSION|bool }},
                         "debug": {{ DEBUG|bool }},
                         "filtered": {% if tree.is_filtered %}true{% else %}false{% endif %},
-                        "site": {{ tree.site.pk }},
+                        "site": {{ tree.site.pk|unlocalize }},
                         "hasAddRootPermission": {{ has_add_permission|yesno:"true,false" }},
                         "lang": {
                             "code": "{{ preview_language|lower }}",

--- a/cms/templates/admin/cms/page/tree/menu.html
+++ b/cms/templates/admin/cms/page/tree/menu.html
@@ -1,4 +1,4 @@
-{% load i18n cms_admin admin_urls %}
+{% load i18n cms_admin admin_urls l10n %}
 
 {# INFO: columns are defined in base.html options #}
 {% spaceless %}
@@ -17,8 +17,8 @@
     {% endblock %}
     "
     {% if is_popup %}onclick="opener.dismissRelatedLookupPopup(window, {{ page.id }}); return false;"{% endif %}
-    data-id="{{ page.pk }}"
-    data-node-id="{{ node.pk }}"
+    data-id="{{ page.pk|unlocalize }}"
+    data-node-id="{{ node.pk|unlocalize }}"
     data-slug="{{ page.get_slug }}"
     data-is-home="{{ page.is_home|yesno:"true,false" }}"
     data-move-permission="{{ has_move_page_permission|yesno:"true,false" }}"
@@ -198,7 +198,7 @@
                     <div{% if has_add_page_permission %} class="cms-hover-tooltip cms-hover-tooltip-left cms-hover-tooltip-delay"
                         data-cms-tooltip="{% autoescape on %}{% trans 'New sub page' %}{% endautoescape %}"{% endif %}>
                         {% if has_add_page_permission %}
-                            <a href="{% url opts|admin_urlname:'add' %}?parent_node={{ node.pk }}"
+                            <a href="{% url opts|admin_urlname:'add' %}?parent_node={{ node.pk|unlocalize }}"
                                 class="js-cms-pagetree-add-page cms-btn cms-btn-default cms-icon cms-icon-plus">
                         {% else %}
                             <span class="cms-btn cms-btn-default cms-btn-disabled cms-icon cms-icon-plus">
@@ -212,7 +212,7 @@
                     </div>
                 </div>
                 <div class="js-cms-pagetree-actions-dropdown cms-tree-item cms-tree-item-button cms-pagetree-dropdown js-cms-pagetree-dropdown" data-lazy-url="{% url opts|admin_urlname:'actions_menu' page.id %}">
-                    <a data-node-id="{{ node.pk }}" data-id="{{ page.pk }}" href="#" class="js-cms-pagetree-dropdown-trigger js-cms-pagetree-options cms-pagetree-dropdown-trigger cms-btn cms-btn-default cms-btn-no-border cms-icon cms-icon-menu">
+                    <a data-node-id="{{ node.pk|unlocalize }}" data-id="{{ page.pk|unlocalize }}" href="#" class="js-cms-pagetree-dropdown-trigger js-cms-pagetree-options cms-pagetree-dropdown-trigger cms-btn cms-btn-default cms-btn-no-border cms-icon cms-icon-menu">
                         <span class="sr-only">{% autoescape on %}{% trans "Options" %}{% endautoescape %}</span>
                     </a>
 
@@ -234,7 +234,7 @@
                                 </a>
                             </li>
                             <li>
-                                <a href="#" data-node-id="{{ node.pk }}" data-id="{{ page.pk }}" class="cms-pagetree-dropdown-item-disabled">
+                                <a href="#" data-node-id="{{ node.pk|unlocalize }}" data-id="{{ page.pk|unlocalize }}" class="cms-pagetree-dropdown-item-disabled">
                                     <span class="cms-icon cms-icon-alias"></span>
                                     <span>{% autoescape on %}{% trans "Paste" %}{% endautoescape %}</span>
                                 </a>

--- a/cms/templates/admin/cms/page/tree/menu.html
+++ b/cms/templates/admin/cms/page/tree/menu.html
@@ -76,7 +76,7 @@
         <div class="cms-tree-col">
             <div class="cms-tree-item cms-tree-item-preview
                 {# INFO: highlight active icon when in sidebar mode #}
-                {% if page.id|unlocalize|slugify == request.GET.page_id|slugify %} cms-tree-preview-active{% endif %}">
+                {% if page.id|slugify == request.GET.page_id|slugify %} cms-tree-preview-active{% endif %}">
                 <div class="cms-tree-item-inner cms-hover-tooltip cms-hover-tooltip-left cms-hover-tooltip-delay" data-cms-tooltip="{% autoescape on %}{% trans "View on site" %}{% endautoescape %}">
                     <a class="js-cms-pagetree-page-view" href="{% url opts|admin_urlname:'preview_page' page.id lang %}"{% if lang in page_languages %} target="_top"{% endif %}">
                         <span class="sr-only">{% autoescape on %}{% trans "View on site" %}{% endautoescape %}</span>

--- a/cms/templates/admin/cms/page/tree/menu.html
+++ b/cms/templates/admin/cms/page/tree/menu.html
@@ -16,7 +16,7 @@
         {% endif %}
     {% endblock %}
     "
-    {% if is_popup %}onclick="opener.dismissRelatedLookupPopup(window, {{ page.id }}); return false;"{% endif %}
+    {% if is_popup %}onclick="opener.dismissRelatedLookupPopup(window, {{ page.id|unlocalize }}); return false;"{% endif %}
     data-id="{{ page.pk|unlocalize }}"
     data-node-id="{{ node.pk|unlocalize }}"
     data-slug="{{ page.get_slug }}"
@@ -76,7 +76,7 @@
         <div class="cms-tree-col">
             <div class="cms-tree-item cms-tree-item-preview
                 {# INFO: highlight active icon when in sidebar mode #}
-                {% if page.id|slugify == request.GET.page_id|slugify %} cms-tree-preview-active{% endif %}">
+                {% if page.id|unlocalize|slugify == request.GET.page_id|slugify %} cms-tree-preview-active{% endif %}">
                 <div class="cms-tree-item-inner cms-hover-tooltip cms-hover-tooltip-left cms-hover-tooltip-delay" data-cms-tooltip="{% autoescape on %}{% trans "View on site" %}{% endautoescape %}">
                     <a class="js-cms-pagetree-page-view" href="{% url opts|admin_urlname:'preview_page' page.id lang %}"{% if lang in page_languages %} target="_top"{% endif %}">
                         <span class="sr-only">{% autoescape on %}{% trans "View on site" %}{% endautoescape %}</span>
@@ -152,7 +152,7 @@
             <div class="cms-tree-item cms-tree-item-menu{% if not has_change_permission %} cms-tree-item-disabled{% endif %} js-cms-tree-item-menu">
                 <div class="cms-tree-item-inner">
                     {% if has_change_permission %}
-                        <a href="{% url opts|admin_urlname:'change_innavigation' page.id %}?language={{ preview_language }}&amp;{{ page.id }}={{ page.in_navigation|yesno:"1,0" }}">
+                        <a href="{% url opts|admin_urlname:'change_innavigation' page.id %}?language={{ preview_language }}&amp;{{ page.id|unlocalize }}={{ page.in_navigation|yesno:"1,0" }}">
                     {% endif %}
                         {% if page.in_navigation %}
                             <div class="cms-hover-tooltip cms-hover-tooltip-left cms-hover-tooltip-delay"

--- a/cms/templates/cms/toolbar/dragitem.html
+++ b/cms/templates/cms/toolbar/dragitem.html
@@ -47,7 +47,7 @@
             </div>
         {% endif %}
 
-        <span class="cms-dragitem-text" title="{{ plugin.plugin_type }} ID: {{ plugin.pk }}"><strong>{{ plugin.get_plugin_name }}</strong> {{ plugin.get_short_description }}</span>
+        <span class="cms-dragitem-text" title="{{ plugin.plugin_type }} ID: {{ plugin.pk|unlocalize }}"><strong>{{ plugin.get_plugin_name }}</strong> {{ plugin.get_short_description }}</span>
     </div>
 
     <div class="cms-collapsable-container cms-hidden

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -1923,10 +1923,10 @@ class PageTest(PageTestBase):
                                created_by=admin_user, published=True, parent=root,
                                slug="child-page-{}".format(i),)
 
-        last_child = create_page("grand-child-page-{}".format(page.pk),
-                                "nav_playground.html", "fr",
-                               created_by=admin_user, published=True, parent=page,
-                               slug="grand-child-page-{}".format(page.pk),)
+        create_page("grand-child-page-{}".format(page.pk),
+                    "nav_playground.html", "fr",
+                    created_by=admin_user, published=True, parent=page,
+                    slug="grand-child-page-{}".format(page.pk),)
 
         self.assertTrue(page.pk > 1000)
 

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -3,6 +3,7 @@ import json
 import sys
 from unittest import skipUnless
 
+from django.conf import settings
 from django.contrib import admin
 from django.contrib.sites.models import Site
 from django.core.cache import cache
@@ -15,7 +16,6 @@ from django.urls import clear_url_caches
 from django.utils.encoding import force_str
 from django.utils.timezone import now as tz_now
 from django.utils.translation import override as force_language
-from django.conf import settings
 
 from cms import constants
 from cms.admin.pageadmin import PageAdmin


### PR DESCRIPTION
## Description

This fixes #7175 by:

1. unlocalizing page and node ids when rendering admin/cms/page/tree/menu.html
2. sanitizing page and node ids received from `request.GET` in cms/admin/pageadmin.py to make sure only unlocalized integers are passed on to `int`. 

See #7175 for a detailed description of the problem being addressed. 

<strike>NOTE: the new test takes approximately 10 seconds (on my old laptop) because it has to create 1000 pages to trigger the problem. If you see a more convenient way of triggering the problem, please let me know!</strike>

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
