### PR TITLE
ci: Pin jinja2 due to import error from sphinx

### DIFF
--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -15,6 +15,7 @@ pyenchant==3.0.1
 pyflakes>=2.1
 python-coveralls>2.5.0
 sphinx==1.8.5
+jinja2==3.0.3  # next release incompatible with pinned sphinx version
 sphinxcontrib-spelling<7.0.0  # restriction for py35 tests
 unittest-xml-reporting==1.11.0
 


### PR DESCRIPTION
## Description

The sphinx version in use with tests must have an unrestricted dependency on jinja2 and it's moved some bits around causing an import error.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* [Related error](https://github.com/django-cms/django-cms/runs/5688759623?check_suite_focus=true)

```
======================================================================
ERROR: test_html (cms.tests.test_docs.DocsTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/sphinx/registry.py", line 472, in load_extension
    mod = __import__(extname, None, None, ['setup'])
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/sphinx/builders/latex/__init__.py", line 37, in <module>
    from sphinx.writers.latex import DEFAULT_SETTINGS, LaTeXWriter, LaTeXTranslator
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/sphinx/writers/latex.py", line 33, in <module>
    from sphinx.util.template import LaTeXRenderer
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/sphinx/util/template.py", line 17, in <module>
    from sphinx.jinja2glue import SphinxFileSystemLoader
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/sphinx/jinja2glue.py", line 16, in <module>
    from jinja2 import FileSystemLoader, BaseLoader, TemplateNotFound, \
ImportError: cannot import name 'contextfunction' from 'jinja2' (/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/jinja2/__init__.py)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/runner/work/django-cms/django-cms/cms/tests/test_docs.py", line [63](https://github.com/django-cms/django-cms/runs/5688759623?check_suite_focus=true#step:6:63), in test_html
    status=status,
  File "/opt/hostedtoolcache/Python/3.7.12/x[64](https://github.com/django-cms/django-cms/runs/5688759623?check_suite_focus=true#step:6:64)/lib/python3.7/site-packages/sphinx/application.py", line 224, in __init__
    self.setup_extension(extension)
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/sphinx/application.py", line 449, in setup_extension
    self.registry.load_extension(self, extname)
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/sphinx/registry.py", line 4[75](https://github.com/django-cms/django-cms/runs/5688759623?check_suite_focus=true#step:6:75), in load_extension
    raise ExtensionError(__('Could not import extension %s') % extname, err)
sphinx.errors.ExtensionError: Could not import extension sphinx.builders.latex (exception: cannot import name 'contextfunction' from 'jinja2' (/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/jinja2/__init__.py))
```

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
