### PR TITLE
 feat: Improved admin_manager

### DIFF
--- a/cms/models/managers.py
+++ b/cms/models/managers.py
@@ -130,8 +130,8 @@ class PageContentAdminQuerySet(models.QuerySet):
         return self.filter(**kwargs)
     
     def latest(self):
-        """Returns the latest version (if a versioning package is installed). 
-        Without versioning every page content is the latest."""
+        """Returns the latest version (if a versioning package is installed) including discared 
+        or unpublished page content. Without versioning every page content is the latest."""
         return self
 
 

--- a/cms/models/managers.py
+++ b/cms/models/managers.py
@@ -125,13 +125,14 @@ class PageContentManager(WithUserMixin, models.Manager):
 
 class PageContentAdminQuerySet(models.QuerySet):
     def current_content(self, **kwargs):
-        """Returns the currently valid content that matches the filter given in kwargs.
-        (if a versioning package is installed). Without versioning every page us current."""
+        """If a versioning package is installed, this returns the currently valid content 
+        that matches the filter given in kwargs. Used to find content to be copied, e.g.. 
+        Without versioning every page is current."""
         return self.filter(**kwargs)
 
     def latest_content(self, **kwargs):
-        """Returns the latest version (if a versioning package is installed) that matches the
-        filter given in kwargsincluding discared or unpublished page content. Without versioning
+        """If a versioning package is installed, returns the latest version that matches the
+        filter given in kwargs including discared or unpublished page content. Without versioning
         every page content is the latest."""
         return self.filter(**kwargs)
 

--- a/cms/models/managers.py
+++ b/cms/models/managers.py
@@ -128,9 +128,9 @@ class PageContentAdminQuerySet(models.QuerySet):
         """Returns the currently valid content that matches the filter given in kwargs.
         (if a versioning package is installed). Without versioning every page us current."""
         return self.filter(**kwargs)
-    
+
     def latest(self):
-        """Returns the latest version (if a versioning package is installed) including discared 
+        """Returns the latest version (if a versioning package is installed) including discared
         or unpublished page content. Without versioning every page content is the latest."""
         return self
 

--- a/cms/models/managers.py
+++ b/cms/models/managers.py
@@ -129,7 +129,7 @@ class PageContentAdminQuerySet(models.QuerySet):
         (if a versioning package is installed). Without versioning every page us current."""
         return self.filter(**kwargs)
 
-    def latest(self):
+    def latest_content(self):
         """Returns the latest version (if a versioning package is installed) including discared
         or unpublished page content. Without versioning every page content is the latest."""
         return self

--- a/cms/models/managers.py
+++ b/cms/models/managers.py
@@ -125,8 +125,8 @@ class PageContentManager(WithUserMixin, models.Manager):
 
 class PageContentAdminQuerySet(models.QuerySet):
     def current_content(self, **kwargs):
-        """If a versioning package is installed, this returns the currently valid content 
-        that matches the filter given in kwargs. Used to find content to be copied, e.g.. 
+        """If a versioning package is installed, this returns the currently valid content
+        that matches the filter given in kwargs. Used to find content to be copied, e.g..
         Without versioning every page is current."""
         return self.filter(**kwargs)
 

--- a/cms/models/managers.py
+++ b/cms/models/managers.py
@@ -125,7 +125,14 @@ class PageContentManager(WithUserMixin, models.Manager):
 
 class PageContentAdminQuerySet(models.QuerySet):
     def current_content(self, **kwargs):
+        """Returns the currently valid content that matches the filter given in kwargs.
+        (if a versioning package is installed). Without versioning every page us current."""
         return self.filter(**kwargs)
+    
+    def latest(self):
+        """Returns the latest version (if a versioning package is installed). 
+        Without versioning every page content is the latest."""
+        return self
 
 
 class PageContentAdminManager(PageContentManager):

--- a/cms/models/managers.py
+++ b/cms/models/managers.py
@@ -124,8 +124,8 @@ class PageContentManager(WithUserMixin, models.Manager):
 
 
 class PageContentAdminQuerySet(models.QuerySet):
-    def current_content_iterator(self, **kwargs):
-        return iter(self.filter(**kwargs))
+    def current_content(self, **kwargs):
+        return self.filter(**kwargs)
 
 
 class PageContentAdminManager(PageContentManager):

--- a/cms/models/managers.py
+++ b/cms/models/managers.py
@@ -130,8 +130,8 @@ class PageContentAdminQuerySet(models.QuerySet):
         return self.filter(**kwargs)
 
     def latest_content(self, **kwargs):
-        """Returns the latest version (if a versioning package is installed) that matches the 
-        filter given in kwargsincluding discared or unpublished page content. Without versioning 
+        """Returns the latest version (if a versioning package is installed) that matches the
+        filter given in kwargsincluding discared or unpublished page content. Without versioning
         every page content is the latest."""
         return self.filter(**kwargs)
 

--- a/cms/models/managers.py
+++ b/cms/models/managers.py
@@ -129,10 +129,11 @@ class PageContentAdminQuerySet(models.QuerySet):
         (if a versioning package is installed). Without versioning every page us current."""
         return self.filter(**kwargs)
 
-    def latest_content(self):
-        """Returns the latest version (if a versioning package is installed) including discared
-        or unpublished page content. Without versioning every page content is the latest."""
-        return self
+    def latest_content(self, **kwargs):
+        """Returns the latest version (if a versioning package is installed) that matches the 
+        filter given in kwargsincluding discared or unpublished page content. Without versioning 
+        every page content is the latest."""
+        return self.filter(**kwargs)
 
 
 class PageContentAdminManager(PageContentManager):

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -503,7 +503,7 @@ class Page(models.Model):
             PageUrl.objects.with_user(user).create(**new_url)
 
         # copy titles of this page
-        for title in translations.current_content_iterator():
+        for title in translations.current_content():
             new_title = model_to_dict(title)
             new_title.pop("id", None)  # No PK
             new_title["page"] = new_page

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -931,4 +931,4 @@ class PageContentTests(CMSTestCase):
         self.assertEqual(PageContent.admin_manager.filter(page=self.page).count(), 2)
 
         # test if the current_content_iterator sees both page contents
-        self.assertEqual(len(list(PageContent.admin_manager.all().current_content_iterator(page=self.page))), 2)
+        self.assertEqual(len(list(PageContent.admin_manager.all().current_content(page=self.page))), 2)

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -931,4 +931,4 @@ class PageContentTests(CMSTestCase):
         self.assertEqual(PageContent.admin_manager.filter(page=self.page).count(), 2)
 
         # test if the current_content_iterator sees both page contents
-        self.assertEqual(len(list(PageContent.admin_manager.all().current_content(page=self.page))), 2)
+        self.assertEqual(len(list(PageContent.admin_manager.filter(page=self.page).current_content())), 2)


### PR DESCRIPTION
## Description

The `admin_manager` provided access to `current_content_iterator` which allowed to "filter" out all current versions of the model if some sort of versioning is installed by returning an iterator.

This method is now replaced by `current_content()` which is a filter that returns a queryset that only contains the current verison of the objects. Not only is it more convenient to have a qs returned, djangocms-versioning now can implement this much more efficiently.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* https://github.com/django-cms/djangocms-versioning/pull/318
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
