### PR TITLE
docs: Added note to publish_pages API docs about it being a generator

### DIFF
--- a/docs/reference/api_references.rst
+++ b/docs/reference/api_references.rst
@@ -178,6 +178,15 @@ Functions and constants
     :param site: Specify a site to publish pages for specified site only; if not specified pages from all sites are published
     :type site: :class:`django.contrib.sites.models.Site` instance
 
+    .. note::
+
+        This function is a generator, so you'll need to iterate over the result to actually publish
+        all pages. This can be done in a single line using ``list()``:
+
+        .. code-block:: python
+
+            list(publish_pages())
+
 .. function:: get_page_draft(page):
 
     Returns the draft version of a page, regardless if the passed in


### PR DESCRIPTION
## Description

This change adds a note to the documentation for the `publish_pages` API function, telling it is implemented as a generator.

I was quite surprised about this recently, and it was suggested on django CMS’s Slack server that I’d create a PR for it, so here it is :)

## Related resources

* [The original message on Slack](https://django-cmsworkspace.slack.com/archives/C01EBCEK49E/p1673972043226899)

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

**Note**: I didn’t add this to the changelog as the change felt too small to end up in there. If this is still required, let me know :)

-----

A screenshot showing the rendered documentation with my change:

![Schermafbeelding 000135](https://user-images.githubusercontent.com/573675/213913384-1f71b3b0-ab4b-434d-b041-c2b473094521.png)
