### PR TITLE
fix(sec): upgrade tornado to 6.3.2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -135,7 +135,7 @@ tomli==2.0.1
     # via
     #   build
     #   pep517
-tornado==6.2
+tornado==6.3.2
     # via livereload
 urllib3==1.26.11
     # via requests


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in tornado 6.2
- [CVE-2023-28370](https://www.oscs1024.com/hd/CVE-2023-28370)


### What did I do？
Upgrade tornado from 6.2 to 6.3.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS