### PR TITLE
Fix ``get_object`` call which was missing request

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@
 * Backported from develop: Added support for Github Actions based CI.
 * Backported from develop: Added Support for testing frontend, docs, test and linting in different/parallel CI pipelines.
 * Backported from develop: Remove travis integration from the project as the project has moved to Github Actions.
+* Fixed usage of ``get_object`` in ``edit_title_fields`` of the page admin.
 
 
 === 3.6.0 (unreleased) ===

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -714,7 +714,7 @@ class PageAdmin(admin.ModelAdmin):
         return HttpResponse(json.dumps({"id": new_page.pk}), content_type='application/json')
 
     def edit_title_fields(self, request, page_id, language):
-        page = self.get_object(request, page_id)
+        page = self.get_object(request, object_id=page_id)
         translation = page.get_title_obj(language, fallback=False)
 
         if not self.has_change_permission(request, obj=page):

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -705,16 +705,16 @@ class PageAdmin(admin.ModelAdmin):
         page_languages = page.get_languages()
         site_languages = get_language_list(site_id=site.pk)
 
-        if not any(lang in  page_languages for lang in site_languages):
+        if not any(lang in page_languages for lang in site_languages):
             message = force_str(_("Error! The page you're pasting is not "
-                                   "translated in any of the languages configured by the target site."))
+                                  "translated in any of the languages configured by the target site."))
             return jsonify_request(HttpResponseBadRequest(message))
 
         new_page = form.copy_page()
         return HttpResponse(json.dumps({"id": new_page.pk}), content_type='application/json')
 
     def edit_title_fields(self, request, page_id, language):
-        page = self.get_object(page_id)
+        page = self.get_object(request, page_id)
         translation = page.get_title_obj(language, fallback=False)
 
         if not self.has_change_permission(request, obj=page):


### PR DESCRIPTION
## Description

In `get_content_obj` the first call is to `get_object` is missing an argument.

```
    def edit_title_fields(self, request, page_id, language):
        page = self.get_object(page_id)
```

But `get_object` takes the request as the first argument and then the object ID as the second.

## Related resources

* Django source; https://github.com/django/django/blame/main/django/contrib/admin/options.py#L851

## Checklist

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
