### PR TITLE
fix: Mark language and user middleware synchronous for ASGI (#7985)

### DIFF
--- a/cms/middleware/language.py
+++ b/cms/middleware/language.py
@@ -9,6 +9,8 @@ if DJANGO_2_2:
 
 
 class LanguageCookieMiddleware(MiddlewareMixin):
+    async_capable = False
+
     def __init__(self, get_response):
         super().__init__(get_response)
 

--- a/cms/middleware/user.py
+++ b/cms/middleware/user.py
@@ -7,6 +7,8 @@ from django.utils.deprecation import MiddlewareMixin
 
 
 class CurrentUserMiddleware(MiddlewareMixin):
+    async_capable = False
+
     def __init__(self, get_response=None):
         self.get_response = get_response
         # One-time configuration and initialization.


### PR DESCRIPTION
## Description

Mark LanguageCookieMiddleware and CurrentUserMiddleware as non-asynchronous so that django wraps them properly to run in an asynchronous ASGI middleware stack.  It's a pretty simple fix.

## Related resources

Issue
* #7985

## Checklist

* [ ] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [ x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
