### PR TITLE
fix: readable messages in dark-mode

### DIFF
--- a/cms/static/cms/sass/settings/_cms.scss
+++ b/cms/static/cms/sass/settings/_cms.scss
@@ -342,7 +342,7 @@ $dialog-shadow: $modal-shadow;
 // Toolbar messages + screenblock + login form
 $messages-width: 300px;
 $messages-padding: 6px 10px 8px;
-$messages-color: $white;
+$messages-color: white;
 $messages-font-size: 12px;
 $messages-line-height: 16px;
 $messages-border-radius: $border-radius-base;


### PR DESCRIPTION
## Description

Fixes #7738 for v3. 

The messages should always appear with white text on dark background.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7738 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
