### PR TITLE
fix: 7828, try using uv as pip replacement

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,9 +54,9 @@ jobs:
       run: |
         sudo apt install gettext gcc -y
         python -m pip install --upgrade pip
-        pip install pytest
-        pip install -r test_requirements/${{ matrix.requirements-file }}
-        pip install -r test_requirements/databases.txt
+        pip install pytest uv
+        uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
+        uv pip install --system -r test_requirements/databases.txt
         python setup.py install
 
     - name: Test with django test runner
@@ -112,9 +112,9 @@ jobs:
       run: |
         sudo apt install gettext gcc -y
         python -m pip install --upgrade pip
-        pip install pytest
-        pip install -r test_requirements/${{ matrix.requirements-file }}
-        pip install -r test_requirements/databases.txt
+        pip install pytest uv
+        uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
+        uv pip install --system -r test_requirements/databases.txt
         python setup.py install
 
 
@@ -157,8 +157,8 @@ jobs:
       run: |
         sudo apt install gettext gcc -y
         python -m pip install --upgrade pip
-        pip install pytest
-        pip install -r test_requirements/${{ matrix.requirements-file }}
+        pip install pytest uv
+        uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
         python setup.py install
 
     - name: Test with django test runner
@@ -190,9 +190,10 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt install gettext gcc -y
-        python -m pip install --upgrade pip
-        pip install -r test_requirements/${{ matrix.requirements-file }}
-        pip install pytest ${{ matrix.django-version }}
+        python -m pip install --upgrade pip 
+        pip install uv
+        uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
+        uv pip install --system pytest ${{ matrix.django-version }}
         python setup.py install
 
     - name: Test with django test runner
@@ -239,9 +240,10 @@ jobs:
       run: |
         sudo apt install gettext gcc -y
         python -m pip install --upgrade pip
-        pip install -r test_requirements/${{ matrix.requirements-file }}
-        pip install pytest ${{ matrix.django-version }}
-        pip install -r test_requirements/databases.txt
+        pip install uv
+        uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
+        uv pip install --system pytest ${{ matrix.django-version }}
+        uv pip install --system -r test_requirements/databases.txt
         python setup.py install
 
     - name: Test with django test runner
@@ -289,9 +291,10 @@ jobs:
       run: |
         sudo apt install gettext gcc -y
         python -m pip install --upgrade pip
-        pip install -r test_requirements/${{ matrix.requirements-file }}
-        pip install pytest ${{ matrix.django-version }}
-        pip install -r test_requirements/databases.txt
+        pip install uv
+        uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
+        uv pip install --system pytest ${{ matrix.django-version }}
+        uv pip install --system -r test_requirements/databases.txt
         python setup.py install
 
     - name: Test with django test runner

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,10 +172,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.12']
-        requirements-file: ['requirements_base.txt']
-        django-version: [
-          'https://github.com/django/django/archive/main.tar.gz'
-        ]
+        requirements-file: ['requirement_base_django_main.txt']
         os: [
           ubuntu-20.04,
         ]
@@ -193,7 +190,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install uv
         uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
-        uv pip install --system pytest ${{ matrix.django-version }}
+        uv pip install --system pytest
         python setup.py install
 
     - name: Test with django test runner
@@ -208,10 +205,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.12']
-        requirements-file: ['requirements_base.txt']
-        django-version: [
-          'django @ https://github.com/django/django/archive/main.tar.gz'
-        ]
+        requirements-file: ['requirement_base_django_main.txt']
         os: [
           ubuntu-20.04,
         ]
@@ -242,7 +236,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install uv
         uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
-        uv pip install --system pytest ${{ matrix.django-version }}
+        uv pip install --system pytest
         uv pip install --system -r test_requirements/databases.txt
         python setup.py install
 
@@ -260,10 +254,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.12']
-        requirements-file: ['requirements_base.txt']
-        django-version: [
-          'https://github.com/django/django/archive/main.tar.gz'
-        ]
+        requirements-file: ['requirement_base_django_main.txt']
         os: [
           ubuntu-20.04,
         ]
@@ -293,7 +284,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install uv
         uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
-        uv pip install --system pytest ${{ matrix.django-version }}
+        uv pip install --system pytest
         uv pip install --system -r test_requirements/databases.txt
         python setup.py install
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,7 +190,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt install gettext gcc -y
-        python -m pip install --upgrade pip 
+        python -m pip install --upgrade pip
         pip install uv
         uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
         uv pip install --system pytest ${{ matrix.django-version }}
@@ -210,7 +210,7 @@ jobs:
         python-version: ['3.12']
         requirements-file: ['requirements_base.txt']
         django-version: [
-          'https://github.com/django/django/archive/main.tar.gz'
+          'django @ https://github.com/django/django/archive/main.tar.gz'
         ]
         os: [
           ubuntu-20.04,

--- a/test_requirements/requirement_base_django_main.txt
+++ b/test_requirements/requirement_base_django_main.txt
@@ -1,0 +1,2 @@
+-r requirements_base.txt
+django @ https://github.com/django/django/archive/refs/heads/main.zip

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -20,5 +20,5 @@ ruff
 setuptools  # Since python 3.12
 
 # FIXME: - Remove when a django 3.0 compatible djangocms-text-ckeditor version is released
-https://github.com/ojii/django-better-test/archive/8aa2407d097fe3789b74682f0e6bd7d15d449416.zip#egg=django-better-test
-https://github.com/ojii/django-app-manage/archive/65da18ef234a4e985710c2c0ec760023695b40fe.zip#egg=django-app-manage
+django-better-test @ https://github.com/ojii/django-better-test/archive/8aa2407d097fe3789b74682f0e6bd7d15d449416.zip#egg=django-better-test
+django-app-manage @ https://github.com/ojii/django-app-manage/archive/65da18ef234a4e985710c2c0ec760023695b40fe.zip#egg=django-app-manage


### PR DESCRIPTION
## Description

Replace stock `pip` with `uv` from Astral (Same folks that wrote `ruff` linter).

## Related resources

#7828 

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
