### PR TITLE
fix: Placeholders must not disallow deletion of their source objects

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -369,11 +369,6 @@ class PageAdmin(admin.ModelAdmin):
             **get_deleted_objects_additional_kwargs
         )
 
-        # `django.contrib.admin.utils.get_deleted_objects()` only returns the verbose_name of a model,
-        # we hence have to use that name in order to allow the deletion of objects otherwise prevented.
-        perms_needed.discard(Placeholder._meta.verbose_name)
-        perms_needed.discard(PageContent._meta.verbose_name)
-
         if request.POST and not protected:  # The user has confirmed the deletion.
             if perms_needed:
                 raise PermissionDenied
@@ -1262,13 +1257,6 @@ class PageContentAdmin(admin.ModelAdmin):
         perms_needed = set(
             list(perms_needed_url) + list(perms_needed_translation) + list(perms_needed_plugins)
         )
-
-        # This is bad and I should feel bad.
-        if 'placeholder' in perms_needed:
-            perms_needed.remove('placeholder')
-
-        if 'page content' in perms_needed:
-            perms_needed.remove('page content')
 
         if request.method == 'POST':
             if perms_needed:

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -192,9 +192,11 @@ class PlaceholderAdminMixin(metaclass=PlaceholderAdminMixinBase):
 class PlaceholderAdmin(admin.ModelAdmin):
 
     def has_add_permission(self, request):
+        # Placeholders are created by the system
         return False
 
     def has_change_permission(self, request, obj=None):
+        # Placeholders are not editable in the admin
         return False
 
     def has_delete_permission(self, request, obj=None):

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -198,10 +198,18 @@ class PlaceholderAdmin(admin.ModelAdmin):
         return False
 
     def has_delete_permission(self, request, obj=None):
-        return False
+        # Placeholders are deleted by cascading the deletion of their source object
+        # so we don't need to check for delete permissions here.
+        return True
 
     def has_module_permission(self, request):
+        # Do not show in admin
         return False
+
+    def delete_view(self, request, object_id, extra_context=None):
+        # Placeholder are deleted by cascading the deletion of their source object
+        # but the admin's delete view is not available for placeholders.
+        raise PermissionDenied
 
     def get_urls(self):
         """


### PR DESCRIPTION
## Description

Placeholder's admin delete view returns `PermissionDenied` since `has_delete_permission()` of the placeholder admin used to always return `False`. A side effect is that any object cascading a delete to a placeholder will not be deletable.

For `PageContent` this block used to be manually removed.

For custom models with `PlaceholderRelationFields` deleting used to be impossible.

This PR ensures that the placeholder admin delete view keeps returning `PermissionDenied` but allows deleting placeholders. This renders the manual deletion check for pages and page contents unnecessary.


## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* https://github.com/django-cms/djangocms-versioning/issues/394#issuecomment-2078973964
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
