### PR TITLE
fix: default light mode

### DIFF
--- a/cms/static/cms/sass/settings/_cms.scss
+++ b/cms/static/cms/sass/settings/_cms.scss
@@ -30,7 +30,7 @@ $black: var(--dca-black);
     color-scheme: dark light;
 }
 
-root[data-color-scheme="light"] {
+:root[data-color-scheme="light"] {
     color-scheme: light;
 }
 


### PR DESCRIPTION
## Description

When you access the page with edit mode ON, with default settings `CMS_COLOR_SCHEME = "light"`
There is default color scheme dark and not light.

## Checklist

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
