### PR TITLE
feat: add cache ttl extension point

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ unreleased
 * Revert change to the toolbar sites menu to use ``http`` protocol.
 * Fix edit plugin popup width (remove 850px width constraint).
 * Fix except block using list instead of tuple. (#7334)
+* Added cache ttl extension point.
 
 3.10.0 (2022-03-26)
 ===================

--- a/docs/how_to/caching.rst
+++ b/docs/how_to/caching.rst
@@ -54,6 +54,7 @@ Have a look at the following settings to enable/disable various caching behaviou
 - :setting:`CMS_PAGE_CACHE`
 - :setting:`CMS_PLACEHOLDER_CACHE`
 - :setting:`CMS_PLUGIN_CACHE`
+- :setting:`CMS_LIMIT_TTL_CACHE_FUNCTION`
 
 
 

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -1006,6 +1006,18 @@ Default value of the ``cache`` attribute of plugins. Should plugins be cached by
     If you disable the plugin cache be sure to restart the server and clear the cache afterwards.
 
 
+..  setting:: CMS_LIMIT_TTL_CACHE_FUNCTION
+
+CMS_LIMIT_TTL_CACHE_FUNCTION
+============================
+
+default
+    ``None``
+
+If defined, specifies the function to be called that allows to limit the page cache ttl value 
+using a business logic. The function receives one argument, the `response`, and returns an `int`
+the max business value of the page cache ttl.
+
 ..  setting:: CMS_MAX_PAGE_PUBLISH_REVERSIONS
 
 


### PR DESCRIPTION
## Description

Adds the setting `CMS_CACHE_LIMIT_TTL_MODULE` that should have the
`limit_page_cache_ttl` function that would be called to limit the cache
ttl of a page using business logic.
Closes #7296

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--

Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* the issue #7296
* previous PR #7297

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

It will need a test so the interface of the extension point is preserved for the future.
If merged, this new feature would need to go to the docs.
The idea of this PR is to complement the issue.