### PR TITLE
ci: Adjust CI triggers to mostly PR runs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,6 @@
 name: Docs
 
-on: [push, pull_request]
+on: pull_request
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,6 +1,6 @@
 name: django CMS frontend.yml
 
-on: [push, pull_request]
+on: pull_request
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,6 +1,6 @@
 name: django CMS linters.yml
 
-on: [push, pull_request]
+on: pull_request
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: django CMS test.yml
 
-on: [push, pull_request]
+on: pull_request
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test_startcmsproject.yml
+++ b/.github/workflows/test_startcmsproject.yml
@@ -1,6 +1,6 @@
 name: djangocms mysite test
 
-on: [push, pull_request]
+on: pull_request
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Description

This stops the things we want to see running on PRs from also running on `push` because it seems to duplicate all these jobs and takes ages for all the checks to run.

Maybe we want things running on pushes to develop/develop-4 as well, but for now, this might speed things up.

## Related resources

* https://github.com/orgs/community/discussions/26940

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
