### PR TITLE
Remove delete page from toolbar

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+4.2 (in progress)
+=================
+
+Features:
+---------
+* Remove menu item "Delete page…" from toolbar.
+
+
 4.1.0 (2023-12-22)
 ==================
 

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -371,12 +371,10 @@ class PageAdmin(admin.ModelAdmin):
             **get_deleted_objects_additional_kwargs
         )
 
-        # This is bad and I should feel bad.
-        if _('placeholder') in perms_needed:
-            perms_needed.remove('placeholder')
-
-        if _('page content') in perms_needed:
-            perms_needed.remove('page content')
+        # `django.contrib.admin.utils.get_deleted_objects()` only returns the verbose_name of a model,
+        # we hence have to use that name in order to allow the deletion of objects otherwise prevented.
+        perms_needed.discard(Placeholder._meta.verbose_name)
+        perms_needed.discard(PageContent._meta.verbose_name)
 
         if request.POST and not protected:  # The user has confirmed the deletion.
             if perms_needed:

--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -672,10 +672,3 @@ class PageToolbar(CMSToolbar):
                 disabled=(not edit_mode or not can_change),
                 on_success=refresh,
             )
-
-            # delete
-            delete_url = admin_reverse('cms_page_delete', args=(self.page.pk,))
-            delete_disabled = not edit_mode or not user_can_delete_page(self.request.user, page=self.page)
-            on_delete_redirect_url = self.get_on_delete_redirect_url()
-            current_page_menu.add_modal_item(_('Delete page'), url=delete_url, on_close=on_delete_redirect_url,
-                                             disabled=delete_disabled)


### PR DESCRIPTION
## Description

Currently the toolbar offers a menu item to delete the current page.
This is problematic, because the user first has to change into edit mode, before allowing him to delete that page.
Moreover, after deletion which page shall the browser render?

@fsbraun and I therefore discussed on Slack and concluded, that deleting a page only shall be possible through the page tree.

* [x] I have opened this pull request against ``develop``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
