### PR TITLE
fix: `edit_mode_active` was a property, not cached property

### DIFF
--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -410,7 +410,7 @@ class CMSToolbarBase(BaseToolbar):
             return True
         return False
 
-    @property
+    @cached_property
     def edit_mode_active(self):
         """``True`` if editing mode is active。"""
         # Cannot be cached since it changes depending on the object.


### PR DESCRIPTION
## Description

Replacing a cached property by a property in a subclass leads to side-effects. 

This PR fixes a regression introduced in #7850 which leads to djangocms-versioning tests to fail.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
