### PR TITLE
fix: Pull transifex strings from base directory when building a release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,7 @@ This release includes 3 pull requests, and was created with the help of the foll
 * Fabian Braun (1 pull request)
 * Github Release Action (2 pull requests)
 
+With the review help of the following contributors:
 
 
 Thanks to all contributors for their efforts!

--- a/scripts/transifex-pull-strings
+++ b/scripts/transifex-pull-strings
@@ -5,9 +5,10 @@ set -e
 SCRIPTS=$(dirname "$(realpath "$0")")
 ROOT=$(git rev-parse --show-toplevel)
 
-cd "${ROOT}/cms"
-
+cd "${ROOT}"
 "${SCRIPTS}/tx" --token "$TX_TOKEN" pull --force
+
+cd "${ROOT}/cms"
 django-admin compilemessages
 
 "${SCRIPTS}/filter-locale-changes"


### PR DESCRIPTION
## Description

Currently, they are pulled from the `cms` directory leading to a "no found" error and effectively ignoring any new translations.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
