### PR TITLE
fix: page tree display and status alignment

### DIFF
--- a/cms/static/cms/sass/components/pagetree/_node-state.scss
+++ b/cms/static/cms/sass/components/pagetree/_node-state.scss
@@ -8,7 +8,7 @@
     border: 2px solid $white;
     background: $white;
     vertical-align: top;
-
+    margin-top: 8px;
 }
 .cms-btn {
     .cms-pagetree-node-state {

--- a/cms/static/cms/sass/components/pagetree/_tree.scss
+++ b/cms/static/cms/sass/components/pagetree/_tree.scss
@@ -40,6 +40,12 @@
     touch-action: none;
 }
 
+#changelist {
+    display: block;
+    align-items: flex-start;
+    justify-content: space-between;
+}
+
 //###########################################################
 // CONTAINER
 // general container around the jstree or elements
@@ -94,7 +100,6 @@
 // handles top header area styles
 .cms-pagetree-header {
     position: relative;
-    display: table;
     display: flex;
     width: 100%;
     box-sizing: border-box;


### PR DESCRIPTION
## Description

Django's styles add flex to the `changelist` element which causes the page tree to flex on large screens (greater than about 700px)


## Related resources

With the django styles alone;

![Screenshot 2022-03-09 at 16 23 43](https://user-images.githubusercontent.com/1461191/157489070-84e368c9-a863-413a-8e70-234cbaa4c9d5.png)

Following this fix;

![Screenshot 2022-03-09 at 16 42 43](https://user-images.githubusercontent.com/1461191/157489188-eb25d99c-f261-4a51-b706-ab98dbe78fb8.png)

I've also added a margin to improve the alignment of the language status button/icon.

## Checklist

* [x] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
