### PR TITLE
fix: Disable workflow concurrency to bring stability back to the CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,9 +2,9 @@ name: Docs
 
 on: [push, pull_request]
 
-concurrency:
-  group: ${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+#concurrency:
+#  group: ${{ github.head_ref || github.run_id }}
+#  cancel-in-progress: true
 
 jobs:
   docs:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -2,10 +2,9 @@ name: django CMS frontend.yml
 
 on: [push, pull_request]
 
-concurrency:
-  group: ${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
+#concurrency:
+#  group: ${{ github.head_ref || github.run_id }}
+#  cancel-in-progress: true
 
 jobs:
   frontend:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -2,10 +2,9 @@ name: django CMS linters.yml
 
 on: [push, pull_request]
 
-concurrency:
-  group: ${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
+#concurrency:
+#  group: ${{ github.head_ref || github.run_id }}
+#  cancel-in-progress: true
 
 jobs:
   flake8:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: django CMS test.yml
 
 on: [push, pull_request]
 
-concurrency:
-  group: ${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+#concurrency:
+#  group: ${{ github.head_ref || github.run_id }}
+#  cancel-in-progress: true
 
 jobs:
   database-postgres:


### PR DESCRIPTION
## Description

The concurrency settings added to the workflows yesterday is proving unstable/erratic. This disables that functionality until we understand more.

I have raised this with github support.

## Checklist

* [x] I have opened this pull request against ``develop``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
