### PR TITLE
fix: Remove discontinued discourse server from docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -76,7 +76,6 @@ Community & Association
 You can join us online:
 
 * in our `django CMS Slack channel <https://www.django-cms.org/slack>`_
-* on our `Discourse forum <https://discourse.django-cms.org>`_
 
 You can join a work group and work collaboratively on django CMS
 

--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,7 @@ The demo platform is kindly provided by Divio, platinum member of the django CMS
 Getting Help
 ************
 
-Please head over to our `Slack channel <https://www.django-cms.org/slack>`_ or our `discourse forum <https://discourse.django-cms.org/>`_ for support.
+Please head over to our `Slack channel <https://www.django-cms.org/slack>`_ for support.
 
 ********************
 Professional support

--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -51,7 +51,6 @@ DEFAULT_HELP_MENU_ITEMS = (
     (_("Getting started developer guide"), 'https://docs.django-cms.org/en/latest/introduction/index.html'),
     (_("Documentation"), 'https://docs.django-cms.org/en/latest/'),
     (_("User guide"), 'https://docs.google.com/document/d/1f5eWyD_sxUSok436fSqDI0NHcpQ88CXQoDoQm9ZXb0s/'),
-    (_("Support Forum"), 'https://discourse.django-cms.org/'),
     (_("Support Slack"), 'https://www.django-cms.org/slack'),
     (_("What's new"), 'https://www.django-cms.org/en/blog/'),
 )

--- a/cms/utils/conf.py
+++ b/cms/utils/conf.py
@@ -81,7 +81,7 @@ DEFAULTS = {
     'ENABLE_HELP': True,  # Adds help menu toolbar
     'EXTRA_HELP_MENU_ITEMS': (),
     'HELP_MENU_ITEMS': (
-        (_('Community forum'), 'https://discourse.django-cms.org/'),
+        (_('Community chat'), 'https://www.django-cms.org/slack/'),
         (_('Documentation'), 'https://docs.django-cms.org/en/latest/'),
         (_('Getting started'), 'https://www.django-cms.org/en/get-started-django-cms/'),
         (_('Talk to us'), 'https://www.django-cms.org/en/support/'),

--- a/docs/contributing/code.rst
+++ b/docs/contributing/code.rst
@@ -28,7 +28,7 @@ Basic requirements and standards
 ********************************
 
 If you're interested in developing a new feature for the CMS, it is recommended
-that you first discuss it on the `Discourse forum <https://discourse.django-cms.org>`_ so as
+that you first discuss it on the `Slack channel <https://www.django-cms.org/slack>`_ so as
 not to do any work that will not get merged in anyway.
 
 - Code will be reviewed and tested by at least one core developer, preferably
@@ -107,8 +107,7 @@ coverage will only be accepted with a very good reason; bug-fixing patches
 **must** demonstrate the bug with a test to avoid regressions and to check
 that the fix works.
 
-We have a `Slack Channel`_, a `Discourse forum
-<https://discourse.django-cms.org>`_, and of course the code reviews mechanism on GitHub - do use them.
+We have a `Slack Channel`_ and of course the code reviews mechanism on GitHub - do use them.
 
 
 .. _contributing_frontend:

--- a/docs/contributing/code_of_conduct.rst
+++ b/docs/contributing/code_of_conduct.rst
@@ -13,7 +13,7 @@ We will not tolerate abusive behaviour or language or any form of harassment.
 
 Individuals whose behaviour is a cause for concern will be given a warning, and
 if necessary will be excluded from participation in official django CMS
-channels (Slack group, Discourse forum, email lists, IRC channels, etc) and
+channels (Slack group, email lists, etc) and
 events. The `Django Software Foundation
 <http://djangoproject.com/foundation/>`_ will also be informed of the issue.
 

--- a/docs/contributing/development-community.rst
+++ b/docs/contributing/development-community.rst
@@ -77,21 +77,15 @@ to stay updated with the latest news and to connect with other users across the 
 You can join us online:
 
 * in our `django CMS Slack channel <https://www.django-cms.org/slack>`_
-* on our `Discourse forum <https://discourse.django-cms.org>`_
 * on `StackOverflow <https://stackoverflow.com/questions/tagged/django-cms>`_
 
 You should make sure to join our Slack workspace. It is our main communication platform. Users from all over the world
 use Slack to talk about django CMS and to support each other in answering support requests.
-For people who prefer to use a traditional user board, we have set up a Discourse forum.
-It contains question and answer threads about django CMS and is actively monitored by our team of supporters.
-It can also be used to request features.
-Our Discord server is used for ad hoc online meetings or for after work hangouts.
 StackOverflow is a very popular, community-based space to find and contribute answers to technical challenges
 
 
 You can also follow:
 
-* the `Travis Continuous Integration build reports <https://travis-ci.com/django-cms/django-cms>`_
 * the `@djangocms <https://twitter.com/djangocms>`_ Twitter account for general announcements
 * the `django CMS Association LinkedIn <https://www.linkedin.com/company/django-cms-association>`_ account
 

--- a/docs/contributing/management.rst
+++ b/docs/contributing/management.rst
@@ -27,7 +27,7 @@ Raising an issue
 
 
 Except in the case of security matters, of course, you're welcome to raise
-issues in any way that suits you - :ref:`using Discourse, or the Slack group
+issues in any way that suits you -  the Slack group
 <development-community>` or in person if you happen to meet another django CMS
 developer.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -87,7 +87,7 @@ The `django CMS Association <https://www.django-cms.org/en/about-us/>`_ is a non
 organisation that exists to support the development of django CMS and its community.
 
 
-.. rst-class:: column column3
+.. rst-class:: column column2
 
 Slack
 =====
@@ -97,16 +97,7 @@ Join `our friendly Slack group <https://www.django-cms.org/slack>`_ for
 other members of the community.
 
 
-.. rst-class:: column column3
-
-Discourse
-=========
-
-Our `Discourse forum <https://discourse.django-cms.org>`_ is also used for
-discussion of django CMS, particularly to manage its technical development process.
-
-
-.. rst-class:: column column3
+.. rst-class:: column column2
 
 StackOverflow
 =============

--- a/docs/introduction/index.rst
+++ b/docs/introduction/index.rst
@@ -42,5 +42,4 @@ hand, rather than using the quickstart project, see :doc:`/how_to/install` and t
 rest of the tutorials.
 
 Either way, you'll be able to find support and help from the numerous friendly members of the
-django CMS community, either on our `Discourse forum <https://discourse.django-cms.org>`_ or `our
-Slack group <https://www.django-cms.org/slack>`_.
+django CMS community on `our Slack group <https://www.django-cms.org/slack>`_.

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -1069,7 +1069,7 @@ CMS_EXTRA_HELP_MENU_ITEMS
 Example::
 
     CMS_EXTRA_HELP_MENU_ITEMS = (
-        (_('Community forum'), 'https://discourse.django-cms.org/'),
+        (_('Community chat'), 'https://www.django-cms.org/slack'),
         (_('Documentation'), 'https://docs.django-cms.org/en/latest/'),
         (_('Getting started'), 'https://www.django-cms.org/en/get-started-django-cms/'),
         (_('Talk to us'), 'https://www.django-cms.org/en/support/'),


### PR DESCRIPTION
## Description

The discourse forum has been discontinued, we need to remove it from the docs and the toolbar.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
