### PR TITLE
fix: Incorrect DjangoCMS-Versioning links

### DIFF
--- a/cms/api.py
+++ b/cms/api.py
@@ -537,7 +537,7 @@ def publish_page(page, user, language):
 
         Publishing pages has been removed from django CMS core in version 4 onward.
 
-        For publishing functionality see `djangocms-versioning: <https://github.com/django-cms/djangocms-verisoning>`_
+        For publishing functionality see `djangocms-versioning: <https://github.com/django-cms/djangocms-versioning>`_
     """
     warnings.warn('This API function has been removed. For publishing functionality use a package that adds '
                   'publishing, such as: djangocms-versioning.',
@@ -550,7 +550,7 @@ def publish_pages(include_unpublished=False, language=None, site=None):
 
         Publishing pages has been removed from django CMS core in version 4 onward.
 
-        For publishing functionality see `djangocms-versioning: <https://github.com/django-cms/djangocms-verisoning>`_
+        For publishing functionality see `djangocms-versioning: <https://github.com/django-cms/djangocms-versioning>`_
     """
     warnings.warn('This API function has been removed. For publishing functionality use a package that adds '
                   'publishing, such as: djangocms-versioning.',
@@ -563,7 +563,7 @@ def get_page_draft(page):
 
         The concept of draft pages has been removed from django CMS core in version 4 onward.
 
-        For draft functionality see `djangocms-versioning: <https://github.com/django-cms/djangocms-verisoning>`_
+        For draft functionality see `djangocms-versioning: <https://github.com/django-cms/djangocms-versioning>`_
     """
     warnings.warn('This API function has been removed. For publishing functionality use a package that adds '
                   'publishing, such as: djangocms-versioning.',

--- a/cms/extensions/models.py
+++ b/cms/extensions/models.py
@@ -63,7 +63,7 @@ class BaseExtension(models.Model):
             This method used to "publish" this extension as part of the a larger operation on the target.
             Publishing pages has been removed from django CMS core in version 4 onward.
 
-            For publishing functionality see `djangocms-versioning: <https://github.com/django-cms/djangocms-verisoning>`_
+            For publishing functionality see `djangocms-versioning: <https://github.com/django-cms/djangocms-versioning>`_
         """
         import warnings
         warnings.warn('This API function has been removed. For publishing functionality use a package that adds '


### PR DESCRIPTION
## Description
I've changed the links to djangocms-versioning that had spelling mistakes.

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
