### PR TITLE
fix: Fixed RecursionError when extending templates

### DIFF
--- a/cms/test_utils/project/placeholderapp/nested_placeholderapp/templates/placeholder_tests/nested_extend.html
+++ b/cms/test_utils/project/placeholderapp/nested_placeholderapp/templates/placeholder_tests/nested_extend.html
@@ -1,0 +1,16 @@
+{% extends "placeholder_tests/nested_extend.html" %}
+
+{% load cms_tags %}
+
+{% comment %}
+This file should result in following placeholders:
+
+    - recursed_one   (from cms/test_utils/project/placeholderapp/nested_placeholderapp/templates/placeholder_tests/nested_extend.html)
+    - two            (from cms/test_utils/project/placeholderapp/templates/placeholder_tests/nested_extend.html)
+    - recursed_three (from cms/test_utils/project/placeholderapp/templates/placeholder_tests/nested_extend.html)
+
+{% endcomment %}
+
+{% block one %}
+    {% placeholder "recursed_one" %}
+{% endblock %}

--- a/cms/test_utils/project/placeholderapp/templates/placeholder_tests/nested_extend.html
+++ b/cms/test_utils/project/placeholderapp/templates/placeholder_tests/nested_extend.html
@@ -1,0 +1,16 @@
+{% extends "placeholder_tests/nested_extend.html" %}
+
+{% load cms_tags %}
+
+{% comment %}
+This file should result in following placeholders:
+
+    - recursed_one   (from cms/test_utils/project/placeholderapp/nested_placeholderapp/templates/placeholder_tests/nested_extend.html)
+    - two            (from cms/test_utils/project/placeholderapp/templates/placeholder_tests/nested_extend.html)
+    - recursed_three (from cms/test_utils/project/placeholderapp/templates/placeholder_tests/nested_extend.html)
+
+{% endcomment %}
+
+{% block three %}
+    {% placeholder "recursed_three" %}
+{% endblock %}

--- a/cms/test_utils/project/templates/placeholder_tests/nested_extend.html
+++ b/cms/test_utils/project/templates/placeholder_tests/nested_extend.html
@@ -1,0 +1,15 @@
+{% load cms_tags %}
+
+{% block one %}
+	{% placeholder "one" %}
+{% endblock %}
+
+{% block two %}
+	{% placeholder "two" %}
+{% endblock %}
+
+{% block three %}
+	{% placeholder "three" %}
+{% endblock %}
+
+{% block four %}{% endblock %}

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -13,8 +13,8 @@ from django.utils.encoding import force_str
 from django.utils.numberformat import format
 from sekizai.context import SekizaiContext
 
-import cms
 from cms import constants
+from cms import __file__ as cms_root_path
 from cms.api import add_plugin, create_page, create_title
 from cms.exceptions import DuplicatePlaceholderWarning, PluginLimitReached
 from cms.models.fields import PlaceholderField
@@ -122,11 +122,12 @@ class PlaceholderTestCase(TransactionCMSTestCase):
 
     def test_placeholder_recursive_deeper_extend(self):
         template_settings = copy.deepcopy(settings.TEMPLATES)
+        cms_root_dir = os.path.dirname(cms_root_path)
         template_settings[0]["DIRS"] = [
-            os.path.join(os.path.dirname(cms.__file__), 'test_utils', 'project', 'placeholderapp',
+            os.path.join(cms_root_dir, 'test_utils', 'project', 'placeholderapp',
                          'nested_placeholderapp', 'templates'),
-            os.path.join(os.path.dirname(cms.__file__), 'test_utils', 'project', 'placeholderapp', 'templates'),
-            os.path.join(os.path.dirname(cms.__file__), 'test_utils', 'project', 'templates'),
+            os.path.join(cms_root_dir, 'test_utils', 'project', 'placeholderapp', 'templates'),
+            os.path.join(cms_root_dir, 'test_utils', 'project', 'templates'),
         ]
         with override_settings(TEMPLATES=template_settings):
             placeholders = _get_placeholder_slots('placeholder_tests/nested_extend.html')

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -1,3 +1,7 @@
+import copy
+import os
+
+import cms
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
@@ -115,6 +119,18 @@ class PlaceholderTestCase(TransactionCMSTestCase):
     def test_placeholder_recursive_extend(self):
         placeholders = _get_placeholder_slots('placeholder_tests/recursive_extend.html')
         self.assertEqual(sorted(placeholders), sorted(['recursed_one', 'recursed_two', 'three']))
+
+    def test_placeholder_recursive_deeper_extend(self):
+        template_settings = copy.deepcopy(settings.TEMPLATES)
+        template_settings[0]["DIRS"] = [
+            os.path.join(os.path.dirname(cms.__file__), 'test_utils', 'project', 'placeholderapp',
+                         'nested_placeholderapp', 'templates'),
+            os.path.join(os.path.dirname(cms.__file__), 'test_utils', 'project', 'placeholderapp', 'templates'),
+            os.path.join(os.path.dirname(cms.__file__), 'test_utils', 'project', 'templates'),
+        ]
+        with override_settings(TEMPLATES=template_settings):
+            placeholders = _get_placeholder_slots('placeholder_tests/nested_extend.html')
+            self.assertEqual(sorted(placeholders), sorted(['recursed_one', 'two', 'recursed_three']))
 
     def test_placeholder_scanning_sekizai_extend_outside_block(self):
         placeholders = _get_placeholder_slots('placeholder_tests/outside_sekizai.html')

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -1,6 +1,18 @@
 import copy
 import os
 
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.core.exceptions import ImproperlyConfigured
+from django.template import Template, TemplateSyntaxError
+from django.template.loader import get_template
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.utils.encoding import force_str
+from django.utils.numberformat import format
+from sekizai.context import SekizaiContext
+
 import cms
 from cms import constants
 from cms.api import add_plugin, create_page, create_title
@@ -29,17 +41,6 @@ from cms.utils.placeholder import (
 )
 from cms.utils.plugins import assign_plugins, has_reached_plugin_limit
 from cms.utils.urlutils import admin_reverse
-from django.conf import settings
-from django.contrib.auth import get_user_model
-from django.core.cache import cache
-from django.core.exceptions import ImproperlyConfigured
-from django.template import Template, TemplateSyntaxError
-from django.template.loader import get_template
-from django.test import TestCase
-from django.test.utils import override_settings
-from django.utils.encoding import force_str
-from django.utils.numberformat import format
-from sekizai.context import SekizaiContext
 
 
 def _get_placeholder_slots(template):

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -11,8 +11,7 @@ from cms.models.pluginmodel import CMSPlugin
 from cms.plugin_pool import plugin_pool
 from cms.test_utils.fixtures.fakemlng import FakemlngFixtures
 from cms.test_utils.project.fakemlng.models import Translations
-from cms.test_utils.project.placeholderapp.models import (
-    DynamicPlaceholderSlotExample, Example1, TwoPlaceholderExample)
+from cms.test_utils.project.placeholderapp.models import DynamicPlaceholderSlotExample, Example1, TwoPlaceholderExample
 from cms.test_utils.project.sampleapp.models import Category
 from cms.test_utils.testcases import CMSTestCase, TransactionCMSTestCase
 from cms.test_utils.util.mock import AttributeObject
@@ -20,9 +19,14 @@ from cms.tests.test_toolbar import ToolbarTestBase
 from cms.toolbar.toolbar import CMSToolbar
 from cms.toolbar.utils import get_toolbar_from_request
 from cms.utils.conf import get_cms_setting
-from cms.utils.placeholder import (MLNGPlaceholderActions, PlaceholderNoAction,
-                                   _get_nodelist, _scan_placeholders,
-                                   get_placeholder_conf, get_placeholders)
+from cms.utils.placeholder import (
+    MLNGPlaceholderActions,
+    PlaceholderNoAction,
+    _get_nodelist,
+    _scan_placeholders,
+    get_placeholder_conf,
+    get_placeholders,
+)
 from cms.utils.plugins import assign_plugins, has_reached_plugin_limit
 from cms.utils.urlutils import admin_reverse
 from django.conf import settings

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -13,8 +13,8 @@ from django.utils.encoding import force_str
 from django.utils.numberformat import format
 from sekizai.context import SekizaiContext
 
-from cms import constants
 from cms import __file__ as cms_root_path
+from cms import constants
 from cms.api import add_plugin, create_page, create_title
 from cms.exceptions import DuplicatePlaceholderWarning, PluginLimitReached
 from cms.models.fields import PlaceholderField

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -2,6 +2,29 @@ import copy
 import os
 
 import cms
+from cms import constants
+from cms.api import add_plugin, create_page, create_title
+from cms.exceptions import DuplicatePlaceholderWarning, PluginLimitReached
+from cms.models.fields import PlaceholderField
+from cms.models.placeholdermodel import Placeholder
+from cms.models.pluginmodel import CMSPlugin
+from cms.plugin_pool import plugin_pool
+from cms.test_utils.fixtures.fakemlng import FakemlngFixtures
+from cms.test_utils.project.fakemlng.models import Translations
+from cms.test_utils.project.placeholderapp.models import (
+    DynamicPlaceholderSlotExample, Example1, TwoPlaceholderExample)
+from cms.test_utils.project.sampleapp.models import Category
+from cms.test_utils.testcases import CMSTestCase, TransactionCMSTestCase
+from cms.test_utils.util.mock import AttributeObject
+from cms.tests.test_toolbar import ToolbarTestBase
+from cms.toolbar.toolbar import CMSToolbar
+from cms.toolbar.utils import get_toolbar_from_request
+from cms.utils.conf import get_cms_setting
+from cms.utils.placeholder import (MLNGPlaceholderActions, PlaceholderNoAction,
+                                   _get_nodelist, _scan_placeholders,
+                                   get_placeholder_conf, get_placeholders)
+from cms.utils.plugins import assign_plugins, has_reached_plugin_limit
+from cms.utils.urlutils import admin_reverse
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
@@ -13,34 +36,6 @@ from django.test.utils import override_settings
 from django.utils.encoding import force_str
 from django.utils.numberformat import format
 from sekizai.context import SekizaiContext
-
-from cms import constants
-from cms.api import add_plugin, create_page, create_title
-from cms.exceptions import DuplicatePlaceholderWarning, PluginLimitReached
-from cms.models.fields import PlaceholderField
-from cms.models.placeholdermodel import Placeholder
-from cms.models.pluginmodel import CMSPlugin
-from cms.plugin_pool import plugin_pool
-from cms.test_utils.fixtures.fakemlng import FakemlngFixtures
-from cms.test_utils.project.fakemlng.models import Translations
-from cms.test_utils.project.placeholderapp.models import DynamicPlaceholderSlotExample, Example1, TwoPlaceholderExample
-from cms.test_utils.project.sampleapp.models import Category
-from cms.test_utils.testcases import CMSTestCase, TransactionCMSTestCase
-from cms.test_utils.util.mock import AttributeObject
-from cms.tests.test_toolbar import ToolbarTestBase
-from cms.toolbar.toolbar import CMSToolbar
-from cms.toolbar.utils import get_toolbar_from_request
-from cms.utils.conf import get_cms_setting
-from cms.utils.placeholder import (
-    MLNGPlaceholderActions,
-    PlaceholderNoAction,
-    _get_nodelist,
-    _scan_placeholders,
-    get_placeholder_conf,
-    get_placeholders,
-)
-from cms.utils.plugins import assign_plugins, has_reached_plugin_limit
-from cms.utils.urlutils import admin_reverse
 
 
 def _get_placeholder_slots(template):


### PR DESCRIPTION
## Description

When you have extends across multiple apps with same path CMS breaks with RecursionError.
Error trace:

```
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 323, in _get_placeholder_nodes_from_extend
    placeholders += _scan_placeholders(_get_nodelist(parent_template), node_class, None, block_names)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 200, in _scan_placeholders
    nodes += _get_placeholder_nodes_from_extend(node, node_class)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 323, in _get_placeholder_nodes_from_extend
    placeholders += _scan_placeholders(_get_nodelist(parent_template), node_class, None, block_names)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 200, in _scan_placeholders
    nodes += _get_placeholder_nodes_from_extend(node, node_class)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 323, in _get_placeholder_nodes_from_extend
    placeholders += _scan_placeholders(_get_nodelist(parent_template), node_class, None, block_names)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 200, in _scan_placeholders
    nodes += _get_placeholder_nodes_from_extend(node, node_class)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 323, in _get_placeholder_nodes_from_extend
    placeholders += _scan_placeholders(_get_nodelist(parent_template), node_class, None, block_names)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 200, in _scan_placeholders
    nodes += _get_placeholder_nodes_from_extend(node, node_class)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 323, in _get_placeholder_nodes_from_extend
    placeholders += _scan_placeholders(_get_nodelist(parent_template), node_class, None, block_names)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 200, in _scan_placeholders
    nodes += _get_placeholder_nodes_from_extend(node, node_class)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 323, in _get_placeholder_nodes_from_extend
    placeholders += _scan_placeholders(_get_nodelist(parent_template), node_class, None, block_names)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 200, in _scan_placeholders
    nodes += _get_placeholder_nodes_from_extend(node, node_class)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 323, in _get_placeholder_nodes_from_extend
    placeholders += _scan_placeholders(_get_nodelist(parent_template), node_class, None, block_names)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 200, in _scan_placeholders
    nodes += _get_placeholder_nodes_from_extend(node, node_class)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 323, in _get_placeholder_nodes_from_extend
    placeholders += _scan_placeholders(_get_nodelist(parent_template), node_class, None, block_names)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 200, in _scan_placeholders
    nodes += _get_placeholder_nodes_from_extend(node, node_class)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 323, in _get_placeholder_nodes_from_extend
    placeholders += _scan_placeholders(_get_nodelist(parent_template), node_class, None, block_names)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 200, in _scan_placeholders
    nodes += _get_placeholder_nodes_from_extend(node, node_class)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 323, in _get_placeholder_nodes_from_extend
    placeholders += _scan_placeholders(_get_nodelist(parent_template), node_class, None, block_names)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 200, in _scan_placeholders
    nodes += _get_placeholder_nodes_from_extend(node, node_class)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 323, in _get_placeholder_nodes_from_extend
    placeholders += _scan_placeholders(_get_nodelist(parent_template), node_class, None, block_names)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 200, in _scan_placeholders
    nodes += _get_placeholder_nodes_from_extend(node, node_class)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 323, in _get_placeholder_nodes_from_extend
    placeholders += _scan_placeholders(_get_nodelist(parent_template), node_class, None, block_names)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 200, in _scan_placeholders
    nodes += _get_placeholder_nodes_from_extend(node, node_class)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 322, in _get_placeholder_nodes_from_extend
    parent_template = _find_topmost_template(extend_node)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 333, in _find_topmost_template
    return _find_topmost_template(node, previous_context=previous_context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/cms/utils/placeholder.py", line 335, in _find_topmost_template
    return extend_node.get_parent(get_context(extend_node))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/venv/lib/python3.11/site-packages/django/template/loader_tags.py", line 129, in get_parent
    return self.find_template(parent, context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/venv/lib/python3.11/site-packages/django/template/loader_tags.py", line 107, in find_template
    template, origin = context.template.engine.find_template(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/venv/lib/python3.11/site-packages/django/template/engine.py", line 157, in find_template
    template = loader.get_template(name, skip=skip)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/venv/lib/python3.11/site-packages/django/template/loaders/base.py", line 28, in get_template
    return Template(
           ^^^^^^^^^
  File "/home/vilo/django-cms/venv/lib/python3.11/site-packages/django/template/base.py", line 154, in __init__
    self.nodelist = self.compile_nodelist()
                    ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/venv/lib/python3.11/site-packages/django/template/base.py", line 200, in compile_nodelist
    return parser.parse()
           ^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/venv/lib/python3.11/site-packages/django/template/base.py", line 513, in parse
    raise self.error(token, e)
  File "/home/vilo/django-cms/venv/lib/python3.11/site-packages/django/template/base.py", line 511, in parse
    compiled_result = compile_func(self, token)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/venv/lib/python3.11/site-packages/django/template/loader_tags.py", line 293, in do_extends
    nodelist = parser.parse()
               ^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/venv/lib/python3.11/site-packages/django/template/base.py", line 513, in parse
    raise self.error(token, e)
  File "/home/vilo/django-cms/venv/lib/python3.11/site-packages/django/template/base.py", line 511, in parse
    compiled_result = compile_func(self, token)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/venv/lib/python3.11/site-packages/django/template/loader_tags.py", line 232, in do_block
    nodelist = parser.parse(("endblock",))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/venv/lib/python3.11/site-packages/django/template/base.py", line 513, in parse
    raise self.error(token, e)
  File "/home/vilo/django-cms/venv/lib/python3.11/site-packages/django/template/base.py", line 511, in parse
    compiled_result = compile_func(self, token)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/venv/lib/python3.11/site-packages/classytags/core.py", line 128, in __init__
    self.kwargs, self.blocks = self.options.parse(parser, tokens)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/venv/lib/python3.11/site-packages/classytags/core.py", line 104, in parse
    argument_parser = argument_parser_class(self)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/venv/lib/python3.11/site-packages/classytags/parser.py", line 14, in __init__
    self.options = options.bootstrap()
                   ^^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/venv/lib/python3.11/site-packages/classytags/core.py", line 92, in bootstrap
    return StructuredOptions(
           ^^^^^^^^^^^^^^^^^^
  File "/home/vilo/django-cms/venv/lib/python3.11/site-packages/classytags/utils.py", line 39, in __init__
    self.breakpoints = copy(breakpoints)
                       ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/copy.py", line 76, in copy
    return copier(x)
           ^^^^^^^^^
RecursionError: maximum recursion depth exceeded while calling a Python object
```
This PR fixes this issue. Django basically creates a history of already visited templates, to prevent recursion. For the purpose of "history", is used context which is passed to get_parent call. However, in CMS there is always created new context and Django is unable to create such a "history".
Code where Django creates history: https://github.com/django/django/blob/main/django/template/loader_tags.py#L105
## Related resources

https://github.com/django-cms/django-cms/issues/6563
https://github.com/django-cms/django-cms/pull/6564

## Checklist

* [X] I have opened this pull request against ``develop``
* [X] I have added or modified the tests when changing logic
* [X] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [X] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
