### PR TITLE
fix: Add `--fix-paths` option to `./manage.py cms fix-tree`

### DIFF
--- a/cms/management/commands/subcommands/tree.py
+++ b/cms/management/commands/subcommands/tree.py
@@ -22,7 +22,7 @@ def get_descendants(root):
 
 
 class FixTreeCommand(SubcommandsCommand):
-    help_string = 'Repairing Materialized Path Tree for Pages'
+    help_string = 'Repairing Materialized Path Tree for Pages and Plugins'
     command_name = 'fix-tree'
 
     def add_arguments(self, parser):

--- a/cms/management/commands/subcommands/tree.py
+++ b/cms/management/commands/subcommands/tree.py
@@ -25,12 +25,21 @@ class FixTreeCommand(SubcommandsCommand):
     help_string = 'Repairing Materialized Path Tree for Pages'
     command_name = 'fix-tree'
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--fix-paths',
+            action='store_true',
+            default=False,
+            help='Fix paths for pages and plugins - takes a long time',
+        )
+
     def handle(self, *args, **options):
         """
         Repairs the tree
         """
+        fix_paths = options.get('fix_paths', False)
         self.stdout.write('fixing page tree')
-        TreeNode.fix_tree()
+        TreeNode.fix_tree(fix_paths=fix_paths)
 
         root_nodes = TreeNode.objects.filter(parent__isnull=True)
 
@@ -54,7 +63,7 @@ class FixTreeCommand(SubcommandsCommand):
             self._update_descendants_tree(root)
 
         self.stdout.write('fixing plugin tree')
-        CMSPlugin.fix_tree()
+        CMSPlugin.fix_tree(fix_paths=fix_paths)
         self.stdout.write('all done')
 
     def _update_descendants_tree(self, root):

--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -355,14 +355,14 @@ class CMSPlugin(MP_Node, metaclass=PluginModelBase):
         return new_plugin
 
     @classmethod
-    def fix_tree(cls, destructive=False):
+    def fix_tree(cls, **kwargs):
         """
         Fixes the plugin tree by first calling treebeard fix_tree and the
         recalculating the correct position property for each plugin.
         """
         from cms.utils.plugins import reorder_plugins
 
-        super().fix_tree(destructive)
+        super().fix_tree(**kwargs)
         for placeholder in Placeholder.objects.all():
             for language, __ in settings.LANGUAGES:
                 order = CMSPlugin.objects.filter(

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ REQUIREMENTS = [
     'Django>=3.2',
     'django-classy-tags>=0.7.2',
     'django-formtools>=2.1',
-    'django-treebeard>=4.3',
+    'django-treebeard>=4.3,!=4.5',
     'django-sekizai>=0.7',
     'djangocms-admin-style>=1.2',
     'packaging',


### PR DESCRIPTION
## Description

This PR excludes django-treebeard 4.5 as a compatible dependency.

It also adds a `--fix-paths` option to the management command `cms fix-tree`. This rebuilds the django-treebeard paths for both pages and plugins if it has got corrupted. This at least helped partially in #7743.

It is passed through to django-treebeard's `fix_tree` class method for `MP_Node` subclasses. (`destructive`is deprecated and replaced by `fix_paths`.  By passing through, older usages remain intact.)

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7743 
* #6980

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
