### PR TITLE
docs: Restore overwritten release notes for version 3.11.4 in docs

### DIFF
--- a/docs/upgrade/3.11.4.rst
+++ b/docs/upgrade/3.11.4.rst
@@ -1,34 +1,45 @@
 .. _upgrade-to-3.11.4:
 
-######################
- release notes 3.11.3
-######################
-
-This release focuses on Django 4.2 support which will be LTS. django CMS version 3.11.x will be supported until the end of life of Django 4.2 estimated for April 2026.
-
-Compared to 3.11.2 it fixes a bug which broke the dropdown menu in the page tree.
+#####################
+ release notes 3.11.4
+#####################
 
 ********************
 What's new in 3.11.4
 ********************
 
-Bug Fixes:
-----------
-* Remove superfluous curly bracket left behind on PR 7488 (#7529) -- Corentin Bettiol
-* Fix admin tests (#6848) for some post requests (#7535) -- Fabian Braun
+Features:
+ ---------
+ * Update dark mode switch to be compatible with Django 4.2 admin dark mode (#7549) (1106ae6d7) -- Fabian Braun
 
-Statistics:
------------
+ Bug Fixes:
+ ----------
+ * Toolbar action button becomes hard to read in dark mode (c626022ba) -- Fabian Braun
+ * Backport v4.1.0rc4 fixes - Admin language and styling (#7630) (#7641) (90b72ebea) -- Fabian Braun
+ * diff-dom freezing on content refresh: #7460 (#7600) (d8e9c527e) -- Vinit Kumar
+ * Fixed RecursionError when extending templates (#7594) (c99f78759) -- mihalikv
+ * JS issues with running CMS under cypress (#7591) (ce4c29948) -- Vinit Kumar
+ * Mitigate performance hit due to deprecation warnings for v4.1 (#7587) (9908d7e70) -- Fabian Braun
+ * create page wizard fails with Asian page titles/unicode slugs (#7565) (0ab640ce3) -- Fabian Braun
+ * require Django >= 3.2 (#7562) (a77358b93) -- Fabian Braun
+ * respect pre-set (48353c2d6) -- Fabian Braun
+ * lint menus app (#7534) (927b60b47) -- Vinit Kumar
+ * remove curly bracket left behind on PR 7488 (#7529) (123f7df91) -- Corentin Bettiol
 
-This release includes 2 pull requests, and was created with the help of the following contributors (in alphabetical order):
+ Statistics:
+ -----------
 
-* Corentin Bettiol (1 pull request)
-* Fabian Braun (1 pull requests)
+ This release includes 45 pull requests, and was created with the help of the following contributors (in alphabetical order):
 
-With the review help of the following contributors:
-
-* Fabian Braun
-* Vinit Kumar
+ * ChengDaqi2023 (1 pull request)
+ * Corentin Bettiol (1 pull request)
+ * Fabian Braun (30 pull requests)
+ * Github Release Action (3 pull requests)
+ * Vinit Kumar (3 pull requests)
+ * caption (1 pull request)
+ * dependabot[bot] (0 pull request)
+ * mihalikv (1 pull request)
+ * suryadev99 (1 pull request)
 
 Thanks to all contributors for their efforts!
 


### PR DESCRIPTION
## Description

Apparently, the release notes for version 3.11.4 were overwritten by those of 3.11.3. This PR restores them for the docs.

Thanks to @svandeneertwegh for pointing this out!

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* https://docs.django-cms.org/en/release-3.11.x/upgrade/index.html
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
