### PR TITLE
fix: Fail silently when rendering a placeholder on a missing toolbar object

### DIFF
--- a/.github/workflows/new_contributor_pr.yml
+++ b/.github/workflows/new_contributor_pr.yml
@@ -29,6 +29,7 @@ jobs:
     needs: new
     steps:
       - name: Send Discord Webhook
+        continue-on-error: true
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
           DISCORD_EMBEDS: |

--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -13,6 +13,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import override
 
 from cms.cache.placeholder import get_placeholder_cache, set_placeholder_cache
+from cms.exceptions import PlaceholderNotFound
 from cms.models import PageContent, Placeholder
 from cms.toolbar.utils import (
     get_placeholder_toolbar_js,
@@ -343,6 +344,8 @@ class ContentRenderer(BaseRenderer):
         # Not page, therefore we will use toolbar object as
         # the current object and render the placeholder
         current_obj = self.toolbar.get_object()
+        if current_obj is None:
+            raise PlaceholderNotFound(f"No object found for placeholder '{slot}'")
         rescan_placeholders_for_obj(current_obj)
         placeholder = Placeholder.objects.get_for_obj(current_obj).get(slot=slot)
         content = self.render_placeholder(

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -11,7 +11,7 @@ from sekizai.context import SekizaiContext
 
 from cms import constants
 from cms.api import add_plugin, create_page, create_page_content
-from cms.exceptions import DuplicatePlaceholderWarning
+from cms.exceptions import DuplicatePlaceholderWarning, PlaceholderNotFound
 from cms.models.fields import PlaceholderField
 from cms.models.placeholdermodel import Placeholder
 from cms.models.pluginmodel import CMSPlugin
@@ -140,6 +140,17 @@ class PlaceholderTestCase(TransactionCMSTestCase):
         t = Template('{% include "placeholder_tests/outside_nested_sekizai.html" %}')
         phs = sorted(node.get_declaration().slot for node in _scan_placeholders(t.nodelist))
         self.assertListEqual(phs, sorted(['two', 'new_one', 'base_outside']))
+
+    def test_placeholder_scanning_no_object(self):
+        """Placeholder scanning for a template without a toolbar object raises PlaceholderNotFound"""
+
+        context = SekizaiContext()
+        request = self.get_request(language="en", page=None)
+        toolbar = get_toolbar_from_request(request)
+        renderer = toolbar.get_content_renderer()
+        with self.assertRaises(PlaceholderNotFound):
+            renderer.render_obj_placeholder("someslot", context, False)
+
 
     def test_fieldsets_requests(self):
         response = self.client.get(admin_reverse('placeholderapp_example1_add'))

--- a/cms/utils/placeholder.py
+++ b/cms/utils/placeholder.py
@@ -1,6 +1,7 @@
 import operator
 import warnings
 from collections import OrderedDict
+from typing import Union
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -406,11 +407,13 @@ def rescan_placeholders_for_obj(obj):
     return existing
 
 
-def get_declared_placeholders_for_obj(obj):
+def get_declared_placeholders_for_obj(obj: Union[models.Model, None]) -> list[Placeholder]:
     """Returns declared placeholders for an object. The object is supposed to have a method ``get_template``
     which returns the template path as a string that renders the object. ``get_declared_placeholders`` returns
     a list of placeholders used in the template by the ``{% placeholder %}`` template tag.
     """
+    if obj is None:
+        return []
     if not hasattr(obj, "get_template"):
         raise NotImplementedError(
             "%s should implement get_template" % obj.__class__.__name__


### PR DESCRIPTION
## Description
Fixes #7952

If there is no toolbar object available, trying to render a placeholder now raises the `PlaceholderNotFound` exception.

This leads the `{% placeholder %}` template tag to silently fail and return and empty string.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7952
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
