### PR TITLE
Fix: Release script discards changes in compiled mo files

### DIFF
--- a/scripts/transifex-pull-strings
+++ b/scripts/transifex-pull-strings
@@ -8,7 +8,7 @@ ROOT=$(git rev-parse --show-toplevel)
 cd "${ROOT}"
 "${SCRIPTS}/tx" --token "$TX_TOKEN" pull --force
 
+"${SCRIPTS}/filter-locale-changes"
+
 cd "${ROOT}/cms"
 django-admin compilemessages
-
-"${SCRIPTS}/filter-locale-changes"


### PR DESCRIPTION
## Description

This affects the release script, which currently fails to commit changes in compiled *.mo files.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
