### PR TITLE
fix: Language chooser does not contain

### DIFF
--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -731,7 +731,7 @@ class Page(models.Model):
             self.update_languages(page_languages)
 
     def update_languages(self, languages):
-        languages = ",".join(languages)
+        languages = ",".join(set(languages))
         # Update current instance
         self.languages = languages
         # Commit. It's important to not call save()

--- a/menus/utils.py
+++ b/menus/utils.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.urls import NoReverseMatch, resolve, reverse
+from django.urls import NoReverseMatch, resolve, Resolver404, reverse
 
 from cms.utils import get_current_site, get_language_from_request
 from cms.utils.i18n import (
@@ -139,24 +139,35 @@ class DefaultLanguageChanger(object):
         with force_language(page_language):
             try:
                 view = resolve(self.request.path_info)
-            except:  # NOQA
+            except (NoReverseMatch, Resolver404):  # NOQA
                 view = None
-        if hasattr(self.request, 'toolbar') and self.request.toolbar.obj:
-            with force_language(lang):
-                try:
-                    return self.request.toolbar.obj.get_absolute_url()
-                except:  # NOQA
-                    pass
+        if (
+            hasattr(self.request, 'toolbar') and
+            self.request.toolbar.obj and
+            hasattr(self.request.toolbar.obj, "get_absolute_url")
+        ):
+            # Toolbar object
+            try:
+                # First see, if object can get language-specific absolute urls (like PageContent)
+                return self.request.toolbar.obj.get_absolute_url(language=lang)
+            except TypeError:
+                # Object's get_absolute_url does not accept language parameter, set the language
+                with force_language(lang):
+                    try:
+                        url = self.request.toolbar.obj.get_absolute_url()
+                    except NoReverseMatch:
+                        url = None
+                if url:
+                    return url
         elif view and view.url_name not in ('pages-details-by-slug', 'pages-root'):
             view_name = view.url_name
             if view.namespace:
                 view_name = "%s:%s" % (view.namespace, view_name)
-            url = None
             with force_language(lang):
                 try:
                     url = reverse(view_name, args=view.args, kwargs=view.kwargs, current_app=view.app_name)
                 except NoReverseMatch:
-                    pass
+                    url = None
             if url:
                 return url
         return '%s%s' % (self.get_page_path(lang), self.app_path)


### PR DESCRIPTION
## Description

Fixes issue #7692 at least for content objects which do not have `language` as a grouping field or - if they have - allow for a `language` argument in their `.get_absolute_url()` method (such as, e.g., `PageContent`).

Overall, this still feels unsatisfying:
* The user is only directed to the public URLs, leaving preview or edit mode.
* Currently, there is no generic way for the django CMS core to identify content objects of a given language.
* Since the language menu uses the same `DefaultLanguageChanger` class, new content objects (such as alias or blog) have to provide their own language menu, creating unnecessary code repetition.

I make this PR a draft to resolve the remaining shortcomings. Options include
1. Add a complementary method `get_for_language(language)` to let a content model decide itself how to provide the appropriate language. Downside: Potentially inefficient since caching takes place in the grouper model (`Page`)
2. Add a complementary property to indicate how to find a content object's grouper object (would be `"page"` for `PageContent` since `page_content.page` gets the grouper object) to call its `get_content_object` method. Downside: A (potentially) unnecessary implicit convention.
3. Extend the CMS config for toolbar-enabled models to optionally provide the model's field to get to its grouper object. 

I am favouring the third option, but would appreciate any feedback! 


## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7692
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
