### PR TITLE
docs: Update docs for frontend testing

### DIFF
--- a/docs/contributing/code.rst
+++ b/docs/contributing/code.rst
@@ -127,7 +127,7 @@ Frontend
 In order to be able to work with the frontend tooling contributing to the
 django CMS you need to have the following dependencies installed:
 
-    1. `Node <https://nodejs.org/>`_ version 6.10.1 (will install npm 3.10.10 as well).
+    1. `Node <https://nodejs.org/>`_ version 18.19.0 (will install npm 10.2.3 as well).
        We recommend using `NVM <https://github.com/creationix/nvm>`_ to get
        the correct version of Node.
     2. gulp - see `Gulp's Getting Started notes <https://github.com/gulpjs/gulp/blob/master/docs/getting-started.md>`_

--- a/docs/contributing/testing.rst
+++ b/docs/contributing/testing.rst
@@ -124,17 +124,13 @@ dj-database-url compatible value.
 Running Frontend Tests
 **********************
 
-We have two types of frontend tests: unit tests and integration tests.
 For unit tests we are using `Karma <http://karma-runner.github.io/>`_ as a
 test runner and `Jasmine <http://jasmine.github.io/>`_ as a test framework.
-
-Integration tests run on `PhantomJS <http://phantomjs.org/>`_ and are
-built using `CasperJS <http://casperjs.org/>`_.
 
 In order to be able to run them you need to install necessary dependencies as
 outlined in :ref:`frontend tooling installation instructions <contributing_frontend>`.
 
-Linting runs against the test files as well with ``gulp tests:lint``. In order
+Linting runs against the test files as well with ``gulp lint``. In order
 to run linting continuously, do::
 
     gulp watch
@@ -145,16 +141,16 @@ Unit tests
 
 Unit tests can be run like this::
 
-    gulp tests:unit
+    gulp unitTest
 
 If your code is failing and you want to run only specific files, you can provide
 the ``--tests`` parameter with comma separated file names, like this::
 
-    gulp tests:unit --tests=cms.base,cms.modal
+    gulp unitTest --tests=cms.base,cms.modal
 
 If you want to run tests continuously you can use the watch command::
 
-    gulp tests:unit:watch
+    gulp unitTest --watch
 
 This will rerun the suite whenever source or test file is changed.
 By default the tests are running on `PhantomJS <http://phantomjs.org/>`_, but
@@ -170,56 +166,6 @@ the build entirely using ``[skip ci]``.
 
 We're using Jasmine as a test framework and Istanbul as a code coverage tool.
 
-
-Integration tests
-=================
-
-In order to run integration tests you'll have to install at least the version
-of django CMS from the current directory and django-app-helper into into your virtualenv.
-All commands should be run from the root of the repository. If you do not have
-virtualenv yet, create and activate it first::
-
-    virtualenv env
-    . env/bin/activate
-
-Then install minimum required dependencies::
-
-    pip install -r test_requirements/django-1.8.txt
-    pip install -e .
-
-Now you'll be able to run a tests with this command::
-
-    gulp tests:integration
-
-The command will start a server, wait for a minute for the migrations to run
-and will run integration tests against it.  It will use ``testdb.sqlite`` as the
-database. If you want to start with a clean state you could use ``--clean``
-argument.
-
-Some tests require different server configuration, so it is possible that the
-server will stop, and another variation will start with different arguments.
-Take a look inside `testserver.py` if you need to customise the test server
-settings.
-
-While debugging you can use the ``--tests`` parameter as well in order to run test
-suites separately.::
-
-    gulp tests:integration --tests=pagetree
-    gulp tests:integration --tests=loginAdmin,toolbar
-
-If specified tests require different servers they will be grouped to speed
-things up, so the order might not be the same as you specify in the argument.
-
-When running locally, it sometimes helps to visualise the tests output. For that
-you can install `casperjs visual debugging utility <https://github.com/vxsx/casperjs-visual-debugging>`_,
-and run the tests with additional ``--visual`` argument. It will try to
-communicate with the server and display the progress of the test, which you then
-can also rewind.
-
-It might sometimes be useful not to restart the server when creating the tests,
-for that you can run ``python testserver.py`` with necessary arguments in one
-shell and ``gulp tests:integration --no-server`` in another. However you would
-need to clean the state yourself if the test you've been writing fails.
 
 *************
 Writing tests


### PR DESCRIPTION
## Description

- Change docs Node version from 6 to 18
- Fix docs commands for running unit tests
- Remove docs integratration tests section, as they're not running anymore in CI (and won't run locally)

## Related resources

* #7725 

## Checklist

* [x] I have opened this pull request against ``develop``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
