### PR TITLE
fix: `./manage.py cms check` showed wrong error message

### DIFF
--- a/cms/utils/check.py
+++ b/cms/utils/check.py
@@ -232,13 +232,11 @@ def check_middlewares(output):
             'cms.middleware.toolbar.ToolbarMiddleware',
             'cms.middleware.language.LanguageCookieMiddleware',
         )
-        if getattr(settings, 'MIDDLEWARE', None):
-            middlewares = settings.MIDDLEWARE
-        else:
-            middlewares = settings.MIDDLEWARE_CLASSES
+        middlewares = getattr(settings, 'MIDDLEWARE', [])
+
         for middleware in required_middlewares:
             if middleware not in middlewares:
-                section.error("%s middleware must be in MIDDLEWARE_CLASSES" % middleware)
+                section.error("%s middleware must be in MIDDLEWARE" % middleware)
 
 
 @define_check


### PR DESCRIPTION
## Description
I updated checks to resolve an issue where an incorrect error was being displayed. The changes include:
* Removed references to the deprecated `MIDDLEWARE_CLASSES`
* Assigned middlewares to an empty list if the attribute 'MIDDLEWARE' was not found.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->
* #7818 


## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
