### PR TITLE
fix: also use key-length of 200 for the actual cache-key of placeholders

### DIFF
--- a/cms/cache/placeholder.py
+++ b/cms/cache/placeholder.py
@@ -133,7 +133,13 @@ def _get_placeholder_cache_key(placeholder, lang, site_id, request, soft=False):
     if sub_key_list:
         cache_key += '|' + '|'.join(sub_key_list)
 
-    if len(cache_key) > 250:
+    # django itself adds "version" add the end of cache-keys, e.g. "<key>:1".
+    # -> If `cache.set()` is for example called with `version=""`, it still adds
+    #    `:` at the end. So if we check the length for `> 250`, a length of 249
+    #    or even 250 ends up in an InvalidCacheKey-exception.
+    # In order to avoid these errors, we hash the keys at a lower length to also
+    # have a little buffer.
+    if len(cache_key) > 200:
         cache_key = '{prefix}|{hash}'.format(
             prefix=prefix,
             hash=hashlib.sha1(cache_key.encode('utf-8')).hexdigest(),


### PR DESCRIPTION
- missing "functionality" for changes of #7595 and #7657

Seems like I forgot this change with mentioned issue/pull-request. With this change the cache-key error will actually be avoided.
Sorry for the mistake with the changes before - should've seen that since the `_cache_key`-function is the one I am overriding via workaround right now.