### PR TITLE
fix: Allow viewing page settings even if page cannot be changed

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -1051,6 +1051,24 @@ class PageContentAdmin(admin.ModelAdmin):
         )
         return can_change_page
 
+    def has_view_permission(self, request, obj=None):
+        """
+        Return true if the current user has permission on the page.
+        Return the string 'All' if the user has all rights.
+        """
+        # Identical to has_change_permission, but will remain untouched by any subclassing
+        # as done, e.g., by djangocms-versioning
+        site = get_site(request)
+
+        if obj:
+            return page_permissions.user_can_change_page(request.user, page=obj.page, site=site)
+        can_view_page = page_permissions.user_can_change_at_least_one_page(
+            user=request.user,
+            site=get_site(request),
+            use_cache=False,
+        )
+        return can_view_page
+
     def has_delete_permission(self, request, obj=None):
         """
         Returns True if the current user has permission to delete the page.

--- a/cms/tests/test_permmod.py
+++ b/cms/tests/test_permmod.py
@@ -591,7 +591,7 @@ class GlobalPermissionTests(CMSTestCase):
                 with self.assertNumQueries(FuzzyInt(3, max_queries)):
                     # internally this calls PageAdmin.has_[add|change|delete|view]_permission()
                     expected_perms = {'add': True, 'change': True, 'delete': False}
-                    expected_perms.update({'view': False})  # Why
+                    expected_perms.update({'view': expected_perms['change']})
                     self.assertEqual(expected_perms, site._registry[PageContent].get_model_perms(request))
 
             # can't use the above loop for this test, as we're testing that
@@ -619,7 +619,7 @@ class GlobalPermissionTests(CMSTestCase):
                 request.current_page = None
                 request.session = {}
                 expected_perms = {'add': True, 'change': True, 'delete': False}
-                expected_perms.update({'view': False})
+                expected_perms.update({'view': expected_perms['change']})
                 self.assertEqual(expected_perms, site._registry[PageContent].get_model_perms(request))
 
     def test_has_page_add_permission_with_target(self):


### PR DESCRIPTION


## Description

This PR fixes https://github.com/django-cms/djangocms-versioning/issues/409

django CMS does not differentiate user or page-based permissions to change or view page settings.

Since django CMS versioning overwrites the `has_change_permission` method of the `PageContentAdmin` class, it needs a `has_view_permission` method, too. By default, they do return the same logic based on the user's ability to change this page. It is however not overwritten when a subclass adds to the `has_change_permission` logic.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* https://github.com/django-cms/djangocms-versioning/issues/409
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
