### PR TITLE
fix: data-theme typo for 'auto'

### DIFF
--- a/cms/static/cms/sass/settings/_cms.scss
+++ b/cms/static/cms/sass/settings/_cms.scss
@@ -26,7 +26,7 @@ $black: var(--dca-black);
     --focus-brightness: 0.95;
 }
 
-:root, :root[data-them="auto"] {
+:root, :root[data-theme="auto"] {
     color-scheme: dark light;
 }
 


### PR DESCRIPTION
## Description

Simple typo mistake for css selector data-theme auto.

## Checklist

* [x] I have opened this pull request against ``develop``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
