### PR TITLE
docs: Remove outdated link to djangocms-installer from docs

### DIFF
--- a/docs/how_to/install.rst
+++ b/docs/how_to/install.rst
@@ -550,7 +550,7 @@ Next steps
 **********
 
 The :ref:`tutorials for developers <tutorials>` will help you understand how to approach django CMS as a developer.
-Note that the tutorials assume you have installed the CMS using the django CMS Installer, but with a little
+Note that the tutorials assume you have installed the CMS using the django CMS Quistart project, but with a little
 adaptation you'll be able to use it as a basis.
 
 To deploy your django CMS project on a production web server, please refer to the :doc:`Django deployment documentation

--- a/docs/how_to/install.rst
+++ b/docs/how_to/install.rst
@@ -4,8 +4,9 @@
 How to install django CMS by hand
 #################################
 
-The easiest way to install django CMS is by using the automated `django CMS installer
-<https://github.com/nephila/djangocms-installer>`_. This is the recommended way to start with new projects, and it's
+The easiest way to install django CMS is by using the automated `django CMS quckstart
+<https://github.com/django-cms/django-cms-quickstart>`_ project. This is the
+recommended way to start with (docker-based) new projects, and it's
 what we use in the :ref:`tutorial section of this documentation <tutorials>`.
 
 If you prefer to do things manually, this how-to guide will take you through the process.
@@ -211,7 +212,7 @@ Sekizai
 =======
 
 `Django Sekizai <https://github.com/ojii/django-sekizai>`_ is required by the CMS for static files management. You need
-to have ``'sekizai'`` listed in ``INSTALLED_APPS``, 
+to have ``'sekizai'`` listed in ``INSTALLED_APPS``,
 
 .. code-block:: python
 
@@ -232,11 +233,17 @@ and ``'sekizai.context_processors.sekizai'`` in the ``TEMPLATES['OPTIONS']['cont
             'OPTIONS': {
                 'context_processors': [
                     ...
+                    'django.template.context_processors.i18n',
                     'sekizai.context_processors.sekizai',
                 ],
             },
         },
     ]
+
+.. note::
+
+    ``django.template.context_processors.i18n`` is needed for the
+    wizards to work properly.
 
 
 Middleware

--- a/docs/how_to/languages.rst
+++ b/docs/how_to/languages.rst
@@ -4,7 +4,7 @@
 How to serve multiple languages
 ###############################
 
-If you used the `django CMS installer <https://github.com/nephila/djangocms-installer>`_ to start your project, you'll find
+If you used `django CMS quickstart <https://github.com/django-cms/django-cms-quickstart>`_ to start your project, you'll find
 that it's already set up for serving multilingual content. Our :ref:`installation` guide also does the same.
 
 This guide specifically describes the steps required to enable multilingual support, in case you need to it manually.

--- a/docs/introduction/index.rst
+++ b/docs/introduction/index.rst
@@ -38,7 +38,7 @@ in the order presented here.
     09-third_party
 
 If you want to install django CMS into an existing project, or prefer to configure django CMS by
-hand, rather than using the automated installer, see :doc:`/how_to/install` and then follow the
+hand, rather than using the quickstart project, see :doc:`/how_to/install` and then follow the
 rest of the tutorials.
 
 Either way, you'll be able to find support and help from the numerous friendly members of the

--- a/docs/topics/commonly_used_plugins.rst
+++ b/docs/topics/commonly_used_plugins.rst
@@ -25,12 +25,12 @@ that has been created.
 django CMS Core Addons
 **********************
 
-We maintain a set of *Core Addons* for django CMS. 
+We maintain a set of *Core Addons* for django CMS.
 
 You don't need to use them, and for many of them alternatives exist, but they represent a good way
 to get started with a reliable project set-up. We recommend them for new users of django CMS in
 particular. For example, if you start a project on `Divio Cloud <https://divio.com/>`_ or using the
-`django CMS installer <https://github.com/nephila/djangocms-installer>`_, this is the set of addons
+`django CMS quickstart <https://github.com/django-cms/django-cms-quickstart>`_, this is the set of addons
 you'll have installed by default.
 
 The django CMS Core Addons are:
@@ -82,7 +82,7 @@ Deprecated addons
 Some older plugins that you may have encountered are now deprecated and we advise against
 incorporating them into new projects.
 
-These are: 
+These are:
 
 * `cmsplugin-filer <https://github.com/divio/cmsplugin-filer>`_
 * `Aldryn Style <https://github.com/aldryn/aldryn-style>`_


### PR DESCRIPTION
## Description

This removes the outdated mention of djangocms-installer from the docs. The docs have pointed to django-cms-quickstart for a while now, but a link to djanogcms-installer remained in the docs despite its use not being discussed. 

It also adds a note on the need of the `django.template.context_processors.i18n` context processor for the wizards work properly. (#5828)

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #5828
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
