### PR TITLE
Make Plugin Confirm Template configurable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ unreleased
 
 * Added dark mode support to css
 * Fix publishing of static placeholders outside of CMS pages
+* Allow to override the template rendered after a plugin has been saved.
 
 3.9.0 (2021-06-30)
 ==================
@@ -55,7 +56,7 @@ Bug Fixes:
 * Fix styles issues, caused by switching to the ``display: flex`` on the page tree renderer.
 * Fixed missing builtin arguments on main ``cms`` management command causing it to crash
 * Fixed template label nested translation
-* Fixed a bug where the fallback page title whould be returned instead of the one from the current language
+* Fixed a bug where the fallback page title would be returned instead of the one from the current language
 * Fixed an issue when running migrations on a multi database project
 * Fixes #7033: also check for Django 3.2, now that 3.9 supports it. (#7054) (02083f2dc) -- Marco Bonetti
 

--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -98,7 +98,8 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
     module = _("Generic")  # To be overridden in child classes
 
     form = None
-    change_form_template = "admin/cms/page/plugin/change_form.html"
+    change_form_template = 'admin/cms/page/plugin/change_form.html'
+    plugin_confirm_template = 'admin/cms/page/plugin/confirm_form.html'
     # Should the plugin be rendered in the admin?
     admin_preview = False
 
@@ -295,7 +296,7 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
         if extra_context:
             context.update(extra_context)
         return render_to_response(
-            request, 'admin/cms/page/plugin/confirm_form.html', context
+            request, self.plugin_confirm_template, context
         )
 
     def save_model(self, request, obj, form, change):


### PR DESCRIPTION
## Description

This small fix allows to override the template rendered after a plugin has been saved.

## Related resources

None

## Checklist

* [x] I have opened this pull request against ``develop``
* [ ] I have added or modified the tests when changing logic [^1]
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

[^1]: No additional tests required, because nothing changed.