### PR TITLE
fix: Preview icon takes user to the language of the page content object

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 unreleased
 ==========
 
+* Fixed a bug where menu link is outdated when page moved.
 * Unified icon font with icons for versioning, moderation and version locking
 * Django 4.1 and 4.0 support
 * Python 3.10 support
@@ -34,6 +35,7 @@ unreleased
 ==================
 
 * Introduced Django 2.2 support.
+=======
 * Removed the ``cms moderator`` command.
 * Dropped Django < 1.11 support.
 * Removed the translatable content get / set methods from ``CMSPlugin`` model.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,7 +35,6 @@ unreleased
 ==================
 
 * Introduced Django 2.2 support.
-=======
 * Removed the ``cms moderator`` command.
 * Dropped Django < 1.11 support.
 * Removed the translatable content get / set methods from ``CMSPlugin`` model.

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -921,7 +921,7 @@ class Page(models.Model):
         for page_content in cached_page_content:
             self.page_content_cache[page_content.language] = page_content
 
-        # Reload if explicitly needed or language not in title cache
+        # Reload if explicitly needed or language not in content cache
         if force_reload or language not in self.page_content_cache:
             for page_content in self.pagecontent_set.all():
                 self.page_content_cache[page_content.language] = page_content

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -434,11 +434,12 @@ class Page(models.Model):
             .values_list('language', flat=True)
         )
 
+<<<<<<< HEAD
         for language in languages:
             if not self.is_home:
                 self._update_url_path(language)
             self._update_url_path_recursive(language)
-        self.clear_cache()
+        self.clear_cache(menu=True)
         return self
 
     def _clear_placeholders(self, language):

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -434,7 +434,6 @@ class Page(models.Model):
             .values_list('language', flat=True)
         )
 
-<<<<<<< HEAD
         for language in languages:
             if not self.is_home:
                 self._update_url_path(language)

--- a/cms/templatetags/cms_admin.py
+++ b/cms/templatetags/cms_admin.py
@@ -8,7 +8,7 @@ from django.contrib.admin.views.main import ERROR_FLAG
 from django.template.loader import render_to_string
 from django.utils.encoding import force_str
 from django.utils.safestring import mark_safe
-from django.utils.translation import get_language, override
+from django.utils.translation import get_language
 from django.utils.translation import gettext_lazy as _
 
 from cms.models import Page

--- a/cms/templatetags/cms_admin.py
+++ b/cms/templatetags/cms_admin.py
@@ -11,9 +11,10 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import get_language, override
 from django.utils.translation import gettext_lazy as _
 
+from cms.models import Page
 from cms.models.contentmodels import PageContent
 from cms.toolbar.utils import get_object_preview_url
-from cms.utils import i18n
+from cms.utils import get_language_from_request, i18n
 from cms.utils.urlutils import admin_reverse
 
 register = template.Library()
@@ -57,6 +58,11 @@ class GetPreviewUrl(AsTag):
     )
 
     def get_value(self, context, page_content):
+        if isinstance(page_content, Page):
+            # Advanced settings wants a preview for a Page object.
+            page_content = page_content.get_content_obj(
+                language=get_language_from_request(context["request"])
+            )
         if not page_content:
             return ""
         return get_object_preview_url(page_content, language=page_content.language)

--- a/cms/templatetags/cms_admin.py
+++ b/cms/templatetags/cms_admin.py
@@ -8,7 +8,7 @@ from django.contrib.admin.views.main import ERROR_FLAG
 from django.template.loader import render_to_string
 from django.utils.encoding import force_str
 from django.utils.safestring import mark_safe
-from django.utils.translation import get_language
+from django.utils.translation import get_language, override
 from django.utils.translation import gettext_lazy as _
 
 from cms.models.contentmodels import PageContent
@@ -63,9 +63,9 @@ class GetPreviewUrl(AsTag):
             from django.contrib.contenttypes.models import ContentType
 
             GetPreviewUrl.page_content_type = ContentType.objects.get_for_model(PageContent).pk
-
-        return admin_reverse('cms_placeholder_render_object_preview',
-                             args=[GetPreviewUrl.page_content_type, page_content.pk])
+        with override(page_content.language):
+            return admin_reverse('cms_placeholder_render_object_preview',
+                                 args=[GetPreviewUrl.page_content_type, page_content.pk])
 
 
 register.tag(GetPreviewUrl.name, GetPreviewUrl)

--- a/cms/templatetags/cms_admin.py
+++ b/cms/templatetags/cms_admin.py
@@ -12,6 +12,7 @@ from django.utils.translation import get_language, override
 from django.utils.translation import gettext_lazy as _
 
 from cms.models.contentmodels import PageContent
+from cms.toolbar.utils import get_object_preview_url
 from cms.utils import i18n
 from cms.utils.urlutils import admin_reverse
 
@@ -58,14 +59,7 @@ class GetPreviewUrl(AsTag):
     def get_value(self, context, page_content):
         if not page_content:
             return ""
-        if GetPreviewUrl.page_content_type is None:
-            # Use class as cache
-            from django.contrib.contenttypes.models import ContentType
-
-            GetPreviewUrl.page_content_type = ContentType.objects.get_for_model(PageContent).pk
-        with override(page_content.language):
-            return admin_reverse('cms_placeholder_render_object_preview',
-                                 args=[GetPreviewUrl.page_content_type, page_content.pk])
+        return get_object_preview_url(page_content, language=page_content.language)
 
 
 register.tag(GetPreviewUrl.name, GetPreviewUrl)

--- a/cms/tests/test_menu.py
+++ b/cms/tests/test_menu.py
@@ -301,6 +301,40 @@ class FixturesMenuTests(MenusFixture, BaseMenuTest):
             [page.get_absolute_url() for page in pages],
         )
 
+    def test_show_page_in_menu_after_move_page(self):
+        """
+        Test checks if the menu cache is cleaned after move page.
+        """
+        page = create_page('page to move', 'nav_playground.html', 'en')
+
+        request = self.get_request('/')
+        renderer = menu_pool.get_renderer(request)
+        renderer.draft_mode_active = True
+        nodes_before = renderer.get_nodes()
+        index_before = [i for i, s in enumerate(nodes_before) if s.title == page.get_title()]
+        self.assertEqual(CacheKey.objects.count(), 1)
+
+        with self.login_user_context(self.get_superuser()):
+            # Moves the page to the second position in the tree
+            data = {'id': page.pk, 'position': 1}
+            endpoint = self.get_admin_url(Page, 'move_page', page.pk)
+            response = self.client.post(endpoint, data)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(CacheKey.objects.count(), 0)
+
+        request = self.get_request('/')
+        renderer = menu_pool.get_renderer(request)
+        renderer.draft_mode_active = True
+        nodes_after = renderer.get_nodes()
+        index_after = [i for i, s in enumerate(nodes_after) if s.title == page.get_title()]
+
+        self.assertEqual(CacheKey.objects.count(), 1)
+        self.assertNotEqual(
+            index_before,
+            index_after,
+            'Index should not be the same after move page in navigation'
+        )
+
     def test_cms_menu_public_with_multiple_languages(self):
         pages = self.get_all_pages().order_by('node__path')
 

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -1284,6 +1284,20 @@ class PageTest(PageTestBase):
             del sys.modules['cms.test_utils.project.sampleapp.cms_apps']
         self.apphook_clear()
 
+    def test_advanced_settings_view_on_site(self):
+        """Advanced Page Settings `View on Site` object tool links to the Page's current language
+        content preview url"""
+        from cms.toolbar.utils import get_object_preview_url
+        superuser = self.get_superuser()
+        cms_page = create_page('app', 'nav_playground.html', 'en')
+        cms_page_content = cms_page.get_content_obj(language='en')
+        endpoint = self.get_admin_url(Page, 'advanced', cms_page.pk)
+
+        with self.login_user_context(superuser):
+            response = self.client.get(endpoint)
+
+        self.assertContains(response, get_object_preview_url(cms_page_content, language="en"))
+
     def test_form_url_page_change(self):
         superuser = self.get_superuser()
         with self.login_user_context(superuser):

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -27,7 +27,7 @@ from cms.models import (
     PageUrl,
     Placeholder,
 )
-from cms.templatetags.cms_admin import get_page_display_name
+from cms.templatetags.cms_admin import get_page_display_name, GetPreviewUrl
 from cms.templatetags.cms_js_tags import json_filter
 from cms.templatetags.cms_tags import (
     _get_page_by_untyped_arg,
@@ -43,6 +43,20 @@ from cms.utils.placeholder import get_placeholders
 
 
 class TemplatetagTests(CMSTestCase):
+
+    def test_get_preview_url(self):
+        """The get_preview_url template tag returns the content preview url for its language:
+        If a page is given, take the current language (en), if a page_content is given,
+        take its language (de for this test)"""
+        page = create_page("page_a", "nav_playground.html", "en")
+        german_content = create_page_content("de", "Seite_a", page)
+
+        page_preview_url = GetPreviewUrl.get_value(None, context={"request": None}, page_content=page)
+        german_content_preview_url = GetPreviewUrl.get_value(None, context={}, page_content=german_content)
+
+        self.assertIn("/en", page_preview_url)
+        self.assertIn("/de/", german_content_preview_url)
+
 
     def test_get_admin_tree_title(self):
         page = create_page("page_a", "nav_playground.html", "en")

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -27,7 +27,7 @@ from cms.models import (
     PageUrl,
     Placeholder,
 )
-from cms.templatetags.cms_admin import get_page_display_name, GetPreviewUrl
+from cms.templatetags.cms_admin import GetPreviewUrl, get_page_display_name
 from cms.templatetags.cms_js_tags import json_filter
 from cms.templatetags.cms_tags import (
     _get_page_by_untyped_arg,


### PR DESCRIPTION
## Description

This PR fixes a bug similar to https://github.com/django-cms/djangocms-versioning/pull/325:

* If the preview icon in the page tree was clicked for a page content object with a different language than the admin language, an empty preview was shown 
* The page content was previewed in the admin language, where it has no content (since it is of a different language).
* Additionally, the same template tag used in the advanced settings returned a likely invalid preview URL.
* The template tag `get_preview_url` in `cms_admin` now uses the appropriate `get_object_preview_url` utility function. 
* The PR adds tests for both bugs to it.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* https://github.com/django-cms/djangocms-versioning/pull/325
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
