### PR TITLE
fix: Undo RTL bug and moved the structure board back to the right for LTR

### DIFF
--- a/cms/static/cms/sass/components/_structureboard.scss
+++ b/cms/static/cms/sass/components/_structureboard.scss
@@ -371,6 +371,9 @@
             margin-inline-start: $structure-dragarea-padding-horizontal - 10px;
             cursor: pointer;
             transform: rotate(180deg);
+            [dir="rtl"] & {
+                transform: rotate(0deg);
+            }
         }
         .cms-dragitem-text {
             cursor: pointer;
@@ -378,6 +381,9 @@
     }
     .cms-dragitem-expanded:before {
         transform: rotate(-90deg);
+        [dir="rtl"] & {
+            transform: rotate(-90deg);
+        }
     }
     // #DRAGGABLES/states#
 
@@ -467,7 +473,7 @@
 
     &.cms-structure-condensed {
         width: 416px;
-        left: 0;
+        inset-inline-end: 0;
         box-shadow: 0 0 5px 0 rgba(0,0,0,.2);
         .cms-structure-content {
             padding-inline: 15px;

--- a/cms/static/cms/sass/components/_toolbar.scss
+++ b/cms/static/cms/sass/components/_toolbar.scss
@@ -184,6 +184,10 @@
                 display: block;
                 .cms-icon {
                     display: block;
+                    [dir="rtl"] & {
+                        // undo arrow rotation for RTL
+                        transform: rotate(0deg);
+                    }
                 }
 
             }


### PR DESCRIPTION
## Description

This PR fixes a regression introduced with RTL support. 

It also adjusts the arrows for menus and the structure board to point left instead of right.

It is raised against `release/4.1.x` to be quickly included in the release process of 4.1.1. It will hit `develop-4` upon merging back the 4.1.1 release.

![image](https://github.com/django-cms/django-cms/assets/16904477/dc319a51-8811-4873-8771-ca6ceca1060f)



## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* https://github.com/django-cms/djangocms-versioning/issues/402
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
