### PR TITLE
feat: add setting to redirect slugs to lowercase

### DIFF
--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -7,7 +7,7 @@ from django.core.cache import cache
 from django.http import Http404
 from django.template import Variable
 from django.test.utils import override_settings
-from django.urls import clear_url_caches
+from django.urls import clear_url_caches, reverse
 
 from cms.api import create_page, create_title, publish_page
 from cms.models import PagePermission, Placeholder, UserSettings
@@ -176,6 +176,18 @@ class ViewTests(CMSTestCase):
         response = details(request, one.get_path())
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response['Location'], redirect + params)
+
+    @override_settings(CMS_REDIRECT_TO_LOWERCASE_SLUG=True)
+    def test_redirecting_to_lowercase_slug(self):
+        redirect = '/en/one/'
+        one = create_page("one", "nav_playground.html", "en", published=True,
+                          redirect=redirect)
+        url = reverse('pages-details-by-slug', kwargs={"slug": "One"})
+        request = self.get_request(url)
+        response = details(request, one.get_path())
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], redirect)
+
 
     def test_login_required(self):
         self.create_homepage("page", "nav_playground.html", "en", published=True, login_required=True)

--- a/cms/utils/conf.py
+++ b/cms/utils/conf.py
@@ -90,6 +90,7 @@ DEFAULTS = {
     'COLOR_SCHEME': 'light',
     'COLOR_SCHEME_TOGGLE': False,
     'REDIRECT_PRESERVE_QUERY_PARAMS': False,
+    'REDIRECT_TO_LOWERCASE_SLUG': False,
 }
 
 

--- a/cms/views.py
+++ b/cms/views.py
@@ -76,6 +76,19 @@ def details(request, slug):
         # and there's no pages
         return _render_welcome_page(request)
 
+
+    if not page and get_cms_setting("REDIRECT_TO_LOWERCASE_SLUG"):
+        # Redirect to the lowercase version of the slug
+        if slug.lower() != slug:
+            # Only redirect if the slug changes
+            redirect_url = reverse("pages-details-by-slug", kwargs={"slug": slug.lower()})
+            if get_cms_setting('REDIRECT_PRESERVE_QUERY_PARAMS'):
+                query_string = request.META.get('QUERY_STRING')
+                if query_string:
+                    redirect_url += "?" + query_string
+            return HttpResponseRedirect(redirect_url)
+
+
     if not page:
         # raise 404
         _handle_no_page(request)

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -1200,3 +1200,15 @@ default
     ``False``
 
 This indicates to the CMS that redirects should preserve the query parameters.
+
+
+..  setting:: CMS_REDIRECT_TO_LOWERCASE_SLUG
+
+CMS_REDIRECT_TO_LOWERCASE_SLUG
+==============================
+
+default
+    ``False``
+
+This indicates to the CMS that it should redirect requests with an non-lowercase
+slug to its lowercase version if no page with that slug is found.


### PR DESCRIPTION
## Description

This commit adds the REDIRECT_TO_LOWERCASE_SLUG option which will cause the cms to redirect requests with an non-lowercase slug if no page with that slug is found.


<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #1324 

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.