### PR TITLE
Fixes #7288 by also catching AttributeError, when the current toolbar…

### DIFF
--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -326,7 +326,7 @@ class CMSToolbar(BaseToolbar):
             with force_language(self.request_language):
                 try:
                     return self.obj.get_draft_url()
-                except NoReverseMatch:
+                except (NoReverseMatch, AttributeError):
                     try:
                         return self.obj.get_absolute_url()
                     except NoReverseMatch:

--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -329,7 +329,7 @@ class CMSToolbar(BaseToolbar):
                 except (NoReverseMatch, AttributeError):
                     try:
                         return self.obj.get_absolute_url()
-                    except NoReverseMatch:
+                    except (NoReverseMatch, AttributeError):
                         pass
         return ''
 


### PR DESCRIPTION
… object doesn't define get_draft_url()

Fixes https://github.com/django-cms/django-cms/issues/7288

## Description

See description in #7288: `get_object_draft_url` assumes that the current toolbar object has a `get_draft_url()` method, and only catches `NoReverseMatch` but fails to handle  `AttributeError` as well, when no such method is defined.


## Related resources

Discussion on Slack: https://django-cmsworkspace.slack.com/archives/C01EBCEK49E/p1648718708538749

## Checklist

* [ ] I have opened this pull request against ``develop`` (Opened against release/3.10.x as requested)
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
