### PR TITLE
fix: Delete orphaned plugin management command for django CMS 4

### DIFF
--- a/cms/management/commands/subcommands/delete_orphaned_plugins.py
+++ b/cms/management/commands/subcommands/delete_orphaned_plugins.py
@@ -44,10 +44,10 @@ Type 'yes' to continue, or 'no' to cancel: """ % (len(uninstalled_instances), le
             self.stdout.write('... deleting any instances of uninstalled plugins and empty plugin instances\n')
 
             for instance in uninstalled_instances:
-                instance.delete()
+                instance.placeholder.delete_plugin(instance)
 
             for instance in unsaved_instances:
-                instance.delete()
+                instance.placeholder.delete_plugin(instance)
 
             self.stdout.write(
                 'Deleted instances of: \n    %s uninstalled plugins  \n    %s plugins with unsaved instances\n' % (

--- a/cms/management/commands/subcommands/delete_orphaned_plugins.py
+++ b/cms/management/commands/subcommands/delete_orphaned_plugins.py
@@ -44,10 +44,16 @@ Type 'yes' to continue, or 'no' to cancel: """ % (len(uninstalled_instances), le
             self.stdout.write('... deleting any instances of uninstalled plugins and empty plugin instances\n')
 
             for instance in uninstalled_instances:
-                instance.placeholder.delete_plugin(instance)
+                if instance.placeholder:
+                    instance.placeholder.delete_plugin(instance)
+                else:
+                    instance.delete()
 
             for instance in unsaved_instances:
-                instance.placeholder.delete_plugin(instance)
+                if instance.placeholder:
+                    instance.placeholder.delete_plugin(instance)
+                else:
+                    instance.delete()
 
             self.stdout.write(
                 'Deleted instances of: \n    %s uninstalled plugins  \n    %s plugins with unsaved instances\n' % (


### PR DESCRIPTION
## Description

This PR changes the `plugin.delete()` call of the management command into a django CMS version 4 safe way ('plugin.placeholder.delete_plugin(plugin)`): As of django CMS version 4 plugins **must** be deleted through their placeholder.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7813 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
