### PR TITLE
fix(sec): upgrade certifi to 2022.12.07

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,7 +14,7 @@ beautifulsoup4==4.11.1
     # via furo
 build==0.8.0
     # via pip-tools
-certifi==2022.6.15
+certifi==2022.12.07
     # via requests
 charset-normalizer==2.1.0
     # via requests


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in certifi 2022.6.15
- [CVE-2022-23491](https://www.oscs1024.com/hd/CVE-2022-23491)


### What did I do？
Upgrade certifi from 2022.6.15 to 2022.12.07 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS