### PR TITLE
fix: return _handle_no_page when page is None

### DIFF
--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -74,6 +74,14 @@ class ViewTests(CMSTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, reverse('admin:cms_pagecontent_changelist'))
 
+    def test_handle_no_page_for_rool_url_no_homepage(self):
+        """
+        Test details view when visiting root and homepage doesn't exist
+        """
+        create_page("one", "nav_playground.html", "en")
+        response = self.client.get("/en/")
+        self.assertEqual(response.status_code, 302)
+
     def test_apphook_not_hooked(self):
         """
         Test details view when apphook pool has apphooks, but they're not

--- a/cms/views.py
+++ b/cms/views.py
@@ -115,8 +115,10 @@ def details(request, slug):
             return HttpResponseRedirect(redirect_url)
 
     if not page:
-        # raise 404
-        _handle_no_page(request)
+        # raise 404 or redirect to PageContent's
+        # changelist in the admin if this is a
+        # request to the root URL
+        return _handle_no_page(request)
 
     request.current_page = page
 


### PR DESCRIPTION
## Description
Return ``_handle_no_page`` when page is ``None``.

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7763

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [X] I have opened this pull request against ``develop-4``
* [X] I have added or modified the tests when changing logic
* [X] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [X] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
