### PR TITLE
fix: Make messages readable in dark mode, remove iOS9 compatibility tweak that creates unnecessary scrollbars

### DIFF
--- a/cms/static/cms/sass/components/_structureboard.scss
+++ b/cms/static/cms/sass/components/_structureboard.scss
@@ -564,19 +564,6 @@
     }
 }
 
-
-@at-root .cms-structure-mode-structure {
-    // overflow: hidden;
-
-    // min-height is necessary for iOS9
-    // when we have a page that has content
-    // that takes less than a screen structureboard
-    // becomes unusable because it tries to fit
-    // in the size of the content and not the size
-    // of the device screen
-    min-height: 100%;
-}
-
 // hide elements when dragging
 @at-root .ui-sortable-helper.cms-draggable .cms-submenu-btn {
     display: none !important;
@@ -595,7 +582,7 @@
     left: 0;
     top: 0;
     bottom: 0;
-    background: #fff !important;
+    background: $white !important;
     opacity: .5;
     z-index: 9999;
 }

--- a/cms/static/cms/sass/settings/_cms.scss
+++ b/cms/static/cms/sass/settings/_cms.scss
@@ -346,13 +346,13 @@ $messages-color: $white;
 $messages-font-size: 12px;
 $messages-line-height: 16px;
 $messages-border-radius: $border-radius-base;
-$messages-bgcolor: rgba(0, 0, 0, 0.74);
+$messages-bgcolor: rgba(var(--dca-shadow), 0.74);
 $messages-font-weight: 200;
 $messages-close-area-size: 20px;
 $messages-close-icon-size: 10px;
 
 $screenblock-color: $white;
-$screenblock-bgcolor: rgba(0, 0, 0, 0.9);
+$screenblock-bgcolor: rgba(var(--dca-shadow), 0.9);
 $screenblock-inner-position: 300px;
 
 $login-form-input-font-size: $font-size-normal;


### PR DESCRIPTION
This PR is a minor css fix which improves

* Messages readability in dark mode
* Avoids unnecessary scroll bars when using the structure board on a otherwise scroll free page

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
