### PR TITLE
fix: Versioning-safe implementation of placeholder inheritance

### DIFF
--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -578,3 +578,6 @@ class EmptyToolbar(BaseToolbar):
     def __init__(self, request):
         self.request = request
         super().__init__()
+
+    def get_object(self):
+        return None


### PR DESCRIPTION
## Description

The `ContentRenderer.render_page_placeholders` implementation is not versioning-safe, i.e. assumes that there is exactly one `PageContent` object per `Page` and language. This PR improves the implementation using the `admin_manager`.

This will allow `{% placeholder "my_placeholder" inherit %}` to also work with versioned page contents, such as provided by djangocms-versioning. (For it to actually work with djangocms-versioning, however, an additional change to djangocms-versioning is needed, to not deactivate the inherit functionality.)

Results with djangocms-versioning:
* When rendered at the URL (i.e. public endpoint): The placeholder only inherits from also public placeholders
* When previewed: The placeholder inherits from the latest parent placeholder (i.e. public or draft)
* When edited: Inherited placeholders are empty to allow for adding content

Then changes are covered by tests. Additional tests need to go into djangocms-versioning if the inheritance feature is activated again.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* https://github.com/django-cms/djangocms-versioning/issues/410
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
