### PR TITLE
fix: Remove second cancel button from modal

### DIFF
--- a/cms/static/cms/sass/components/_modal.scss
+++ b/cms/static/cms/sass/components/_modal.scss
@@ -1,8 +1,6 @@
 //##############################################################################
 // MODAL
 
-@use "sass:math";
-
 // Editing plugins in frontend
 .cms-modal {
     display: none;
@@ -153,7 +151,7 @@
     display: block;
     position: absolute;
     top: 50%;
-    margin-top: math.div(-$modal-header-button-area-size, 2);
+    margin-top: -$modal-header-button-area-size / 2;
     right: $padding-normal;
     color: $gray-light;
     text-align: center;
@@ -162,7 +160,7 @@
     cursor: pointer;
     &:before {
         position: relative;
-        top: math.div($modal-header-button-area-size - $icon-size, 2);
+        top: ($modal-header-button-area-size - $icon-size) / 2;
     }
     &:hover {
         color: $color-primary;
@@ -225,7 +223,7 @@
     a {
         color: $color-primary;
         &:hover {
-            filter: brightness(0.8);
+            color: darken($color-primary, 20%);
         }
         &:after {
             content: "/";
@@ -252,10 +250,14 @@
     padding: 0 $modal-resize-size 0 $padding-normal;
 }
 .cms-modal-item-buttons {
-    $margin: math.div($toolbar-height - $toolbar-button-height, 2);
+    $margin: ($toolbar-height - $toolbar-button-height) / 2;
     @extend .cms-toolbar-item-buttons;
     float: right;
     margin-left: $margin;
+
+    .cancel-link {
+        display: none;
+    }
 }
 .cms-modal-item-buttons-left {
     float: left;
@@ -264,10 +266,10 @@
 // alter footer when html markup is loaded
 .cms-modal-markup {
     .cms-modal-foot {
-        height: math.div($modal-footer-height, 2);
+        height: $modal-footer-height / 2;
     }
     .cms-modal-body {
-        bottom: math.div($modal-footer-height, 2);
+        bottom: $modal-footer-height / 2;
     }
 }
 


### PR DESCRIPTION
## Description

Some admin views provide their own cancel button. This PR removes it from the modal, since it has its own cancel button.

This is especially true for V4 packages. This is an example from versioning (see three modal buttons):

<img width="803" alt="image" src="https://github.com/django-cms/django-cms/assets/16904477/5b760e0a-0b8b-4827-8217-fbb8cab12dc1">


## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
