### PR TITLE
fix: Added deprecation warning to `get_current_language()`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ unreleased
 * Fix bug where switching color scheme affects other settings
 * Unlocalize page and node ids when rendering the page tree in the admin (#7175)
 * Fixed permission denied error after page create (#6866)
+* Add deprecation warning to ``cms.utils.i18n.get_current_language()`` (#6720)
 
 3.11.0 (2022-08-02)
 ===================

--- a/cms/utils/i18n.py
+++ b/cms/utils/i18n.py
@@ -80,7 +80,8 @@ def get_current_language():
     """
     warnings.warn(
         "get_current_language() is deprecated; use django.utils.translation.get_language().",
-        DeprecationWarning
+        DeprecationWarning,
+        stacklevel=2
     )
     language_code = translation.get_language()
     return get_language_code(language_code)

--- a/cms/utils/i18n.py
+++ b/cms/utils/i18n.py
@@ -80,7 +80,7 @@ def get_current_language():
     """
     warnings.warn(
         "get_current_language() is deprecated; use django.utils.translation.get_language().",
-        warnings.DeprecationWarning
+        DeprecationWarning
     )
     language_code = translation.get_language()
     return get_language_code(language_code)

--- a/cms/utils/i18n.py
+++ b/cms/utils/i18n.py
@@ -1,3 +1,4 @@
+import warnings
 from contextlib import contextmanager
 
 from django.conf import settings
@@ -59,13 +60,13 @@ def get_language_code(language_code, site_id=None):
 
     languages = get_language_list(site_id)
 
-    if language_code in languages: # direct hit
+    if language_code in languages:  # direct hit
         return language_code
 
     for lang in languages:
-        if language_code.split('-')[0] == lang: # base language hit
+        if language_code.split('-')[0] == lang:  # base language hit
             return lang
-        if lang.split('-')[0] == language_code: # base language hit
+        if lang.split('-')[0] == language_code:  # base language hit
             return lang
     return language_code
 
@@ -77,6 +78,10 @@ def get_current_language():
     It's a replacement for Django's translation.get_language() to make sure the LANGUAGE_CODE will be found in LANGUAGES.
     Overcomes this issue: https://code.djangoproject.com/ticket/9340
     """
+    warnings.warn(
+        "get_current_language() is deprecated; use django.utils.translation.get_language().",
+        warnings.DeprecationWarning
+    )
     language_code = translation.get_language()
     return get_language_code(language_code)
 


### PR DESCRIPTION
## Description

This adds a deprecation warning to `get_current_language()` to address #6720.

After this I'll update all internal use of this function to use `translation.get_language()` from django itself (at least I think this is the correct course of action).

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #6720

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
