### PR TITLE
fix: Render structure view in toolbar object's language

### DIFF
--- a/cms/cache/placeholder.py
+++ b/cms/cache/placeholder.py
@@ -96,14 +96,7 @@ def _get_placeholder_cache_key(placeholder, lang, site_id, request, soft=False):
     """
     prefix = get_cms_setting('CACHE_PREFIX')
     version, vary_on_list = _get_placeholder_cache_version(placeholder, lang, site_id)
-    main_key = '{prefix}|render_placeholder|id:{id}|lang:{lang}|site:{site}|tz:{tz}|v:{version}'.format(
-        prefix=prefix,
-        id=placeholder.pk,
-        lang=lang,
-        site=site_id,
-        tz=get_timezone_name(),
-        version=version,
-    )
+    main_key = f'{prefix}|render_placeholder|id:{placeholder.pk}|lang:{lang}|site:{site_id}|tz:{get_timezone_name()}|v:{version}'
 
     if not soft:
         # We are about to write to the cache, so we want to get the latest

--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -53,13 +53,7 @@ class Placeholder(models.Model):
         return self.slot
 
     def __repr__(self):
-        display = "<{module}.{class_name} id={id} slot='{slot}' object at {location}>".format(
-            module=self.__module__,
-            class_name=self.__class__.__name__,
-            id=self.pk,
-            slot=self.slot,
-            location=hex(id(self)),
-        )
+        display = f"<{self.__module__}.{self.__class__.__name__} id={self.pk} slot='{self.slot}' object at {hex(id(self))}>"
         return display
 
     def clear(self, language=None):

--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -186,13 +186,7 @@ class CMSPlugin(models.Model, metaclass=PluginModelBase):
         return force_str(self.pk)
 
     def __repr__(self):
-        display = "<{module}.{class_name} id={id} plugin_type='{plugin_type}' object at {location}>".format(
-            module=self.__module__,
-            class_name=self.__class__.__name__,
-            id=self.pk,
-            plugin_type=(self.plugin_type),
-            location=hex(id(self)),
-        )
+        display = f"<{self.__module__}.{self.__class__.__name__} id={self.pk} plugin_type='{self.plugin_type}' object at {hex(id(self))}>"
         return display
 
     def get_plugin_name(self):

--- a/cms/templatetags/cms_js_tags.py
+++ b/cms/templatetags/cms_js_tags.py
@@ -30,17 +30,21 @@ def bool(value):
         return 'false'
 
 
-@register.simple_tag()
-def render_cms_structure_js(renderer, obj):
+@register.simple_tag(takes_context=True)
+def render_cms_structure_js(context, renderer, obj):
     markup_bits = []
     obj_placeholders_by_slot = rescan_placeholders_for_obj(obj)
     declared_placeholders = get_declared_placeholders_for_obj(obj)
+    try:
+        lang = context["request"].toolbar.request_language
+    except AttributeError:
+        lang = None
 
     for placeholder_node in declared_placeholders:
         obj_placeholder = obj_placeholders_by_slot.get(placeholder_node.slot)
 
         if obj_placeholder:
-            placeholder_js = renderer.render_placeholder(obj_placeholder, language=None, page=obj)
+            placeholder_js = renderer.render_placeholder(obj_placeholder, language=lang, page=obj)
             markup_bits.append(placeholder_js)
 
     return mark_safe('\n'.join(markup_bits))

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -1952,23 +1952,19 @@ class EditModelTemplateTagTest(ToolbarTestBase):
         response.render()
         self.assertContains(
             response,
-            '<template class="cms-plugin cms-plugin-start cms-plugin-cms-page-get_page_title-{0} cms-render-model">'
+            f'<template class="cms-plugin cms-plugin-start cms-plugin-cms-page-get_page_title-{page.pk} cms-render-model">'
             '</template>'
-            '{1}'
-            '<template class="cms-plugin cms-plugin-end cms-plugin-cms-page-get_page_title-{0} cms-render-model">'
-            '</template>'.format(
-                page.pk, page.get_page_title(language)
-            )
+            f'{page.get_page_title(language)}'
+            f'<template class="cms-plugin cms-plugin-end cms-plugin-cms-page-get_page_title-{page.pk} cms-render-model">'
+            '</template>'
         )
         self.assertContains(
             response,
-            '<template class="cms-plugin cms-plugin-start cms-plugin-cms-page-get_menu_title-{0} cms-render-model">'
+            f'<template class="cms-plugin cms-plugin-start cms-plugin-cms-page-get_menu_title-{page.pk} cms-render-model">'
             '</template>'
-            '{1}'
-            '<template class="cms-plugin cms-plugin-end cms-plugin-cms-page-get_menu_title-{0} cms-render-model">'
-            '</template>'.format(
-                page.pk, page.get_menu_title(language)
-            )
+            f'{page.get_menu_title(language)}'
+            f'<template class="cms-plugin cms-plugin-end cms-plugin-cms-page-get_menu_title-{page.pk} cms-render-model">'
+            '</template>'
         )
         self.assertContains(
             response,

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -1,7 +1,6 @@
 import re
 import sys
 
-from cms.utils.urlutils import admin_reverse
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
@@ -27,6 +26,7 @@ from cms.toolbar.utils import (
 )
 from cms.utils.conf import get_cms_setting
 from cms.utils.page import get_page_from_request
+from cms.utils.urlutils import admin_reverse
 from cms.views import details, login, render_object_structure
 from menus.menu_pool import menu_pool
 

--- a/cms/utils/apphook_reload.py
+++ b/cms/utils/apphook_reload.py
@@ -89,10 +89,7 @@ def reload_urlconf(urlconf=None, new_revision=None):
 
 
 def log_reloading_apphook(global_revision, local_revision):
-    debug_msg = "   New revision!!!! RELOAD!\n      {0} ({1})\n   -> {2} ({3})".format(
-        global_revision, type(global_revision),
-        local_revision, type(local_revision),
-    )
+    debug_msg = f"   New revision!!!! RELOAD!\n      {global_revision} ({type(global_revision)})\n   -> {local_revision} ({type(local_revision)})"
     logger.debug(debug_msg)
 
 


### PR DESCRIPTION
## Description

#7781 introduced a regression as described in #7841: The structure board renders the placeholders of the toolbar's language instead of the object's (i.e. page content's) language.

This PR fixes the regression and adds a regression test.


## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7841 
* #7781 

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
