### PR TITLE
fix: empty actions shown without unwanted spaces

### DIFF
--- a/cms/admin/utils.py
+++ b/cms/admin/utils.py
@@ -48,6 +48,8 @@ class ChangeListActionsMixin(metaclass=forms.MediaDefiningClass):
         )
         css = {"all": (static_with_version("cms/css/cms.admin.css"),)}
 
+    EMPTY_ACTION = mark_safe('<span class="cms-empty-action"></span>')
+
     def get_actions_list(
         self,
     ) -> typing.List[typing.Callable[[models.Model, HttpRequest], str]]:
@@ -77,12 +79,11 @@ class ChangeListActionsMixin(metaclass=forms.MediaDefiningClass):
 
         def list_actions(obj: models.Model) -> str:
             """The name of this inner function must not change. css styling and js depends on it."""
-            EMPTY = mark_safe('<span class="cms-empty-action"></span>')
             return format_html_join(
                 "",
                 "{}",
                 (
-                    (action(obj, request) or EMPTY,)
+                    (action(obj, request),)
                     for action in self.get_actions_list()
                 ),
             )
@@ -147,7 +148,7 @@ class ChangeListActionsMixin(metaclass=forms.MediaDefiningClass):
             {
                 "url": url or "",
                 "icon": icon,
-                "action": action,
+                "get": action == "get",
                 "disabled": disabled,
                 "keepsideframe": keepsideframe,
                 "title": title,
@@ -557,7 +558,7 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
                 keepsideframe=False,
                 name="view",
             )
-        return ""
+        return self.EMPTY_ACTION
 
     def _get_settings_action(self, obj: models.Model, request: HttpRequest) -> str:
         edit_url = admin_reverse(

--- a/cms/admin/utils.py
+++ b/cms/admin/utils.py
@@ -148,7 +148,7 @@ class ChangeListActionsMixin(metaclass=forms.MediaDefiningClass):
             {
                 "url": url or "",
                 "icon": icon,
-                "get": action == "get",
+                "method": action,
                 "disabled": disabled,
                 "keepsideframe": keepsideframe,
                 "title": title,

--- a/cms/static/cms/js/admin/actions.js
+++ b/cms/static/cms/js/admin/actions.js
@@ -14,7 +14,7 @@
            .cms-actions-dropdown-menu-item-anchor`)
             .on('click', function(e) {
                 let action = $(e.currentTarget);
-                let formMethod = action.attr('class').indexOf('cms-form-get-method') !== -1 ? 'GET': 'POST';
+                let formMethod = action.attr('class').indexOf('cms-form-post-method') !== -1 ? 'POST': 'GET';
                 let keepSideFrame = action.attr('class').indexOf('js-keep-sideframe') !== -1;
 
                 if (formMethod === 'GET') {

--- a/cms/templates/admin/cms/icons/base.html
+++ b/cms/templates/admin/cms/icons/base.html
@@ -1,5 +1,5 @@
 {% spaceless %}
-<a class="btn{% if disabled %} inactive{% endif %}{% if get|default_if_none:True %} cms-form-get-method{% endif %}{% if burger_menu %} cms-burger-action-btn{% endif %} cms-action-btn cms-action-{% block name %}{{ name }}{% endblock %}{% if action|default_if_none:True %} js-action{% endif %} {% if keepsideframe|default_if_none:True %}js-keep-sideframe{% else %}js-close-sideframe{% endif %}"{% if not disabled %} href="{{ url }}"{% endif %} title="{% block title %}{{ title }}{% endblock %}">
+<a class="btn{% if disabled %} inactive{% endif %} cms-form-{{ method }}-method{% if burger_menu %} cms-burger-action-btn{% endif %} cms-action-btn{% block name %}{% if name %} cms-action-{{ name }}{% endif %}{% endblock %}{% if action|default_if_none:True %} js-action{% endif %} {% if keepsideframe|default_if_none:True %}js-keep-sideframe{% else %}js-close-sideframe{% endif %}"{% if not disabled %} href="{{ url }}"{% endif %} title="{% block title %}{{ title }}{% endblock %}">
     <span class="cms-icon cms-icon-{% block icon %}{{ icon }}{% endblock %}"></span>
 </a>
 {% endspaceless %}

--- a/cms/tests/test_grouper_admin.py
+++ b/cms/tests/test_grouper_admin.py
@@ -79,6 +79,30 @@ class ChangeListActionsTestCase(SetupMixin, CMSTestCase):
                                           f'/change/?language=en"')
             self.assertContains(response, 'class="cms-icon cms-icon-view"')
 
+    def test_get_action(self):
+        admin = site._registry[GrouperModel]
+
+        get_action = admin.admin_action_button(
+            "/some/url",
+            icon="info",
+            title="Info",
+            action="get",
+        )
+        self.assertIn("cms-form-get-method", get_action)
+        self.assertNotIn("cms-form-post-method", get_action)
+
+    def test_post_action(self):
+        admin = site._registry[GrouperModel]
+
+        get_action = admin.admin_action_button(
+            "/some/url",
+            icon="bin",
+            title="Delete",
+            action="post",
+        )
+        self.assertNotIn("cms-form-get-method", get_action)
+        self.assertIn("cms-form-post-method", get_action)
+
 
 class GrouperModelAdminTestCase(SetupMixin, CMSTestCase):
     def test_form_class_created(self):


### PR DESCRIPTION
## Description

* Fixing a leftover code bit that inserts unwanted spaces between actions. 
* Also updates icon template to comply with docs.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
