### PR TITLE
feat: Allow for Django 4.1 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,13 @@ from setuptools import find_packages, setup
 
 
 REQUIREMENTS = [
-    'Django>=2.2, <4.1',
+    'Django>=2.2, <4.2',
     'django-classy-tags>=0.7.2',
     'django-formtools>=2.1',
     'django-treebeard>=4.3',
     'django-sekizai>=0.7',
     'djangocms-admin-style>=1.2',
+    'packaging',
 ]
 
 


### PR DESCRIPTION
## Description

PR #7418 introduced support for Django 4.1 but setup.py did not allow for Django 4.1. This mini-PR fixes this.

"packaging" is named as a dependency which replaces the diskutil's deprecated `LooseVersion`

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7418
* [Deprecation of distutils](https://peps.python.org/pep-0632/)

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
