### PR TITLE
ci: Fix discord notification action version

### DIFF
--- a/.github/workflows/new_contributor_pr.yml
+++ b/.github/workflows/new_contributor_pr.yml
@@ -8,7 +8,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  build:
+  new:
     name: Hello new contributor
     runs-on: ubuntu-latest
     steps:
@@ -23,9 +23,13 @@ jobs:
             If you're a Slack user and haven't joined us, please do [here](https://www.django-cms.org/slack)!
 
             Welcome aboard ⛵️!
-
+  discord:
+    name: Discord Notification
+    runs-on: ubuntu-latest
+    needs: new
+    steps:
       - name: Send Discord Webhook
-        uses: Ilshidur/action-discord@v2
+        uses: Ilshidur/action-discord@master
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           content: |


### PR DESCRIPTION
The discord notication version is currently invalid.

This also puts a "needs" on the discord webhook because it looks like that might run for everything whereas I'd hope the new contributor actions check something first. So the webhook is dependant on that first job.