### PR TITLE
fix: page content's `get_absolute_url` needs to return URL of page content's language

### DIFF
--- a/cms/models/contentmodels.py
+++ b/cms/models/contentmodels.py
@@ -269,7 +269,9 @@ class PageContent(models.Model):
             return None
 
     def get_absolute_url(self, language=None):
-        return self.page.get_absolute_url(language=language)
+        """Get the absolute url for the page content. If language is specified it will return
+        the absolute url of the corresponding "sister" content."""
+        return self.page.get_absolute_url(language=language or self.language)
 
 
 class EmptyPageContent:

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -62,6 +62,25 @@ class PagesTestCase(TransactionCMSTestCase):
             self.assertEqual(page_2.get_absolute_url(language='en'), '/en/inner/')
             self.assertEqual(page_2.get_absolute_url(language='fr'), '/fr/french-inner/')
 
+    def test_absolute_url_page_content(self):
+        page = self.create_homepage("page", "nav_playground.html", "en")
+        create_page_content("fr", "french home", page)
+        page_2 = create_page("inner", "nav_playground.html", "en", parent=page)
+        content_2 = create_page_content("fr", "french inner", page_2)
+
+        # content_2 is French
+        self.assertEqual(content_2.get_absolute_url(), '/fr/french-inner/')
+        # if language specified, get the language version's url
+        self.assertEqual(content_2.get_absolute_url(language='en'), '/en/inner/')
+        # for completeness: specify own language
+        self.assertEqual(content_2.get_absolute_url(language='fr'), '/fr/french-inner/')
+
+        # The above result does not change if language is changed
+        with force_language('en'):
+            self.assertEqual(content_2.get_absolute_url(), '/fr/french-inner/')
+            self.assertEqual(content_2.get_absolute_url(language='en'), '/en/inner/')
+            self.assertEqual(content_2.get_absolute_url(language='fr'), '/fr/french-inner/')
+
     def test_get_root_page(self):
         _create = functools.partial(
             create_page,


### PR DESCRIPTION
## Description

The page content's `get_absolute_url` should return the URL of the page content object, i.e. in the page content's language. 

This is relevant, for example, for the "View published" button in versioning.
<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Underlying issue

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->
With the current language being, say, English, clicking "View published" for a page content object in a different language will lead to the English published URL.

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
