### PR TITLE
fix: replace ' by ′ in fr translation − no more "page d\u0027accueil"!

### DIFF
--- a/cms/locale/fr/LC_MESSAGES/django.po
+++ b/cms/locale/fr/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # adrien.delhorme, 2014
 # Adrien Delhorme, 2017,2019,2021
@@ -152,7 +152,7 @@ msgid "An application instance with this name already exists."
 msgstr "Il existe déjà une instance d'application portant ce nom."
 
 msgid "You can't move the home page inside another page"
-msgstr "Vous ne pouvez pas déplacer la page d'accueil sous une autre page"
+msgstr "Vous ne pouvez pas déplacer la page d′accueil sous une autre page"
 
 msgid "Yes"
 msgstr "Oui"
@@ -324,7 +324,7 @@ msgid "New page"
 msgstr "Nouvelle page"
 
 msgid "The page is not eligible to be home."
-msgstr "La page ne peut pas être la page d'accueil."
+msgstr "La page ne peut pas être la page d′accueil."
 
 msgid "View restriction"
 msgstr "Restriction d'affichage"
@@ -1021,7 +1021,7 @@ msgid "Paste"
 msgstr "Coller"
 
 msgid "Set as home"
-msgstr "Défini comme page d'accueil"
+msgstr "Défini comme page d′accueil"
 
 msgid "is restricted"
 msgstr "est restreint"

--- a/cms/templates/admin/cms/page/tree/actions_dropdown.html
+++ b/cms/templates/admin/cms/page/tree/actions_dropdown.html
@@ -12,7 +12,7 @@
         >
             <a{% if not has_copy_page_permission %} class="cms-pagetree-dropdown-item-disabled"{% endif %} href="#" title="{% filter escapejs %}{% trans "Copy" %}{% endfilter %}">
                 <span class="cms-icon cms-icon-copy"></span>
-                <span>{% filter escapejs %}{% trans "Copy" %}{% endfilter %}<span>
+                <span>{% trans "Copy" %}<span>
             </a>
         </li>
         <li
@@ -25,7 +25,7 @@
             <a{% if not has_move_page_permission %} class="cms-pagetree-dropdown-item-disabled"{% endif %}
                 href="#"                 title="{% filter escapejs %}{% trans "Cut" %}{% endfilter %}">
                 <span class="cms-icon cms-icon-scissors"></span>
-                <span>{% filter escapejs %}{% trans "Cut" %}{% endfilter %}<span>
+                <span>{% trans "Cut" %}<span>
             </a>
         </li>
         <li>
@@ -34,7 +34,7 @@
                 class="{% if has_add_permission %}js-cms-tree-item-paste{% endif %}
                 {% if not has_add_permission or not paste_enabled %} cms-pagetree-dropdown-item-disabled{% endif %}">
                 <span class="cms-icon cms-icon-alias"></span>
-                <span>{% filter escapejs %}{% trans "Paste" %}{% endfilter %}</span>
+                <span>{% trans "Paste" %}</span>
             </a>
         </li>
         <li>
@@ -44,21 +44,21 @@
                 <a href="#" class="cms-pagetree-dropdown-item-disabled">
             {% endif %}
                     <span class="cms-icon cms-icon-bin"></span>
-                    <span>{% filter escapejs %}{% trans "Delete" %}...{% endfilter %}</span>
+                    <span>{% trans "Delete" %}...</span>
                 </a>
         </li>
         {% if has_change_permission and page.is_potential_home %}
             <li class="js-cms-tree-item-set-home">
                 <a href="{% url opts|admin_urlname:'set_home' page.id %}" title="{% filter escapejs %}{% trans "Set as home" %}{% endfilter %}">
                     <span class="cms-icon cms-icon-home"></span>
-                    <span>{% filter escapejs %}{% trans "Set as home" %}{% endfilter %}</span>
+                    <span>{% trans "Set as home" %}</span>
                 </a>
             </li>
         {% else %}
             <li class="js-cms-tree-item-set-home">
                 <a href="#" class="cms-pagetree-dropdown-item-disabled">
                     <span class="cms-icon cms-icon-home"></span>
-                    <span>{% filter escapejs %}{% trans "Set as home" %}{% endfilter %}</span>
+                    <span>{% trans "Set as home" %}</span>
                 </a>
             </li>
         {% endif %}
@@ -69,7 +69,7 @@
                 <a href="#" class="cms-pagetree-dropdown-item-disabled">
             {% endif %}
                     <span class="cms-icon cms-icon-cogs"></span>
-                    <span>{% filter escapejs %}{% trans "Advanced settings" %}{% endfilter %}</span>
+                    <span>{% trans "Advanced settings" %}</span>
                 </a>
         </li>
         {% if CMS_PERMISSION %}
@@ -80,7 +80,7 @@
                     <a href="#" class="cms-pagetree-dropdown-item-disabled">
                 {% endif %}
                         <span class="cms-icon cms-icon-lock"></span>
-                        <span>{% filter escapejs %}{% trans "Permissions" %}{% endfilter %}</span>
+                        <span>{% trans "Permissions" %}</span>
                     </a>
             </li>
         {% endif %}
@@ -94,27 +94,27 @@
             <p title="{% filter escapejs %}{% trans "publication end date" %}{% endfilter %}: {{ page.publication_end_date|date:"Y-m-d" }}"><strong>{% filter escapejs %}{% trans "publication end date" %}{% endfilter %}:</strong> {{ page.publication_end_date|date:"Y-m-d" }}</p>
         {% endif %}
         <p title="{% filter escapejs %}{% trans "is restricted" %}: {% if page_is_restricted %}{% trans "Yes" %}{% else %}{% trans "No" %}{% endif %}{% endfilter %}">
-            <strong>{% filter escapejs %}{% trans "is restricted" %}{% endfilter %}:</strong>
+            <strong>{% trans "is restricted" %}:</strong>
             {% if page_is_restricted %}
-                {% filter escapejs %}{% trans "Yes" %}{% endfilter %}
+                {% trans "Yes" %}
             {% else %}
-                {% filter escapejs %}{% trans "No" %}{% endfilter %}
+                {% trans "No" %}
             {% endif %}
         </p>
         {% if page.changed_by %}
-            <p title="{% filter escapejs %}{% trans "last change by" %}{% endfilter %}: {{ page.changed_by }}"><strong>{% filter escapejs %}{% trans "last change by" %}{% endfilter %}:</strong> {{ page.changed_by }}</p>
+            <p title="{% filter escapejs %}{% trans "last change by" %}{% endfilter %}: {{ page.changed_by }}"><strong>{% trans "last change by" %}:</strong> {{ page.changed_by }}</p>
         {% endif %}
         {% if page.changed_date %}
-            <p title="{% filter escapejs %}{% trans "last change on" %}{% endfilter %}: {{ page.changed_date|date:"Y-m-d H:i:s" }}"><strong>{% filter escapejs %}{% trans "last change on" %}{% endfilter %}:</strong> {{ page.changed_date|date:"Y-m-d H:i:s" }}</p>
+            <p title="{% filter escapejs %}{% trans "last change on" %}{% endfilter %}: {{ page.changed_date|date:"Y-m-d H:i:s" }}"><strong>{{% trans "last change on" %}:</strong> {{ page.changed_date|date:"Y-m-d H:i:s" }}</p>
         {% endif %}
         {% if page.get_template_display %}
-            <p title="{% filter escapejs %}{% trans "template" %}{% endfilter %}: {{ page.get_template_display }}"><strong>{% filter escapejs %}{% trans "template" %}{% endfilter %}:</strong> {{ page.get_template_display }}</p>
+            <p title="{% filter escapejs %}{% trans "template" %}{% endfilter %}: {{ page.get_template_display }}"><strong>{% trans "template" %}:</strong> {{ page.get_template_display }}</p>
         {% endif %}
         {% if metadata %}
-            <p title="{% filter escapejs %}{% trans "meta" %}{% endfilter %}: {{ metadata }}"><strong>{% filter escapejs %}{% trans "meta" %}{% endfilter %}:</strong> {{ metadata }}</p>
+            <p title="{% filter escapejs %}{% trans "meta" %}{% endfilter %}: {{ metadata }}"><strong>{% trans "meta" %}:</strong> {{ metadata }}</p>
         {% endif %}
         {% if page.site %}
-            <p title="{% filter escapejs %}{% trans "site" %}{% endfilter %}: {{ page.site }}"><strong>{% filter escapejs %}{% trans "site" %}{% endfilter %}:</strong> {{ page.site }}</p>
+            <p title="{% filter escapejs %}{% trans "site" %}{% endfilter %}: {{ page.site }}"><strong>{% trans "site" %}:</strong> {{ page.site }}</p>
         {% endif %}
     </li>
 </ul>


### PR DESCRIPTION
We can use this method (replace by a typographically valid char, but which does nothing in javascript) on other translations when there's a problem with  `escapejs` (ie using [those chars](https://github.com/django/django/blob/34b328814976a2e2f7907361a494202763649f3f/django/utils/html.py#L31-L42)) in order to fix those slight annoyances.

* [x] I have opened this pull request against ``develop``
* [ ] I have added or modified the tests when changing logic (can't think of a way to retrieve all the translations that are displayed after a call to `escapejs`, so no test for now for this)
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
