### PR TITLE
fix: Cross-talk between grouper admins due to common list initialization

### DIFF
--- a/cms/admin/utils.py
+++ b/cms/admin/utils.py
@@ -240,13 +240,14 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
     EMPTY_CONTENT_VALUE = _("Empty content")
     LC_SORTED_FIELDS = (models.CharField,)
 
-    _content_obj_cache = {}
     _content_cache_request_hash = None
-    _content_qs_cache = {}
     _content_content_type = None
-    _content_subquery_fields = []
 
     def __init__(self, model, admin_site):
+        self._content_subquery_fields = []
+        self._content_obj_cache = {}
+        self._content_qs_cache = {}
+
         super().__init__(model, admin_site)
 
         # Identify content model

--- a/cms/static/cms/js/admin/language-selector.js
+++ b/cms/static/cms/js/admin/language-selector.js
@@ -29,7 +29,7 @@
                     window.location.search = replaceQueryParam('language', this.dataset.url, window.location.search);
                 }
             });
-
+            $('#content input:not(.language_button):not([type="hidden"])').first().focus();
             /* Set the content inline language defaults */
             var selected_language = element.find('input.selected').attr('name');
 

--- a/cms/templates/admin/cms/grouper/change_list.html
+++ b/cms/templates/admin/cms/grouper/change_list.html
@@ -1,6 +1,6 @@
 {% extends "admin/change_list.html" %}{% load i18n %}
 {% block search %}
-  <div class="language-selector" style="width: fit-content; margin-bottom: 1em;">
+  <div class="language-selector" style="display: inline; width: fit-content; margin-bottom: 1em;">
     <label>{% trans "Language" %}:&nbsp;</label>
     <select class="language-selector js-language-selector" style="min-width: 180px;">
       {% for code, lang in cl.model_admin.get_language_tuple %}


### PR DESCRIPTION
## Description

`GrouperModelAdmin` initialized a private list property to an empty list outside `__init__`. Since the list is a python object only a reference to a single list is stored in every `GrouperModelAdmin` instance leading to potential "cross-talk" between admins of different grouper models.

Fix better language tab layout of `GrouperModelAdmin` if used with plain Django admin.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
