### PR TITLE
fix: ci jinja2 version 3.1.0 failures

### DIFF
--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -9,6 +9,7 @@ django-treebeard>=4.3
 djangocms-admin-style>=1.5
 docutils<0.18  # Fix for: https://github.yuuza.net/sphinx-doc/sphinx/issues/9727
 iptools
+jinja2<3.1.0  # 3.1.0 removes contextfunction breaking the html generation tests
 mock>=2.0.0
 Pillow==5.2.0
 pyenchant==3.0.1


### PR DESCRIPTION
Fix for CI error: 

  File "/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/sphinx/jinja2glue.py", line 16, in <module>
    from jinja2 import FileSystemLoader, BaseLoader, TemplateNotFound, \
ImportError: cannot import name 'contextfunction' from 'jinja2' (/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/jinja2/__init__.py)