### PR TITLE
feat: Re-enable showing the toolbar to anonymous users

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,9 @@
 
 === 4.0.0 (unreleased) ===
-
+* feat: Re-enable showing the toolbar to anonymous users
+* Backport django 3.2 support
+* Backport django 3.1 support
+* Backport django 3.0 support
 * Allow Pagecontent.limit_visibility_in_menu to be reset once it has been set
 * Backported from develop: Added support for Github Actions based CI.
 * Backported from develop: Added Support for testing frontend, docs, test and linting in different/parallel CI pipelines.

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -29,6 +29,7 @@ from cms.toolbar.items import (ToolbarAPIMixin, LinkItem, ItemSearchResult,
                                Break, SubMenu, AjaxItem)
 from cms.toolbar.toolbar import CMSToolbar
 from cms.toolbar.utils import get_object_edit_url, get_object_preview_url, get_object_structure_url
+from cms.utils.conf import get_cms_setting
 from cms.utils.i18n import get_language_tuple
 from cms.utils.urlutils import admin_reverse
 from cms.views import details
@@ -551,13 +552,21 @@ class ToolbarTests(ToolbarTestBase):
         response = self.client.post(endpoint, {'username': username, 'password': username})
         self.assertRedirects(response, page.get_absolute_url(), fetch_redirect_response=False)
 
+    @override_settings(CMS_TOOLBAR_ANONYMOUS_ON=True)
+    def test_show_toolbar_login_anonymous(self):
+        page = create_page("toolbar-page", "nav_playground.html", "en")
+        page_url = "%s?%s" % (page.get_absolute_url(), get_cms_setting('TOOLBAR_URL__ENABLE'))
+        response = self.client.get(page_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'cms-toolbar')
+
     @override_settings(CMS_TOOLBAR_ANONYMOUS_ON=False)
     # Test toolbar on
     def test_hide_toolbar_login_anonymous_setting(self):
         page = create_page("toolbar-page", "nav_playground.html", "en")
         response = self.client.get(page.get_absolute_url())
         self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, 'cms-form-login')
+        self.assertNotContains(response, 'cms-toolbar')
 
     def test_admin_logout_staff(self):
         with override_settings(CMS_PERMISSION=True):

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -561,7 +561,6 @@ class ToolbarTests(ToolbarTestBase):
         self.assertContains(response, 'cms-toolbar')
 
     @override_settings(CMS_TOOLBAR_ANONYMOUS_ON=False)
-    # Test toolbar on
     def test_hide_toolbar_login_anonymous_setting(self):
         page = create_page("toolbar-page", "nav_playground.html", "en")
         response = self.client.get(page.get_absolute_url())

--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -200,10 +200,12 @@ class CMSToolbar(BaseToolbar):
     def init_toolbar(self, request, request_path=None):
         self.request = request
         self.is_staff = self.request.user.is_staff
-        self.show_toolbar = self.is_staff
 
+        anonymous_on = get_cms_setting('TOOLBAR_ANONYMOUS_ON')
         enable_toolbar = get_cms_setting('CMS_TOOLBAR_URL__ENABLE')
         disable_toolbar = get_cms_setting('CMS_TOOLBAR_URL__DISABLE')
+
+        self.show_toolbar = self.is_staff or (anonymous_on and request.user.is_anonymous())
 
         if self.show_toolbar:
             edit_mode = (

--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -205,7 +205,7 @@ class CMSToolbar(BaseToolbar):
         enable_toolbar = get_cms_setting('CMS_TOOLBAR_URL__ENABLE')
         disable_toolbar = get_cms_setting('CMS_TOOLBAR_URL__DISABLE')
 
-        self.show_toolbar = self.is_staff or (anonymous_on and request.user.is_anonymous())
+        self.show_toolbar = self.is_staff or (anonymous_on and request.user.is_anonymous)
 
         if self.show_toolbar:
             edit_mode = (

--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -200,12 +200,11 @@ class CMSToolbar(BaseToolbar):
     def init_toolbar(self, request, request_path=None):
         self.request = request
         self.is_staff = self.request.user.is_staff
+        self.show_toolbar = self.is_staff
 
         anonymous_on = get_cms_setting('TOOLBAR_ANONYMOUS_ON')
         enable_toolbar = get_cms_setting('CMS_TOOLBAR_URL__ENABLE')
         disable_toolbar = get_cms_setting('CMS_TOOLBAR_URL__DISABLE')
-
-        self.show_toolbar = self.is_staff
 
         # Handle showing the toolbar for anonymouse users when they supply
         # the enable toolbar parameter

--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -205,7 +205,12 @@ class CMSToolbar(BaseToolbar):
         enable_toolbar = get_cms_setting('CMS_TOOLBAR_URL__ENABLE')
         disable_toolbar = get_cms_setting('CMS_TOOLBAR_URL__DISABLE')
 
-        self.show_toolbar = self.is_staff or (anonymous_on and request.user.is_anonymous)
+        self.show_toolbar = self.is_staff
+
+        # Handle showing the toolbar for anonymouse users when they supply
+        # the enable toolbar parameter
+        if (anonymous_on and request.user.is_anonymous) and enable_toolbar in self.request.GET:
+            self.show_toolbar = True
 
         if self.show_toolbar:
             edit_mode = (


### PR DESCRIPTION
Allowing anonymous users added as part of the following commit which was removed from v4, I suspect as part of a cleanup of the toolbar show / hide logic: https://github.com/django-cms/django-cms/commit/9aa11aebbf3f887fdc292fe31165023c0c247ad1

Provides the ability to enable the toolbar when not logged in. The use case for this is, you’re on a web page, you want to login but the only way currently is to type the login url directly or “/admin”, the side affect is that when you are redirected back when logging in you are redirected to the “/admin” url rather than the page you were on. 

Related documentation: https://hackmd.io/5Sj6X5XhTJOmZgNj8e_KCw?view#Configuration
