### PR TITLE
fix: Add check for Django's i18n context processor needed for wizards to work

### DIFF
--- a/cms/tests/test_check.py
+++ b/cms/tests/test_check.py
@@ -61,15 +61,30 @@ class CheckTests(CheckAssertMixin, TestCase):
         with self.settings(INSTALLED_APPS=apps):
             self.assertCheck(False, errors=1)
 
+    def test_no_django_i18n_context_processor(self):
+        override = {'TEMPLATES': deepcopy(settings.TEMPLATES)}
+        override['TEMPLATES'][0]['OPTIONS']['context_processors'] = [
+            'sekizai.context_processors.sekizai',
+            'cms.context_processors.cms_settings'
+        ]
+        with self.settings(**override):
+            self.assertCheck(False, errors=1)
+
     def test_no_cms_settings_context_processor(self):
         override = {'TEMPLATES': deepcopy(settings.TEMPLATES)}
-        override['TEMPLATES'][0]['OPTIONS']['context_processors'] = ['sekizai.context_processors.sekizai']
+        override['TEMPLATES'][0]['OPTIONS']['context_processors'] = [
+            'sekizai.context_processors.sekizai',
+            'django.template.context_processors.i18n',
+        ]
         with self.settings(**override):
             self.assertCheck(False, errors=1)
 
     def test_no_sekizai_template_context_processor(self):
         override = {'TEMPLATES': deepcopy(settings.TEMPLATES)}
-        override['TEMPLATES'][0]['OPTIONS']['context_processors'] = ['cms.context_processors.cms_settings']
+        override['TEMPLATES'][0]['OPTIONS']['context_processors'] = [
+            'cms.context_processors.cms_settings',
+            'django.template.context_processors.i18n',
+        ]
         with self.settings(**override):
             self.assertCheck(False, errors=2)
 

--- a/cms/utils/check.py
+++ b/cms/utils/check.py
@@ -216,14 +216,6 @@ def check_i18n(output):
         else:
             section.error("SITE_ID must be an integer, not %r" % settings.SITE_ID)
 
-    # django.template.context_processors.i18n
-        processors = list(
-            chain(*[template['OPTIONS'].get('context_processors', []) for template in settings.TEMPLATES]))
-        if 'django.template.context_processors.i18n' in processors:
-            section.success("Django's i18n template context processor is installed")
-        else:
-            section.error("Django's i18n context processor is not installed, could not find "
-                          "'django.template.context_processors.i18n' in TEMPLATES option context_processors")
 
 @define_check
 def check_middlewares(output):
@@ -256,6 +248,7 @@ def check_context_processors(output):
             chain(*[template['OPTIONS'].get('context_processors', []) for template in settings.TEMPLATES]))
         required_processors = (
             'cms.context_processors.cms_settings',
+            'django.template.context_processors.i18n'
         )
         for processor in required_processors:
             if processor not in processors:

--- a/cms/utils/check.py
+++ b/cms/utils/check.py
@@ -216,6 +216,14 @@ def check_i18n(output):
         else:
             section.error("SITE_ID must be an integer, not %r" % settings.SITE_ID)
 
+    # django.template.context_processors.i18n
+        processors = list(
+            chain(*[template['OPTIONS'].get('context_processors', []) for template in settings.TEMPLATES]))
+        if 'django.template.context_processors.i18n' in processors:
+            section.success("Django's i18n template context processor is installed")
+        else:
+            section.error("Django's i18n context processor is not installed, could not find "
+                          "'django.template.context_processors.i18n' in TEMPLATES option context_processors")
 
 @define_check
 def check_middlewares(output):
@@ -338,9 +346,9 @@ def check_copy_relations(output):
                     ))
 
         if not section.warnings:
-            section.finish_success('All plugins and page/title extensions have "copy_relations" method if needed.')
+            section.finish_success('All plugins and page/page content extensions have "copy_relations" method if needed.')
         else:
-            section.finish_success('Some plugins or page/title extensions do not define a "copy_relations" method.\n'
+            section.finish_success('Some plugins or page/page content extensions do not define a "copy_relations" method.\n'
                                    'This might lead to data loss when publishing or copying plugins/extensions.\n'
                                    'See https://django-cms.readthedocs.io/en/latest/extending_cms/custom_plugins.html#handling-relations or '  # noqa
                                    'https://django-cms.readthedocs.io/en/latest/extending_cms/extending_page_title.html#handling-relations.')  # noqa
@@ -354,7 +362,8 @@ def check(output):
 
     Returns whether the configuration/environment are okay (has no errors)
     """
-    title = "Checking django CMS installation"
+    import cms
+    title = f"Checking django CMS {cms.__version__} installation"
     border = '*' * len(title)
     output.write_line(output.colorize(border, opts=['bold']))
     output.write_line(output.colorize(title, opts=['bold']))


### PR DESCRIPTION

## Description

This µ-PR adds a check to ensure the `django.template.context_processors.i18n` is available. If it is missing, django CMS wizards will not work and show a spurious error message. See #5828.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #5828 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
