### PR TITLE
feat: Update new_contributor_pr.yml

### DIFF
--- a/.github/workflows/new_contributor_pr.yml
+++ b/.github/workflows/new_contributor_pr.yml
@@ -18,8 +18,37 @@ jobs:
           pr-message: |
             Hello! Thank you for your contribution! 🎉
 
-            As it's your first contribution be sure to check out the [contribution docs](https://docs.django-cms.org/en/latest/contributing/index.html).
+            As it's your first contribution, be sure to check out the [contribution docs](https://docs.django-cms.org/en/latest/contributing/index.html).
 
             If you're a Slack user and haven't joined us, please do [here](https://www.django-cms.org/slack)!
 
             Welcome aboard ⛵️!
+
+      - name: Send Discord Webhook
+        uses: Ilshidur/action-discord@v2
+        with:
+          webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          content: |
+            {
+              "embeds": [
+                {
+                  "title": "New Contributor Alert",
+                  "description": "A new contributor has opened a pull request!",
+                  "color": 3066993,  # You can customize the color here
+                  "fields": [
+                    {
+                      "name": "Repository",
+                      "value": "${{ github.repository }}"
+                    },
+                    {
+                      "name": "Pull Request",
+                      "value": "${{ github.event.pull_request.html_url }}"
+                    },
+                    {
+                      "name": "Contributor",
+                      "value": "${{ github.event.pull_request.user.login }}"
+                    }
+                  ]
+                }
+              ]
+            }


### PR DESCRIPTION
## Description

Altered the new_contributor github action to send a discord webhook post to the discord server.
This will now show when someone has contributed to the project for the first time on discord ( https://discord.gg/Ecg8HQ9RTG )
![image](https://github.com/django-cms/django-cms/assets/108408216/6f37645f-79dd-4162-aa79-84e4768f75e4)


## Related resources


## Checklist

* [x] I have opened this pull request against ``develop-4``
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
