### PR TITLE
fix: sideframe history nav button wrapping

### DIFF
--- a/cms/static/cms/sass/components/_sideframe.scss
+++ b/cms/static/cms/sass/components/_sideframe.scss
@@ -97,7 +97,7 @@
 }
 
 .cms-sideframe-history {
-    width: $sideframe-button-area-size * 2 + 1px;
+    width: $sideframe-button-area-size * 2 + 2px;
     border-right: 1px solid $gray-lighter;
 
     .cms-icon {


### PR DESCRIPTION
## Description

The "CMS Sideframe History" navigation's triangles should not wrap.

## Related resources

* fixes #7654

## Checklist

* [x] I have opened this pull request against ``develop``
* (N/A) I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

> **Note**
> I am unsure how to run tests and the change seems independent of tests (unless there are integrated UI tests), so I skipped running tests. I ran `npx gulp lint`, and received warnings independent of my change.