### PR TITLE
fix: Also clear menu cache if page permissions are changed

### DIFF
--- a/cms/signals/permissions.py
+++ b/cms/signals/permissions.py
@@ -27,8 +27,9 @@ def post_save_user(instance, raw, created, **kwargs):
     page_user.__dict__.update(instance.__dict__)
     page_user.save()
 
-    clear_user_permission_cache(instance
-                                )
+    clear_user_permission_cache(instance)
+    menu_pool.clear(all=True)
+
 
 def post_save_user_group(instance, raw, created, **kwargs):
     """The same like post_save_user, but for Group, required only when
@@ -51,14 +52,17 @@ def post_save_user_group(instance, raw, created, **kwargs):
 
 def pre_save_user(instance, raw, **kwargs):
     clear_user_permission_cache(instance)
+    menu_pool.clear(all=True)
 
 
 def pre_delete_user(instance, **kwargs):
     clear_user_permission_cache(instance)
+    menu_pool.clear(all=True)
 
 
 def pre_save_group(instance, raw, **kwargs):
     if instance.pk:
+        menu_pool.clear(all=True)
         user_set = instance.user_set
         for user in user_set.all():
             clear_user_permission_cache(user)
@@ -66,12 +70,17 @@ def pre_save_group(instance, raw, **kwargs):
 
 def pre_delete_group(instance, **kwargs):
     user_set = instance.user_set
+    menu_pool.clear(all=True)
     for user in user_set.all():
         clear_user_permission_cache(user)
 
 
 def user_m2m_changed(instance, action, reverse, pk_set, **kwargs):
-    if action in ('pre_add', 'pre_remove',):
+    if action in (
+        "pre_add",
+        "pre_remove",
+    ):
+        menu_pool.clear(all=True)
         if reverse:
             for user in User.objects.filter(pk__in=pk_set):
                 clear_user_permission_cache(user)
@@ -80,6 +89,7 @@ def user_m2m_changed(instance, action, reverse, pk_set, **kwargs):
 
 
 def _clear_users_permissions(instance):
+    menu_pool.clear(all=True)
     if instance.user:
         clear_user_permission_cache(instance.user)
     if instance.group:
@@ -98,7 +108,6 @@ def pre_delete_pagepermission(instance, **kwargs):
 
 def pre_save_globalpagepermission(instance, raw, **kwargs):
     _clear_users_permissions(instance)
-    menu_pool.clear(all=True)
 
 
 def pre_delete_globalpagepermission(instance, **kwargs):

--- a/cms/signals/permissions.py
+++ b/cms/signals/permissions.py
@@ -89,13 +89,14 @@ def user_m2m_changed(instance, action, reverse, pk_set, **kwargs):
 
 
 def _clear_users_permissions(instance):
-    menu_pool.clear(all=True)
     if instance.user:
         clear_user_permission_cache(instance.user)
+        menu_pool.clear(all=True)
     if instance.group:
         user_set = instance.group.user_set
         for user in user_set.all():
             clear_user_permission_cache(user)
+        menu_pool.clear(all=True)
 
 
 def pre_save_pagepermission(instance, raw, **kwargs):


### PR DESCRIPTION
## Description

This PR completes the resolution of #7962 and adds to the (already merged) PR #7963.

Any invalidation of the permissions cache needs to also invalidate the menu cache, since the menu reflects if users have permission to see a page.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7962 
* #7963 

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
