### PR TITLE
fix: Unlocalize ids to avoid js errors for ids greater than 999

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -1,4 +1,5 @@
 import json
+import re
 from collections import namedtuple
 
 import django
@@ -1351,9 +1352,12 @@ class PageContentAdmin(admin.ModelAdmin):
         """
         site = get_site(request)
         pages = Page.objects.on_site(site).order_by('node__path')
-        node_id = request.GET.get('nodeId')
-        open_nodes = list(map(int, request.GET.getlist('openNodes[]')))
-
+        node_id = re.sub(r'[^\d]', '', request.GET.get('nodeId', '')) or None
+        open_nodes = list(map(
+            int,
+            [re.sub(r'[^\d]', '', node) for node in
+             request.GET.getlist('openNodes[]')]
+        ))
         if node_id:
             page = get_object_or_404(pages, node_id=int(node_id))
             pages = page.get_descendant_pages().filter(Q(node__in=open_nodes) | Q(node__parent__in=open_nodes))

--- a/cms/templates/admin/cms/page/tree/actions_dropdown.html
+++ b/cms/templates/admin/cms/page/tree/actions_dropdown.html
@@ -1,12 +1,12 @@
-{% load i18n admin_urls %}
+{% load i18n l10n admin_urls %}
 {% spaceless %}
 <ul class="cms-pagetree-dropdown-menu-inner">
     {% block actions %}
         <li
             {% if has_copy_page_permission %}
                 class="js-cms-tree-item-copy"
-                data-id="{{ page.pk }}"
-                data-node-id="{{ node.pk }}"
+                data-id="{{ page.pk|unlocalize }}"
+                data-node-id="{{ node.pk|unlocalize }}"
                 data-apphook="{{ page.application_urls|default_if_none:"" }}"
             {% endif %}
         >
@@ -18,8 +18,8 @@
         <li
             {% if has_move_page_permission %}
                 class="js-cms-tree-item-cut"
-                data-id="{{ page.pk }}"
-                data-node-id="{{ node.pk }}"
+                data-id="{{ page.pk|unlocalize }}"
+                data-node-id="{{ node.pk|unlocalize }}"
             {% endif %}
         >
             <a{% if not has_move_page_permission %} class="cms-pagetree-dropdown-item-disabled"{% endif %}
@@ -29,8 +29,8 @@
             </a>
         </li>
         <li>
-            <a href="#" data-id="{{ page.pk }}"
-                data-node-id="{{ node.pk }}"
+            <a href="#" data-id="{{ page.pk|unlocalize }}"
+                data-node-id="{{ node.pk|unlocalize }}"
                 class="{% if has_add_permission %}js-cms-tree-item-paste{% endif %}
                 {% if not has_add_permission or not paste_enabled %} cms-pagetree-dropdown-item-disabled{% endif %}">
                 <span class="cms-icon cms-icon-paste"></span>

--- a/cms/templates/admin/cms/page/tree/base.html
+++ b/cms/templates/admin/cms/page/tree/base.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_list.html" %}
-{% load i18n admin_list static admin_urls cms_admin cms_js_tags cms_static cms_tags %}
+{% load i18n l10n admin_list static admin_urls cms_admin cms_js_tags cms_static cms_tags %}
 
 {# TODO might not need that #}
 {% block title %}{% trans "List of pages" %}{% endblock %}
@@ -108,7 +108,7 @@
                                 </li>
                                 {% for site in tree.sites %}
                                     <li{% if site.pk == tree.site.pk %} class="active"{% endif %}>
-                                        <a href="#{{ site.pk }}" class="js-cms-pagetree-site-trigger" data-id="{{ site.pk }}">{{ site.name }}</a>
+                                        <a href="#{{ site.pk|unlocalize }}" class="js-cms-pagetree-site-trigger" data-id="{{ site.pk|unlocalize }}">{{ site.name }}</a>
                                     </li>
                                 {% endfor %}
                                 {% if has_recover_permission %}
@@ -127,7 +127,7 @@
                         <form method="post" class="js-cms-pagetree-site-form cms-hidden">
                             <select name="site">
                                 {% for site in tree.sites %}
-                                    <option value="{{ site.pk }}">{{ site.name }}</option>
+                                    <option value="{{ site.pk|unlocalize }}">{{ site.name }}</option>
                                 {% endfor %}
                             </select>
                             {% csrf_token %}
@@ -193,7 +193,7 @@
                             "permission": {{ CMS_PERMISSION|bool }},
                             "debug": {{ DEBUG|bool }},
                             "filtered": {% if tree.is_filtered %}true{% else %}false{% endif %},
-                            "site": {{ tree.site.pk }},
+                            "site": {{ tree.site.pk|unlocalize }},
                             "hasAddRootPermission": {{ has_add_permission|yesno:"true,false" }},
                             "lang": {
                                 "code": "{{ preview_language|lower }}",
@@ -257,7 +257,7 @@
                         "permission": {{ CMS_PERMISSION|bool }},
                         "debug": {{ DEBUG|bool }},
                         "filtered": {% if tree.is_filtered %}true{% else %}false{% endif %},
-                        "site": {{ tree.site.pk }},
+                        "site": {{ tree.site.pk|unlocalize }},
                         "hasAddRootPermission": {{ has_add_permission|yesno:"true,false" }},
                         "lang": {
                             "code": "{{ preview_language|lower }}",

--- a/cms/templates/admin/cms/page/tree/menu.html
+++ b/cms/templates/admin/cms/page/tree/menu.html
@@ -1,4 +1,4 @@
-{% load i18n cms_admin admin_urls %}
+{% load i18n l10n cms_admin admin_urls %}
 
 {# INFO: columns are defined in base.html options #}
 {% spaceless %}
@@ -16,9 +16,9 @@
         {% endif %}
     {% endblock %}
     "
-    {% if is_popup %}onclick="opener.dismissRelatedLookupPopup(window, {{ page.id }}); return false;"{% endif %}
-    data-id="{{ page.pk }}"
-    data-node-id="{{ node.pk }}"
+    {% if is_popup %}onclick="opener.dismissRelatedLookupPopup(window, {{ page.pk|unlocalize }}); return false;"{% endif %}
+    data-id="{{ page.pk|unlocalize }}"
+    data-node-id="{{ node.pk|unlocalize }}"
     data-slug="{{ page_content.slug }}"
     data-is-home="{{ page.is_home|yesno:"true,false" }}"
     data-move-permission="{{ has_move_page_permission|yesno:"true,false" }}"
@@ -158,7 +158,7 @@
                     <div{% if has_add_page_permission %} class="cms-hover-tooltip cms-hover-tooltip-left cms-hover-tooltip-delay"
                         data-cms-tooltip="{% autoescape on %}{% trans 'New sub page' %}{% endautoescape %}"{% endif %}>
                         {% if has_add_page_permission %}
-                            <a href="{% url opts|admin_urlname:'add' %}?parent_node={{ node.pk }}&language={{ lang }}"
+                            <a href="{% url opts|admin_urlname:'add' %}?parent_node={{ node.pk|unlocalize }}&language={{ lang }}"
                                 class="js-cms-pagetree-add-page cms-btn cms-btn-default cms-icon cms-icon-plus">
                         {% else %}
                             <span class="cms-btn cms-btn-default cms-btn-disabled cms-icon cms-icon-plus">
@@ -172,7 +172,7 @@
                     </div>
                 </div>
                 <div class="js-cms-pagetree-actions-dropdown cms-tree-item cms-tree-item-button cms-pagetree-dropdown js-cms-pagetree-dropdown" data-lazy-url="{% url 'admin:cms_page_actions_menu' page.pk %}">
-                    <a data-node-id="{{ node.pk }}" data-id="{{ page.pk }}" href="#" class="js-cms-pagetree-dropdown-trigger js-cms-pagetree-options cms-pagetree-dropdown-trigger cms-btn cms-btn-default cms-btn-no-border cms-icon cms-icon-menu">
+                    <a data-node-id="{{ node.pk|unlocalize }}" data-id="{{ page.pk|unlocalize }}" href="#" class="js-cms-pagetree-dropdown-trigger js-cms-pagetree-options cms-pagetree-dropdown-trigger cms-btn cms-btn-default cms-btn-no-border cms-icon cms-icon-menu">
                         <span class="sr-only">{% autoescape on %}{% trans "Options" %}{% endautoescape %}</span>
                     </a>
 
@@ -194,7 +194,7 @@
                                 </a>
                             </li>
                             <li>
-                                <a href="#" data-node-id="{{ node.pk }}" data-id="{{ page.pk }}" class="cms-pagetree-dropdown-item-disabled">
+                                <a href="#" data-node-id="{{ node.pk|unlocalize }}" data-id="{{ page.pk|unlocalize }}" class="cms-pagetree-dropdown-item-disabled">
                                     <span class="cms-icon cms-icon-paste"></span>
                                     <span>{% autoescape on %}{% trans "Paste" %}{% endautoescape %}</span>
                                 </a>

--- a/cms/templates/cms/toolbar/dragitem.html
+++ b/cms/templates/cms/toolbar/dragitem.html
@@ -47,7 +47,7 @@
             </div>
         {% endif %}
 
-        <span class="cms-dragitem-text" title="{{ plugin.plugin_type }} ID: {{ plugin.pk }}"><strong>{{ plugin.get_plugin_name }}</strong> {{ plugin.get_short_description }}</span>
+        <span class="cms-dragitem-text" title="{{ plugin.plugin_type }} ID: {{ plugin.pk|unlocalize }}"><strong>{{ plugin.get_plugin_name }}</strong> {{ plugin.get_short_description }}</span>
     </div>
 
     <div class="cms-collapsable-container cms-hidden


### PR DESCRIPTION

## Description

On sites that have more than 1000 pages, when rendering [admin/cms/page/tree/menu.html](https://github.com/django-cms/django-cms/blob/develop/cms/templates/admin/cms/page/tree/menu.html#L20) all the page ids and node ids are rendered localized, with e.g. commas or apostrophes for thousands separators.

When we then expand a node, those node's `data-id` are picked up and stored in local storage under `cms_cookie` in their localized form.

This has been fixed in 3.11 but remains open for the `develop-4` branch.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7188 
* #7175

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
