### PR TITLE
docs: remove git switch for quickstart

### DIFF
--- a/docs/introduction/01-install.rst
+++ b/docs/introduction/01-install.rst
@@ -72,7 +72,6 @@ folder (i.e. ``cd ~/Projects``), then
     git clone git@github.com:django-cms/django-cms-quickstart.git
 
     cd django-cms-quickstart
-    git switch -t origin/support/cms-4.1.x
     docker compose build web
     docker compose up -d database_default
     docker compose run web python manage.py migrate


### PR DESCRIPTION
Remove git switch since 4.1.0 is released

## Description

Quickstart instructions no longer need to switch 

## Related resources

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
