### PR TITLE
Replace PositiveSmallIntegerField against PositiveIntegerField

### DIFF
--- a/cms/migrations/0026_title_placeholders.py
+++ b/cms/migrations/0026_title_placeholders.py
@@ -20,6 +20,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='placeholder',
             name='title_id',
-            field=models.PositiveSmallIntegerField(null=True),
+            field=models.PositiveIntegerField(null=True),
         ),
     ]


### PR DESCRIPTION
## Description

In performing a migration towards version 4 I encountered a "value to big for small integer" exception.

This is because migration 0026 adds a temporary field for `title_id`. In my case some values do not fit in there. 