### PR TITLE
fix: Sitemaps in v4 relied on availability of `PageUrl` instead of `PageContent`

### DIFF
--- a/cms/sitemaps/cms_sitemap.py
+++ b/cms/sitemaps/cms_sitemap.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 
 from django.contrib.sitemaps import Sitemap
-from django.db.models import Q, Subquery, OuterRef
+from django.db.models import OuterRef, Q, Subquery
 
 from cms.models import PageContent, PageUrl
 from cms.utils import get_current_site

--- a/cms/sitemaps/cms_sitemap.py
+++ b/cms/sitemaps/cms_sitemap.py
@@ -56,7 +56,8 @@ class CMSSitemap(Sitemap):
             .order_by('page__node__path')
             .annotate(content_pk=Subquery(
                 PageContent.objects
-                .filter(Q(redirect="") | Q(redirect=None), page=OuterRef("page"), language=OuterRef("language"))
+                .filter(page=OuterRef("page"), language=OuterRef("language"))
+                .filter(Q(redirect="") | Q(redirect=None))
                 .values_list("pk")[:1]
             ))
             .filter(content_pk__isnull=False)  # Remove page content with redirects

--- a/cms/sitemaps/cms_sitemap.py
+++ b/cms/sitemaps/cms_sitemap.py
@@ -48,20 +48,10 @@ class CMSSitemap(Sitemap):
         site = get_current_site()
         languages = get_public_languages(site_id=site.pk)
 
-        (
-            PageUrl
-            .objects
-            .get_for_site(site)
-            .select_related('page')
-            .filter(language__in=languages, path__isnull=False, page__login_required=False)
-            .order_by('page__node__path')
-        )
-
         return list(
             PageUrl
             .objects
             .get_for_site(site)
-            .select_related('page')
             .filter(language__in=languages, path__isnull=False, page__login_required=False)
             .order_by('page__node__path')
             .annotate(content_pk=Subquery(

--- a/cms/sitemaps/cms_sitemap.py
+++ b/cms/sitemaps/cms_sitemap.py
@@ -54,6 +54,7 @@ class CMSSitemap(Sitemap):
             .get_for_site(site)
             .filter(language__in=languages, path__isnull=False, page__login_required=False)
             .order_by('page__node__path')
+            .select_related("page")
             .annotate(content_pk=Subquery(
                 PageContent.objects
                 .filter(page=OuterRef("page"), language=OuterRef("language"))

--- a/cms/sitemaps/cms_sitemap.py
+++ b/cms/sitemaps/cms_sitemap.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 
 from django.contrib.sitemaps import Sitemap
-from django.db.models import Q
+from django.db.models import Q, Subquery, OuterRef
 
 from cms.models import PageContent, PageUrl
 from cms.utils import get_current_site
@@ -47,35 +47,17 @@ class CMSSitemap(Sitemap):
         # supply a new items() method which doesn't filter out the redirects.
         site = get_current_site()
         languages = get_public_languages(site_id=site.pk)
-        all_urls = (
-            PageUrl
-            .objects
-            .get_for_site(site)
-            .select_related('page')
-            .filter(language__in=languages, path__isnull=False, page__login_required=False)
-            .order_by('page__node__path')
-        )
-        excluded_titles_by_page = defaultdict(set)
-        excluded_translations = (
+
+        included_contents= (
             PageContent
             .objects
-            .filter(language__in=languages, page__node__site=site)
-            .exclude(Q(redirect='') | Q(redirect__isnull=True))
-            .values_list('page', 'language')
+            .filter(language__in=languages, page__node__site=site, page__login_required=False)
+            .filter(Q(redirect='') | Q(redirect__isnull=True))
+            .order_by('page__node__path')
+            .annotate(url=Subquery(PageUrl.objects.filter(language=OuterRef("language"), path__isnull=False))[:1])
         )
 
-        for page_id, language in excluded_translations:
-            excluded_titles_by_page[page_id].add(language)
-
-        valid_urls = []
-
-        for page_url in all_urls:
-            excluded = excluded_titles_by_page.get(page_url.page_id, [])
-
-            if page_url.language in excluded:
-                continue
-            valid_urls.append(page_url)
-        return valid_urls
+        return [page_content.url for page_content in included_contents if page_content.url]
 
     def lastmod(self, page_url):
         return page_url.page.changed_date


### PR DESCRIPTION
## Description

This PR changes the way sitemaps are generated for the page tree:

* Only `PageUrl` objects with an attached `PageContent` are taken into account
* This is required for the sitemaps to reflect versioning states, e.g. when using djangocms-versioning
* Number of database requests is reduced

## Related resources


* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] Existing tests cover functionality
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
