### PR TITLE
fix: preserve `view_class` in decorated views

### DIFF
--- a/cms/tests/test_apphooks.py
+++ b/cms/tests/test_apphooks.py
@@ -26,7 +26,7 @@ from cms.test_utils.project.placeholderapp.models import Example1
 from cms.test_utils.testcases import CMSTestCase
 from cms.tests.test_menu_utils import DumbPageLanguageUrl
 from cms.toolbar.toolbar import CMSToolbar
-from cms.utils.compat import DJANGO_2_2, DJANGO_3
+from cms.utils.compat import DJANGO_2_2, DJANGO_3, DJANGO_4_1
 from cms.utils.conf import get_cms_setting
 from cms.utils.urlutils import admin_reverse
 from menus.menu_pool import menu_pool
@@ -307,7 +307,7 @@ class ApphooksTestCase(CMSTestCase):
         view_names = (
             ('sample-settings', 'sample_view'),
             ('sample-class-view', 'ClassView'),
-            ('sample-class-based-view', 'view' if not (DJANGO_3 or DJANGO_2_2) else 'ClassBasedView' ),
+            ('sample-class-based-view', 'ClassBasedView' ),
         )
 
         with force_language("en"):

--- a/cms/utils/decorators.py
+++ b/cms/utils/decorators.py
@@ -20,6 +20,8 @@ def cms_perms(func):
         return func(request, *args, **kwargs)
     inner.__module__ = func.__module__
     inner.__doc__ = func.__doc__
+    if hasattr(func, "view_class"):
+        inner.view_class = func.view_class
     if hasattr(func, '__name__'):
         inner.__name__ = func.__name__
     elif hasattr(func, '__class__'):


### PR DESCRIPTION
## Description

Add a check to preserve the `view_class` of a decorated function. Will allow retrieving a CBV name from a resolved URL

## Related resources

Open issue: https://github.com/django-cms/django-cms/issues/7653

## Checklist

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
