### PR TITLE
fix: render content in place `redirect_on_fallback` is False

### DIFF
--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -82,7 +82,6 @@ class BaseRenderer:
 
     def __init__(self, request):
         self.request = request
-        self.request_language = get_language_from_request(self.request)
         self._cached_templates = {}
         self._cached_plugin_classes = {}
         self._placeholders_content_cache = {}
@@ -111,6 +110,10 @@ class BaseRenderer:
     def plugin_pool(self):
         import cms.plugin_pool
         return cms.plugin_pool.plugin_pool
+
+    @cached_property
+    def request_language(self):
+        return get_language_from_request(self.request)
 
     def get_placeholder_plugin_menu(self, placeholder, page=None):
         registered_plugins = self.plugin_pool.registered_plugins

--- a/cms/test_utils/testcases.py
+++ b/cms/test_utils/testcases.py
@@ -31,6 +31,7 @@ from cms.models.permissionmodels import (
 )
 from cms.plugin_rendering import ContentRenderer, StructureRenderer
 from cms.test_utils.util.context_managers import UserLoginContext
+from cms.toolbar.utils import get_toolbar_from_request
 from cms.utils.compat import DJANGO_4_1
 from cms.utils.conf import get_cms_setting
 from cms.utils.permissions import set_current_user
@@ -661,6 +662,12 @@ class BaseCMSTestCase:
         }
         plugin = add_plugin(placeholder, plugin_type, language, **plugin_data[plugin_type])
         return plugin
+
+    def _render_placeholder(self, placeholder, context, **kwargs):
+        request = context['request']
+        toolbar = get_toolbar_from_request(request)
+        content_renderer = toolbar.content_renderer
+        return content_renderer.render_placeholder(placeholder, context, **kwargs)
 
 
 class CMSTestCase(BaseCMSTestCase, testcases.TestCase):

--- a/cms/tests/test_multilingual.py
+++ b/cms/tests/test_multilingual.py
@@ -211,7 +211,7 @@ class MultilingualTestCase(CMSTestCase):
             # url uses "en" as the request language
             # but the site is configured to use "de" and "fr"
             response = self.client.get('/en/')
-            self.assertRedirects(response, '/de/')
+            self.assertEqual(response.status_code, 200)
             response = self.client.get('/en/%s/' % page_2.get_path('de'))
             self.assertEqual(response.status_code, 404)
 
@@ -235,8 +235,10 @@ class MultilingualTestCase(CMSTestCase):
             with self.login_user_context(superuser):
                 # url uses "en" as the request language
                 # but the site is configured to use "de" and "fr"
+                # and no redirect on fallback so cms will render
+                # in place
                 response = self.client.get('/en/')
-                self.assertRedirects(response, '/de/')
+                self.assertEqual(response.status_code, 200)
                 response = self.client.get('/en/%s/' % page_2.get_path('de'))
                 self.assertEqual(response.status_code, 404)
 
@@ -284,7 +286,9 @@ class MultilingualTestCase(CMSTestCase):
 
         with self.settings(CMS_LANGUAGES=lang_settings):
             response = self.client.get("/de/")
-            self.assertRedirects(response, '/en/')
+            # as per the comments above, the content should
+            # be rendered in place, no redirect should happen
+            self.assertEqual(response.status_code, 200)
 
     def test_no_english_defined(self):
         with self.settings(

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -70,13 +70,6 @@ def register_plugins(*plugins):
             plugin_pool.unregister_plugin(plugin)
 
 
-def _render_placeholder(placeholder, context, **kwargs):
-    request = context['request']
-    toolbar = get_toolbar_from_request(request)
-    content_renderer = toolbar.content_renderer
-    return content_renderer.render_placeholder(placeholder, context, **kwargs)
-
-
 class DumbFixturePlugin(CMSPluginBase):
     model = CMSPlugin
     name = "Dumb Test Plugin. It does nothing."
@@ -277,7 +270,7 @@ class PluginsTestCase(PluginsTestBaseCase):
             self.assertEqual(db_plugin_2.position, 2)
             # Finally we render the placeholder to test the actual content
             context = self.get_context(page_en.get_absolute_url(), page=page_en)
-            rendered_placeholder = _render_placeholder(ph_en, context)
+            rendered_placeholder = self._render_placeholder(ph_en, context)
             self.assertEqual(rendered_placeholder, "I'm the firstI'm the second")
 
     def test_plugin_order_alt(self):
@@ -316,7 +309,7 @@ class PluginsTestCase(PluginsTestBaseCase):
 
             # Finally we render the placeholder to test the actual content
             draft_page_context = self.get_context(cms_page.get_absolute_url(), page=cms_page)
-            rendered_placeholder = _render_placeholder(placeholder, draft_page_context)
+            rendered_placeholder = self._render_placeholder(placeholder, draft_page_context)
             self.assertEqual(rendered_placeholder, "I'm the firstI'm the secondI'm the third")
 
     def test_plugin_position(self):
@@ -633,7 +626,7 @@ class PluginsTestCase(PluginsTestBaseCase):
         )
 
         # this should not raise any errors, but just ignore the empty plugin
-        out = _render_placeholder(placeholder, self.get_context(), width=300)
+        out = self._render_placeholder(placeholder, self.get_context(), width=300)
         self.assertFalse(len(out))
         self.assertFalse(len(placeholder._plugins_cache))
 

--- a/cms/utils/__init__.py
+++ b/cms/utils/__init__.py
@@ -1,6 +1,7 @@
 # TODO: this is just stuff from utils.py - should be split / moved
 
 from cms.utils.i18n import (
+    get_current_language,
     get_default_language,
     get_language_code,
     get_language_list,
@@ -27,8 +28,9 @@ def get_language_from_request(request, current_page=None):
         language = get_language_code(language)
         if language not in get_language_list(site_id):
             language = None
-    if not language:
-        language = get_language_code(getattr(request, 'LANGUAGE_CODE', None))
+    if not language and request:
+        # get the active language
+        language = get_current_language()
     if language:
         if language not in get_language_list(site_id):
             language = None

--- a/cms/views.py
+++ b/cms/views.py
@@ -16,7 +16,7 @@ from django.shortcuts import render
 from django.urls import Resolver404, resolve, reverse
 from django.utils.cache import patch_cache_control
 from django.utils.timezone import now
-from django.utils.translation import get_language_from_request
+from django.utils.translation import activate, get_language_from_request
 from django.views.decorators.http import require_POST
 
 from cms.apphook_pool import apphook_pool
@@ -179,9 +179,9 @@ def details(request, slug):
         # There is no page with the requested language
         # and there's no configured fallbacks
         return _handle_no_page(request)
-    elif language_is_unavailable and (redirect_on_fallback or page.is_home):
+    elif language_is_unavailable and redirect_on_fallback:
         # There is no page with the requested language and
-        # the user has explicitly requested to redirect on fallbacks,
+        # redirect_on_fallback is True,
         # so redirect to the first configured / available fallback language
         fallback = fallback_languages[0]
         redirect_url = page.get_absolute_url(fallback, fallback=False)
@@ -212,7 +212,17 @@ def details(request, slug):
     if page.login_required and not request.user.is_authenticated:
         return redirect_to_login(quote(request.get_full_path()), settings.LOGIN_URL)
 
-    content = page.get_content_obj(language=request_language)
+    content_language = request_language
+    if language_is_unavailable:
+        # When redirect_on_fallback is False and
+        # language is unavailable, render the page
+        # in the first fallback language available
+        # by switching to it
+        content_language = fallback_languages[0]
+        activate(content_language)
+        request.LANGUAGE_CODE = content_language
+
+    content = page.get_content_obj(language=content_language)
     # use the page object with populated cache
     content.page = page
     if hasattr(request, 'toolbar'):


### PR DESCRIPTION
## Description

* Render content in place ``redirect_on_fallback`` is False.
* Make the homepage follow the behaviour of other pages for ``redirect_on_fallback``.

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

*  #5839

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [X] I have opened this pull request against ``develop-4``
* [X] I have added or modified the tests when changing logic
* [X] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
