### PR TITLE
fix: Link both user and group from global page permissions to change form

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 ##########
 django CMS
 ##########
+.. image:: https://static.pepy.tech/badge/django-cms
+    :target: https://pepy.tech/project/django-cms
+    :alt: Downloads
 .. image:: https://travis-ci.org/django-cms/django-cms.svg?branch=develop
     :target: https://travis-ci.org/django-cms/django-cms
 .. image:: https://img.shields.io/pypi/v/django-cms.svg

--- a/cms/admin/permissionadmin.py
+++ b/cms/admin/permissionadmin.py
@@ -133,7 +133,7 @@ class ViewRestrictionInlineAdmin(PagePermissionInlineAdmin):
 
 class GlobalPagePermissionAdmin(admin.ModelAdmin):
     list_display = ['user', 'group', 'can_change', 'can_delete', 'can_publish', 'can_change_permissions']
-    list_filter = ['user', 'group', 'site', 'can_change', 'can_delete', 'can_publish', 'can_change_permissions']
+    list_filter = ['sites', 'user', 'group', 'can_change', 'can_delete', 'can_publish', 'can_change_permissions']
     list_display_links = ['user', 'group']
 
     form = GlobalPagePermissionAdminForm

--- a/cms/admin/permissionadmin.py
+++ b/cms/admin/permissionadmin.py
@@ -133,7 +133,7 @@ class ViewRestrictionInlineAdmin(PagePermissionInlineAdmin):
 
 class GlobalPagePermissionAdmin(admin.ModelAdmin):
     list_display = ['user', 'group', 'can_change', 'can_delete', 'can_publish', 'can_change_permissions']
-    list_filter = ['user', 'group', 'can_change', 'can_delete', 'can_publish', 'can_change_permissions']
+    list_filter = ['user', 'group', 'site', 'can_change', 'can_delete', 'can_publish', 'can_change_permissions']
     list_display_links = ['user', 'group']
 
     form = GlobalPagePermissionAdminForm

--- a/cms/admin/permissionadmin.py
+++ b/cms/admin/permissionadmin.py
@@ -134,6 +134,7 @@ class ViewRestrictionInlineAdmin(PagePermissionInlineAdmin):
 class GlobalPagePermissionAdmin(admin.ModelAdmin):
     list_display = ['user', 'group', 'can_change', 'can_delete', 'can_publish', 'can_change_permissions']
     list_filter = ['user', 'group', 'can_change', 'can_delete', 'can_publish', 'can_change_permissions']
+    list_display_links = ['user', 'group']
 
     form = GlobalPagePermissionAdminForm
     search_fields = []


### PR DESCRIPTION
## Description

* This PR solves the following issue requested by adding the link to both the user and the group field.
* Also it adds a filter for the site

![](https://discourse.django-cms.org/uploads/default/original/1X/e491fdde746c61aef50a5fdb5866ba0917dd51ff.png)

Can we improve this list in order to set the “change link” to another thing than the (empty) “user” (maybe user and group, or an id)?

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* https://discourse.django-cms.org/t/improve-global-page-permission-look-in-admin/267
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
