### PR TITLE
fix: switch git clone to https to prevent "Permission denied (publickey)" error

### DIFF
--- a/docs/introduction/01-install.rst
+++ b/docs/introduction/01-install.rst
@@ -45,7 +45,7 @@ Open the terminal application on your computer and go to a safe folder (i.e. cd 
 
 ::
 
-      git clone git@github.com:django-cms/django-cms-quickstart.git
+      git clone https://github.com/django-cms/django-cms-quickstart.git
       cd django-cms-quickstart
       docker compose build web
       docker compose up -d database_default


### PR DESCRIPTION
Using `https://github.com/django-cms/django-cms-quickstart.git` instead of `git@github.com:django-cms/django-cms-quickstart.git` fixes the issue with running the `git clone` command resulting in the error:
>git@github.com: Permission denied (publickey).
>fatal: Could not read from remote repository.
>
>Please make sure you have the correct access rights
>and the repository exists.

## Description

I think just switching the instructions to `git clone` via HTTPS would be simpler than adding instructions for setting up an SSH key to get the original command working, but I don't want to step on any toes if established contributors think otherwise.

**The front page of https://www.django-cms.org (in the "Getting Started" card) will also need to be updated along similar lines**. I don't know where that code lives.

## Related resources

https://github.com/django-cms/django-cms/issues/7305 seems to be about the same issue.


## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [X] I have opened this pull request against ``develop``
* [X] I have added or modified the tests when changing logic (**N/A**)
* [X] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [X] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
