### PR TITLE
fix: some Django antipatterns

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -34,7 +34,7 @@ from django.template.response import SimpleTemplateResponse, TemplateResponse
 from django.urls import re_path
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_str
-from django.utils.translation import gettext, gettext_lazy as _
+from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 
 from cms import operations
@@ -279,7 +279,7 @@ class PageAdmin(admin.ModelAdmin):
             raise self._get_404_exception(object_id)
 
         if not page.is_potential_home():
-            return HttpResponseBadRequest(gettext("The page is not eligible to be home."))
+            return HttpResponseBadRequest(_("The page is not eligible to be home."))
 
         new_home_tree, old_home_tree = page.set_as_homepage(request.user)
 
@@ -597,7 +597,7 @@ class PageAdmin(admin.ModelAdmin):
 
         # Does the user have permissions to do this...?
         if not can_move_page or (target and not target.has_add_permission(user)):
-            message = gettext(
+            message = _(
                 "Error! You don't have permissions to move this page. Please reload the page"
             )
             return jsonify_request(HttpResponseForbidden(message))
@@ -706,14 +706,14 @@ class PageAdmin(admin.ModelAdmin):
             can_copy_page = page_permissions.user_can_add_page(user, site)
 
         if not can_copy_page:
-            message = gettext("Error! You don't have permissions to copy this page.")
+            message = _("Error! You don't have permissions to copy this page.")
             return jsonify_request(HttpResponseForbidden(message))
 
         page_languages = page.get_languages()
         site_languages = get_language_list(site_id=site.pk)
 
         if not any(lang in page_languages for lang in site_languages):
-            message = gettext(
+            message = _(
                 "Error! "
                 "The page you're pasting is not translated in any of the languages configured by the target site."
             )
@@ -727,7 +727,7 @@ class PageAdmin(admin.ModelAdmin):
         translation = page.get_content_obj(language, fallback=False)
 
         if not self.has_change_permission(request, obj=page):
-            return HttpResponseForbidden(gettext("You do not have permission to edit this page"))
+            return HttpResponseForbidden(_("You do not have permission to edit this page"))
 
         if page is None:
             raise self._get_404_exception(page_id)
@@ -1182,12 +1182,12 @@ class PageContentAdmin(admin.ModelAdmin):
         to_template = request.POST.get("template", None)
 
         if to_template not in dict(get_cms_setting('TEMPLATES')):
-            return HttpResponseBadRequest(gettext("Template not valid"))
+            return HttpResponseBadRequest(_("Template not valid"))
 
         page_content.template = to_template
         page_content.save()
 
-        return HttpResponse(gettext("The template was successfully changed"))
+        return HttpResponse(_("The template was successfully changed"))
 
     @require_POST
     @transaction.atomic
@@ -1204,7 +1204,7 @@ class PageContentAdmin(admin.ModelAdmin):
         page = source_page_content.page
 
         if not target_language or target_language not in get_language_list(site_id=page.node.site_id):
-            return HttpResponseBadRequest(gettext("Language must be set to a supported language!"))
+            return HttpResponseBadRequest(_("Language must be set to a supported language!"))
 
         target_page_content = page.get_content_obj(target_language, fallback=False)
 
@@ -1214,7 +1214,7 @@ class PageContentAdmin(admin.ModelAdmin):
             plugins = placeholder.get_plugins_list(source_page_content.language)
 
             if not target.has_add_plugins_permission(request.user, plugins):
-                return HttpResponseForbidden(gettext("You do not have permission to copy these plugins."))
+                return HttpResponseForbidden(_("You do not have permission to copy these plugins."))
             copy_plugins_to_placeholder(plugins, target, language=target_language)
         return HttpResponse("ok")
 
@@ -1227,7 +1227,7 @@ class PageContentAdmin(admin.ModelAdmin):
         request_language = get_site_language_from_request(request, site_id=page.node.site_id)
 
         if not self.has_delete_translation_permission(request, language, page):
-            return HttpResponseForbidden(gettext("You do not have permission to delete this page"))
+            return HttpResponseForbidden(_("You do not have permission to delete this page"))
 
         if page is None:
             raise self._get_404_exception(object_id)
@@ -1342,7 +1342,7 @@ class PageContentAdmin(admin.ModelAdmin):
             else:
                 # Only this page? Can be permissions or versioning, or ...
                 message = "You cannot change this page's navigation status"
-            return HttpResponseForbidden(gettext(message))
+            return HttpResponseForbidden(_(message))
 
         if page_content is None:
             raise self._get_404_exception(object_id)

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -18,6 +18,7 @@ from django.core.exceptions import (
 from django.db import transaction
 from django.db.models import Prefetch, Q
 from django.db.models.query import QuerySet
+from django.db.utils import IntegrityError
 from django.forms.fields import IntegerField
 from django.http import (
     Http404,
@@ -34,7 +35,7 @@ from django.template.response import SimpleTemplateResponse, TemplateResponse
 from django.urls import re_path
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_str
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext, gettext_lazy as _
 from django.views.decorators.http import require_POST
 
 from cms import operations
@@ -279,7 +280,7 @@ class PageAdmin(admin.ModelAdmin):
             raise self._get_404_exception(object_id)
 
         if not page.is_potential_home():
-            return HttpResponseBadRequest(force_str(_("The page is not eligible to be home.")))
+            return HttpResponseBadRequest(gettext("The page is not eligible to be home."))
 
         new_home_tree, old_home_tree = page.set_as_homepage(request.user)
 
@@ -597,8 +598,8 @@ class PageAdmin(admin.ModelAdmin):
 
         # Does the user have permissions to do this...?
         if not can_move_page or (target and not target.has_add_permission(user)):
-            message = force_str(
-                _("Error! You don't have permissions to move this page. Please reload the page")
+            message = gettext(
+                "Error! You don't have permissions to move this page. Please reload the page"
             )
             return jsonify_request(HttpResponseForbidden(message))
 
@@ -706,15 +707,17 @@ class PageAdmin(admin.ModelAdmin):
             can_copy_page = page_permissions.user_can_add_page(user, site)
 
         if not can_copy_page:
-            message = force_str(_("Error! You don't have permissions to copy this page."))
+            message = gettext("Error! You don't have permissions to copy this page.")
             return jsonify_request(HttpResponseForbidden(message))
 
         page_languages = page.get_languages()
         site_languages = get_language_list(site_id=site.pk)
 
         if not any(lang in page_languages for lang in site_languages):
-            message = force_str(_("Error! The page you're pasting is not "
-                                  "translated in any of the languages configured by the target site."))
+            message = gettext(
+                "Error! "
+                "The page you're pasting is not translated in any of the languages configured by the target site."
+            )
             return jsonify_request(HttpResponseBadRequest(message))
 
         new_page = form.copy_page(user)
@@ -725,7 +728,7 @@ class PageAdmin(admin.ModelAdmin):
         translation = page.get_content_obj(language, fallback=False)
 
         if not self.has_change_permission(request, obj=page):
-            return HttpResponseForbidden(force_str(_("You do not have permission to edit this page")))
+            return HttpResponseForbidden(gettext("You do not have permission to edit this page"))
 
         if page is None:
             raise self._get_404_exception(page_id)
@@ -1180,12 +1183,12 @@ class PageContentAdmin(admin.ModelAdmin):
         to_template = request.POST.get("template", None)
 
         if to_template not in dict(get_cms_setting('TEMPLATES')):
-            return HttpResponseBadRequest(force_str(_("Template not valid")))
+            return HttpResponseBadRequest(gettext("Template not valid"))
 
         page_content.template = to_template
         page_content.save()
 
-        return HttpResponse(force_str(_("The template was successfully changed")))
+        return HttpResponse(gettext("The template was successfully changed"))
 
     @require_POST
     @transaction.atomic
@@ -1202,7 +1205,7 @@ class PageContentAdmin(admin.ModelAdmin):
         page = source_page_content.page
 
         if not target_language or target_language not in get_language_list(site_id=page.node.site_id):
-            return HttpResponseBadRequest(force_str(_("Language must be set to a supported language!")))
+            return HttpResponseBadRequest(gettext("Language must be set to a supported language!"))
 
         target_page_content = page.get_content_obj(target_language, fallback=False)
 
@@ -1212,7 +1215,7 @@ class PageContentAdmin(admin.ModelAdmin):
             plugins = placeholder.get_plugins_list(source_page_content.language)
 
             if not target.has_add_plugins_permission(request.user, plugins):
-                return HttpResponseForbidden(force_str(_('You do not have permission to copy these plugins.')))
+                return HttpResponseForbidden(gettext("You do not have permission to copy these plugins."))
             copy_plugins_to_placeholder(plugins, target, language=target_language)
         return HttpResponse("ok")
 
@@ -1225,7 +1228,7 @@ class PageContentAdmin(admin.ModelAdmin):
         request_language = get_site_language_from_request(request, site_id=page.node.site_id)
 
         if not self.has_delete_translation_permission(request, language, page):
-            return HttpResponseForbidden(force_str(_("You do not have permission to delete this page")))
+            return HttpResponseForbidden(gettext("You do not have permission to delete this page"))
 
         if page is None:
             raise self._get_404_exception(object_id)
@@ -1336,11 +1339,11 @@ class PageContentAdmin(admin.ModelAdmin):
         if not self.has_change_permission(request, obj=page_content):
             if self.has_change_permission(request):
                 # General (permission) problem
-                message = _("You do not have permission to change a page's navigation status")
+                message = "You do not have permission to change a page's navigation status"
             else:
                 # Only this page? Can be permissions or versioning, or ...
-                message = _("You cannot change this page's navigation status")
-            return HttpResponseForbidden(force_str(message))
+                message = "You cannot change this page's navigation status"
+            return HttpResponseForbidden(gettext(message))
 
         if page_content is None:
             raise self._get_404_exception(object_id)

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -18,7 +18,6 @@ from django.core.exceptions import (
 from django.db import transaction
 from django.db.models import Prefetch, Q
 from django.db.models.query import QuerySet
-from django.db.utils import IntegrityError
 from django.forms.fields import IntegerField
 from django.http import (
     Http404,

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -21,7 +21,7 @@ from django.urls import re_path
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_str
 from django.utils.html import conditional_escape
-from django.utils.translation import get_language_from_path, gettext as _
+from django.utils.translation import get_language_from_path, gettext, gettext as _
 from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.decorators.http import require_POST
 
@@ -117,13 +117,13 @@ class FrontendEditableAdminMixin:
         if not fields:
             context = {
                 'opts': opts,
-                'message': force_str(_("Field %s not found")) % raw_fields
+                'message': gettext("Field %s not found") % raw_fields
             }
             return render(request, 'admin/cms/page/plugin/error_form.html', context)
         if not request.user.has_perm(f"{self.model._meta.app_label}.change_{self.model._meta.model_name}"):
             context = {
                 'opts': opts,
-                'message': force_str(_("You do not have permission to edit this item"))
+                'message': gettext("You do not have permission to edit this item")
             }
             return render(request, 'admin/cms/page/plugin/error_form.html', context)
             # Dynamically creates the form class with only `field_name` field
@@ -361,11 +361,11 @@ class PlaceholderAdmin(admin.ModelAdmin):
         plugin_type = plugin_data['plugin_type']
 
         if not self.has_add_plugin_permission(request, placeholder, plugin_type):
-            message = force_str(_('You do not have permission to add a plugin'))
+            message = gettext('You do not have permission to add a plugin')
             return HttpResponseForbidden(message)
 
         if not placeholder.check_source(request.user):
-            message = force_str(_('You do not have permission to add a plugin'))
+            message = gettext('You do not have permission to add a plugin')
             return HttpResponseForbidden(message)
 
         plugin_class = plugin_pool.get_plugin(plugin_type)
@@ -417,7 +417,7 @@ class PlaceholderAdmin(admin.ModelAdmin):
         target_placeholder = get_object_or_404(Placeholder, pk=target_placeholder_id)
 
         if not target_language or target_language not in get_language_list():
-            return HttpResponseBadRequest(force_str(_("Language must be set to a supported language!")))
+            return HttpResponseBadRequest(gettext("Language must be set to a supported language!"))
 
         copy_to_clipboard = target_placeholder.pk == request.toolbar.clipboard.pk
         source_plugin_id = request.POST.get('source_plugin_id', None)
@@ -457,11 +457,11 @@ class PlaceholderAdmin(admin.ModelAdmin):
         old_plugins = [source_plugin] + list(source_plugin.get_descendants())
 
         if not self.has_copy_plugins_permission(request, old_plugins):
-            message = _('You do not have permission to copy these plugins.')
-            raise PermissionDenied(force_str(message))
+            message = gettext('You do not have permission to copy these plugins.')
+            raise PermissionDenied(message)
 
         if not target_placeholder.check_source(request.user):
-            message = _('You do not have permission to copy these plugins.')
+            message = gettext('You do not have permission to copy these plugins.')
             raise PermissionDenied(message)
 
         # Empty the clipboard
@@ -482,12 +482,12 @@ class PlaceholderAdmin(admin.ModelAdmin):
         old_plugins = source_placeholder.get_plugins_list(language=source_language)
 
         if not self.has_copy_plugins_permission(request, old_plugins):
-            message = _('You do not have permission to copy this placeholder.')
-            raise PermissionDenied(force_str(message))
+            message = gettext('You do not have permission to copy this placeholder.')
+            raise PermissionDenied(message)
 
         if not target_placeholder.check_source(request.user):
-            message = _('You do not have permission to copy this placeholder.')
-            raise PermissionDenied(force_str(message))
+            message = gettext('You do not have permission to copy this placeholder.')
+            raise PermissionDenied(message)
 
         # Empty the clipboard
         target_placeholder.clear()
@@ -528,12 +528,12 @@ class PlaceholderAdmin(admin.ModelAdmin):
         )
 
         if not has_permissions:
-            message = _('You do not have permission to copy these plugins.')
-            raise PermissionDenied(force_str(message))
+            message = gettext('You do not have permission to copy these plugins.')
+            raise PermissionDenied(message)
 
         if not target_placeholder.check_source(request.user):
-            message = _('You do not have permission to copy these plugins.')
-            raise PermissionDenied(force_str(message))
+            message = gettext('You do not have permission to copy these plugins.')
+            raise PermissionDenied(message)
 
         target_tree_order = target_placeholder.get_plugin_tree_order(
             language=target_language,
@@ -577,7 +577,7 @@ class PlaceholderAdmin(admin.ModelAdmin):
         try:
             plugin_id = int(plugin_id)
         except ValueError:
-            return HttpResponseNotFound(force_str(_("Plugin not found")))
+            return HttpResponseNotFound(gettext("Plugin not found"))
 
         obj = self._get_plugin_from_id(plugin_id)
 
@@ -585,10 +585,10 @@ class PlaceholderAdmin(admin.ModelAdmin):
         plugin_instance = obj.get_plugin_class_instance(admin=self.admin_site)
 
         if not self.has_change_plugin_permission(request, obj):
-            return HttpResponseForbidden(force_str(_("You do not have permission to edit this plugin")))
+            return HttpResponseForbidden(gettext("You do not have permission to edit this plugin"))
 
         if not obj.placeholder.check_source(request.user):
-            message = force_str(_("You do not have permission to edit this plugin"))
+            message = gettext("You do not have permission to edit this plugin")
             return HttpResponseForbidden(message)
 
         response = plugin_instance.change_view(request, str(plugin_id))
@@ -732,11 +732,11 @@ class PlaceholderAdmin(admin.ModelAdmin):
         plugins = [plugin] + list(plugin.get_descendants())
 
         if not self.has_copy_from_clipboard_permission(request, target_placeholder, plugins):
-            message = force_str(_("You have no permission to paste this plugin"))
+            message = gettext("You have no permission to paste this plugin")
             raise PermissionDenied(message)
 
         if not target_placeholder.check_source(request.user):
-            message = force_str(_("You have no permission to paste this plugin"))
+            message = gettext("You have no permission to paste this plugin")
             raise PermissionDenied(message)
 
         if target_parent:
@@ -792,11 +792,11 @@ class PlaceholderAdmin(admin.ModelAdmin):
         plugins = plugin.placeholder_ref.get_plugins_list()
 
         if not self.has_copy_from_clipboard_permission(request, target_placeholder, plugins):
-            message = force_str(_("You have no permission to paste this placeholder"))
+            message = gettext("You have no permission to paste this placeholder")
             raise PermissionDenied(message)
 
         if not target_placeholder.check_source(request.user):
-            message = force_str(_("You have no permission to paste this placeholder"))
+            message = gettext("You have no permission to paste this placeholder")
             raise PermissionDenied(message)
 
         action_token = self._send_pre_placeholder_operation(
@@ -849,19 +849,19 @@ class PlaceholderAdmin(admin.ModelAdmin):
         source_placeholder = plugin.placeholder
 
         if not self.has_move_plugin_permission(request, plugin, source_placeholder):
-            message = force_str(_("You have no permission to move this plugin"))
+            message = gettext("You have no permission to move this plugin")
             raise PermissionDenied(message)
 
         if target_placeholder and not self.has_move_plugin_permission(request, plugin, target_placeholder):
-            message = force_str(_("You have no permission to move this plugin"))
+            message = gettext("You have no permission to move this plugin")
             raise PermissionDenied(message)
 
         if not source_placeholder.check_source(request.user):
-            message = force_str(_("You have no permission to move this plugin"))
+            message = gettext("You have no permission to move this plugin")
             raise PermissionDenied(message)
 
         if target_placeholder and not target_placeholder.check_source(request.user):
-            message = force_str(_("You have no permission to move this plugin"))
+            message = gettext("You have no permission to move this plugin")
             raise PermissionDenied(message)
 
         if target_parent:
@@ -913,11 +913,11 @@ class PlaceholderAdmin(admin.ModelAdmin):
         source_placeholder = plugin.placeholder
 
         if not self.has_move_plugin_permission(request, plugin, source_placeholder):
-            message = force_str(_("You have no permission to cut this plugin"))
+            message = gettext("You have no permission to cut this plugin")
             raise PermissionDenied(message)
 
         if not source_placeholder.check_source(request.user):
-            message = force_str(_("You have no permission to cut this plugin"))
+            message = gettext("You have no permission to cut this plugin")
             raise PermissionDenied(message)
 
         action_token = self._send_pre_placeholder_operation(
@@ -962,11 +962,11 @@ class PlaceholderAdmin(admin.ModelAdmin):
         plugin = self._get_plugin_from_id(plugin_id)
 
         if not self.has_delete_plugin_permission(request, plugin):
-            return HttpResponseForbidden(force_str(
-                _("You do not have permission to delete this plugin")))
+            message = gettext("You do not have permission to delete this plugin")
+            return HttpResponseForbidden(message)
 
         if not plugin.placeholder.check_source(request.user):
-            message = force_str(_("You do not have permission to delete this plugin"))
+            message = gettext("You do not have permission to delete this plugin")
             raise PermissionDenied(message)
 
         opts = plugin._meta
@@ -1044,10 +1044,11 @@ class PlaceholderAdmin(admin.ModelAdmin):
             return HttpResponseRedirect(admin_reverse('index', current_app=self.admin_site.name))
 
         if not self.has_clear_placeholder_permission(request, placeholder, language):
-            return HttpResponseForbidden(force_str(_("You do not have permission to clear this placeholder")))
+            message = gettext("You do not have permission to clear this placeholder")
+            return HttpResponseForbidden(message)
 
         if not placeholder.check_source(request.user):
-            message = force_str(_("You do not have permission to clear this placeholder"))
+            message = gettext("You do not have permission to clear this placeholder")
             raise PermissionDenied(message)
 
         opts = Placeholder._meta
@@ -1064,7 +1065,8 @@ class PlaceholderAdmin(admin.ModelAdmin):
         if request.POST:
             # The user has already confirmed the deletion.
             if perms_needed:
-                return HttpResponseForbidden(force_str(_("You do not have permission to clear this placeholder")))
+                message = gettext("You do not have permission to clear this placeholder")
+                return HttpResponseForbidden(message)
 
             operation_token = self._send_pre_placeholder_operation(
                 request,

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -21,7 +21,7 @@ from django.urls import re_path
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_str
 from django.utils.html import conditional_escape
-from django.utils.translation import get_language_from_path, gettext, gettext as _
+from django.utils.translation import get_language_from_path, gettext as _
 from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.decorators.http import require_POST
 
@@ -117,13 +117,13 @@ class FrontendEditableAdminMixin:
         if not fields:
             context = {
                 'opts': opts,
-                'message': gettext("Field %s not found") % raw_fields
+                'message': _("Field %s not found") % raw_fields
             }
             return render(request, 'admin/cms/page/plugin/error_form.html', context)
         if not request.user.has_perm(f"{self.model._meta.app_label}.change_{self.model._meta.model_name}"):
             context = {
                 'opts': opts,
-                'message': gettext("You do not have permission to edit this item")
+                'message': _("You do not have permission to edit this item")
             }
             return render(request, 'admin/cms/page/plugin/error_form.html', context)
             # Dynamically creates the form class with only `field_name` field
@@ -361,11 +361,11 @@ class PlaceholderAdmin(admin.ModelAdmin):
         plugin_type = plugin_data['plugin_type']
 
         if not self.has_add_plugin_permission(request, placeholder, plugin_type):
-            message = gettext('You do not have permission to add a plugin')
+            message = _('You do not have permission to add a plugin')
             return HttpResponseForbidden(message)
 
         if not placeholder.check_source(request.user):
-            message = gettext('You do not have permission to add a plugin')
+            message = _('You do not have permission to add a plugin')
             return HttpResponseForbidden(message)
 
         plugin_class = plugin_pool.get_plugin(plugin_type)
@@ -417,7 +417,7 @@ class PlaceholderAdmin(admin.ModelAdmin):
         target_placeholder = get_object_or_404(Placeholder, pk=target_placeholder_id)
 
         if not target_language or target_language not in get_language_list():
-            return HttpResponseBadRequest(gettext("Language must be set to a supported language!"))
+            return HttpResponseBadRequest(_("Language must be set to a supported language!"))
 
         copy_to_clipboard = target_placeholder.pk == request.toolbar.clipboard.pk
         source_plugin_id = request.POST.get('source_plugin_id', None)
@@ -457,11 +457,11 @@ class PlaceholderAdmin(admin.ModelAdmin):
         old_plugins = [source_plugin] + list(source_plugin.get_descendants())
 
         if not self.has_copy_plugins_permission(request, old_plugins):
-            message = gettext('You do not have permission to copy these plugins.')
+            message = _('You do not have permission to copy these plugins.')
             raise PermissionDenied(message)
 
         if not target_placeholder.check_source(request.user):
-            message = gettext('You do not have permission to copy these plugins.')
+            message = _('You do not have permission to copy these plugins.')
             raise PermissionDenied(message)
 
         # Empty the clipboard
@@ -482,11 +482,11 @@ class PlaceholderAdmin(admin.ModelAdmin):
         old_plugins = source_placeholder.get_plugins_list(language=source_language)
 
         if not self.has_copy_plugins_permission(request, old_plugins):
-            message = gettext('You do not have permission to copy this placeholder.')
+            message = _('You do not have permission to copy this placeholder.')
             raise PermissionDenied(message)
 
         if not target_placeholder.check_source(request.user):
-            message = gettext('You do not have permission to copy this placeholder.')
+            message = _('You do not have permission to copy this placeholder.')
             raise PermissionDenied(message)
 
         # Empty the clipboard
@@ -528,11 +528,11 @@ class PlaceholderAdmin(admin.ModelAdmin):
         )
 
         if not has_permissions:
-            message = gettext('You do not have permission to copy these plugins.')
+            message = _('You do not have permission to copy these plugins.')
             raise PermissionDenied(message)
 
         if not target_placeholder.check_source(request.user):
-            message = gettext('You do not have permission to copy these plugins.')
+            message = _('You do not have permission to copy these plugins.')
             raise PermissionDenied(message)
 
         target_tree_order = target_placeholder.get_plugin_tree_order(
@@ -577,7 +577,7 @@ class PlaceholderAdmin(admin.ModelAdmin):
         try:
             plugin_id = int(plugin_id)
         except ValueError:
-            return HttpResponseNotFound(gettext("Plugin not found"))
+            return HttpResponseNotFound(_("Plugin not found"))
 
         obj = self._get_plugin_from_id(plugin_id)
 
@@ -585,10 +585,10 @@ class PlaceholderAdmin(admin.ModelAdmin):
         plugin_instance = obj.get_plugin_class_instance(admin=self.admin_site)
 
         if not self.has_change_plugin_permission(request, obj):
-            return HttpResponseForbidden(gettext("You do not have permission to edit this plugin"))
+            return HttpResponseForbidden(_("You do not have permission to edit this plugin"))
 
         if not obj.placeholder.check_source(request.user):
-            message = gettext("You do not have permission to edit this plugin")
+            message = _("You do not have permission to edit this plugin")
             return HttpResponseForbidden(message)
 
         response = plugin_instance.change_view(request, str(plugin_id))
@@ -732,11 +732,11 @@ class PlaceholderAdmin(admin.ModelAdmin):
         plugins = [plugin] + list(plugin.get_descendants())
 
         if not self.has_copy_from_clipboard_permission(request, target_placeholder, plugins):
-            message = gettext("You have no permission to paste this plugin")
+            message = _("You have no permission to paste this plugin")
             raise PermissionDenied(message)
 
         if not target_placeholder.check_source(request.user):
-            message = gettext("You have no permission to paste this plugin")
+            message = _("You have no permission to paste this plugin")
             raise PermissionDenied(message)
 
         if target_parent:
@@ -792,11 +792,11 @@ class PlaceholderAdmin(admin.ModelAdmin):
         plugins = plugin.placeholder_ref.get_plugins_list()
 
         if not self.has_copy_from_clipboard_permission(request, target_placeholder, plugins):
-            message = gettext("You have no permission to paste this placeholder")
+            message = _("You have no permission to paste this placeholder")
             raise PermissionDenied(message)
 
         if not target_placeholder.check_source(request.user):
-            message = gettext("You have no permission to paste this placeholder")
+            message = _("You have no permission to paste this placeholder")
             raise PermissionDenied(message)
 
         action_token = self._send_pre_placeholder_operation(
@@ -849,19 +849,19 @@ class PlaceholderAdmin(admin.ModelAdmin):
         source_placeholder = plugin.placeholder
 
         if not self.has_move_plugin_permission(request, plugin, source_placeholder):
-            message = gettext("You have no permission to move this plugin")
+            message = _("You have no permission to move this plugin")
             raise PermissionDenied(message)
 
         if target_placeholder and not self.has_move_plugin_permission(request, plugin, target_placeholder):
-            message = gettext("You have no permission to move this plugin")
+            message = _("You have no permission to move this plugin")
             raise PermissionDenied(message)
 
         if not source_placeholder.check_source(request.user):
-            message = gettext("You have no permission to move this plugin")
+            message = _("You have no permission to move this plugin")
             raise PermissionDenied(message)
 
         if target_placeholder and not target_placeholder.check_source(request.user):
-            message = gettext("You have no permission to move this plugin")
+            message = _("You have no permission to move this plugin")
             raise PermissionDenied(message)
 
         if target_parent:
@@ -913,11 +913,11 @@ class PlaceholderAdmin(admin.ModelAdmin):
         source_placeholder = plugin.placeholder
 
         if not self.has_move_plugin_permission(request, plugin, source_placeholder):
-            message = gettext("You have no permission to cut this plugin")
+            message = _("You have no permission to cut this plugin")
             raise PermissionDenied(message)
 
         if not source_placeholder.check_source(request.user):
-            message = gettext("You have no permission to cut this plugin")
+            message = _("You have no permission to cut this plugin")
             raise PermissionDenied(message)
 
         action_token = self._send_pre_placeholder_operation(
@@ -962,11 +962,11 @@ class PlaceholderAdmin(admin.ModelAdmin):
         plugin = self._get_plugin_from_id(plugin_id)
 
         if not self.has_delete_plugin_permission(request, plugin):
-            message = gettext("You do not have permission to delete this plugin")
+            message = _("You do not have permission to delete this plugin")
             return HttpResponseForbidden(message)
 
         if not plugin.placeholder.check_source(request.user):
-            message = gettext("You do not have permission to delete this plugin")
+            message = _("You do not have permission to delete this plugin")
             raise PermissionDenied(message)
 
         opts = plugin._meta
@@ -1044,11 +1044,11 @@ class PlaceholderAdmin(admin.ModelAdmin):
             return HttpResponseRedirect(admin_reverse('index', current_app=self.admin_site.name))
 
         if not self.has_clear_placeholder_permission(request, placeholder, language):
-            message = gettext("You do not have permission to clear this placeholder")
+            message = _("You do not have permission to clear this placeholder")
             return HttpResponseForbidden(message)
 
         if not placeholder.check_source(request.user):
-            message = gettext("You do not have permission to clear this placeholder")
+            message = _("You do not have permission to clear this placeholder")
             raise PermissionDenied(message)
 
         opts = Placeholder._meta
@@ -1065,7 +1065,7 @@ class PlaceholderAdmin(admin.ModelAdmin):
         if request.POST:
             # The user has already confirmed the deletion.
             if perms_needed:
-                message = gettext("You do not have permission to clear this placeholder")
+                message = _("You do not have permission to clear this placeholder")
                 return HttpResponseForbidden(message)
 
             operation_token = self._send_pre_placeholder_operation(

--- a/cms/utils/admin.py
+++ b/cms/utils/admin.py
@@ -1,6 +1,4 @@
-import json
-
-from django.http import HttpResponse
+from django.http import JsonResponse
 from django.utils.encoding import smart_str
 
 NOT_FOUND_RESPONSE = "NotFound"
@@ -13,4 +11,4 @@ def jsonify_request(response):
          * content: original response content
     """
     content = {'status': response.status_code, 'content': smart_str(response.content, response.charset)}
-    return HttpResponse(json.dumps(content), content_type="application/json")
+    return JsonResponse(content)


### PR DESCRIPTION
## Description

**This PR does not change any functionality!**

It just fixes two anti-patterns in django-CMS:

`force_str(_("…some text…"))` is completely useless because it forces to stringify a proxy object. A better and faster way is to use `gettext("…some text…")` directly.

`HttpResponse(json.dumps(content), content_type="application/json")` probably is a legacy statement. Django introduced `JsonResponse` many versions ago.


## Related resources

We discussed about this during one of our biweekly meetings.

## Checklist

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

I ran all unit tests successfully on my local environment.