### PR TITLE
TASK: Add missing watchFiles task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -192,7 +192,7 @@ const testsIntegration = (done) => {
         logger: gutil.log.bind(gutil),
         waitForMigrations: 5 // seconds
     });
-    done();  
+    done();
 }
 
 const webpackBundle = function(opts) {
@@ -231,3 +231,4 @@ gulp.task('bundle', webpackBundle());
 gulp.task('unitTest', unitTest);
 gulp.task('testsIntegration',testsIntegration);
 gulp.task('tests', gulp.series(unitTest, testsIntegration));
+gulp.task("watchFiles", watchFiles);


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

watchFiles was defined as a function, but has not been added as a gulp task yet. So you couldn't use the gulp watchFiles command before.

## Related resources
![Bildschirmfoto 2022-02-12 um 15 22 24](https://user-images.githubusercontent.com/39345336/153715087-edbebd6d-0ae9-4221-89ec-b32da8fbc389.png)

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

So now you can use the `gulp watchFiles` command. This will track your work, and if something is changed in the js or sass files, it will tell you it. It also shows you if there any errors.