### PR TITLE
fix(security): Hide sensible information (#7270)

### DIFF
--- a/cms/templates/cms/toolbar/toolbar_javascript.html
+++ b/cms/templates/cms/toolbar/toolbar_javascript.html
@@ -24,7 +24,7 @@ CMS.config = {
         'toolbar': '{% language cms_toolbar.request_language %}{% cms_admin_url "cms_usersettings_get_toolbar" %}{% endlanguage %}'
     },
     'lang': {
-        {% if user.is_authenticated %}
+        {% if debug and user.is_authenticated %}
         'debug': '{% filter escapejs %}{% blocktrans %}Development version using django CMS {{ cms_version }}, Django {{ django_version }}, Python {{ python_version }}{% endblocktrans %}{% endfilter %}',
         {% endif %}
         'cancel': '{% filter escapejs %}{% trans "Cancel" %}{% endfilter %}',

--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -469,6 +469,8 @@ class CMSToolbar(BaseToolbar):
 
         with force_language(self.toolbar_language):
             # needed to populate the context with sekizai content
+            if 'debug' not in context:
+                context['debug'] = settings.DEBUG
             render_to_string('cms/toolbar/toolbar_javascript.html', flatten_context(context))
 
         # render everything below the tag


### PR DESCRIPTION
## Description

Hide sensible information about python/django/django cms versions which project uses.

Closes #7270 

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7270

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [X] I have opened this pull request against ``develop``
* [X] I have added or modified the tests when changing logic
* [X] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [X] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
