### PR TITLE
fix: Documentation typo

### DIFF
--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -213,7 +213,7 @@ class CMSPlugin(models.Model, metaclass=PluginModelBase):
     def get_plugin_instance(self, admin=None):
         """
         For a plugin instance (usually as a CMSPluginBase), this method
-        returns the downcasted (i.e., correctly typed subclass of CMSPluginBase) instacnce and the plugin class
+        returns the downcasted (i.e., correctly typed subclass of CMSPluginBase) instance and the plugin class
 
         :return: Tuple (instance, plugin)
 


### PR DESCRIPTION
## Description

While looking through documentation, I found typo in description of `CMSPlugin.get_plugin_instance` method.
https://docs.django-cms.org/en/latest/reference/plugins.html#cms.models.pluginmodel.CMSPlugin.get_plugin_instance


## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
