### PR TITLE
fix: Backport v4.1.0rc4 fixes - Admin language and styling (#7630)

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -24,3 +24,5 @@ jobs:
     - run: |
           gulp unitTest
           gulp lint
+    - run: gulp icons
+    - run: gulp sass

--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -1,3 +1,4 @@
+import contextlib
 from collections import OrderedDict
 from functools import partial
 
@@ -7,6 +8,7 @@ from django.template import Context
 from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
 from django.utils.safestring import mark_safe
+from django.utils.translation import override
 
 from cms.cache.placeholder import get_placeholder_cache, set_placeholder_cache
 from cms.toolbar.utils import get_placeholder_toolbar_js, get_plugin_toolbar_js, get_toolbar_from_request
@@ -287,7 +289,9 @@ class ContentRenderer(BaseRenderer):
             self._rendered_placeholders[placeholder.pk] = rendered_placeholder
 
         if editable:
-            data = self.get_editable_placeholder_context(placeholder, page=page)
+            request = context.get("request", None)
+            with override(request.toolbar.toolbar_language) if request else contextlib.nullcontext():
+                data = self.get_editable_placeholder_context(placeholder, page=page)
             data['content'] = placeholder_content
             placeholder_content = self.placeholder_edit_template.format(**data)
 

--- a/cms/static/cms/sass/components/_pluginpicker.scss
+++ b/cms/static/cms/sass/components/_pluginpicker.scss
@@ -91,5 +91,14 @@
     padding-left: 20px;
     border: 2px solid $color-primary;
     border-radius: $border-radius-base;
-    background-color: rgba($color-primary-fallback, 20%);
+    background-color: $white;
+    &:after {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right:0 ;
+        background-color: rgba($color-primary-fallback, 40%);
+    }
 }

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -18,7 +18,7 @@ from django.urls import reverse
 from django.utils.encoding import smart_str
 from django.utils.html import escape
 from django.utils.http import urlencode
-from django.utils.translation import get_language
+from django.utils.translation import get_language, override
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import override as force_language
 from sekizai.templatetags.sekizai_tags import RenderBlock, SekizaiParser
@@ -985,8 +985,10 @@ class CMSAdminURL(AsTag):
     )
 
     def get_value(self, context, viewname, args, kwargs):
+        if hasattr(context.get("request"), "toolbar"):
+            with override(context["request"].toolbar.toolbar_language):
+                return admin_reverse(viewname, args=args, kwargs=kwargs)
         return admin_reverse(viewname, args=args, kwargs=kwargs)
-
 
 
 register.tag('page_attribute', PageAttribute)

--- a/cms/utils/check.py
+++ b/cms/utils/check.py
@@ -208,7 +208,7 @@ def check_i18n(output):
                              "'en_US'): '%s' provided" % lang[0])
         if settings.SITE_ID == hash(settings.SITE_ID):
             for site, items in get_cms_setting('LANGUAGES').items():
-                if type(site) == int:
+                if isinstance(site, int):
                     for lang in items:
                         if lang['code'].find('_') > -1:
                             section.warn("CMS_LANGUAGES entries must contain valid language codes, not locales (e.g.: "

--- a/cms/utils/encoder.py
+++ b/cms/utils/encoder.py
@@ -10,7 +10,7 @@ class SafeJSONEncoder(DjangoJSONEncoder):
             return type(o)((esc(k), self._recursive_escape(v)) for (k, v) in o.items())
         if isinstance(o, (list, tuple)):
             return type(o)(self._recursive_escape(v) for v in o)
-        if type(o) is bool:
+        if isinstance(o, bool):
             return o
         try:
             return type(o)(esc(o))


### PR DESCRIPTION
* build: release 3.11.2 (#7526)

* [3.11.2 release process] Bumped version to 3.11.2

* [3.11.2 release process] compiling new static files

* [3.11.2 release process] updating latest docs

* Update 3.11.2.rst

* Update 3.11.2.rst

* Update 3.11.2.rst

* Update CHANGELOG.rst

* Update 3.11.2.rst

* Update CHANGELOG.rst



* Update 3.11.2.rst

---------




* Update README.rst

* build: merge develop into release/3.11.x (#7539)

* build: Merge release 3.11.2 back into develop (#7528)

* Release 3.10.0 RC1 (#7215)

* [3.10.0rc1 release process] Bumped version to 3.10.0rc1
* [3.10.0rc1 release process] compilemessages
* [3.10.0rc1 release process] compiling new static files
* [3.10.0rc1 release process] updating latest docs

* Update release/3.10 from develop (#7219)

* Fix script typos (#7201)
* [refactor] Typos in release scripts
* This was correct.



* feat: Added concurrency option to github workflows (#7205)
* fix: Disable workflow concurrency to bring stability back to the CI (#7209)
* Upgrade Gulp and Nodejs (#7208)
* feat: upgrade sass and gulp sass so that it installs on a modern node.js
* fix: upgrade some packages and gulp config to 4.x series
* fix: add support for icons working as well
* Feat: get some tasks to work
* fix: port one more tasks even if it is still erroring
* wip: still broken config for webpack bundle
* fix: let the new tests run
* fix: issue with lint task
* fix: some more issues with loaders
* feat: get some tests passing atleast
* fix: the frontend tests pass now
* feat: generate new lock file
* feat: use gulp 4.x
* feat: make build use node16 as well
* feat: add .nvmrc for a consistent experience
* feat: Run workflows in concurrency groups (#7211)
* feat: Added concurrency config using unique workflow groups
* Remove whitespace to test cancellation
* Remove whitespace to test cancellation 2




* Add toolbar fix for broken CMS in the release 3.10.x (#7233)

* Fix script typos (#7201)

* [refactor] Typos in release scripts

* This was correct.



* feat: Added concurrency option to github workflows (#7205)

* fix: Disable workflow concurrency to bring stability back to the CI (#7209)

* Upgrade Gulp and Nodejs (#7208)

* feat: upgrade sass and gulp sass so that it installs on a modern node.js

* fix: upgrade some packages and gulp config to 4.x series

* fix: add support for icons working as well

* Feat: get some tasks to work

* fix: port one more tasks even if it is still erroring

* wip: still broken config for webpack bundle

* fix: let the new tests run

* fix: issue with lint task

* fix: some more issues with loaders

* feat: get some tests passing atleast

* fix: the frontend tests pass now

* feat: generate new lock file

* feat: use gulp 4.x

* feat: make build use node16 as well

* feat: add .nvmrc for a consistent experience

* feat: Run workflows in concurrency groups (#7211)

* feat: Added concurrency config using unique workflow groups

* Remove whitespace to test cancellation

* Remove whitespace to test cancellation 2



* fix: Toolbar bug in 3.10 (#7232)







* fix: using .nvmrc to target teh right nvm version

* Release/3.10.x (#7260) Releasing 3.10.0RC2

* [3.10.0rc2 release process] Bumped version to 3.10.0rc2
* [3.10.0rc2 release process] compilemessages
* [3.10.0rc2 release process] compiling new static files
* [3.10.0rc2 release process] updating latest docs

* Update release script to make it compatible with BSD (macos) compatible

* Update release script to make it compatible with BSD (macos) compatible

* Release/3.10.x (#7275)

* Fixes #7288 by also catching AttributeError, when the current toolbar… (#7289)

* Fixes #7288 by also catching AttributeError, when the current toolbar object doesn't define get_draft_url()

* #7288: also catch AttributeError when `get_absolute_url()` isn't defined.

* Fix for django 2.2 in middleware [#7290] (#7293)

* Fix for django 2.2 in middleware [#7290]

* Address isort concern

* Update release script to make it compatible with BSD (macos) compatible

* Update release script to make it compatible with BSD (macos) compatible (#7294)

* Fix version number in bump commit

* Fix release script version commit. (#7295)

* Update release script to make it compatible with BSD (macos) compatible

* Fix version number in bump commit

* build: Release 3.11.0rc1 (#7326)

* [3.11.0 release process] Bumped version to 3.11.0

* [3.11.0 release process] compilemessages

* [3.11.0 release process] compiling new static files

* [3.11.0 release process] updating latest docs

* [3.11.0rc1 release process] Bumped version to 3.11.0rc1

* Added static files

* Removed static files of 0.3.11 release

* Manually added changes to the upgrade docs

* Adjusted upgrade note header

* fix: typos in CHANGELOG.rst

* build: release 3.10.1rc1 (#7330)

* fix: Use http rather than https in toolbar sites menu (#7331)

* fix: Revert change to the toolbar sites menu to use ``http`` protocol (#7332)

* fix: Rename changelog title to fix release script

* fix: Changelog title for 3.10.1rc1 (#7345)

* fix: Request missing from test rendering (#7346)

* fix: Changelog titles for 3.10.x (#7347)

* build: Release 3.10.1 (#7348)

* ci: Merge develop into release/3.11 (#7350)

* Release 3.10.0 RC1 (#7215)

* [3.10.0rc1 release process] Bumped version to 3.10.0rc1
* [3.10.0rc1 release process] compilemessages
* [3.10.0rc1 release process] compiling new static files
* [3.10.0rc1 release process] updating latest docs

* Update release/3.10 from develop (#7219)

* Fix script typos (#7201)
* [refactor] Typos in release scripts
* This was correct.



* feat: Added concurrency option to github workflows (#7205)
* fix: Disable workflow concurrency to bring stability back to the CI (#7209)
* Upgrade Gulp and Nodejs (#7208)
* feat: upgrade sass and gulp sass so that it installs on a modern node.js
* fix: upgrade some packages and gulp config to 4.x series
* fix: add support for icons working as well
* Feat: get some tasks to work
* fix: port one more tasks even if it is still erroring
* wip: still broken config for webpack bundle
* fix: let the new tests run
* fix: issue with lint task
* fix: some more issues with loaders
* feat: get some tests passing atleast
* fix: the frontend tests pass now
* feat: generate new lock file
* feat: use gulp 4.x
* feat: make build use node16 as well
* feat: add .nvmrc for a consistent experience
* feat: Run workflows in concurrency groups (#7211)
* feat: Added concurrency config using unique workflow groups
* Remove whitespace to test cancellation
* Remove whitespace to test cancellation 2




* Add toolbar fix for broken CMS in the release 3.10.x (#7233)

* Fix script typos (#7201)

* [refactor] Typos in release scripts

* This was correct.



* feat: Added concurrency option to github workflows (#7205)

* fix: Disable workflow concurrency to bring stability back to the CI (#7209)

* Upgrade Gulp and Nodejs (#7208)

* feat: upgrade sass and gulp sass so that it installs on a modern node.js

* fix: upgrade some packages and gulp config to 4.x series

* fix: add support for icons working as well

* Feat: get some tasks to work

* fix: port one more tasks even if it is still erroring

* wip: still broken config for webpack bundle

* fix: let the new tests run

* fix: issue with lint task

* fix: some more issues with loaders

* feat: get some tests passing atleast

* fix: the frontend tests pass now

* feat: generate new lock file

* feat: use gulp 4.x

* feat: make build use node16 as well

* feat: add .nvmrc for a consistent experience

* feat: Run workflows in concurrency groups (#7211)

* feat: Added concurrency config using unique workflow groups

* Remove whitespace to test cancellation

* Remove whitespace to test cancellation 2



* fix: Toolbar bug in 3.10 (#7232)







* fix: using .nvmrc to target teh right nvm version

* Release/3.10.x (#7260) Releasing 3.10.0RC2

* [3.10.0rc2 release process] Bumped version to 3.10.0rc2
* [3.10.0rc2 release process] compilemessages
* [3.10.0rc2 release process] compiling new static files
* [3.10.0rc2 release process] updating latest docs

* Update release script to make it compatible with BSD (macos) compatible

* Update release script to make it compatible with BSD (macos) compatible

* Release/3.10.x (#7275)

* Fixes #7288 by also catching AttributeError, when the current toolbar… (#7289)

* Fixes #7288 by also catching AttributeError, when the current toolbar object doesn't define get_draft_url()

* #7288: also catch AttributeError when `get_absolute_url()` isn't defined.

* Fix for django 2.2 in middleware [#7290] (#7293)

* Fix for django 2.2 in middleware [#7290]

* Address isort concern

* Update release script to make it compatible with BSD (macos) compatible

* Update release script to make it compatible with BSD (macos) compatible (#7294)

* Fix version number in bump commit

* Fix release script version commit. (#7295)

* Update release script to make it compatible with BSD (macos) compatible

* Fix version number in bump commit

* fix: typos in CHANGELOG.rst

* ci: Sync release/3.10.x with develop (#7328)

* Release 3.10.0 RC1 (#7215)

* [3.10.0rc1 release process] Bumped version to 3.10.0rc1
* [3.10.0rc1 release process] compilemessages
* [3.10.0rc1 release process] compiling new static files
* [3.10.0rc1 release process] updating latest docs

* Update release/3.10 from develop (#7219)

* Fix script typos (#7201)
* [refactor] Typos in release scripts
* This was correct.



* feat: Added concurrency option to github workflows (#7205)
* fix: Disable workflow concurrency to bring stability back to the CI (#7209)
* Upgrade Gulp and Nodejs (#7208)
* feat: upgrade sass and gulp sass so that it installs on a modern node.js
* fix: upgrade some packages and gulp config to 4.x series
* fix: add support for icons working as well
* Feat: get some tasks to work
* fix: port one more tasks even if it is still erroring
* wip: still broken config for webpack bundle
* fix: let the new tests run
* fix: issue with lint task
* fix: some more issues with loaders
* feat: get some tests passing atleast
* fix: the frontend tests pass now
* feat: generate new lock file
* feat: use gulp 4.x
* feat: make build use node16 as well
* feat: add .nvmrc for a consistent experience
* feat: Run workflows in concurrency groups (#7211)
* feat: Added concurrency config using unique workflow groups
* Remove whitespace to test cancellation
* Remove whitespace to test cancellation 2




* Add toolbar fix for broken CMS in the release 3.10.x (#7233)

* Fix script typos (#7201)

* [refactor] Typos in release scripts

* This was correct.



* feat: Added concurrency option to github workflows (#7205)

* fix: Disable workflow concurrency to bring stability back to the CI (#7209)

* Upgrade Gulp and Nodejs (#7208)

* feat: upgrade sass and gulp sass so that it installs on a modern node.js

* fix: upgrade some packages and gulp config to 4.x series

* fix: add support for icons working as well

* Feat: get some tasks to work

* fix: port one more tasks even if it is still erroring

* wip: still broken config for webpack bundle

* fix: let the new tests run

* fix: issue with lint task

* fix: some more issues with loaders

* feat: get some tests passing atleast

* fix: the frontend tests pass now

* feat: generate new lock file

* feat: use gulp 4.x

* feat: make build use node16 as well

* feat: add .nvmrc for a consistent experience

* feat: Run workflows in concurrency groups (#7211)

* feat: Added concurrency config using unique workflow groups

* Remove whitespace to test cancellation

* Remove whitespace to test cancellation 2



* fix: Toolbar bug in 3.10 (#7232)







* fix: using .nvmrc to target teh right nvm version

* Release/3.10.x (#7260) Releasing 3.10.0RC2

* [3.10.0rc2 release process] Bumped version to 3.10.0rc2
* [3.10.0rc2 release process] compilemessages
* [3.10.0rc2 release process] compiling new static files
* [3.10.0rc2 release process] updating latest docs

* Update release script to make it compatible with BSD (macos) compatible

* Update release script to make it compatible with BSD (macos) compatible

* Release/3.10.x (#7275)

* Fixes #7288 by also catching AttributeError, when the current toolbar… (#7289)

* Fixes #7288 by also catching AttributeError, when the current toolbar object doesn't define get_draft_url()

* #7288: also catch AttributeError when `get_absolute_url()` isn't defined.

* Fix for django 2.2 in middleware [#7290] (#7293)

* Fix for django 2.2 in middleware [#7290]

* Address isort concern

* Update release script to make it compatible with BSD (macos) compatible (#7294)

* Fix release script version commit. (#7295)

* Update release script to make it compatible with BSD (macos) compatible

* Fix version number in bump commit

* fix: typos in CHANGELOG.rst







* build: release 3.10.1rc1 (#7330)

* fix: Use http rather than https in toolbar sites menu (#7331)

* fix: Use http rather than https in toolbar sites menu (#7331)

* fix: Revert change to the toolbar sites menu to use ``http`` protocol (#7332)

* Fix for "Permission denied (publickey)" error (#7333)

Using https fixes the issue with running the `git clone` command resulting in the error:
>git@github.com: Permission denied (publickey).
>fatal: Could not read from remote repository.
>
>Please make sure you have the correct access rights
>and the repository exists.

* feat: Configurable dark mode (#7329)

* Feat:	Dark mode support, including input from @marksweb, bugfix for tooltips
* Add:	Color scheme configurable
* Add:	Toolbar toggle (always on)
* Add:	CMS_COLOR_SCHEME_TOGGLE setting
* Add:	color scheme toggle test
* Fix:	Only set color scheme in cms iframes
* Add:	Basic documentation of new settings
* Fix:	color scheme switch as css variables
* Fix:	Cascade settings into iframes of iframes (e.g., cms plugins inside ckeditor)
* Fix:	no toggle in collapsed toolbar




* fix: dark mode tweaks and test fixes (requests in context) (#7338)

* Fix:		toolbar bug 3.10.rc1

* Feat:	Dark mode support, including input from @marksweb, bugfix for tooltips

* Upstream change to be able to merge

* Feat: Dark mode support, including input from @marksweb, bugfix for tooltips

* Revert "Fix:		toolbar bug 3.10.rc1"

This reverts commit 592a2b604e8f72b8e9c948e83163394cc6e8fe3d.

* Fix:		Recommit toolbar fix (??)

* Fix:		After lint failure: Remove spaces added by PyCharm

* Fix:		Wizzard button color

* Fix:		Correct toolbar according to cms_path
Fix:		Avoid unnecessary toolbar loading

* TASK: use isort to sort imports

* Fix:		Remove unused css rule
Fix:		Add plugin search bar text did not reflect dark mode

* Fix:		Toolbar tests to include request object for TextPlugin

* Fix:		Pass a request (None) for the processors test





* fix: remove fixed width for edit plugin popup (=> autowidth) (#7337)

* fix: remove fixed width for edit plugin popup (=> autowidth)

Same behavior as new popup

* fix: revert bundled js

* fix: update changelog

* fix: remove trailing comma

* fix: Except block using list instead of tuple (#7342)

* Release 3.10.0 RC1 (#7215)

* [3.10.0rc1 release process] Bumped version to 3.10.0rc1
* [3.10.0rc1 release process] compilemessages
* [3.10.0rc1 release process] compiling new static files
* [3.10.0rc1 release process] updating latest docs

* Update release/3.10 from develop (#7219)

* Fix script typos (#7201)
* [refactor] Typos in release scripts
* This was correct.



* feat: Added concurrency option to github workflows (#7205)
* fix: Disable workflow concurrency to bring stability back to the CI (#7209)
* Upgrade Gulp and Nodejs (#7208)
* feat: upgrade sass and gulp sass so that it installs on a modern node.js
* fix: upgrade some packages and gulp config to 4.x series
* fix: add support for icons working as well
* Feat: get some tasks to work
* fix: port one more tasks even if it is still erroring
* wip: still broken config for webpack bundle
* fix: let the new tests run
* fix: issue with lint task
* fix: some more issues with loaders
* feat: get some tests passing atleast
* fix: the frontend tests pass now
* feat: generate new lock file
* feat: use gulp 4.x
* feat: make build use node16 as well
* feat: add .nvmrc for a consistent experience
* feat: Run workflows in concurrency groups (#7211)
* feat: Added concurrency config using unique workflow groups
* Remove whitespace to test cancellation
* Remove whitespace to test cancellation 2




* Add toolbar fix for broken CMS in the release 3.10.x (#7233)

* Fix script typos (#7201)

* [refactor] Typos in release scripts

* This was correct.



* feat: Added concurrency option to github workflows (#7205)

* fix: Disable workflow concurrency to bring stability back to the CI (#7209)

* Upgrade Gulp and Nodejs (#7208)

* feat: upgrade sass and gulp sass so that it installs on a modern node.js

* fix: upgrade some packages and gulp config to 4.x series

* fix: add support for icons working as well

* Feat: get some tasks to work

* fix: port one more tasks even if it is still erroring

* wip: still broken config for webpack bundle

* fix: let the new tests run

* fix: issue with lint task

* fix: some more issues with loaders

* feat: get some tests passing atleast

* fix: the frontend tests pass now

* feat: generate new lock file

* feat: use gulp 4.x

* feat: make build use node16 as well

* feat: add .nvmrc for a consistent experience

* feat: Run workflows in concurrency groups (#7211)

* feat: Added concurrency config using unique workflow groups

* Remove whitespace to test cancellation

* Remove whitespace to test cancellation 2



* fix: Toolbar bug in 3.10 (#7232)







* fix: using .nvmrc to target teh right nvm version

* Release/3.10.x (#7260) Releasing 3.10.0RC2

* [3.10.0rc2 release process] Bumped version to 3.10.0rc2
* [3.10.0rc2 release process] compilemessages
* [3.10.0rc2 release process] compiling new static files
* [3.10.0rc2 release process] updating latest docs

* Update release script to make it compatible with BSD (macos) compatible

* Update release script to make it compatible with BSD (macos) compatible

* Release/3.10.x (#7275)

* Fixes #7288 by also catching AttributeError, when the current toolbar… (#7289)

* Fixes #7288 by also catching AttributeError, when the current toolbar object doesn't define get_draft_url()

* #7288: also catch AttributeError when `get_absolute_url()` isn't defined.

* Fix for django 2.2 in middleware [#7290] (#7293)

* Fix for django 2.2 in middleware [#7290]

* Address isort concern

* Update release script to make it compatible with BSD (macos) compatible (#7294)

* Fix release script version commit. (#7295)

* Update release script to make it compatible with BSD (macos) compatible

* Fix version number in bump commit

* fix: typos in CHANGELOG.rst

* fix: Change except catch using list to tuple [#7334]

* fix: typo in changelog







* feat: add cache ttl extension point (#7299)

Adds the setting `CMS_CACHE_LIMIT_TTL_CLASS` that should have a `limit_page_cache_ttl` method that would be called to limit the cache ttl of a page using business logic.
Closes #7296

* fix: Rename changelog title to fix release script

* fix: Changelog title for 3.10.1rc1 (#7345)

* fix: Request missing from test rendering (#7346)

* fix: Changelog titles for 3.10.x (#7347)

* build: Release 3.10.1 (#7348)












* Update CHANGELOG.rst



* Update CHANGELOG.rst



* Update CHANGELOG.rst



* Update CHANGELOG.rst



* Update docs/upgrade/3.10.1.rst



* ci: Flake8 fixes (#7372)

* Release 3.10.0 RC1 (#7215)

* [3.10.0rc1 release process] Bumped version to 3.10.0rc1
* [3.10.0rc1 release process] compilemessages
* [3.10.0rc1 release process] compiling new static files
* [3.10.0rc1 release process] updating latest docs

* Update release/3.10 from develop (#7219)

* Fix script typos (#7201)
* [refactor] Typos in release scripts
* This was correct.



* feat: Added concurrency option to github workflows (#7205)
* fix: Disable workflow concurrency to bring stability back to the CI (#7209)
* Upgrade Gulp and Nodejs (#7208)
* feat: upgrade sass and gulp sass so that it installs on a modern node.js
* fix: upgrade some packages and gulp config to 4.x series
* fix: add support for icons working as well
* Feat: get some tasks to work
* fix: port one more tasks even if it is still erroring
* wip: still broken config for webpack bundle
* fix: let the new tests run
* fix: issue with lint task
* fix: some more issues with loaders
* feat: get some tests passing atleast
* fix: the frontend tests pass now
* feat: generate new lock file
* feat: use gulp 4.x
* feat: make build use node16 as well
* feat: add .nvmrc for a consistent experience
* feat: Run workflows in concurrency groups (#7211)
* feat: Added concurrency config using unique workflow groups
* Remove whitespace to test cancellation
* Remove whitespace to test cancellation 2




* Add toolbar fix for broken CMS in the release 3.10.x (#7233)

* Fix script typos (#7201)

* [refactor] Typos in release scripts

* This was correct.



* feat: Added concurrency option to github workflows (#7205)

* fix: Disable workflow concurrency to bring stability back to the CI (#7209)

* Upgrade Gulp and Nodejs (#7208)

* feat: upgrade sass and gulp sass so that it installs on a modern node.js

* fix: upgrade some packages and gulp config to 4.x series

* fix: add support for icons working as well

* Feat: get some tasks to work

* fix: port one more tasks even if it is still erroring

* wip: still broken config for webpack bundle

* fix: let the new tests run

* fix: issue with lint task

* fix: some more issues with loaders

* feat: get some tests passing atleast

* fix: the frontend tests pass now

* feat: generate new lock file

* feat: use gulp 4.x

* feat: make build use node16 as well

* feat: add .nvmrc for a consistent experience

* feat: Run workflows in concurrency groups (#7211)

* feat: Added concurrency config using unique workflow groups

* Remove whitespace to test cancellation

* Remove whitespace to test cancellation 2



* fix: Toolbar bug in 3.10 (#7232)







* fix: using .nvmrc to target teh right nvm version

* Release/3.10.x (#7260) Releasing 3.10.0RC2

* [3.10.0rc2 release process] Bumped version to 3.10.0rc2
* [3.10.0rc2 release process] compilemessages
* [3.10.0rc2 release process] compiling new static files
* [3.10.0rc2 release process] updating latest docs

* Update release script to make it compatible with BSD (macos) compatible

* Update release script to make it compatible with BSD (macos) compatible

* Release/3.10.x (#7275)

* Fixes #7288 by also catching AttributeError, when the current toolbar… (#7289)

* Fixes #7288 by also catching AttributeError, when the current toolbar object doesn't define get_draft_url()

* #7288: also catch AttributeError when `get_absolute_url()` isn't defined.

* Fix for django 2.2 in middleware [#7290] (#7293)

* Fix for django 2.2 in middleware [#7290]

* Address isort concern

* Update release script to make it compatible with BSD (macos) compatible

* Update release script to make it compatible with BSD (macos) compatible (#7294)

* Fix version number in bump commit

* Fix release script version commit. (#7295)

* Update release script to make it compatible with BSD (macos) compatible

* Fix version number in bump commit

* fix: typos in CHANGELOG.rst

* build: release 3.10.1rc1 (#7330)

* fix: Use http rather than https in toolbar sites menu (#7331)

* fix: Revert change to the toolbar sites menu to use ``http`` protocol (#7332)

* fix: Rename changelog title to fix release script

* fix: Changelog title for 3.10.1rc1 (#7345)

* fix: Request missing from test rendering (#7346)

* fix: Changelog titles for 3.10.x (#7347)

* build: Release 3.10.1 (#7348)

* Update CHANGELOG.rst



* Update CHANGELOG.rst



* Update CHANGELOG.rst



* Update CHANGELOG.rst



* Update docs/upgrade/3.10.1.rst



* ci: Flake8 fixes

* Addressing review comment [#7372]








(cherry picked from commit 3b2dc101772bbfca75ab51b678a51025d6872b31)

* Add release candidate to changelog version

* Change 3.11.0rc1 release date to fix `make-changelog`

* build: Release 3.11.0 (#7373)

* fix: Added language to page cache key (#7354)

* Update install.rst (#7368)

Remove bug in `python manage.py command`

* Updated changelog for 3.11.0

* feat: Release/3.11.1 (#7431)

* ci: stale bot added (#7298)

* ci: Added codespell (#7355)



* ci: codespell config taken from #7292

* fix: Added language to page cache key (#7354)

* ci: Remove a superfluous installation of codespell (#7356)

* build: bump django from 3.2.13 to 3.2.14 in /docs (#7358)

Bumps [django](https://github.com/django/django) from 3.2.13 to 3.2.14.
- [Release notes](https://github.com/django/django/releases)
- [Commits](https://github.com/django/django/compare/3.2.13...3.2.14)

---
updated-dependencies:
- dependency-name: django dependency-type: direct:production ...





* typo (#7360)

* Update install.rst (#7368)

Remove bug in `python manage.py command`

* ci: Flake8 fixes (#7372)

* Release 3.10.0 RC1 (#7215)

* [3.10.0rc1 release process] Bumped version to 3.10.0rc1
* [3.10.0rc1 release process] compilemessages
* [3.10.0rc1 release process] compiling new static files
* [3.10.0rc1 release process] updating latest docs

* Update release/3.10 from develop (#7219)

* Fix script typos (#7201)
* [refactor] Typos in release scripts
* This was correct.



* feat: Added concurrency option to github workflows (#7205)
* fix: Disable workflow concurrency to bring stability back to the CI (#7209)
* Upgrade Gulp and Nodejs (#7208)
* feat: upgrade sass and gulp sass so that it installs on a modern node.js
* fix: upgrade some packages and gulp config to 4.x series
* fix: add support for icons working as well
* Feat: get some tasks to work
* fix: port one more tasks even if it is still erroring
* wip: still broken config for webpack bundle
* fix: let the new tests run
* fix: issue with lint task
* fix: some more issues with loaders
* feat: get some tests passing atleast
* fix: the frontend tests pass now
* feat: generate new lock file
* feat: use gulp 4.x
* feat: make build use node16 as well
* feat: add .nvmrc for a consistent experience
* feat: Run workflows in concurrency groups (#7211)
* feat: Added concurrency config using unique workflow groups
* Remove whitespace to test cancellation
* Remove whitespace to test cancellation 2




* Add toolbar fix for broken CMS in the release 3.10.x (#7233)

* Fix script typos (#7201)

* [refactor] Typos in release scripts

* This was correct.



* feat: Added concurrency option to github workflows (#7205)

* fix: Disable workflow concurrency to bring stability back to the CI (#7209)

* Upgrade Gulp and Nodejs (#7208)

* feat: upgrade sass and gulp sass so that it installs on a modern node.js

* fix: upgrade some packages and gulp config to 4.x series

* fix: add support for icons working as well

* Feat: get some tasks to work

* fix: port one more tasks even if it is still erroring

* wip: still broken config for webpack bundle

* fix: let the new tests run

* fix: issue with lint task

* fix: some more issues with loaders

* feat: get some tests passing atleast

* fix: the frontend tests pass now

* feat: generate new lock file

* feat: use gulp 4.x

* feat: make build use node16 as well

* feat: add .nvmrc for a consistent experience

* feat: Run workflows in concurrency groups (#7211)

* feat: Added concurrency config using unique workflow groups

* Remove whitespace to test cancellation

* Remove whitespace to test cancellation 2



* fix: Toolbar bug in 3.10 (#7232)







* fix: using .nvmrc to target teh right nvm version

* Release/3.10.x (#7260) Releasing 3.10.0RC2

* [3.10.0rc2 release process] Bumped version to 3.10.0rc2
* [3.10.0rc2 release process] compilemessages
* [3.10.0rc2 release process] compiling new static files
* [3.10.0rc2 release process] updating latest docs

* Update release script to make it compatible with BSD (macos) compatible

* Update release script to make it compatible with BSD (macos) compatible

* Release/3.10.x (#7275)

* Fixes #7288 by also catching AttributeError, when the current toolbar… (#7289)

* Fixes #7288 by also catching AttributeError, when the current toolbar object doesn't define get_draft_url()

* #7288: also catch AttributeError when `get_absolute_url()` isn't defined.

* Fix for django 2.2 in middleware [#7290] (#7293)

* Fix for django 2.2 in middleware [#7290]

* Address isort concern

* Update release script to make it compatible with BSD (macos) compatible

* Update release script to make it compatible with BSD (macos) compatible (#7294)

* Fix version number in bump commit

* Fix release script version commit. (#7295)

* Update release script to make it compatible with BSD (macos) compatible

* Fix version number in bump commit

* fix: typos in CHANGELOG.rst

* build: release 3.10.1rc1 (#7330)

* fix: Use http rather than https in toolbar sites menu (#7331)

* fix: Revert change to the toolbar sites menu to use ``http`` protocol (#7332)

* fix: Rename changelog title to fix release script

* fix: Changelog title for 3.10.1rc1 (#7345)

* fix: Request missing from test rendering (#7346)

* fix: Changelog titles for 3.10.x (#7347)

* build: Release 3.10.1 (#7348)

* Update CHANGELOG.rst



* Update CHANGELOG.rst



* Update CHANGELOG.rst



* Update CHANGELOG.rst



* Update docs/upgrade/3.10.1.rst



* ci: Flake8 fixes

* Addressing review comment [#7372]









* build: bump django from 3.2.14 to 3.2.15 in /docs (#7379)

Bumps [django](https://github.com/django/django) from 3.2.14 to 3.2.15.
- [Release notes](https://github.com/django/django/releases)
- [Commits](https://github.com/django/django/compare/3.2.14...3.2.15)

---
updated-dependencies:
- dependency-name: django dependency-type: direct:production ...






* fix: default light mode (#7381)

* ci: Merging release/3.11.0 (#7377)

* docs: Bump requirements (#7382)

* docs: Bump requirements

* docs: Bump python verion used by RTD

* docs: Have RTD install from setup.py

* chore: Fix spelling errors

* docs: build against python 3.8

* docs: try to install from `setup.py` using conf file

* docs: Install from pip then setup

* ci: Install django-cms from pip again

* fix: CMS check management command fixed [#7386]

* ci: sync isort line length (#7353)

* docs: fixing a link (#7393)

* docs: fixing a link

misspelled URL

* Update CONTRIBUTING.rst





* refactor: Move js API functions to CMS.Helpers to make them available also to the admin site (#7384)

Move CMS.API.Toolbar.get_color_scheme to CMS.API.Helpers.getColorScheme and CMS.API.Toolbar.set_color_scheme to CMS.API.Helpers.setColorScheme

* fix: Allow partially overriding CMS_CACHE_DURATIONS (#7339)

* Allow partially overriding CMS_CACHE_DURATIONS

* add doc and changelog



* Adjust paste label in pt-br locale (#7376)

* feat: Add support for tel: and mailto: URIs in Advanced Page Settings redirect field (#7370)


* feat: Add support for tel: and mailto: URIs in Advanced Page Settings redirect field

* docs: Correction of headings around CMSPlugin & CMSPluginBase (#7406)

* fix: Unlocalize page and node ids when rendering the page tree in the admin (#7188)

* #7175: unlocalize page and node ids when rendering the page tree in the admin

* Fix flake8 issue

* Update the test so as not to have to generate one thousand pages.

The downside is that it only works in sqlite

* Make isort happy

* #7155: extend unlocalisation of pks to a few more templates

* #7175: cleanup, dont unlocalize in `if` tags

* Update CHANGELOG about #7175




* fix: Clear page permission cache on page create (#6866)

* Clear page permission cache on page create
* Correct changelog entry
* Update test_add_page.py
* Update CHANGELOG.rst



* fix: Changing color scheme resets session settings to defaults (#7407)

* Fix: incorrect saveing of color scheme in CMS.settings
* Add: changelog entry :-)

* ci: Added pre-commit ci config (#7409)

* perf: Don't count users when CMS_RAW_ID_USERS=True (#7414)

* perf: Don't count users when CMS_RAW_ID_USERS=True

When using CMS_RAW_ID_USERS=True on a Postgres database with many users, counting the users is slow and will always yield the same result.

Only count users when using an integer value as a threshold and reuse the same logic for both PagePermissionInlineAdmin and GlobalPagePermissionAdmin.

* Ensure that only integer settings of CMS_RAW_ID_USERS are compared to the number of users

* Add documentation for the CMS_RAW_ID_USER=True setting

* fix isort for added tests

* Fix: in python this is always True: isinstance(False, int)



* fix: CMS check management command fixed [#7412] (#7413)

* fix: CMS check management command fixed [#7412]


* ci: Some tests misusing assertTrue for comparisons fix (#7241)

* Fix issue avoid-misusing-assert-true found at https://codereview.doctor

* feat: Support for Django 4.1 (#7404)

* support: Django 4.1
* Fix: apphook test
* Run tests on all databases




* build: bump django from 3.2.15 to 3.2.16 in /docs (#7417)

* build: bump minimatch and gulp-if (#7416)

Bumps [minimatch](https://github.com/isaacs/minimatch) to 3.0.4 and updates ancestor dependency [gulp-if](https://github.com/robrich/gulp-if). These dependencies need to be updated together.


Updates `minimatch` from 1.0.0 to 3.0.4
- [Release notes](https://github.com/isaacs/minimatch/releases)
- [Commits](https://github.com/isaacs/minimatch/compare/v1.0.0...v3.0.4)

Updates `gulp-if` from 1.2.5 to 3.0.0
- [Release notes](https://github.com/robrich/gulp-if/releases)
- [Commits](https://github.com/robrich/gulp-if/commits/3.0.0)

---
updated-dependencies:
- dependency-name: minimatch dependency-type: indirect
- dependency-name: gulp-if dependency-type: direct:development ...







* fix: Added deprecation warning to `get_current_language()` (#7410)

* fix: Added deprecation warning to `cms.utils.i18n.get_current_language()`

* fix: Added deprecation warning to `cms.utils.i18n.get_current_language()`

* Added stack level to deprecation warning



* feat: add Python 3.11 support for Django CMS (#7422)

* fix: test python3.11

Authored-by: Vinit Kumar <vinit.kumar@kidskonnect.nl>


* fix: Adds a deprecation warning for SEND_BROKEN_LINK_EMAILS (#7420)

* Fix:		toolbar bug 3.10.rc1

* Feat:	Dark mode support, including input from @marksweb, bugfix for tooltips

* Upstream change to be able to merge

* Feat: Dark mode support, including input from @marksweb, bugfix for tooltips

* Revert "Fix:		toolbar bug 3.10.rc1"

This reverts commit 592a2b604e8f72b8e9c948e83163394cc6e8fe3d.

* Fix:		Recommit toolbar fix (??)

* Fix:		After lint failure: Remove spaces added by PyCharm

* Fix:		Wizzard button color

* Fix:		Correct toolbar according to cms_path
Fix:		Avoid unnecessary toolbar loading

* TASK: use isort to sort imports

* Fix:	Move CMS.API.Toolbar.get_color_scheme to CMS.API.Helpers.getColorScheme and CMS.API.Toolbar.set_color_scheme to CMS.API.Helpers.setColorScheme

* Fix:		Typo in comment

* Fix:		Typos in comments

* Fix:		Typos in comments

* Add:		Changelog entry

* Fix:		base unit test for js frontend

* Add:		Basic set/get color scheme test

* fix:	deprecate SEND_BROKEN_LINK_EMAILS setting

* fix: flake8 w504





* fix: Prefer titles matching request language (#7144)

* prefer titles matching request language
* add comments on use of annotate
* fix wayward imports
* Add changelog entry




* [3.11.1rc1 release process] Building locales

* [3.11.1rc1 release process] Bumped version to 3.11.1rc1

* [3.11.1rc1 release process] compilemessages

* [3.11.1rc1 release process] compiling new static files

* [3.11.1rc1 release process] updating latest docs

* Update and rename .rst to 3.11.1.rst

* Update 3.11.1.rst

* Update index.rst

* [3.11.1rc1 release process] Building locales

* Update 3.11.1.rst

* Update index.rst

* Update index.rst

* Update index.rst

* Update index.rst

* Update index.rst

* Fix:		Allow setup to run before dependencies are installed

* Update transifex translations




























* feat: Add github actions for publishing on pyi (#7438)

* Add github actions for publishing on pyi
* Fix branch trigger to branch `release/**`
* Also run publish to test pypi on develop

* build: Release v3.11.1 (#7455)

* fix: Build docs always from the current local version (#7472) (#7475)

* Fix: Build docs always from local version

* Remove local files from requirements.in

* Update `make-release` script

* Add comments

* Sync Makefile

* Install docs requirements from the docs folder in github action

* Install docs requirements from docs directory for tests

* Rebase on repo dir

* feat: add download statistics to readme (#7474)

* Add download stats to readme

* Fix: Downloads at position 1

* Undo: Recover accidentally deleted line.

* docs: Added note to publish_pages API docs about it being a generator (#7483)

* fix: Link both user and group from global page permissions to change form (#7486)

* Better link change list to change form
* Add filter for site

* Make messages readable in dark mode, remove iOS9 compatibility trick which leads to unnecessary scoll bars (#7485)

* fix: replace ' by ′ in fr translation − no more "page d\u0027accueil"! (#7488)

* fix: replace ' by ′ in fr translation

no more "page d\u0027accueil"!

* Remove unnecessary escapes filter where translations

{% filter "escapejs" %} ... {% endfilter %} only belongs to situations where data is put into html attributes or js code.



* docs: Update formatting in how-to/install.rst to avoid misunderstanding (#7501)

* Update install.rst

* Update install.rst

* feat: add setting so redirect preserve params (#7489)

Added a new setting that allow to configure globally if the django-cms redirects preserving the query parameters.
`REDIRECT_PRESERVE_QUERY_PARAMS`.
This feature is usefull for example:
1. marketing campains extra parameters,
2. social networks extra parameters like `fbclick`,
3. custom developed parameters, after that page has been moved, the older URLs for that page should preserve the functionality.

* improved code readability (#7503)



* feat: add setting to redirect slugs to lowercase (#7509)

This commit adds the REDIRECT_TO_LOWERCASE_SLUG option which will cause the cms to redirect requests with an non-lowercase slug if no page with that slug is found.

Implements #1324

* docs: Update incomplete color scheme docs (#7512)

* fix/merge_errors

* Update incomplete color scheme docs

* fix typos

* fix typos (#7514)

* feat: add django 4.2 support (#7481)

* revert: test change done earlier

* feat: add django 4.2a1 to requirements and to the CI

* fix: typo in the test.yml file

* fix: update django to the stable

* feat: some more updates to get the CI running

* fix: two lint related issues

* fix: update compatibility matrix to include django 4.2 support

* ci: more deprecations in light of upcoming v4 (#7480)

* Add deprecation warnings to cms.api

* Fix typos

---------



* ci: introduce ruff in place of flake8 for improved speed (#7504)

* revert: test change done earlier

* feat: replace flake8 with ruff

* fix: code cleanup as per ruff recommendations

* fix: cleanup code

* fix: use flake-to-ruff to convert our config to ruff.toml file

* fix: one more bypass

* fix: review feedback

* fix: cleanup code for usage dict, list and unnecessary usage

Authored-by: Vinit Kumar <vinit.kumar@kidskonnect.nl>


* fix: broken ci tests

* fix: isort issues in the forms.py

* fix: explanation of the rules bypass

* fix: isort issues

* revert: changes to the testcases.py

* fix: use ruff to format imports

* fix: ignore isort for this file as it causes circular import issues

* Update cms/toolbar/toolbar.py



* Update cms/api.py



---------




* build: release 3.11.2 (#7526)

* [3.11.2 release process] Bumped version to 3.11.2

* [3.11.2 release process] compiling new static files

* [3.11.2 release process] updating latest docs

* Update 3.11.2.rst

* Update 3.11.2.rst

* Update 3.11.2.rst

* Update CHANGELOG.rst

* Update 3.11.2.rst

* Update CHANGELOG.rst



* Update 3.11.2.rst

---------




* Update README.rst

---------








































* FIX: remove curly bracket left behind on PR 7488 (#7529)

see this comment for more infos: https://github.com/django-cms/django-cms/pull/7488\#issuecomment-1513517082

* fix: lint menus app (#7534)

* feat: add support for testing menus with ruff as well

* fix: autofix issues with ruff

* Fix #6848 (#7535)



---------








































* build: Merge build into release 3.11.x (#7540)

* [3.11.3 release process] Bumped version to 3.11.3

* [3.11.3 release process] compiling new static files

* [3.11.3 release process] updating latest docs

* Update 3.11.3.rst

* Update CHANGELOG.rst

* Update CHANGELOG.rst

* Update 3.11.3.rst

---------



* Dynamic unihan decoder selection based on page language

* Update test

* Fix ruff issues

* fix: backport v4.1.0rc4 fixes

* Do not enforce request object in context when rendering placeholders

* Add css and icon built to frontend tests

* fix typo, update cms_tags

---------

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
