### PR TITLE
perf: Don't count users when CMS_RAW_ID_USERS=True

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ unreleased
 * Fix bug where switching color scheme affects other settings
 * Unlocalize page and node ids when rendering the page tree in the admin (#7175)
 * Fixed permission denied error after page create (#6866)
+* Improved performance when using CMS_RAW_ID_USERS=True on a Postgres DB with many users
 
 3.11.0 (2022-08-02)
 ===================

--- a/cms/admin/permissionadmin.py
+++ b/cms/admin/permissionadmin.py
@@ -39,8 +39,8 @@ def users_exceed_threshold():
     threshold = get_cms_setting('RAW_ID_USERS')
 
     # Don't bother counting the users when not using an integer threshold
-    if not isinstance(threshold, int):
-        return bool(threshold)
+    if threshold is True or threshold is False or not isinstance(threshold, int):
+        return (threshold)
 
     # Given a fresh django-cms install and a django settings with the
     # CMS_RAW_ID_USERS = CMS_PERMISSION = True

--- a/cms/admin/permissionadmin.py
+++ b/cms/admin/permissionadmin.py
@@ -32,15 +32,15 @@ class TabularInline(admin.TabularInline):
 
 def users_exceed_threshold():
     """
-    Check if the number of users exceed the configured threshold. Only bother
+    Check if the number of users exceeds the configured threshold. Only bother
     counting the users when using an integer threshold, otherwise return the
-    value of the setting to avoid a potentially expensive DB query.
+    truthy value of the setting to avoid a potentially expensive DB query.
     """
     threshold = get_cms_setting('RAW_ID_USERS')
 
     # Don't bother counting the users when not using an integer threshold
-    if threshold is True or threshold is False:
-        return threshold
+    if not isinstance(threshold, int):
+        return bool(threshold)
 
     # Given a fresh django-cms install and a django settings with the
     # CMS_RAW_ID_USERS = CMS_PERMISSION = True
@@ -97,8 +97,8 @@ class PagePermissionInlineAdmin(TabularInline):
     def get_formset(self, request, obj=None, **kwargs):
         """
         Some fields may be excluded here. User can change only
-        permissions which are available for him. E.g. if user does not haves
-        can_publish flag, he can't change assign can_publish permissions.
+        permissions which are available for them. E.g. if user does not have
+        can_publish flag, they can't change assign can_publish permissions.
         """
         exclude = self.exclude or []
         if obj:

--- a/cms/tests/test_admin.py
+++ b/cms/tests/test_admin.py
@@ -16,9 +16,7 @@ from djangocms_text_ckeditor.models import Text
 
 from cms import api
 from cms.admin.pageadmin import PageAdmin
-from cms.admin.permissionadmin import (
-    GlobalPagePermissionAdmin, PagePermissionInlineAdmin,
-)
+from cms.admin.permissionadmin import GlobalPagePermissionAdmin, PagePermissionInlineAdmin
 from cms.api import add_plugin, create_page, create_title, publish_page
 from cms.constants import TEMPLATE_INHERITANCE_MAGIC
 from cms.models import StaticPlaceholder

--- a/cms/tests/test_admin.py
+++ b/cms/tests/test_admin.py
@@ -16,6 +16,9 @@ from djangocms_text_ckeditor.models import Text
 
 from cms import api
 from cms.admin.pageadmin import PageAdmin
+from cms.admin.permissionadmin import (
+    GlobalPagePermissionAdmin, PagePermissionInlineAdmin,
+)
 from cms.api import add_plugin, create_page, create_title, publish_page
 from cms.constants import TEMPLATE_INHERITANCE_MAGIC
 from cms.models import StaticPlaceholder
@@ -1389,3 +1392,54 @@ class AdminPageTreeTests(AdminTestsBase):
         #       ⊢ Beta
         #   ⊢ Delta
         #       ⊢ Gamma
+
+
+class AdminPerformanceTests(AdminTestsBase):
+
+    def test_raw_id_threshold_page_permission_inline_admin(self):
+        """
+        Only count users when using an integer value as threshold for
+        CMS_RAW_ID_USERS.
+        """
+        with self.settings(CMS_RAW_ID_USERS=1):
+            with self.assertNumQueries(1):
+                self.assertEqual(PagePermissionInlineAdmin.raw_id_fields, [])
+
+        # Create users to check if threshold is honored
+        self._get_guys()
+
+        with self.settings(CMS_RAW_ID_USERS=False):
+            with self.assertNumQueries(0):
+                self.assertEqual(PagePermissionInlineAdmin.raw_id_fields, [])
+
+        with self.settings(CMS_RAW_ID_USERS=True):
+            with self.assertNumQueries(0):
+                self.assertEqual(PagePermissionInlineAdmin.raw_id_fields, ['user'])
+
+        with self.settings(CMS_RAW_ID_USERS=1):
+            with self.assertNumQueries(1):
+                self.assertEqual(PagePermissionInlineAdmin.raw_id_fields, ['user'])
+
+    def test_raw_id_threshold_global_page_permission_admin(self):
+        """
+        Only count users when using an integer value as threshold for
+        CMS_RAW_ID_USERS.
+        """
+        with self.settings(CMS_RAW_ID_USERS=1):
+            with self.assertNumQueries(1):
+                self.assertEqual(GlobalPagePermissionAdmin.raw_id_fields, [])
+
+        # Create users to check if threshold is honored
+        self._get_guys()
+
+        with self.settings(CMS_RAW_ID_USERS=False):
+            with self.assertNumQueries(0):
+                self.assertEqual(GlobalPagePermissionAdmin.raw_id_fields, [])
+
+        with self.settings(CMS_RAW_ID_USERS=True):
+            with self.assertNumQueries(0):
+                self.assertEqual(GlobalPagePermissionAdmin.raw_id_fields, ['user'])
+
+        with self.settings(CMS_RAW_ID_USERS=1):
+            with self.assertNumQueries(1):
+                self.assertEqual(GlobalPagePermissionAdmin.raw_id_fields, ['user'])

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -851,11 +851,16 @@ This setting only applies if :setting:`CMS_PERMISSION` is ``True``
 
 The ``view restrictions`` and ``page permissions`` inlines on the
 :class:`cms.models.Page` admin change forms can cause performance problems
-where there are many thousands of users being put into simple select boxes. If
-set to a positive integer, this setting forces the inlines on that page to use
+where there are many thousands of users being put into simple select boxes.
+
+If set to a positive integer, this setting forces the inlines on that page to use
 standard Django admin raw ID widgets rather than select boxes if the number of
 users in the system is greater than that number, dramatically improving
 performance.
+
+If set to ``True`` it forces the inlines on Page admin to use raw ID widgets
+without even counting the number of users, giving an additional performance
+improvement.
 
 .. note:: Using raw ID fields in combination with ``limit_choices_to`` causes
           errors due to excessively long URLs if you have many thousands of
@@ -1015,7 +1020,7 @@ CMS_LIMIT_TTL_CACHE_FUNCTION
 default
     ``None``
 
-If defined, specifies the function to be called that allows to limit the page cache ttl value 
+If defined, specifies the function to be called that allows to limit the page cache ttl value
 using a business logic. The function receives one argument, the `response`, and returns an `int`
 the max business value of the page cache ttl.
 


### PR DESCRIPTION
## Description

**This replaces PR #6945 by @Pankrat a while ago. It was created by cherry picking his changes and adding a type check to satisfy the reviewer's comments. Additionally, it clarifies the new `CMS_RAW_ID_USERS=True` setting in the docs.**

When using `CMS_RAW_ID_USERS=True` on a Postgres database with many users, counting the users is slow and will always yield the same result.

Only count users when using an integer value as a threshold and reuse the same logic for both `PagePermissionInlineAdmin` and `GlobalPagePermissionAdmin`.

### Background

When looking into performance issues for one of our websites, we found that Django CMS would regularly count all users in our Postgres database. Unfortunately, `SELECT COUNT(*) FROM huge_table` is slow in Postgres and easily takes 500ms or more if you have more than a million records in your table (exact numbers depend on the DB host of course).

I first looked into [improving the speed of the count query](https://www.cybertec-postgresql.com/en/postgresql-count-made-fast/), but this is not easy to achieve in a way that is compatible with different DB backends.

The easiest option was to not run this query at all when using the documented and widely used (AFAICT) `CMS_RAW_ID_USERS = True`.

The change should be backward compatible with the following exceptions:

* `CMS_RAW_ID_USERS = True` will use raw IDs, even if you have just one or zero users in the DB (since `2 > True` but not `1 >  True` in Python). Since the current behavior could be considered a (rather academic) bug, I don't think this is a deal-breaker.
* `CMS_RAW_ID_USERS = 0` will trigger a count and use raw IDs when there's one user or more. If that's a problem, I could check if `threshold` is "truthy" like in the original implementation.

## Checklist

* [x] I have opened this pull request against ``develop``
* [x] I have updated the **CHANGELOG.rst**
* [x] I have added or modified the tests when changing logic