### PR TITLE
fix: Extension toolbar

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -372,10 +372,10 @@ class PageAdmin(admin.ModelAdmin):
         )
 
         # This is bad and I should feel bad.
-        if 'placeholder' in perms_needed:
+        if _('placeholder') in perms_needed:
             perms_needed.remove('placeholder')
 
-        if 'page content' in perms_needed:
+        if _('page content') in perms_needed:
             perms_needed.remove('page content')
 
         if request.POST and not protected:  # The user has confirmed the deletion.

--- a/cms/tests/test_extensions.py
+++ b/cms/tests/test_extensions.py
@@ -407,7 +407,7 @@ class ExtensionAdminTestCase(CMSTestCase):
                 current_page_menu = self._setup_extension_toolbar()
                 if current_page_menu:
                     position = 0
-                    urls = self.get_title_extension_admin()
+                    urls = self.get_page_content_extension_admin()
                     for title_extension, url in urls:
                         current_page_menu.add_modal_item(
                             'TestItem',


### PR DESCRIPTION
## Description

This PR does fix the page content extension toolbar:
* Renames `get_title_extension_admin` to `get_page_content_extension_admin` (old name stays with a deprecation warning)
* Takes the current page content from the toolbar object if available (from page as a fallback). This works also, if going back to old versions when using djangocms-versioning.
* If used without the language argument, it picks the `latest_content` filter which - if versioning is installed - is the latest version (draft, published, or unpublished, archived in that order). I recommend to not use this variant, since it is not necessarily in sync with the currently shown toolbar object

@jrief can you test if this solves your issue #7704?

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7704 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
