### PR TITLE
fix: JS issues with running CMS under cypress

### DIFF
--- a/cms/static/cms/js/modules/cms.base.js
+++ b/cms/static/cms/js/modules/cms.base.js
@@ -1,4 +1,4 @@
-/**cmsbase.js
+/**
  * CMS.API.Helpers
  * Multiple helpers used across all CMS features
  */

--- a/cms/static/cms/js/modules/cms.base.js
+++ b/cms/static/cms/js/modules/cms.base.js
@@ -105,35 +105,39 @@ export const Helpers = {
 
         // if there is an ajax reload, prioritize
         if (ajax) {
-            parent.CMS.API.locked = true;
-            // check if the url has changed, if true redirect to the new path
-            // this requires an ajax request
-            $.ajax({
-                async: false,
-                type: 'GET',
-                url: parent.CMS.config.request.url,
-                data: data || {
-                    model: parent.CMS.config.request.model,
-                    pk: parent.CMS.config.request.pk
-                },
-                success: function(response) {
-                    parent.CMS.API.locked = false;
+            // Check if this is running inside a sideframe and then access
+            // the CMS APIs from the parent window
+            if (parent.CMS && parent.CMS.API && parent.CMS.API.locked) {
+                parent.CMS.API.locked = true;
+                // check if the url has changed, if true redirect to the new path
+                // this requires an ajax request
+                $.ajax({
+                    async: false,
+                    type: 'GET',
+                    url: parent.CMS.config.request.url,
+                    data: data || {
+                        model: parent.CMS.config.request.model,
+                        pk: parent.CMS.config.request.pk
+                    },
+                    success: function(response) {
+                        parent.CMS.API.locked = false;
 
-                    if (response === '' && !url) {
-                        // cancel if response is empty
-                        return false;
-                    } else if (parent.location.pathname !== response && response !== '') {
-                        // api call to the backend to check if the current path is still the same
-                        that.reloadBrowser(response);
-                    } else if (url === 'REFRESH_PAGE') {
-                        // if on_close provides REFRESH_PAGE, only do a reload
-                        that.reloadBrowser();
-                    } else if (url) {
-                        // on_close can also provide a url, reload to the new destination
-                        that.reloadBrowser(url);
+                        if (response === '' && !url) {
+                            // cancel if response is empty
+                            return false;
+                        } else if (parent.location.pathname !== response && response !== '') {
+                            // api call to the backend to check if the current path is still the same
+                            that.reloadBrowser(response);
+                        } else if (url === 'REFRESH_PAGE') {
+                            // if on_close provides REFRESH_PAGE, only do a reload
+                            that.reloadBrowser();
+                        } else if (url) {
+                            // on_close can also provide a url, reload to the new destination
+                            that.reloadBrowser(url);
+                        }
                     }
-                }
-            });
+                });
+            }
 
             // cancel further operations
             return false;

--- a/cms/static/cms/js/modules/cms.base.js
+++ b/cms/static/cms/js/modules/cms.base.js
@@ -1,4 +1,4 @@
-/**
+/**cmsbase.js
  * CMS.API.Helpers
  * Multiple helpers used across all CMS features
  */
@@ -107,7 +107,7 @@ export const Helpers = {
         if (ajax) {
             // Check if this is running inside a sideframe and then access
             // the CMS APIs from the parent window
-            if (parent.CMS && parent.CMS.API && parent.CMS.API.locked) {
+            if (parent.CMS && parent.CMS.API) {
                 parent.CMS.API.locked = true;
                 // check if the url has changed, if true redirect to the new path
                 // this requires an ajax request

--- a/cms/static/cms/js/modules/cms.pagetree.js
+++ b/cms/static/cms/js/modules/cms.pagetree.js
@@ -808,14 +808,18 @@ var PageTree = new Class({
         var parent = win.parent ? win.parent : win;
 
         this.ui.container.on(this.click, '.js-cms-pagetree-page-view', function() {
-            parent.CMS.API.Helpers.setSettings(
-                $.extend(true, {}, CMS.settings, {
-                    sideframe: {
-                        url: null,
-                        hidden: true
-                    }
-                })
-            );
+            // check if the CM is running inside iframe or not. For Cypress tests
+            // this might not always be the case.
+            if (parent.CMS && parent.CMS.API && parent.CMS.API.Helpers) {
+                parent.CMS.API.Helpers.setSettings(
+                    $.extend(true, {}, CMS.settings, {
+                        sideframe: {
+                            url: null,
+                            hidden: true
+                        }
+                    })
+                );
+            }
         });
     },
 

--- a/cms/static/cms/js/modules/cms.pagetree.stickyheader.js
+++ b/cms/static/cms/js/modules/cms.pagetree.stickyheader.js
@@ -72,7 +72,9 @@ var PageTreeStickyHeader = new Class({
         var win = Helpers._getWindow();
 
         if (win && win.parent && win.parent !== win) {
-            return true;
+            // add a check to make sure, we are indeed inside the sideframe
+            // and not get confused when it is run inside cypress.
+            return win.parent.CMS !== undefined && win.parent.CMS.$ !== undefined && win.parent.CMS.API !== undefined;
         }
 
         return false;

--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -148,7 +148,6 @@ max
 Mediaeval
 middleware
 minified
-mis
 misconfiguration
 misspelt
 multi


### PR DESCRIPTION
## Description

For the CMS to work under cypress like test automation tools, there were some issues in JS. As CMS runs majorly in iframe, there are many places in CMS where the JS is used to detect that. However, the detection assumes that CMS itself is not run inside an iframe (which is common when it is run from a test automation tool like cypress). So in these cases, CMS got many crashes and was not able to do some actions as the JS was not correct and it was trying to access the `window.CMS`and `window.CMS.$` and `window.CMS.API`.

The fix basically checks all these cases and makes that these JS code invoked only when CMS is run in the iframe from CMS and not when running under cypress.

Authored-by: Vinit Kumar <vinit.kumar@kidskonnect.nl>



<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources


* Fixes #7590 


## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
