### PR TITLE
fix: Build docs always from the current local version (#7472)

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -41,7 +41,8 @@ html:
 install:
 	@echo "... setting up virtualenv"
 	python3 -m venv env
-	. $(VENV); pip install -r requirements.txt
+	 sed "s/^django-cms=.*$//\./g" requirements.txt > requirements.local.txt
+	. $(VENV); ( cd .. ; pip install -r docs/requirements.local.txt )
 
 	@echo "\n" \
 	      "-------------------------------------------------------------------------------------------------- \n" \

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -40,7 +40,7 @@ django-classy-tags==3.0.1
     # via
     #   django-cms
     #   django-sekizai
-django-cms==3.11.0
+.
     # via -r requirements.in
 django-formtools==2.3
     # via django-cms

--- a/scripts/make-release
+++ b/scripts/make-release
@@ -223,6 +223,11 @@ git commit cms/static -m "${COMMIT_PREFIX}compiling new static files"
 
 
 status "- preparing documentation"
+# Adjust docs/requirements.txt so that it refers to the local version of django CMS
+# (and not to a pypi version)
+sed -i 's/^django-cms=.*$/\./g' docs/requirements.txt
+git add docs/requirements.txt
+
 "${SCRIPTS}/make-changelog" "${FULL_VERSION}"
 
 upgrade_doc="docs/upgrade/${VERSION}.rst"


### PR DESCRIPTION
Cherry-pick changes to develop.

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
