### PR TITLE
docs: Update 02-templates_placeholders.rst

### DIFF
--- a/docs/introduction/02-templates_placeholders.rst
+++ b/docs/introduction/02-templates_placeholders.rst
@@ -89,16 +89,18 @@ Do not forget to add ``djangocms_alias`` to your ``INSTALLED_APPS`` in ``setting
 
 Static aliases are an easy way to display the same content on multiple locations on your website. Static placeholders act almost like normal placeholders, except for the fact that once a static placeholder is created and you added content to it, it will be saved globally. Even when you remove the static placeholders from a template, you can reuse them later.
 
-So let's add a footer to all our pages. Since we want our footer on every single page, we should add it to our **base template** (``mysite/templates/base.html``). Place it near the end of the HTML ``<body>`` element:
+So let's add a footer to all our pages. Since we want our footer on every single page, we should add it to our **base template** (``mysite/templates/base.html``). Place it near the end of the HTML ``<body>`` element, and inside a content block:
 
 .. code-block:: html+django
    :emphasize-lines: 1,3-5
 
         {% load djangocms_alias_tags %}
 
-        <footer>
-          {% static_alias 'footer' %}
-        </footer>
+        {% block content %}
+            <footer>
+              {% static_alias 'footer' %}
+            </footer>
+        {% endblock content %}
 
 
         {% render_block "js" %}


### PR DESCRIPTION
In a fresh install of 4.1.1 and the start project, I discovered the static aliases placeholder only works inside the content block.  I had changed my base.html to use the 3 blocks suggested, so I had to edit that to this before the static aliases showed up:
        {% block content %}
            {% placeholder "feature" %}
            {% placeholder "content" %}
            {% placeholder "splashbox" %}
            <footer>
                {% static_alias "footer" %}
            </footer>
        {% endblock content %}

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
