### PR TITLE
fix: Redirect user to edit url after a successful page creation

### DIFF
--- a/cms/tests/test_wizards.py
+++ b/cms/tests/test_wizards.py
@@ -167,7 +167,7 @@ class TestWizardBase(WizardTestMixin, TransactionCMSTestCase):
 
     def test_get_preview_url(self):
         wizard_preview_mode = Wizard(
-            title=_(u"Page"),
+            title=_("Page"),
             weight=100,
             form=WizardForm,
             model=Page,

--- a/cms/tests/test_wizards.py
+++ b/cms/tests/test_wizards.py
@@ -19,7 +19,10 @@ from cms.models import Page, UserSettings
 from cms.test_utils.project.backwards_wizards.wizards import wizard
 from cms.test_utils.project.sampleapp.cms_wizards import sample_wizard
 from cms.test_utils.testcases import CMSTestCase, TransactionCMSTestCase
-from cms.toolbar.utils import get_object_edit_url
+from cms.toolbar.utils import (
+    get_object_edit_url,
+    get_object_preview_url,
+)
 from cms.utils import get_current_site
 from cms.utils.conf import get_cms_setting
 from cms.utils.setup import setup_cms_apps
@@ -161,6 +164,34 @@ class TestWizardBase(WizardTestMixin, TransactionCMSTestCase):
                 page, language="en")
             self.assertEqual(
                 url, get_object_edit_url(page, language="en"))
+
+    def test_get_preview_url(self):
+        wizard_preview_mode = Wizard(
+            title=_(u"Page"),
+            weight=100,
+            form=WizardForm,
+            model=Page,
+            template_name='my_template.html',  # This doesn't exist anywhere
+            edit_mode_on_success=False
+        )
+
+        user = self.get_superuser()
+        page = create_page(
+            title="Sample Page",
+            template=TEMPLATE_INHERITANCE_MAGIC,
+            language="en",
+            created_by=smart_str(user),
+            parent=None,
+            in_navigation=True,
+        )
+
+        extension = apps.get_app_config('cms').cms_extension
+
+        with patch.object(extension, 'toolbar_enabled_models', {Page: page}):
+            url = wizard_preview_mode.get_success_url(
+                page, language="en")
+            self.assertEqual(
+                url, get_object_preview_url(page, language="en"))
 
     def test_get_model(self):
         self.assertEqual(self.page_wizard.get_model(), Page)

--- a/cms/tests/test_wizards.py
+++ b/cms/tests/test_wizards.py
@@ -19,6 +19,7 @@ from cms.models import Page, UserSettings
 from cms.test_utils.project.backwards_wizards.wizards import wizard
 from cms.test_utils.project.sampleapp.cms_wizards import sample_wizard
 from cms.test_utils.testcases import CMSTestCase, TransactionCMSTestCase
+from cms.toolbar.utils import get_object_edit_url
 from cms.utils import get_current_site
 from cms.utils.conf import get_cms_setting
 from cms.utils.setup import setup_cms_apps
@@ -141,6 +142,25 @@ class TestWizardBase(WizardTestMixin, TransactionCMSTestCase):
         # Now again without a language code
         url = page.get_absolute_url()
         self.assertEqual(self.page_wizard.get_success_url(page), url)
+
+    def test_get_edit_url(self):
+        user = self.get_superuser()
+        page = create_page(
+            title="Sample Page",
+            template=TEMPLATE_INHERITANCE_MAGIC,
+            language="en",
+            created_by=smart_str(user),
+            parent=None,
+            in_navigation=True,
+        )
+
+        extension = apps.get_app_config('cms').cms_extension
+
+        with patch.object(extension, 'toolbar_enabled_models', {Page: page}):
+            url = self.page_wizard.get_success_url(
+                page, language="en")
+            self.assertEqual(
+                url, get_object_edit_url(page, language="en"))
 
     def test_get_model(self):
         self.assertEqual(self.page_wizard.get_model(), Page)

--- a/docs/reference/wizards.rst
+++ b/docs/reference/wizards.rst
@@ -38,6 +38,9 @@ When instantiating a Wizard object, use the keywords:
 :description: The description is optional, but if it is not supplied, the
               CMS will create one from the pattern:
               "Create a new «model.verbose_name» instance."
+:edit_mode_on_success: Whether the user will get redirected to object edit url after a
+                       successful creation or not. This only works if the object is registered 
+                       for toolbar enabled models.
 
 
 .. important::


### PR DESCRIPTION
## Description
Added the wizard property ``edit_mode_on_success`` and defaulted it to True to redirect newly created pages to edit mode instead of preview mode. The related documentation was updated.
<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7688 

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [X] I have opened this pull request against ``develop-4``
* [X] I have added or modified the tests when changing logic
* [X] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
