### PR TITLE
fix: avoid InvalidCacheKey (memcached) for key-length ~249

### DIFF
--- a/cms/cache/placeholder.py
+++ b/cms/cache/placeholder.py
@@ -43,7 +43,13 @@ def _get_placeholder_cache_version_key(placeholder, lang, site_id):
         lang=str(lang),
         site=site_id,
     )
-    if len(key) > 250:
+    # django itself adds "version" add the end of cache-keys, e.g. "<key>:1".
+    # -> If `cache.set()` is for example called with `version=""`, it still adds
+    #    `:` at the end. So if we check the length for `> 250`, a length of 249
+    #    or even 250 ends up in an InvalidCacheKey-exception.
+    # In order to avoid these errors, we hash the keys at a lower length to also
+    # have a little buffer.
+    if len(key) > 200:
         key = '{prefix}|{hash}'.format(
             prefix=prefix,
             hash=hashlib.sha1(key.encode('utf-8')).hexdigest(),


### PR DESCRIPTION
Fix for `InvalidCacheKey`-errors due to lengthy cache-keys.

* #7595

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
