### PR TITLE
Fix: Open new plugin window in language of toolbar not of page

### DIFF
--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import sys
 from collections import OrderedDict
@@ -9,6 +10,7 @@ from django.template import Context
 from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
 from django.utils.safestring import mark_safe
+from django.utils.translation import override
 
 from cms.cache.placeholder import get_placeholder_cache, set_placeholder_cache
 from cms.models import PageContent
@@ -300,7 +302,9 @@ class ContentRenderer(BaseRenderer):
             self._rendered_placeholders[placeholder.pk] = rendered_placeholder
 
         if editable:
-            data = self.get_editable_placeholder_context(placeholder, page=page)
+            request = context.get("request", None)
+            with override(request.toolbar.toolbar_language) if request else contextlib.nullcontext():
+                data = self.get_editable_placeholder_context(placeholder, page=page)
             data['content'] = placeholder_content
             placeholder_content = self.placeholder_edit_template.format(**data)
 

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -24,6 +24,7 @@ from django.utils.html import escape
 from django.utils.http import urlencode
 from django.utils.translation import (
     get_language,
+    override,
 )
 from django.utils.translation import (
     gettext_lazy as _,
@@ -993,6 +994,10 @@ class CMSAdminURL(AsTag):
     )
 
     def get_value(self, context, viewname, args, kwargs):
+        request = context.get("request", None)
+        if request and hasattr(request, "toolbar"):
+            with override(request.toolbar.request.toolbar.toolbar_language):
+                return admin_reverse(viewname, args=args, kwargs=kwargs)
         return admin_reverse(viewname, args=args, kwargs=kwargs)
 
 

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -1502,7 +1502,7 @@ class PageTest(PageTestBase):
 
         admin_user = self.get_superuser()
         root = create_page(
-            "home", "nav_playground.html", "fr", created_by=admin_user, published=True
+            "home", "nav_playground.html", "fr", created_by=admin_user,
         )
         with connection.cursor() as c:
             c.execute('UPDATE SQLITE_SEQUENCE SET seq = 1001 WHERE name="cms_page"')
@@ -1513,7 +1513,6 @@ class PageTest(PageTestBase):
             "nav_playground.html",
             "fr",
             created_by=admin_user,
-            published=True,
             parent=root,
             slug="child-page",
         )
@@ -1523,7 +1522,6 @@ class PageTest(PageTestBase):
             "nav_playground.html",
             "fr",
             created_by=admin_user,
-            published=True,
             parent=page,
             slug="grand-child-page",
         )

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -138,8 +138,7 @@ class ViewTests(CMSTestCase):
     def test_redirect_not_preserving_query_parameters(self):
         # test redirect checking that the query parameters aren't preserved
         redirect = '/en/'
-        one = create_page("one", "nav_playground.html", "en", published=True,
-                          redirect=redirect)
+        one = create_page("one", "nav_playground.html", "en", redirect=redirect)
         url = one.get_absolute_url()
         params = "?param_name=param_value"
         request = self.get_request(url + params)
@@ -151,8 +150,7 @@ class ViewTests(CMSTestCase):
     def test_redirect_preserving_query_parameters(self):
         # test redirect checking that query parameters are preserved
         redirect = '/en/'
-        one = create_page("one", "nav_playground.html", "en", published=True,
-                          redirect=redirect)
+        one = create_page("one", "nav_playground.html", "en", redirect=redirect)
         url = one.get_absolute_url()
         params = "?param_name=param_value"
         request = self.get_request(url + params)
@@ -163,8 +161,7 @@ class ViewTests(CMSTestCase):
     @override_settings(CMS_REDIRECT_TO_LOWERCASE_SLUG=True)
     def test_redirecting_to_lowercase_slug(self):
         redirect = '/en/one/'
-        one = create_page("one", "nav_playground.html", "en", published=True,
-                          redirect=redirect)
+        one = create_page("one", "nav_playground.html", "en", redirect=redirect)
         url = reverse('pages-details-by-slug', kwargs={"slug": "One"})
         request = self.get_request(url)
         response = details(request, one.get_path(language="en"))


### PR DESCRIPTION
## Description

When creating a new plugin, the plugin admin form is shown in the page's language, not in the toolbar's language (unlike editing plugins). See example here: (English toolbar, German add plugin form) <img width="876" alt="image" src="https://github.com/django-cms/django-cms/assets/16904477/c7555eab-ba65-4f02-ada0-22083fbf1e91">


## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #.
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
