### PR TITLE
feat: Added concurrency option to github workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,10 @@ name: Docs
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -2,6 +2,11 @@ name: django CMS frontend.yml
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+
 jobs:
   frontend:
     runs-on: ubuntu-20.04

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -2,6 +2,11 @@ name: django CMS linters.yml
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+
 jobs:
   flake8:
     name: flake8
@@ -21,7 +26,6 @@ jobs:
           linters: flake8
           run: flake8
 
-
   isort:
     runs-on: ubuntu-latest
     steps:
@@ -38,4 +42,3 @@ jobs:
         with:
           linters: isort
           run: isort --check --diff cms
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: django CMS test.yml
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   database-postgres:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Description

Because we're running our workflows on push to all branches, you can build up a queue of jobs. This option will cancel the in-progress jobs so that newer commits get tested without building a queue.

## Checklist

* [x] I have opened this pull request against ``develop``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
