### PR TITLE
fix: Django 5 only allows POST requests to log out

### DIFF
--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -23,6 +23,7 @@ from cms.toolbar.utils import (
 from cms.toolbar_base import CMSToolbar
 from cms.toolbar_pool import toolbar_pool
 from cms.utils import get_language_from_request, page_permissions
+from cms.utils.compat import DJANGO_4_2
 from cms.utils.conf import get_cms_setting
 from cms.utils.i18n import get_language_dict, get_language_tuple
 from cms.utils.page_permissions import (
@@ -343,7 +344,7 @@ class BasicToolbar(CMSToolbar):
             action=admin_reverse('logout'),
             active=True,
             on_success=on_success,
-            method='GET',
+            method='GET' if DJANGO_4_2 else 'POST',
         )
 
     def add_language_menu(self):

--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -344,7 +344,7 @@ class BasicToolbar(CMSToolbar):
             action=admin_reverse('logout'),
             active=True,
             on_success=on_success,
-            method='GET' if DJANGO_4_2 else 'POST',
+            method='POST',
         )
 
     def add_language_menu(self):

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -630,7 +630,7 @@ class ToolbarTests(ToolbarTestBase):
     def test_admin_logout_staff(self):
         with override_settings(CMS_PERMISSION=True):
             with self.login_user_context(self.get_staff()):
-                response = self.client.get('/en/admin/logout/')
+                response = self.client.post('/en/admin/logout/')
                 self.assertTrue(response.status_code, 200)
 
     def test_show_toolbar_without_edit(self):


### PR DESCRIPTION
## Description

Fixes https://github.com/django-cms/cms-template/issues/2. Solution taken from #7724 by @protoroto .

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* https://github.com/django-cms/cms-template/issues/2
* #7724

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
