### PR TITLE
docs: removed reference to language tabs

### DIFF
--- a/docs/how_to/placeholders.rst
+++ b/docs/how_to/placeholders.rst
@@ -97,7 +97,7 @@ I18N Placeholders
 =================
 
 Out of the box :class:`~cms.admin.placeholderadmin.PlaceholderAdminMixin` supports multiple
-languages and will display language tabs. If you extend your model admin class derived from
+languages. If you extend your model admin class derived from
 ``PlaceholderAdminMixin`` and overwrite ``change_form_template`` have a look at
 ``admin/placeholders/placeholder/change_form.html`` to see how to display the language tabs.
 


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->
Removed references to language tabs from `PlaceholderAdminMixin` documentation.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* [Outdated PlaceholderAdminMixin docs](https://github.com/django-cms/django-cms/issues/6519)


## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
