### PR TITLE
feat: send post request if toolbar button has `cms-form-post-method` class

### DIFF
--- a/cms/static/cms/js/admin/actions.js
+++ b/cms/static/cms/js/admin/actions.js
@@ -1,7 +1,7 @@
 (function($) {
     $(function() {
         // INFO: it is not possible to put a form inside a form, so
-        // the versioning actions have to create their own form on click.
+        // the actions have to create their own form on click.
         // Note for any apps inheriting the burger menu, this will also capture those events.
 
         function closeSideFrame() {

--- a/cms/static/cms/js/modules/cms.toolbar.js
+++ b/cms/static/cms/js/modules/cms.toolbar.js
@@ -333,7 +333,7 @@ var Toolbar = new Class({
                 var link = $(el);
 
                 // in case the button has a data-rel attribute
-                if (link.attr('data-rel')) {
+                if (link.attr('data-rel') || link.hasClass('cms-form-post-method')) {
                     link.off(that.click).on(that.click, function(e) {
                         e.preventDefault();
                         that._delegate($(this));
@@ -599,7 +599,19 @@ var Toolbar = new Class({
                 // Else fall through to default, the sideframe is disabled
 
             default:
-                Helpers._getWindow().location.href = el.attr('href');
+                if (el.hasClass('cms-form-post-method')) {
+                    /* Allow post method to be used */
+                    var formToken = document.querySelector('form input[name="csrfmiddlewaretoken"]');
+                    var csrfToken = '<input type="hidden" name="csrfmiddlewaretoken" value="' +
+                        ((formToken ? formToken.value : formToken) || window.CMS.config.csrf) + '">';
+                    var fakeForm = $(
+                        '<form style="display: none" action="' + el.attr('href') + '" method="POST">' + csrfToken +
+                        '</form>'
+                    );
+                    fakeForm.appendTo(Helpers._getWindow().document.body).submit();
+                } else {
+                    Helpers._getWindow().location.href = el.attr('href');
+                }
         }
     },
 

--- a/cms/static/cms/js/modules/cms.toolbar.js
+++ b/cms/static/cms/js/modules/cms.toolbar.js
@@ -586,33 +586,42 @@ var Toolbar = new Class({
             case 'sideframe':
                 // If the sideframe is enabled, show it
                 if (typeof CMS.settings.sideframe_enabled === 'undefined' || CMS.settings.sideframe_enabled) {
-                    var sideframe = CMS.API.Sideframe || new Sideframe({
-                        onClose: el.data('on-close')
-                    });
-
-                    sideframe.open({
-                        url: el.attr('href'),
-                        animate: true
-                    });
+                    this._openSideFrame(el);
                     break;
                 }
                 // Else fall through to default, the sideframe is disabled
 
             default:
                 if (el.hasClass('cms-form-post-method')) {
-                    /* Allow post method to be used */
-                    var formToken = document.querySelector('form input[name="csrfmiddlewaretoken"]');
-                    var csrfToken = '<input type="hidden" name="csrfmiddlewaretoken" value="' +
-                        ((formToken ? formToken.value : formToken) || window.CMS.config.csrf) + '">';
-                    var fakeForm = $(
-                        '<form style="display: none" action="' + el.attr('href') + '" method="POST">' + csrfToken +
-                        '</form>'
-                    );
-                    fakeForm.appendTo(Helpers._getWindow().document.body).submit();
+                    this._sendPostRequest(el);
                 } else {
                     Helpers._getWindow().location.href = el.attr('href');
                 }
         }
+    },
+
+    _openSideFrame: function _openSideFrame(el) {
+        var sideframe = CMS.API.Sideframe || new Sideframe({
+            onClose: el.data('on-close')
+        });
+
+        sideframe.open({
+            url: el.attr('href'),
+            animate: true
+        });
+    },
+
+    _sendPostRequest: function _sendPostRequest(el) {
+        /* Allow post method to be used */
+        var formToken = document.querySelector('form input[name="csrfmiddlewaretoken"]');
+        var csrfToken = '<input type="hidden" name="csrfmiddlewaretoken" value="' +
+            ((formToken ? formToken.value : formToken) || window.CMS.config.csrf) + '">';
+        var fakeForm = $(
+            '<form style="display: none" action="' + el.attr('href') + '" method="POST">' + csrfToken +
+            '</form>'
+        );
+
+        fakeForm.appendTo(Helpers._getWindow().document.body).submit();
     },
 
     /**

--- a/cms/tests/frontend/unit/cms.messages.test.js
+++ b/cms/tests/frontend/unit/cms.messages.test.js
@@ -40,7 +40,8 @@ describe('CMS.Messages', function() {
         it('has options', function() {
             expect(messages.options).toEqual({
                 messageDuration: 300,
-                messageDelay: 3000
+                messageDelay: 3000,
+                messageLength: 160
             });
             messages = new CMS.Messages({
                 messageDuration: 100,
@@ -48,7 +49,8 @@ describe('CMS.Messages', function() {
             });
             expect(messages.options).toEqual({
                 messageDuration: 100,
-                messageDelay: 0
+                messageDelay: 0,
+                messageLength: 160
             });
         });
     });

--- a/docs/how_to/13-toolbar.rst
+++ b/docs/how_to/13-toolbar.rst
@@ -112,7 +112,7 @@ Action                 Text link variant                                        
 Open link              :meth:`~cms.toolbar.items.ToolbarAPIMixin.add_link_item`      :meth:`~cms.toolbar.toolbar.CMSToolbar.add_button`
 Open link in sideframe :meth:`~cms.toolbar.items.ToolbarAPIMixin.add_sideframe_item` :meth:`~cms.toolbar.toolbar.CMSToolbar.add_sideframe_button`
 Open link in modal     :meth:`~cms.toolbar.items.ToolbarAPIMixin.add_modal_item`     :meth:`~cms.toolbar.toolbar.CMSToolbar.add_modal_button`
-POST action            :meth:`~cms.toolbar.items.ToolbarAPIMixin.add_ajax_item`
+Ajax POST action       :meth:`~cms.toolbar.items.ToolbarAPIMixin.add_ajax_item`
 ====================== ============================================================= ===========================================================
 
 The basic form for using any of these is:

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "gulp-sourcemaps": "2.4.1",
         "gulp-util": "3.0.5",
         "imports-loader": "^0.7.1",
-        "istanbul-instrumenter-loader": "*",
+        "istanbul-instrumenter-loader": "latest",
         "jasmine-core": "^2.3.4",
         "karma": "^6.4.2",
         "karma-chrome-launcher": "^3.2.0",
@@ -4869,9 +4869,9 @@
       "dev": true
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001508",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001508.tgz",
-      "integrity": "sha512-sdQZOJdmt3GJs1UMNpCCCyeuS2IEGLXnHyAo9yIO5JJDjbjoVRij4M1qep6P6gFpptD1PqIYgzM+gwJbOi92mw==",
+      "version": "1.0.30001612",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001612.tgz",
+      "integrity": "sha512-lFgnZ07UhaCcsSZgWW0K5j4e69dK1u/ltrL9lTUiFOwNHs12S3UMIEYgBV0Z6C6hRDev7iRnMzzYmKabYdXF9g==",
       "dev": true,
       "funding": [
         {
@@ -26235,9 +26235,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001508",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001508.tgz",
-      "integrity": "sha512-sdQZOJdmt3GJs1UMNpCCCyeuS2IEGLXnHyAo9yIO5JJDjbjoVRij4M1qep6P6gFpptD1PqIYgzM+gwJbOi92mw==",
+      "version": "1.0.30001612",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001612.tgz",
+      "integrity": "sha512-lFgnZ07UhaCcsSZgWW0K5j4e69dK1u/ltrL9lTUiFOwNHs12S3UMIEYgBV0Z6C6hRDev7iRnMzzYmKabYdXF9g==",
       "dev": true
     },
     "capital-case": {


### PR DESCRIPTION

## Description

This PR adds the ability to define toolbar buttons that send POST requests, which is needed for any button changing the database state of the system, e.g., lock, unlock, publish, new draft, ...

Versioning uses its own little js file to add click events to buttons marked by the class`cms-form-post-method`. With this PR, any package can send POST requests by adding the class.

When the toolbar is updated, all events are lost. Therefore, this fixes https://github.com/django-cms/djangocms-versioning/issues/402


## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* https://github.com/django-cms/djangocms-versioning/issues/402

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
