### PR TITLE
fix: `views.details` revealed existence of unpublished language

### DIFF
--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -429,8 +429,9 @@ class PageToolbar(CMSToolbar):
 
         # if the current page has a parent in the request's current language redirect to it
         if parent_page and language in parent_page.get_languages():
-            with force_language(language):
-                return parent_page.get_absolute_url(language=language)
+            return get_object_preview_url(
+                parent_page.pagecontent_set(manager="admin_manager").latest_content(language=language).first()
+            )
 
         # else redirect to root, do not redirect to Page.objects.get_home() because user could have deleted the last
         # page, if DEBUG == False this could cause a 404

--- a/cms/extensions/toolbar.py
+++ b/cms/extensions/toolbar.py
@@ -92,6 +92,7 @@ class ExtensionToolbar(CMSToolbar):
         urls = []
         page = self._get_page()
         if page:
+            page._prefetched_objects_cache = {}  # Remove prefetched objects cache to avoid conflicts
             page_contents = (
                 page.pagecontent_set(manager="admin_manager")
                 .latest_content()

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -607,7 +607,7 @@ class Page(models.Model):
         else:
             languages = [language]
 
-        self.pagecontent_set.filter(language__in=languages).delete()
+        self.pagecontent_set(manager="admin_manager").filter(language__in=languages).delete()
 
     def save(self, **kwargs):
         if self.reverse_id == "":

--- a/cms/utils/page.py
+++ b/cms/utils/page.py
@@ -95,14 +95,10 @@ def get_page_from_request(request, use_path=None, clean_path=None):
         .get_for_site(site)
         .filter(path=path)
         .select_related('page__node')
+        .prefetch_related('page__pagecontent_set')
     )
-    page_urls = list(page_urls)
-
-    try:
-        page = page_urls[0].page
-    except IndexError:
-        page = None
-    else:
+    page = getattr(page_urls.first(), "page", None)
+    if page is not None:
         page.urls_cache = {url.language: url for url in page_urls}
     return page
 

--- a/cms/views.py
+++ b/cms/views.py
@@ -143,9 +143,12 @@ def details(request, slug):
     # get_published_languages will return all languages in draft mode
     # and published only in live mode.
     # These languages are then filtered out by the user allowed languages
+    pagecontent_languages = [
+        pagecontent.language for pagecontent in page._prefetched_objects_cache.get('pagecontent_set', [])
+    ]
     available_languages = [
         language for language in user_languages
-        if language in list(page.get_languages())
+        if language in pagecontent_languages
     ]
 
     own_urls = [


### PR DESCRIPTION
## Description
`page.get_languages()` contains a list of languages, for which translations exist. It does not imply those languages should be visible to the public. djangocms-versioning hides languages upon unpublishing.

This PR removes the access to `page.get_languages()` from django CMS' central view in `views.details`. To avoid additional db accesses, the (public) page content objects a page are prefetched and the available languages are determined through the prefetch cache. This might even reduce the number of DB accesses upon accessing a CMS URL by one (not tested).

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources


* #7849 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
