### PR TITLE
add: Utility function get_placeholder_from_slot for PlaceholderRelationField

### DIFF
--- a/cms/forms/fields.py
+++ b/cms/forms/fields.py
@@ -28,7 +28,7 @@ class LazyChoiceField(forms.ChoiceField):
 class PageSelectFormField(forms.MultiValueField):
     """
     Behaves like a :class:`django.forms.ModelChoiceField` field for the
-    :class:`cms.models.Page` model, but displays itself as a split
+    :class:`cms.models.pagemodel.Page` model, but displays itself as a split
     field with a select drop-down for the site and one for the page. It also
     indents the page names based on what level they're on, so that the page
     select drop-down is easier to use. This takes the same arguments as

--- a/cms/forms/widgets.py
+++ b/cms/forms/widgets.py
@@ -13,7 +13,7 @@ from cms.utils.urlutils import admin_reverse, static_with_version
 
 class PageSelectWidget(MultiWidget):
     """A widget that allows selecting a page by first selecting a site and then
-    a page on that site in a two step process.
+    a page on that site in a two-step process.
     """
     template_name = 'cms/widgets/pageselectwidget.html'
 
@@ -96,6 +96,7 @@ class PageSelectWidget(MultiWidget):
 
 
 class PageSmartLinkWidget(TextInput):
+    """Presents the user with a Select2 widget to select a page and returns the link to this page as a string."""
     template_name = 'cms/widgets/pagesmartlinkwidget.html'
 
     class Media:

--- a/cms/models/fields.py
+++ b/cms/models/fields.py
@@ -120,7 +120,7 @@ class PlaceholderRelationField(GenericRelation):
 
     If you create a model which contains placeholders you first create the ``PlaceHolderRelationField``::
 
-        from cms.models.fields import get_placeholder_from_slot
+        from cms.utils.placeholder import get_placeholder_from_slot
 
         class Post(models.Model):
             ...
@@ -152,22 +152,3 @@ class PlaceholderRelationField(GenericRelation):
 
     def run_checks(self, placeholder, user):
         return all(check_(placeholder, user) for check_ in self.checks)
-
-
-def get_placeholder_from_slot(placeholder_relation: models.Manager, slot: str, template_obj=None) -> Placeholder:
-    """Retrieves the placeholder instance for a PlaceholderRelationField either by scaning the template
-    of the template_obj (if given) or by creating or getting a Placeholder in the database"""
-    if hasattr(template_obj, "get_template"):
-        # Tries to get a placeholder (based on the template for the template_obj
-        # or - if non exists - raises a Placeholder.DoesNotExist exception
-        # Placeholders are marked in the template with {% placeholder %}
-        try:
-            return placeholder_relation.get(slot=slot)
-        except Placeholder.DoesNotExist:
-            from cms.utils.placeholder import rescan_placeholders_for_obj
-            rescan_placeholders_for_obj(template_obj)
-            return placeholder_relation.placeholders.get(slot=slot)
-    else:
-        # Gets or creates the placeholder in any model. Placeholder is
-        # rendered by {% render_placeholder %}
-        return placeholder_relation.get_or_create(slot=slot)[0]

--- a/cms/models/fields.py
+++ b/cms/models/fields.py
@@ -9,7 +9,13 @@ from cms.models.placeholdermodel import Placeholder
 
 class PlaceholderField(models.ForeignKey):
     """
-    A foreign key field to the :class:`cms.models.placeholdermodel.Placeholder` model.
+    .. warning::
+        This field is for django CMS versions below 4 only. It may only used for migrations.
+
+    The ``PlaceholderField`` has been replaced by the :class:`~cms.models.fields.PlaceholderRelationField`,
+    the built-in migrations will automatically take care of the replacement.
+
+    See documentation of :class:`~cms.models.fields.PlaceholderRelationField` for how to replace the code.
     """
     def __init__(self, slotname, default_width=None, actions=None, **kwargs):
         from cms.utils.placeholder import (
@@ -85,8 +91,8 @@ class PlaceholderField(models.ForeignKey):
 
 class PageField(models.ForeignKey):
     """
-    This is a foreign key field to the :class:`cms.models.Page` model
-    that defaults to the :class:`cms.forms.fields.PageSelectFormField` form
+    This is a foreign key field to the :class:`cms.models.pagemodel.Page` model
+    that defaults to the :class:`~cms.forms.fields.PageSelectFormField` form
     field when rendered in forms. It has the same API as the
     :class:`django:django.db.models.ForeignKey` but does not require
     the ``othermodel`` argument.
@@ -110,6 +116,23 @@ class PageField(models.ForeignKey):
 
 
 class PlaceholderRelationField(GenericRelation):
+    """:class:`~django.contrib.contenttypes.fields.GenericForeignKey` to placeholders.
+
+    If you create a model which contains placeholders you first create the ``PlaceHolderRelationField``::
+
+        from cms.models.fields import get_placeholder_from_slot
+
+        class Post(models.Model):
+            ...
+            placeholders = PlaceholderRelationField()  # Generic relation
+
+            @cached_property
+            def content(self):
+                return get_placeholder_from_slot(self.placeholders, "content")  # A specific placeholder
+
+
+
+    """
     default_checks = []
 
     def __init__(self, checks=None, **kwargs):
@@ -129,3 +152,22 @@ class PlaceholderRelationField(GenericRelation):
 
     def run_checks(self, placeholder, user):
         return all(check_(placeholder, user) for check_ in self.checks)
+
+
+def get_placeholder_from_slot(placeholder_relation: models.Manager, slot: str, template_obj=None) -> Placeholder:
+    """Retrieves the placeholder instance for a PlaceholderRelationField either by scaning the template
+    of the template_obj (if given) or by creating or getting a Placeholder in the database"""
+    if hasattr(template_obj, "get_template"):
+        # Tries to get a placeholder (based on the template for the template_obj
+        # or - if non exists - raises a Placeholder.DoesNotExist exception
+        # Placeholders are marked in the template with {% placeholder %}
+        try:
+            return placeholder_relation.get(slot=slot)
+        except Placeholder.DoesNotExist:
+            from cms.utils.placeholder import rescan_placeholders_for_obj
+            rescan_placeholders_for_obj(template_obj)
+            return placeholder_relation.placeholders.get(slot=slot)
+    else:
+        # Gets or creates the placeholder in any model. Placeholder is
+        # rendered by {% render_placeholder %}
+        return placeholder_relation.get_or_create(slot=slot)[0]

--- a/cms/tests/frontend/unit/cms.plugins.test.js
+++ b/cms/tests/frontend/unit/cms.plugins.test.js
@@ -693,7 +693,7 @@ describe('CMS.Plugin', function() {
                 },
                 lang: {
                     success: 'Voila!',
-                    error: 'Test error occured: '
+                    error: 'Test error occurred: '
                 }
             };
             CMS.settings = {
@@ -778,7 +778,7 @@ describe('CMS.Plugin', function() {
             });
             plugin.copyPlugin(plugin.options);
             expect(CMS.API.Messages.open).toHaveBeenCalledWith({
-                message: 'Test error occured: everything is wrong',
+                message: 'Test error occurred: everything is wrong',
                 error: true
             });
         });
@@ -879,7 +879,7 @@ describe('CMS.Plugin', function() {
                 },
                 lang: {
                     success: 'Voila!',
-                    error: 'Test error occured: '
+                    error: 'Test error occurred: '
                 }
             };
             CMS.settings = {
@@ -977,7 +977,7 @@ describe('CMS.Plugin', function() {
             });
             plugin.cutPlugin();
             expect(CMS.API.Messages.open).toHaveBeenCalledWith({
-                message: 'Test error occured: Cannot cut a plugin',
+                message: 'Test error occurred: Cannot cut a plugin',
                 error: true
             });
         });
@@ -1052,7 +1052,7 @@ describe('CMS.Plugin', function() {
                 },
                 lang: {
                     success: 'Voila!',
-                    error: 'Test error occured: '
+                    error: 'Test error occurred: '
                 }
             };
             CMS.settings = {
@@ -1195,7 +1195,7 @@ describe('CMS.Plugin', function() {
                 },
                 lang: {
                     success: 'Voila!',
-                    error: 'Test error occured: '
+                    error: 'Test error occurred: '
                 }
             };
             CMS.settings = {
@@ -1339,7 +1339,7 @@ describe('CMS.Plugin', function() {
             });
             plugin.movePlugin();
             expect(CMS.API.Messages.open).toHaveBeenCalledWith({
-                message: 'Test error occured: Cannot cut a plugin',
+                message: 'Test error occurred: Cannot cut a plugin',
                 error: true
             });
         });

--- a/cms/tests/frontend/unit/cms.toolbar.test.js
+++ b/cms/tests/frontend/unit/cms.toolbar.test.js
@@ -289,7 +289,7 @@ describe('CMS.Toolbar', function () {
                         return {
                             fail: function (callback) {
                                 callback({
-                                    responseText: 'An error occured',
+                                    responseText: 'An error occurred',
                                     status: 418,
                                     statusText: "I'm a teapot"
                                 });
@@ -304,7 +304,7 @@ describe('CMS.Toolbar', function () {
             });
 
             expect(CMS.API.Messages.open).toHaveBeenCalledWith({
-                message: "An error occured | 418 I'm a teapot",
+                message: "An error occurred | 418 I'm a teapot",
                 error: true
             });
         });
@@ -357,7 +357,7 @@ describe('CMS.Toolbar', function () {
                         return {
                             fail: function (callback) {
                                 callback({
-                                    responseText: 'An error occured',
+                                    responseText: 'An error occurred',
                                     status: 418,
                                     statusText: "I'm a teapot"
                                 });

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -982,6 +982,25 @@ class PlaceholderTestCase(TransactionCMSTestCase):
             ordered=False
         )
 
+    def test_placeholder_relation_field_get_slot(self):
+        """
+        This tests the get slot method of PlaceholderRelationField
+        """
+
+        from cms.models.fields import get_placeholder_from_slot
+
+        poll = FancyPoll.objects.create(name='poll 1')
+        slot_1 = get_related_slot(poll.placeholders, slot="slot_1")  # Get placeholder
+        self.assertTrue(isinstance(slot_1, Placeholder))  # Correct type
+        self.assertEqual(slot_1.slot, "slot_1")  # Correct slot
+        self.assertEqual(poll.placeholders.all().count(), 1)  # Has been created?
+
+        slot_2 = get_related_slot(poll.placeholders, "slot_2")  # Get 2nd placeholder
+        self.assertEqual(slot_2.slot, "slot_2")  # right slot
+        self.assertEqual(poll.placeholders.all().count(), 2)  # Two should have been created
+
+        self.assertEqual(slot_1, get_related_slot(poll.placeholders, "slot_1"))  # Still the first slot
+
 
 class PlaceholderActionTests(FakemlngFixtures, CMSTestCase):
     def test_placeholder_no_action(self):

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -987,7 +987,7 @@ class PlaceholderTestCase(TransactionCMSTestCase):
         This tests the get slot method of PlaceholderRelationField
         """
 
-        from cms.models.fields import get_placeholder_from_slot
+        from cms.utils.placeholder import get_placeholder_from_slot
 
         poll = FancyPoll.objects.create(name='poll 1')
         slot_1 = get_placeholder_from_slot(poll.placeholders, slot="slot_1")  # Get placeholder

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -990,16 +990,16 @@ class PlaceholderTestCase(TransactionCMSTestCase):
         from cms.models.fields import get_placeholder_from_slot
 
         poll = FancyPoll.objects.create(name='poll 1')
-        slot_1 = get_related_slot(poll.placeholders, slot="slot_1")  # Get placeholder
+        slot_1 = get_placeholder_from_slot(poll.placeholders, slot="slot_1")  # Get placeholder
         self.assertTrue(isinstance(slot_1, Placeholder))  # Correct type
         self.assertEqual(slot_1.slot, "slot_1")  # Correct slot
         self.assertEqual(poll.placeholders.all().count(), 1)  # Has been created?
 
-        slot_2 = get_related_slot(poll.placeholders, "slot_2")  # Get 2nd placeholder
+        slot_2 = get_placeholder_from_slot(poll.placeholders, "slot_2")  # Get 2nd placeholder
         self.assertEqual(slot_2.slot, "slot_2")  # right slot
         self.assertEqual(poll.placeholders.all().count(), 2)  # Two should have been created
 
-        self.assertEqual(slot_1, get_related_slot(poll.placeholders, "slot_1"))  # Still the first slot
+        self.assertEqual(slot_1, get_placeholder_from_slot(poll.placeholders, "slot_1"))  # Still the first slot
 
 
 class PlaceholderActionTests(FakemlngFixtures, CMSTestCase):

--- a/cms/toolbar/items.py
+++ b/cms/toolbar/items.py
@@ -612,7 +612,7 @@ class ButtonList(BaseItem):
         return item
 
     def add_sideframe_button(self, name, url, active=False, disabled=False, extra_classes=None, on_close=None):
-        """Adds a :class:`~cms.toolbar.items.SideFrameButton` to the button list and returns it."""
+        """Adds a :class:`~cms.toolbar.items.SideframeButton` to the button list and returns it."""
 
         item = SideframeButton(
             name, url,

--- a/cms/utils/placeholder.py
+++ b/cms/utils/placeholder.py
@@ -361,6 +361,9 @@ def rescan_placeholders_for_obj(obj):
 
 
 def get_declared_placeholders_for_obj(obj):
+    """Returns declared placeholders for an object. The object is supposed to have a method ``get_template``
+    which returns the template path as a string that renders the object. ``get_declared_placeholders`` returns
+    a list of placeholders used in the template by the ``{% placeholder %}`` template tag."""
     if not hasattr(obj, 'get_template'):
         raise NotImplementedError('%s should implement get_template' % obj.__class__.__name__)
     return get_placeholders(obj.get_template())

--- a/cms/utils/placeholder.py
+++ b/cms/utils/placeholder.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.db import models
 from django.db.models.query_utils import Q
 from django.template import (
     Context, NodeList, Template, TemplateSyntaxError, Variable, engines,
@@ -14,6 +15,7 @@ from django.template.loader_tags import BlockNode, ExtendsNode, IncludeNode
 from sekizai.helpers import get_varname
 
 from cms.exceptions import DuplicatePlaceholderWarning
+from cms.models import Placeholder
 from cms.utils.conf import get_cms_setting
 
 
@@ -362,3 +364,21 @@ def get_declared_placeholders_for_obj(obj):
     if not hasattr(obj, 'get_template'):
         raise NotImplementedError('%s should implement get_template' % obj.__class__.__name__)
     return get_placeholders(obj.get_template())
+
+
+def get_placeholder_from_slot(placeholder_relation: models.Manager, slot: str, template_obj=None) -> Placeholder:
+    """Retrieves the placeholder instance for a PlaceholderRelationField either by scaning the template
+    of the template_obj (if given) or by creating or getting a Placeholder in the database"""
+    if hasattr(template_obj, "get_template"):
+        # Tries to get a placeholder (based on the template for the template_obj
+        # or - if non exists - raises a Placeholder.DoesNotExist exception
+        # Placeholders are marked in the template with {% placeholder %}
+        try:
+            return placeholder_relation.get(slot=slot)
+        except Placeholder.DoesNotExist:
+            rescan_placeholders_for_obj(template_obj)
+            return placeholder_relation.placeholders.get(slot=slot)
+    else:
+        # Gets or creates the placeholder in any model. Placeholder is
+        # rendered by {% render_placeholder %}
+        return placeholder_relation.get_or_create(slot=slot)[0]

--- a/cms/utils/plugins.py
+++ b/cms/utils/plugins.py
@@ -9,6 +9,7 @@ from django.utils.translation import gettext as _
 
 from cms.exceptions import PluginLimitReached
 from cms.models.pluginmodel import CMSPlugin
+from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 from cms.utils import get_language_from_request
 from cms.utils.placeholder import get_placeholder_conf
@@ -17,12 +18,14 @@ logger = logging.getLogger(__name__)
 
 
 @lru_cache(maxsize=None)
-def get_plugin_class(plugin_type):
+def get_plugin_class(plugin_type: str) -> CMSPluginBase:
+    """Returns the plugin class for a given plugin_type (str)"""
     return plugin_pool.get_plugin(plugin_type)
 
 
 @lru_cache()
-def get_plugin_model(plugin_type):
+def get_plugin_model(plugin_type: str) -> CMSPlugin:
+    """Returns the plugin model class for a given plugin_type (str)"""
     return get_plugin_class(plugin_type).model
 
 
@@ -262,7 +265,7 @@ def get_bound_plugins(plugins):
         plugin_model = get_plugin(plugin_type).model
         plugin_queryset = plugin_model.objects.filter(pk__in=pks)
 
-        # put them in a map so we can replace the base CMSPlugins with their
+        # put them in a map, so we can replace the base CMSPlugins with their
         # downcasted versions
         for instance in plugin_queryset.iterator():
             plugin_lookup[instance.pk] = instance
@@ -306,7 +309,7 @@ def downcast_plugins(plugins,
         if select_placeholder:
             plugin_qs = plugin_qs.select_related('placeholder')
 
-        # put them in a map so we can replace the base CMSPlugins with their
+        # put them in a map, so we can replace the base CMSPlugins with their
         # downcasted versions
         for instance in plugin_qs.iterator():
             placeholder = placeholders_by_id.get(instance.placeholder_id)
@@ -330,8 +333,8 @@ def downcast_plugins(plugins,
 
 def has_reached_plugin_limit(placeholder, plugin_type, language, template=None):
     """
-    Checks if placeholder has reached it's global plugin limit,
-    if not then it checks if it has reached it's plugin_type limit.
+    Checks if placeholder has reached its global plugin limit,
+    if not then it checks if it has reached its plugin_type limit.
     """
     limits = get_placeholder_conf("limits", placeholder.slot, template)
     if limits:


### PR DESCRIPTION
## Description


This PR adds a function `get_placeholder_from_slot` to more easily use the new `PlaceholderRelationField`.

It also adds test and docstrings for PlaceholderRelationField.

Some small fixes in docstrings.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* [Release notes 4.0.0](https://github.com/django-cms/django-cms/blob/develop-4/docs/upgrade/4.0.rst#placeholder-relations)

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
