### PR TITLE
fix: Changing color scheme resets session settings to defaults

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ unreleased
 
 * Make javascript dark mode functions available to popups as CMS.API.getColorScheme
   and CMS.API.setColorScheme
+* Fix bug where switching color scheme affects other settings
 
 3.11.0 (2022-08-02)
 ===================

--- a/cms/static/cms/js/modules/cms.base.js
+++ b/cms/static/cms/js/modules/cms.base.js
@@ -510,8 +510,12 @@ export const Helpers = {
     setColorScheme: function (scheme) {
         let body = $('html');
 
+        if (!CMS.settings) {
+            // Settings loaded? If not, pls. load.
+            this.getSettings();
+        }
         CMS.settings.color_scheme = scheme;
-        this.setSettings(CMS.settings.color_scheme);
+        this.setSettings(CMS.settings);
         if (scheme === 'auto') {
             body.removeAttr('data-color-scheme');
             body.find('div.cms iframe').each(function(i, e) {

--- a/cms/static/cms/js/modules/cms.base.js
+++ b/cms/static/cms/js/modules/cms.base.js
@@ -510,7 +510,8 @@ export const Helpers = {
     setColorScheme: function (scheme) {
         let body = $('html');
 
-        this.setSettings({ color_scheme: scheme });
+        CMS.settings.color_scheme = scheme;
+        this.setSettings(CMS.settings.color_scheme);
         if (scheme === 'auto') {
             body.removeAttr('data-color-scheme');
             body.find('div.cms iframe').each(function(i, e) {


### PR DESCRIPTION
## Description

When changing the color scheme using the toolbar button all setting values are restored to their default values losing all individually changed settings including the reference to the copied page. 

After changing the color scheme 
* pages copied before cannot be pasted any more.
* reload forgets about an open side frame

Tis fix uses the right way to set a setting:

        CMS.settings.color_scheme = scheme;
        CMS.API.Helpers.setSettings(CMS.settings);

instead of 

        CMS.API.Helpers.setSettings({color_scheme: scheme});
       
## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* Many thanks to @jrief who pointed out the issue!
* Potential extension of this PR is the introduction of `this.updateSettings({color_scheme: color})` to avoid similar issues in the future.

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
