### PR TITLE
Backport: feat: Re-enable showing the toolbar to anonymous users

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,9 @@
 
 === 4.0.0 (unreleased) ===
-
+* feat: Re-enable showing the toolbar to anonymous users
+* Backport django 3.2 support
+* Backport django 3.1 support
+* Backport django 3.0 support
 * Allow Pagecontent.limit_visibility_in_menu to be reset once it has been set
 * Backported from develop: Added support for Github Actions based CI.
 * Backported from develop: Added Support for testing frontend, docs, test and linting in different/parallel CI pipelines.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,9 +1,6 @@
 
 === 4.0.0 (unreleased) ===
-* feat: Re-enable showing the toolbar to anonymous users
-* Backport django 3.2 support
-* Backport django 3.1 support
-* Backport django 3.0 support
+* Backported from develop-4: feat: Re-enable showing the toolbar to anonymous users
 * Allow Pagecontent.limit_visibility_in_menu to be reset once it has been set
 * Backported from develop: Added support for Github Actions based CI.
 * Backported from develop: Added Support for testing frontend, docs, test and linting in different/parallel CI pipelines.

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -31,6 +31,7 @@ from cms.toolbar.items import (ToolbarAPIMixin, LinkItem, ItemSearchResult,
                                Break, SubMenu, AjaxItem)
 from cms.toolbar.toolbar import CMSToolbar
 from cms.toolbar.utils import get_object_edit_url, get_object_preview_url, get_object_structure_url
+from cms.utils.conf import get_cms_setting
 from cms.utils.i18n import get_language_tuple
 from cms.utils.urlutils import admin_reverse
 from cms.views import details
@@ -551,13 +552,20 @@ class ToolbarTests(ToolbarTestBase):
         response = self.client.post(endpoint, {'username': username, 'password': username})
         self.assertRedirects(response, page.get_absolute_url(), fetch_redirect_response=False)
 
+    @override_settings(CMS_TOOLBAR_ANONYMOUS_ON=True)
+    def test_show_toolbar_login_anonymous(self):
+        page = create_page("toolbar-page", "nav_playground.html", "en")
+        page_url = "%s?%s" % (page.get_absolute_url(), get_cms_setting('TOOLBAR_URL__ENABLE'))
+        response = self.client.get(page_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'cms-toolbar')
+
     @override_settings(CMS_TOOLBAR_ANONYMOUS_ON=False)
-    # Test toolbar on
     def test_hide_toolbar_login_anonymous_setting(self):
         page = create_page("toolbar-page", "nav_playground.html", "en")
         response = self.client.get(page.get_absolute_url())
         self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, 'cms-form-login')
+        self.assertNotContains(response, 'cms-toolbar')
 
     def test_admin_logout_staff(self):
         with override_settings(CMS_PERMISSION=True):

--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -202,8 +202,14 @@ class CMSToolbar(BaseToolbar):
         self.is_staff = self.request.user.is_staff
         self.show_toolbar = self.is_staff
 
+        anonymous_on = get_cms_setting('TOOLBAR_ANONYMOUS_ON')
         enable_toolbar = get_cms_setting('CMS_TOOLBAR_URL__ENABLE')
         disable_toolbar = get_cms_setting('CMS_TOOLBAR_URL__DISABLE')
+
+        # Handle showing the toolbar for anonymouse users when they supply
+        # the enable toolbar parameter
+        if (anonymous_on and request.user.is_anonymous) and enable_toolbar in self.request.GET:
+            self.show_toolbar = True
 
         if self.show_toolbar:
             edit_mode = (

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -8,7 +8,7 @@ dj-database-url
 djangocms-admin-style>=1.2
 django-sekizai>=0.7
 django-classy-tags>=0.7.2
-https://github.com/divio/djangocms-text-ckeditor/archive/support/4.0.x.zip
+https://github.com/divio/djangocms-text-ckeditor/archive/support/4.0.0.zip
 https://github.com/ojii/django-better-test/archive/8aa2407d097fe3789b74682f0e6bd7d15d449416.zip#egg=django-better-test
 https://github.com/ojii/django-app-manage/archive/65da18ef234a4e985710c2c0ec760023695b40fe.zip#egg=django-app-manage
 iptools


### PR DESCRIPTION
Backported changes from develop-4 (Cherry pick): https://github.com/django-cms/django-cms/commit/2008ca8a85eaf5f875d37c2fbca6ce03b2c7b2d8