### PR TITLE
fix: pagetree css can interfere with other changelists if djangocms-admin-style is absent

### DIFF
--- a/cms/static/cms/sass/components/pagetree/_tree.scss
+++ b/cms/static/cms/sass/components/pagetree/_tree.scss
@@ -40,7 +40,7 @@
     touch-action: none;
 }
 
-#changelist {
+.cms-pagetree-root#changelist {
     display: block;
     align-items: flex-start;
     justify-content: space-between;


### PR DESCRIPTION
## Description

This fixes a small interference of `cms.pagetree.css` with changelist views in the admin when `djangocms-admin-style` is **not** installed. The filter side bar moves below the changelist which is not desired.


## After fix:
![image](https://user-images.githubusercontent.com/16904477/217392232-9d3d3f49-7aab-4706-aa4e-b8f664716e33.png)


## Before fix

![image](https://user-images.githubusercontent.com/16904477/217392319-8431bf30-e483-4da2-9a24-58b50967779f.png)


<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
