### PR TITLE
fix: require Django >= 3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 
 REQUIREMENTS = [
-    'Django>=2.2,<5.0',
+    'Django>=3.2,<5.0',
     'django-classy-tags>=0.7.2',
     'django-formtools>=2.1',
     'django-treebeard>=4.3',


### PR DESCRIPTION
## Description

Django CMS 3.11 supports Django 3.2+ This is so far not reflected in its `setup.py`.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7390
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
