### PR TITLE
docs: Add CONTRIBUTING.rst and CODE_OF_CONDUCT.rst from develop to develop-4 branch

### DIFF
--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -1,0 +1,7 @@
+==========================
+django CMS Code of Conduct
+==========================
+
+django CMS is governed by a `Code of Conduct
+<http://docs.django-cms.org/en/latest/contributing/code_of_conduct.html>`_.
+All participants in our community and its various forums are expected to abide by it.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,102 @@
+============
+CONTRIBUTING
+============
+
+First, thank you very much, that you would like to contribute to django CMS.
+We always welcome contributions, like many other open-source projects. We are
+very thankful to the many `present, past and future contributors <https://github.com/django-cms/django-cms/graphs/contributors>`_, to our `community heroes <https://github.com/django-cms/django-cms-mgmt/blob/master/community%20heros/list%20of%20community%20heros.md>`_ and to the `members of the django CMS Association <https://github.com/django-cms/django-cms-mgmt/blob/master/association/members.md>`_.
+
+
+Code of Conduct
+===============
+
+django CMS is governed by a `Code of Conduct
+<http://docs.django-cms.org/en/latest/contributing/code_of_conduct.html>`_.
+All participants in our community and its various forums are expected to abide by it.
+
+
+Issues
+======
+
+* Please report **any bugs** through `GitHub issues <https://github.com/django-cms/django-cms/issues>`_.
+* For *security issues* please see further below.
+
+Contributing Code
+================
+
+Here’s what the pull request process looks like in brief:
+
+1. Fork our GitHub repository, https://github.com/django-cms/django-cms
+2. Work locally and push your changes to your repository.
+3. When you feel your code is good enough for inclusion, send us a pull request.
+4. After that, please join the `Slack Channel <https://www.django-cms.org/slack>`_ of our Pull Request Review work group (#workgroup-pr-review). This group of friendly community members is dedicated to reviewing pull requests. Report your PR and find a “pr review buddy” who is going to review your pull request.
+5. Get acknowledged by the django CMS community for your contribution :-)
+
+To learn more about basic requirements and standards of code contribution, please familiarize yourself with our comprehensive `documentation <https://docs.django-cms.org/en/latest/contributing/code.html#>`_.
+
+django CMS commits follow the `Conventional Commits Guideline <https://conventionalcommits.org/>`_, please try to follow the Guidelines in your commit messages to ease our review & merge process.
+
+
+Proposing large feature additions
+=================================
+
+In terms of proposing large feature additions, we follow the best practice of `DEPS <https://github.com/django/deps>`_.
+
+To create a proposal...
+
+1. please use this `DEP <https://github.com/django/deps/blob/main/template.rst>`_ template
+
+2. create a discussion in the main `django CMS repository <https://github.com/django-cms/django-cms/discussions>`_
+
+3. join the `Tech Committee <https:/github.com/django-cms/django-cms-mgmt/blob/master/tech-committee/about.md>`_ `Slack Channel <https://www.django-cms.org/slack>`_ (#technical-committee) and ask for a RFC.
+
+4. After RFC is completed, add the proposal to the `agenda <https://hackmd.io/ddhvq_aqS6my9gwhLddyPg>`_ of the TC for approval.
+
+
+Contribution documentation
+==========================
+
+We maintain comprehensive `contribution documentation <http://docs.django-cms.org/en/latest/contributing/>`_.
+Please familiarise yourself with it before submitting any issues or pull requests.
+
+
+Security issues
+===============
+
+Please have a look at our security policy for
+`how to deal with security issues <http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues>`_.
+
+If you think you have discovered a security issue in our code, please do not raise it in any public
+forum until we have had a chance to deal with it.
+
+
+Community & Association
+=======================
+
+You can join us online:
+
+* in our `django CMS Slack channel <https://www.django-cms.org/slack>`_
+
+You can join a work group and work collaboratively on django CMS
+
+* `work groups <https://www.django-cms.org/en/join-work-group/>`_
+
+You can also follow:
+
+* the `@djangocms <https://twitter.com/djangocms>`_ Twitter account for general announcements
+
+You can become a member of the django CMS Association and receive benefits
+
+* `Membership <https://www.django-cms.org/en/memberships/>`_
+
+
+Receive rewards for submitting pull requests
+--------------------------------------------
+
+Sign up for our `Bounty program <https://www.django-cms.org/en/bounty-program/>`_.
+
+
+Join a work group
+=================
+
+As part of the django CMS Association we have formed several `work groups <https://docs.django-cms.org/en/latest/contributing/code.html#>`_ to work together on different django CMS development topics. If you want to become part of contributor team, feel free to join one of our groups. You will meet friendly people and improve your programming skills and make a real difference in the django CMS open source project.


### PR DESCRIPTION
## Description

This adds django CMS' contribution guidelines and code of conduct as they are present in the current `develop` branch to `develop-4`

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
