### PR TITLE
fix: Copy page did not create versions for subpages

### DIFF
--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -180,7 +180,7 @@ class BasePageContentForm(forms.ModelForm):
 
 class AddPageForm(BasePageContentForm):
     source = forms.ModelChoiceField(
-        label=_(u'Page type'),
+        label=_('Page type'),
         queryset=Page.objects.filter(is_page_type=True),
         required=False,
     )
@@ -299,6 +299,7 @@ class AddPageForm(BasePageContentForm):
             translations=False,
             permissions=False,
             extensions=False,
+            user=self._user,
         )
         new_page.update(is_page_type=False)
         return new_page

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -700,7 +700,7 @@ class PageAdmin(admin.ModelAdmin):
                                   "translated in any of the languages configured by the target site."))
             return jsonify_request(HttpResponseBadRequest(message))
 
-        new_page = form.copy_page(request.user)
+        new_page = form.copy_page(user)
         return HttpResponse(json.dumps({"id": new_page.pk}), content_type='application/json')
 
     def edit_title_fields(self, request, page_id, language):

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -1327,7 +1327,12 @@ class PageContentAdmin(admin.ModelAdmin):
         page_content = self.get_object(request, object_id=object_id)
 
         if not self.has_change_permission(request, obj=page_content):
-            message = _("You do not have permission to change this page's in_navigation status")
+            if self.has_change_permission(request):
+                # General (permission) problem
+                message = _("You do not have permission to change a page's navigation status")
+            else:
+                # Only this page? Can be permissions or versioning, or ...
+                message = _("You cannot change this page's navigation status")
             return HttpResponseForbidden(force_str(message))
 
         if page_content is None:

--- a/cms/management/commands/subcommands/copy.py
+++ b/cms/management/commands/subcommands/copy.py
@@ -6,10 +6,9 @@ from django.db import transaction
 
 from cms.api import copy_plugins_to_language
 from cms.management.commands.subcommands.base import SubcommandsCommand
-from cms.models import EmptyPageContent, Page, StaticPlaceholder, PageContent
+from cms.models import EmptyPageContent, Page, PageContent, StaticPlaceholder
 from cms.utils import get_language_list
 from cms.utils.plugins import copy_plugins_to_placeholder
-
 
 User = get_user_model()
 

--- a/cms/management/commands/subcommands/copy.py
+++ b/cms/management/commands/subcommands/copy.py
@@ -1,13 +1,33 @@
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.core.management import CommandError
 from django.db import transaction
 
 from cms.api import copy_plugins_to_language
 from cms.management.commands.subcommands.base import SubcommandsCommand
-from cms.models import EmptyPageContent, Page, StaticPlaceholder
+from cms.models import EmptyPageContent, Page, StaticPlaceholder, PageContent
 from cms.utils import get_language_list
 from cms.utils.plugins import copy_plugins_to_placeholder
+
+
+User = get_user_model()
+
+
+def get_user(options):
+    if options["userid"] and options["username"]:  # pragma: no cover
+        raise CommandError("Only either one of the options '--userid' or '--username' may be given")
+    if options["userid"]:
+        try:
+            return User.objects.get(pk=options["userid"])
+        except User.DoesNotExist:
+            raise CommandError(f"No user with id {options['userid']} found")
+    if options["username"]:  # pragma: no cover
+        try:
+            return User.objects.get(username=options["username"])
+        except User.DoesNotExist:
+            raise CommandError(f"No user with name {options['username']} found")
+    return None  # pragma: no cover
 
 
 class CopyLangCommand(SubcommandsCommand):
@@ -29,6 +49,9 @@ class CopyLangCommand(SubcommandsCommand):
         parser.add_argument('--skip-content', action='store_false', dest='copy_content',
                             default=True, help='If set content is not copied, and the command '
                                                'will only create titles in the given language.')
+        parser.add_argument("--username", type=str, dest='username', default="",
+                            help="Username of user needed create new content objects")
+        parser.add_argument("--userid", type=int, help="User id of user needed create new content objects")
 
     def handle(self, *args, **options):
         verbose = options.get('verbosity') > 1
@@ -36,6 +59,8 @@ class CopyLangCommand(SubcommandsCommand):
         copy_content = options.get('copy_content')
         from_lang = options.get('from_lang')
         to_lang = options.get('to_lang')
+        user = get_user(options)
+
         try:
             site = int(options.get('site', None))
         except Exception:
@@ -55,13 +80,19 @@ class CopyLangCommand(SubcommandsCommand):
                 if isinstance(title, EmptyPageContent):
                     title = page.get_content_obj(from_lang)
                     if verbose:
-                        self.stdout.write('copying title %s from language %s\n' % (title.title, from_lang))
-                    title.id = None
-                    title.language = to_lang
+                        self.stdout.write('copying page content %s from language %s\n' % (title.title, from_lang))
+                    if not user:
+                        raise CommandError('Specify either --userid or --username')
+                    from django.forms import model_to_dict
+                    new_title = model_to_dict(title)
+                    new_title.pop("id", None)  # No PK
+                    new_title["language"] = to_lang
+                    new_title["page"] = page
+                    PageContent.objects.with_user(user).create(**new_title)
 
                     if to_lang not in page.get_languages():
                         page.update_languages(page.get_languages() + [to_lang])
-                    title.save()
+
                 if copy_content:
                     # copy plugins using API
                     if verbose:
@@ -108,6 +139,9 @@ class CopySiteCommand(SubcommandsCommand):
                             help='Language to copy the content from.')
         parser.add_argument('--to-site', action='store', dest='to_site', required=True,
                             help='Language to copy the content to.')
+        parser.add_argument("--username", type=str, dest='username', default="",
+                            help="Username of user needed create new content objects")
+        parser.add_argument("--userid", type=int, help="User id of user needed create new content objects")
 
     def handle(self, *args, **options):
         try:
@@ -125,6 +159,9 @@ class CopySiteCommand(SubcommandsCommand):
 
         from_site = self.get_site(from_site)
         to_site = self.get_site(to_site)
+        user = get_user(options)
+        if not user:
+            raise CommandError('Specify either --userid or --username')
 
         pages = (
             Page
@@ -140,6 +177,7 @@ class CopySiteCommand(SubcommandsCommand):
                 new_page = page.copy_with_descendants(
                     target_node=None,
                     target_site=to_site,
+                    user=user,
                 )
 
                 if page.is_home:

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -449,7 +449,9 @@ class Page(models.Model):
         from cms.models import PageContent
         from cms.utils.page import get_available_slug
 
-        assert user is not None, "No anonymous page copying"
+        if user is None:
+            raise ValueError("Since django CMS 4 the page.copy method requires a user argument")
+
         if parent_node:
             new_node = parent_node.add_child(site=site)
             parent_page = parent_node.item

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -449,7 +449,7 @@ class Page(models.Model):
         from cms.models import PageContent
         from cms.utils.page import get_available_slug
 
-        if user is None:
+        if not user:
             raise ValueError("Since django CMS 4 the page.copy method requires a user argument")
 
         if parent_node:

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -449,6 +449,7 @@ class Page(models.Model):
         from cms.models import PageContent
         from cms.utils.page import get_available_slug
 
+        assert user is not None, "No anonymous page copying"
         if parent_node:
             new_node = parent_node.add_child(site=site)
             parent_page = parent_node.item
@@ -583,6 +584,7 @@ class Page(models.Model):
                 parent_node=parent,
                 translations=True,
                 permissions=copy_permissions,
+                user=user
             )
             nodes_by_id[page.node_id] = new_page.node
         return new_root_page

--- a/cms/tests/test_extensions.py
+++ b/cms/tests/test_extensions.py
@@ -115,7 +115,7 @@ class ExtensionsTestCase(CMSTestCase):
         # asserting original extensions
         self.assertEqual(len(extension_pool.get_page_extensions()), 2)
         self.assertEqual(len(extension_pool.get_page_content_extensions()), 2)
-        copied_page = page.copy_with_descendants(target_node=None, position='last-child')
+        copied_page = page.copy_with_descendants(target_node=None, position='last-child', user=self.get_superuser())
 
         # asserting original + copied extensions
         self.assertEqual(len(extension_pool.get_page_extensions()), 4)
@@ -192,7 +192,7 @@ class ExtensionsTestCase(CMSTestCase):
         self.assertEqual(len(extension_pool.get_page_extensions()), 2)
         self.assertEqual(len(extension_pool.get_page_content_extensions()), 2)
 
-        copied_page = page.copy_with_descendants(target_node=None, position='last-child')
+        copied_page = page.copy_with_descendants(target_node=None, position='last-child', user=self.get_superuser())
 
         # asserting original + copied extensions
         self.assertEqual(len(extension_pool.get_page_extensions()), 4)

--- a/cms/tests/test_management.py
+++ b/cms/tests/test_management.py
@@ -334,7 +334,8 @@ class PageFixtureManagementTestCase(NavextendersFixture, CMSTestCase):
 
         out = StringIO()
         management.call_command(
-            'cms', 'copy', 'lang', '--from-lang=en', '--to-lang=de', interactive=False, stdout=out
+            'cms', 'copy', 'lang', '--from-lang=en', '--to-lang=de', '--userid=%d' % self.get_superuser().id,
+            interactive=False, stdout=out
         )
         pages = Page.objects.on_site(site)
         for page in pages:
@@ -379,6 +380,7 @@ class PageFixtureManagementTestCase(NavextendersFixture, CMSTestCase):
         out = StringIO()
         management.call_command(
             'cms', 'copy', 'lang', '--from-lang=en', '--to-lang=de', '--skip-content',
+            '--userid=%d' % self.get_superuser().id,
             interactive=False, stdout=out
         )
         pages = Page.objects.on_site(site)
@@ -429,6 +431,7 @@ class PageFixtureManagementTestCase(NavextendersFixture, CMSTestCase):
         out = StringIO()
         management.call_command(
             'cms', 'copy', 'site', '--from-site=%s' % site_1_pk, '--to-site=%s' % site_2_pk,
+            '--userid=%d' % self.get_superuser().id,
             stdout=out
         )
 
@@ -479,7 +482,9 @@ class PageFixtureManagementTestCase(NavextendersFixture, CMSTestCase):
 
         out = StringIO()
         management.call_command(
-            'cms', 'copy', 'lang', '--from-lang=en', '--to-lang=de', interactive=False, stdout=out
+            'cms', 'copy', 'lang', '--from-lang=en', '--to-lang=de',
+            '--userid=%d' % self.get_superuser().id,
+            interactive=False, stdout=out
         )
         pages = Page.objects.on_site(site)
         for page in pages:
@@ -509,7 +514,9 @@ class PageFixtureManagementTestCase(NavextendersFixture, CMSTestCase):
 
         out = StringIO()
         management.call_command(
-            'cms', 'copy', 'lang', '--from-lang=en', '--to-lang=de', interactive=False, stdout=out
+            'cms', 'copy', 'lang', '--from-lang=en', '--to-lang=de',
+            '--userid=%d' % self.get_superuser().id,
+            interactive=False, stdout=out
         )
 
         self.assertEqual(CMSPlugin.objects.filter(language='en').count(), number_start_plugins)
@@ -536,7 +543,9 @@ class PageFixtureManagementTestCase(NavextendersFixture, CMSTestCase):
 
         out = StringIO()
         management.call_command(
-            'cms', 'copy', 'lang', '--from-lang=en', '--to-lang=de', '--force', interactive=False,
+            'cms', 'copy', 'lang', '--from-lang=en', '--to-lang=de', '--force',
+            '--userid=%d' % self.get_superuser().id,
+            interactive=False,
             stdout=out
         )
 
@@ -555,7 +564,9 @@ class PageFixtureManagementTestCase(NavextendersFixture, CMSTestCase):
         site = 1
         out = StringIO()
         management.call_command(
-            'cms', 'copy', 'lang', '--from-lang=de', '--to-lang=fr', verbosity=3,
+            'cms', 'copy', 'lang', '--from-lang=de', '--to-lang=fr',
+            '--userid=%d' % self.get_superuser().id,
+            verbosity=3,
             interactive=False, stdout=out
         )
         text = out.getvalue()
@@ -592,6 +603,7 @@ class PageFixtureManagementTestCase(NavextendersFixture, CMSTestCase):
         out = StringIO()
         management.call_command(
             'cms', 'copy', 'lang', '--from-lang=de', '--to-lang=fr', '--site=%s' % site_active,
+            '--userid=%d' % self.get_superuser().id,
             interactive=False, stdout=out
         )
 
@@ -614,8 +626,9 @@ class PageFixtureManagementTestCase(NavextendersFixture, CMSTestCase):
         out = StringIO()
         with self.assertRaises(CommandError) as command_error:
             management.call_command(
-                'cms', 'copy', 'lang', '--from-lang=it', '--to-lang=fr', interactive=False,
-                stdout=out
+                'cms', 'copy', 'lang', '--from-lang=it', '--to-lang=fr',
+                '--userid=%d' % self.get_superuser().id,
+                interactive=False, stdout=out
             )
 
         self.assertEqual(


### PR DESCRIPTION
## Description

This is an urgent fix when copying pages: 

* Children of the page copied did not have Version objects automatically created if djangocms-versioning is installed. 
   Installations can be fixed by running `./manage.py create_versions --username <some_username>` 
* Also, the `./manage.py cms copy` command now requires either a user id or a user name to create new page content models. They can be specified using the command line parameters `--username xy` or `--userid 23`.
* Finally, the "Duplicate page" now creates the correct Version objects automatically.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
