### PR TITLE
docs: Incomplete command to create a virtual env in docs

### DIFF
--- a/docs/introduction/01-install.rst
+++ b/docs/introduction/01-install.rst
@@ -173,7 +173,7 @@ django CMS also has other requirements, which it lists as dependencies in its
 
     .. code-block:: bash
 
-        python3 -m .venv  # create a virtualenv
+        python3 -m venv .venv  # create a virtualenv
         source .venv/bin/activate  # activate it
         pip install --upgrade pip  # Upgrade pip
 


### PR DESCRIPTION
## Description

Fixes a missing `venv` in the command to create a virtual environment
<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7733 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
