### PR TITLE
Develop 4

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -375,6 +375,9 @@ class PageAdmin(admin.ModelAdmin):
         if 'placeholder' in perms_needed:
             perms_needed.remove('placeholder')
 
+        if 'Seiten-Inhalt' in perms_needed:  # dwinter feel even worse in german version this is in german
+            perms_needed.remove('Seiten-Inhalt')
+
         if 'page content' in perms_needed:
             perms_needed.remove('page content')
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ CLASSIFIERS = [
 
 
 setup(
-    name='django-cms',
+    name='cms',
     version=__version__,
     author='Django CMS Association and contributors',
     author_email='info@django-cms.org',


### PR DESCRIPTION
## Description

I in the German version the permission seem to have sometimes(?) German names, so I had to add this.

Not changing the setup file let to a module cms not found error.
