### PR TITLE
feat: Reintroduce `default_plugins` setting

### DIFF
--- a/cms/tests/test_permmod.py
+++ b/cms/tests/test_permmod.py
@@ -139,6 +139,28 @@ class PermissionModeratorTests(CMSTestCase):
             response = self.client.get(self.get_page_add_uri('en'))
             self.assertEqual(response.status_code, 403)
 
+    @override_settings(
+        CMS_PLACEHOLDER_CONF={
+            'col_left': {
+                'default_plugins': [
+                    {
+                        'plugin_type': 'TextPlugin',
+                        'values': {
+                            'body': 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Culpa, repellendus, delectus, quo quasi ullam inventore quod quam aut voluptatum aliquam voluptatibus harum officiis officia nihil minus unde accusamus dolorem repudiandae.'
+                        },
+                    },
+                ]
+            },
+        },
+    )
+    def test_default_plugins(self):
+        with self.login_user_context(self.user_slave):
+            self.assertEqual(CMSPlugin.objects.count(), 0)
+            response = self.client.get(self.slave_page.get_absolute_url(), {'edit': 1})
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(CMSPlugin.objects.count(), 1)
+
+
     def test_super_can_add_plugin(self):
         self._add_plugin(self.user_super, page=self.slave_page)
 

--- a/cms/tests/test_permmod.py
+++ b/cms/tests/test_permmod.py
@@ -9,7 +9,7 @@ from django.test.utils import override_settings
 from cms.admin.forms import save_permissions
 from cms.api import assign_user_to_page, create_page, create_page_user
 from cms.cms_menus import get_visible_nodes
-from cms.models import ACCESS_PAGE, Page, PageContent
+from cms.models import ACCESS_PAGE, CMSPlugin, Page, PageContent
 from cms.models.permissionmodels import (
     ACCESS_PAGE_AND_DESCENDANTS,
     GlobalPagePermission,

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -769,7 +769,7 @@ class PlaceholderTestCase(TransactionCMSTestCase):
             context['request'] = self.get_request(language="en", page=page)
             # Our page should have "en default body 1" AND "en default body 2"
             content = _render_placeholder(placeholder, context)
-            self.assertRegexpMatches(content, "^<p>en default body 1</p>\s*<p>en default body 2</p>$")
+            self.assertRegex(content, r"^<p>en default body 1</p>\s*<p>en default body 2</p>$")
 
     def test_plugins_children_prepopulate(self):
         """

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -607,7 +607,14 @@ class PlaceholderTestCase(TransactionCMSTestCase):
             'main': {
                 'name': 'main content',
                 'plugins': ['TextPlugin', 'LinkPlugin'],
-                'require_parent': False,
+                'default_plugins': [
+                    {
+                        'plugin_type': 'TextPlugin',
+                        'values': {
+                            'body': '<p>Some default text</p>'
+                        },
+                    },
+                ],
             },
             'layout/home.html main': {
                 'name': 'main content with FilerImagePlugin and limit',
@@ -642,8 +649,8 @@ class PlaceholderTestCase(TransactionCMSTestCase):
             returned = get_placeholder_conf('excluded_plugins', 'main', 'layout/other.html')
             self.assertEqual(returned, TEST_CONF['layout/other.html main']['excluded_plugins'])
             # test grandparent inherited value
-            returned = get_placeholder_conf('require_parent', 'main', 'layout/other.html')
-            self.assertEqual(returned, TEST_CONF['main']['require_parent'])
+            returned = get_placeholder_conf('default_plugins', 'main', 'layout/other.html')
+            self.assertEqual(returned, TEST_CONF['main']['default_plugins'])
             # test generic configuration
             returned = get_placeholder_conf('plugins', 'something')
             self.assertEqual(returned, TEST_CONF[None]['plugins'])
@@ -737,6 +744,79 @@ class PlaceholderTestCase(TransactionCMSTestCase):
         # And test the plugin counts remain the same
         self.assertEqual(old_placeholder_1_plugin_count, current_placeholder_1_plugin_count)
         self.assertEqual(old_placeholder_2_plugin_count, current_placeholder_2_plugin_count)
+
+    def test_plugins_prepopulate(self):
+        """ Tests prepopulate placeholder configuration """
+
+        conf = {
+            'col_left': {
+                'default_plugins' : [
+                    {
+                        'plugin_type':'TextPlugin',
+                        'values':{'body':'<p>en default body 1</p>'},
+                    },
+                    {
+                        'plugin_type':'TextPlugin',
+                        'values':{'body':'<p>en default body 2</p>'},
+                    },
+                ]
+            },
+        }
+        with self.settings(CMS_PLACEHOLDER_CONF=conf):
+            page = create_page('page_en', 'col_two.html', 'en')
+            placeholder = page.get_placeholders("en").get(slot='col_left')
+            context = SekizaiContext()
+            context['request'] = self.get_request(language="en", page=page)
+            # Our page should have "en default body 1" AND "en default body 2"
+            content = _render_placeholder(placeholder, context)
+            self.assertRegexpMatches(content, "^<p>en default body 1</p>\s*<p>en default body 2</p>$")
+
+    def test_plugins_children_prepopulate(self):
+        """
+        Validate a default textplugin with a nested default link plugin
+        """
+
+        conf = {
+            'col_left': {
+                'default_plugins': [
+                    {
+                        'plugin_type': 'TextPlugin',
+                        'values': {
+                            'body': '<p>body %(_tag_child_1)s and %(_tag_child_2)s</p>'
+                        },
+                        'children': [
+                            {
+                                'plugin_type': 'LinkPlugin',
+                                'values': {
+                                    'name': 'django',
+                                    'external_link': 'https://www.djangoproject.com/'
+                                },
+                            },
+                            {
+                                'plugin_type': 'LinkPlugin',
+                                'values': {
+                                    'name': 'django-cms',
+                                    'external_link': 'https://www.django-cms.org'
+                                },
+                            },
+                        ]
+                    },
+                ]
+            },
+        }
+
+        with self.settings(CMS_PLACEHOLDER_CONF=conf):
+            page = create_page('page_en', 'col_two.html', 'en')
+            placeholder = page.get_placeholders("en").get(slot='col_left')
+            context = SekizaiContext()
+            context['request'] = self.get_request(language="en", page=page)
+            _render_placeholder(placeholder, context)
+            plugins = placeholder.get_plugins_list()
+            self.assertEqual(len(plugins), 3)
+            self.assertEqual(plugins[0].plugin_type, 'TextPlugin')
+            self.assertEqual(plugins[1].plugin_type, 'LinkPlugin')
+            self.assertEqual(plugins[2].plugin_type, 'LinkPlugin')
+            self.assertTrue(plugins[1].parent == plugins[2].parent and plugins[1].parent == plugins[0])
 
     def test_placeholder_pk_thousands_format(self):
         page = create_page("page", "nav_playground.html", "en")

--- a/cms/tests/test_rendering.py
+++ b/cms/tests/test_rendering.py
@@ -723,6 +723,7 @@ class RenderingTestCase(CMSTestCase):
         r = self.render(self.test_page5)
         self.assertEqual(r, '|' + self.test_data5['text_main'] + '|' + self.test_data5['text_sub'])
 
+    @override_settings(CMS_PLACEHOLDER_CONF={None: {'language_fallback': False}})
     def test_inherit_placeholder_queries(self):
         with self.assertNumQueries(FuzzyInt(6, 10)):
             r = self.render(self.test_page2)

--- a/cms/utils/plugins.py
+++ b/cms/utils/plugins.py
@@ -128,7 +128,7 @@ def create_default_plugins(request, placeholders, template, lang):
 
     def _create_default_plugins(placeholder, confs, parent=None):
         """
-        Auxillary function that builds all of a placeholder's default plugins
+        Auxiliary function that builds all of a placeholder's default plugins
         at the current level and drives the recursion down the tree.
         Returns the plugins at the current level along with all descendants.
         """

--- a/cms/utils/plugins.py
+++ b/cms/utils/plugins.py
@@ -3,6 +3,8 @@ import sys
 from collections import OrderedDict, defaultdict, deque
 from copy import deepcopy
 from functools import lru_cache
+from itertools import starmap
+from operator import itemgetter
 
 from django.utils.encoding import force_str
 from django.utils.translation import gettext as _
@@ -12,6 +14,7 @@ from cms.models.pluginmodel import CMSPlugin
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 from cms.utils import get_language_from_request
+from cms.utils.permissions import has_plugin_permission
 from cms.utils.placeholder import get_placeholder_conf
 
 logger = logging.getLogger(__name__)
@@ -91,6 +94,9 @@ def assign_plugins(request, placeholders, template=None, lang=None):
         .objects
         .filter(placeholder__in=placeholders, language=lang)
     )
+    if not plugins:
+        # Create default plugins if enabled
+        plugins = create_default_plugins(request, placeholders, template, lang)
     plugins = downcast_plugins(plugins, placeholders, request=request)
 
     # split the plugins up by placeholder
@@ -110,6 +116,47 @@ def assign_plugins(request, placeholders, template=None, lang=None):
         placeholder._all_plugins_cache = all_plugins
         # This is only the root plugins.
         placeholder._plugins_cache = layered_plugins
+
+
+def create_default_plugins(request, placeholders, template, lang):
+    """
+    Create all default plugins for the given ``placeholders`` if they have
+    a "default_plugins" configuration value in settings.
+    return all plugins, children, grandchildren (etc.) created
+    """
+    from cms.api import add_plugin
+
+    def _create_default_plugins(placeholder, confs, parent=None):
+        """
+        Auxillary function that builds all of a placeholder's default plugins
+        at the current level and drives the recursion down the tree.
+        Returns the plugins at the current level along with all descendants.
+        """
+        plugins, descendants = [], []
+        addable_confs = (conf for conf in confs
+                         if has_plugin_permission(request.user,
+                                                  conf['plugin_type'], 'add'))
+        for conf in addable_confs:
+            plugin = add_plugin(placeholder, conf['plugin_type'], lang,
+                                target=parent, **conf['values'])
+            if 'children' in conf:
+                args = placeholder, conf['children'], plugin
+                descendants += _create_default_plugins(*args)
+            plugin.notify_on_autoadd(request, conf)
+            plugins.append(plugin)
+        if parent:
+            parent.notify_on_autoadd_children(request, conf, plugins)
+        return plugins + descendants
+
+    unfiltered_confs = ((ph, get_placeholder_conf('default_plugins',
+                                                  ph.slot, template))
+                        for ph in placeholders)
+    # Empty confs must be filtered before filtering on add permission
+    mutable_confs = ((ph, default_plugin_confs)
+                     for ph, default_plugin_confs
+                     in filter(itemgetter(1), unfiltered_confs)
+                     if ph.has_change_permission(request.user))
+    return sum(starmap(_create_default_plugins, mutable_confs), [])
 
 
 def get_plugins_as_layered_tree(plugins):


### PR DESCRIPTION
## Description

This PR undoes #6468 and fixes #7917.

The original reason for removal remains obscured to me.

* The docs contain the feature
* The release notes do not mention the removal (or at least I have not seen this)
* Anyone not using it can remove it from their project by not using the setting

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7917 
* #6468
* #6460

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
