### PR TITLE
fix: editing of apphooked CMS pages without apphook landing page

### DIFF
--- a/cms/test_utils/project/sampleapp/cms_apps.py
+++ b/cms/test_utils/project/sampleapp/cms_apps.py
@@ -84,6 +84,15 @@ class SampleApp3(CMSApp):
         ]
 
 
+class SampleAppWithoutLandingPage(CMSApp):
+    # CMSApp that does not define a view at ''
+
+    name = _("Sample App Without Landing Page")
+
+    def get_urls(self, page=None, language=None, **kwargs):
+        return ["cms.test_utils.project.sampleapp.urls_extra"]
+
+
 class NamespacedApp(CMSApp):
     name = _("Namespaced App")
     app_name = 'namespaced_app_ns'
@@ -136,6 +145,7 @@ apphook_pool.register(SampleApp)
 apphook_pool.register(SampleAppWithExcludedPermissions)
 apphook_pool.register(SampleApp2)
 apphook_pool.register(SampleApp3)
+apphook_pool.register(SampleAppWithoutLandingPage)
 apphook_pool.register(NamespacedApp)
 apphook_pool.register(ParentApp)
 apphook_pool.register(VariableUrlsApp)

--- a/cms/tests/test_apphooks.py
+++ b/cms/tests/test_apphooks.py
@@ -137,7 +137,7 @@ class ApphooksTestCase(CMSTestCase):
         self.apphook_clear()
         hooks = apphook_pool.get_apphooks()
         app_names = [hook[0] for hook in hooks]
-        self.assertEqual(len(hooks), 8)
+        self.assertEqual(len(hooks), 9)
         self.assertIn(NS_APP_NAME, app_names)
         self.assertIn(APP_NAME, app_names)
         self.apphook_clear()
@@ -160,6 +160,26 @@ class ApphooksTestCase(CMSTestCase):
         self.assertTemplateUsed(response, 'nav_playground.html')
 
         self.apphook_clear()
+
+    def test_apphook_without_landing_page(self):
+        """test rendering the apphook without landing page.
+
+        tests for https://github.com/django-cms/django-cms/issues/7765
+        """
+        from django.contrib.contenttypes.models import ContentType
+
+        from cms import views
+        from cms.utils.urlutils import admin_reverse
+
+        APP_NAME = 'SampleAppWithoutLandingPage'
+        [content] = self.create_base_structure(
+            APP_NAME, ["en"], "apphook-without-landing"
+        )
+        content_type = ContentType.objects.get(app_label='cms', model='pagecontent')
+        endpoint = admin_reverse('cms_placeholder_render_object_edit', args=(content_type.pk, content.pk,))
+        # make sure, we do not get views.details as this always uses the
+        # published page content
+        self.assertIsNot(endpoint, views.details)
 
     @override_settings(ROOT_URLCONF='cms.test_utils.project.urls_for_apphook_tests')
     def test_apphook_does_not_crash_django_checks(self):

--- a/cms/views.py
+++ b/cms/views.py
@@ -291,7 +291,8 @@ def render_object_endpoint(request, content_type_id, object_id, require_editable
                     request.toolbar = CMSToolbar(request, request_path=absolute_url)
                     # Resolve the apphook's url to get its view function
                     view_func, args, kwargs = resolve(absolute_url)
-                    return view_func(request, *args, **kwargs)
+                    if view_func is not details:
+                        return view_func(request, *args, **kwargs)
                 except Resolver404:
                     # Apphook does not provide a view for its "root", show warning message
                     return _handle_no_apphook(request)

--- a/docs/introduction/01-install.rst
+++ b/docs/introduction/01-install.rst
@@ -224,7 +224,8 @@ template. It performs the following five steps in one simple go:
    - `djangocms_admin_style <https://github.com/django-cms/djangocms-admin-style>`_ for
      a consistent user experience with django CMS and Django admin.
 
-3. It runs the ``migrate`` command to create the database:
+3. It changes into the project directory and runs the ``migrate`` command to create the 
+   database:
 
    .. code-block::
 
@@ -273,10 +274,12 @@ We suggest to use pip-compile to freeze your requirements as, for example, discu
 Spin up your Django development server (Step 3)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Now you are ready to spin up Django's development server by running:
+Now you are ready to spin up Django's development server by first changing directory into 
+the projcet folder and then spinning up the development server:
 
 .. code-block::
 
+    cd myproject
     python -m manage runserver
 
 You can visit your project's web site by pointing your browser to ``localhost:8000``.

--- a/docs/introduction/01-install.rst
+++ b/docs/introduction/01-install.rst
@@ -275,7 +275,7 @@ Spin up your Django development server (Step 3)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Now you are ready to spin up Django's development server by first changing directory into 
-the projcet folder and then spinning up the development server:
+the project folder and then spinning up the development server:
 
 .. code-block::
 


### PR DESCRIPTION
<!--
    If this is a security-related patch stop immediately!

    See http://docs.django-cms.org/en/latest/contributing/development-policies.html
-->


### Summary

Fixes #7765



### Links to related discussion



### Proposed changes in this pull request
this implements a small patch and a test to make sure, that CMS pages that hold an apphook without a urlpattern at the `""`-location still have the correct pagecontent object at the edit url

### Documentation checklist

* [ ] I have updated CHANGELOG.txt if appropriate
* [ ] I have updated the release notes document if appropriate, with:
    * [ ] general notes
    * [ ] bug-fixes
    * [ ] improvements/new features
    * [ ] backwards-incompatible changes
    * [ ] required upgrade steps
    * [ ] names of contributors
* [ ] I have updated other documentation
* [ ] I have added my name to the AUTHORS file
* [ ] This PR's documentation has been approved by Daniele Procida
