### PR TITLE
fix: change language url parameter to delete_language to prevent collision

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -1233,8 +1233,10 @@ class BasePageAdmin(PlaceholderAdminMixin, admin.ModelAdmin):
         return HttpResponseRedirect(path)
 
     def delete_translation(self, request, object_id, extra_context=None):
-        if 'language' in request.GET:
-            language = request.GET['language']
+        if 'delete_language' in request.GET:
+            language = request.GET['delete_language']
+        elif 'delete_language' in request.POST:
+            language = request.POST['delete_language']
         else:
             language = get_language_from_request(request)
 

--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -551,7 +551,7 @@ class PageToolbar(CMSToolbar):
                 )
                 disabled = len(remove) == 1
                 for code, name in remove:
-                    url = add_url_parameters(translation_delete_url, language=code)
+                    url = add_url_parameters(translation_delete_url, delete_language=code)
                     remove_plugins_menu.add_modal_item(name, url=url, disabled=disabled)
 
             if copy:

--- a/cms/tests/test_admin.py
+++ b/cms/tests/test_admin.py
@@ -196,14 +196,31 @@ class AdminTestCase(AdminTestsBase):
         create_title("de", "delete-page-translation-2", page, slug="delete-page-translation-2")
         create_title("es-mx", "delete-page-translation-es", page, slug="delete-page-translation-es")
         with self.login_user_context(admin_user):
-            response = self.client.get(URL_CMS_TRANSLATION_DELETE % page.pk, {'language': 'de'})
+            response = self.client.get(URL_CMS_TRANSLATION_DELETE % page.pk, {'delete_language': 'de'})
             self.assertEqual(response.status_code, 200)
-            response = self.client.post(URL_CMS_TRANSLATION_DELETE % page.pk, {'language': 'de'})
-            self.assertRedirects(response, URL_CMS_PAGE)
-            response = self.client.get(URL_CMS_TRANSLATION_DELETE % page.pk, {'language': 'es-mx'})
+            self.assertContains(
+                response, 
+                'Are you sure you want to delete the title "delete-page-translation-2 (delete-page-translation-2, de)"?'
+            )
+
+            response = self.client.get(URL_CMS_TRANSLATION_DELETE % page.pk + "?delete_language=de&cms_path=/en/?edit&language=en")
+            
             self.assertEqual(response.status_code, 200)
-            response = self.client.post(URL_CMS_TRANSLATION_DELETE % page.pk, {'language': 'es-mx'})
+            self.assertContains(
+                response, 
+                'Are you sure you want to delete the title "delete-page-translation-2 (delete-page-translation-2, de)"?'
+            )
+            
+            response = self.client.post(URL_CMS_TRANSLATION_DELETE % page.pk, {'delete_language': 'de'})
             self.assertRedirects(response, URL_CMS_PAGE)
+            response = self.client.get(URL_CMS_TRANSLATION_DELETE % page.pk, {'delete_language': 'es-mx'})
+            self.assertEqual(response.status_code, 200)
+            response = self.client.post(URL_CMS_TRANSLATION_DELETE % page.pk, {'delete_language': 'es-mx'})
+            self.assertRedirects(response, URL_CMS_PAGE)
+
+            response = self.client.get(URL_CMS_TRANSLATION_DELETE % page.pk, {'delete_language': 'de'})
+
+            
 
     def test_change_dates(self):
         admin_user, staff = self._get_guys()

--- a/cms/tests/test_admin.py
+++ b/cms/tests/test_admin.py
@@ -216,11 +216,7 @@ class AdminTestCase(AdminTestsBase):
             response = self.client.get(URL_CMS_TRANSLATION_DELETE % page.pk, {'delete_language': 'es-mx'})
             self.assertEqual(response.status_code, 200)
             response = self.client.post(URL_CMS_TRANSLATION_DELETE % page.pk, {'delete_language': 'es-mx'})
-            self.assertRedirects(response, URL_CMS_PAGE)
-
-            response = self.client.get(URL_CMS_TRANSLATION_DELETE % page.pk, {'delete_language': 'de'})
-
-            
+            self.assertRedirects(response, URL_CMS_PAGE)            
 
     def test_change_dates(self):
         admin_user, staff = self._get_guys()

--- a/cms/tests/test_admin.py
+++ b/cms/tests/test_admin.py
@@ -213,7 +213,7 @@ class AdminTestCase(AdminTestsBase):
             response = self.client.get(URL_CMS_TRANSLATION_DELETE % page.pk, {'delete_language': 'es-mx'})
             self.assertEqual(response.status_code, 200)
             response = self.client.post(URL_CMS_TRANSLATION_DELETE % page.pk, {'delete_language': 'es-mx'})
-            self.assertRedirects(response, URL_CMS_PAGE)            
+            self.assertRedirects(response, URL_CMS_PAGE)
 
     def test_change_dates(self):
         admin_user, staff = self._get_guys()

--- a/cms/tests/test_admin.py
+++ b/cms/tests/test_admin.py
@@ -199,18 +199,15 @@ class AdminTestCase(AdminTestsBase):
             response = self.client.get(URL_CMS_TRANSLATION_DELETE % page.pk, {'delete_language': 'de'})
             self.assertEqual(response.status_code, 200)
             self.assertContains(
-                response, 
+                response,
                 'Are you sure you want to delete the title "delete-page-translation-2 (delete-page-translation-2, de)"?'
             )
-
             response = self.client.get(URL_CMS_TRANSLATION_DELETE % page.pk + "?delete_language=de&cms_path=/en/?edit&language=en")
-            
             self.assertEqual(response.status_code, 200)
             self.assertContains(
-                response, 
+                response,
                 'Are you sure you want to delete the title "delete-page-translation-2 (delete-page-translation-2, de)"?'
             )
-            
             response = self.client.post(URL_CMS_TRANSLATION_DELETE % page.pk, {'delete_language': 'de'})
             self.assertRedirects(response, URL_CMS_PAGE)
             response = self.client.get(URL_CMS_TRANSLATION_DELETE % page.pk, {'delete_language': 'es-mx'})

--- a/cms/tests/test_permmod.py
+++ b/cms/tests/test_permmod.py
@@ -956,7 +956,7 @@ class GlobalPermissionTests(CMSTestCase):
         ]
         for user in USERS:
             user.set_password('staff')
-            # re-use the same methods the UserPage form does.
+            # reuse the same methods the UserPage form does.
             # Note that it internally calls .save(), as we've not done so.
             save_permissions({
                 'can_add_page': True,


### PR DESCRIPTION
## Description
Fixes #7605 
The problem is also breafly described in the [comment](https://github.com/django-cms/django-cms/issues/7605#issuecomment-1761176979)
When the user wants to delete the translation for a given page using the buttons in the toolbar, a request is sent to the `translation delete URL` with `&cms_path=/en/?edit&language=en` and the final URL becomes: `http://127.0.0.1:8000/en/admin/cms/page/1/delete-translation/?language=fr&cms_path=/en/?edit&language=en`. In this case django parses the GET parameters as `{"language": ['fr', 'en'], "cms_path": "/en/?edit"}`. language being a list causes django to pick the wrong one and delete the wrong translation. We need to have different keys for "Currently active language" and "Desired translation language for deletion". This PR changes the key for "Desired translation language for deletion" from `language` to `delete_language`
<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
