### PR TITLE
fix: Fixes #7386: consider any version of Django >= 3.0 when checking weth…

### DIFF
--- a/cms/management/commands/subcommands/base.py
+++ b/cms/management/commands/subcommands/base.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from django.core.management.base import BaseCommand, CommandParser
 from django.core.management.color import color_style, no_style
 
-from cms.utils.compat import DJANGO_3_0, DJANGO_3_1, DJANGO_3_2
+from cms.utils.compat import DJANGO_VERSION
 
 
 def add_builtin_arguments(parser):
@@ -36,7 +36,7 @@ def add_builtin_arguments(parser):
         help="Don't colorize the command output.")
     parser.add_argument('--force-color', action='store_true', dest='force_color', default=False,
         help="Colorize the command output.")
-    if DJANGO_3_0 or DJANGO_3_1 or DJANGO_3_2:
+    if DJANGO_VERSION > '3.0':
         parser.add_argument('--skip-checks', action='store_true', dest='skip_checks', default=False,
             help="Skip the checks.")
 

--- a/cms/management/commands/subcommands/base.py
+++ b/cms/management/commands/subcommands/base.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from django.core.management.base import BaseCommand, CommandParser
 from django.core.management.color import color_style, no_style
 
-from cms.utils.compat import DJANGO_VERSION
+from cms.utils.compat import DJANGO_2_2
 
 
 def add_builtin_arguments(parser):
@@ -36,7 +36,7 @@ def add_builtin_arguments(parser):
         help="Don't colorize the command output.")
     parser.add_argument('--force-color', action='store_true', dest='force_color', default=False,
         help="Colorize the command output.")
-    if DJANGO_VERSION > '3.0':
+    if not DJANGO_2_2:
         parser.add_argument('--skip-checks', action='store_true', dest='skip_checks', default=False,
             help="Skip the checks.")
 


### PR DESCRIPTION
…er the BaseCommand requires a `skip-checks` argument.



## Description

`skip_checks` seems to be required in management commands for *any* version of Django >= 3.0. The previous implementation kept adding new `DJANGO_X_Y` variables in the test, but with each new supported Django version, this command was forgotten and broke. See also #7033

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
