### PR TITLE
fix: Update transifex pull strings script for v3 in alignment with v4

### DIFF
--- a/scripts/transifex-pull-strings
+++ b/scripts/transifex-pull-strings
@@ -5,9 +5,10 @@ set -e
 SCRIPTS=$(dirname "$(realpath "$0")")
 ROOT=$(git rev-parse --show-toplevel)
 
-cd "${ROOT}/cms"
-
+cd "${ROOT}"
 "${SCRIPTS}/tx" --token "$TX_TOKEN" pull --force
-django-admin compilemessages
 
 "${SCRIPTS}/filter-locale-changes"
+
+cd "${ROOT}/cms"
+django-admin compilemessages


### PR DESCRIPTION
## Description

The v3 transifex pull script contains a bug which reverts all results from `./manage.py compilemessages` during the built of a new v3 version.

This has been fixed in the v4 repo when building django CMS v4 release candidates. It is important to fix this for v3, too, since typos in some translations have been detected.

The solution is to **first** undo any changes to the `.po` files which are trivial (date stamps only, e.g.) and **then** run `compilemessages`. 


## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
