### PR TITLE
fix: typos in French translations

### DIFF
--- a/cms/locale/fr/LC_MESSAGES/django.po
+++ b/cms/locale/fr/LC_MESSAGES/django.po
@@ -1414,7 +1414,7 @@ msgid ""
 "                        haven't added any pages yet.\n"
 "                    </p>\n"
 "                "
-msgstr "\n<p class=\"cms-welcome-notes\">Vous voyez ce message parce que vous avet <code>DEBUG = True</code> dans le fichier paramètres de django et que vous n'avez pas encore ajouté de pages.\n</p>"
+msgstr "\n<p class=\"cms-welcome-notes\">Vous voyez ce message parce que vous avez <code>DEBUG = True</code> dans le fichier paramètres de django et que vous n'avez pas encore ajouté de page.\n</p>"
 
 msgid "Welcome to django CMS"
 msgstr "Bienvenue sur django CMS"


### PR DESCRIPTION
## Description

`avet` in not a verb in the french language, where as `avez` on the other hand...

Also since there is no page yet, I put page to singular.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* https://dictionnaire.lerobert.com/conjugaison/avoir
