### PR TITLE
fix: Import error from backporting v4 deprecation

### DIFF
--- a/cms/models/managers.py
+++ b/cms/models/managers.py
@@ -325,7 +325,7 @@ class PagePermissionManager(BasicPagePermissionManager):
         from cms.models import PermissionTuple
         allow_list = Q()
         for perm_tuple in get_change_permissions_perm_tuples(user, site, check_global=False):
-           allow_list |= PermissionTuple(perm_tuple).allow_list("page__node")
+            allow_list |= PermissionTuple(perm_tuple).allow_list("page__node")
 
         # get permission set, but without objects targeting user, or any group
         # in which he can be

--- a/cms/sitemaps/cms_sitemap.py
+++ b/cms/sitemaps/cms_sitemap.py
@@ -57,6 +57,7 @@ class CMSSitemap(Sitemap):
 
     def lastmod(self, title):
         modification_dates = [title.page.changed_date, title.page.publication_date]
+
         def plugins_for_placeholder(placeholder):
             return placeholder.get_plugins()
         plugins = from_iterable(map(plugins_for_placeholder, title.page.placeholders.all()))

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -406,7 +406,7 @@ class PageAttribute(AsTag):
             func = getattr(page, "get_%s" % name)
             ret_val = func(language=lang, fallback=True)
             if name == 'page_title':
-                 ret_val = strip_tags(ret_val)
+                ret_val = strip_tags(ret_val)
             elif not isinstance(ret_val, datetime):
                 ret_val = escape(ret_val)
             return ret_val

--- a/cms/tests/test_forms.py
+++ b/cms/tests/test_forms.py
@@ -241,6 +241,7 @@ class FormsTestCase(CMSTestCase):
     def test_lazy_choice_field_behaves_properly(self):
         """Ensure LazyChoiceField is really lazy"""
         choices_called = False
+
         def get_choices():
             nonlocal choices_called
             choices_called = True

--- a/cms/utils/permissions.py
+++ b/cms/utils/permissions.py
@@ -191,14 +191,7 @@ def has_global_permission(user, site, action, use_cache=True):
 
 
 def has_page_permission(user, page, action, use_cache=True):
-    import warnings
-
-    from cms.utils.compat.warnings import RemovedInDjangoCMS43Warning
     from cms.utils.page_permissions import has_generic_permission
-
-    warnings.warn("has_page_permission is deprecated and will be removed in django CMS 4.3. "
-                  "Use cms.utils.page_permissions.has_generic_permission instead.",
-                  RemovedInDjangoCMS43Warning, stacklevel=2)
 
     return has_generic_permission(page, user, action, site=None, check_global=False, use_cache=use_cache)
 


### PR DESCRIPTION
## Description

django CMS 3.11.7 has an import error. This PR removes the wrong import.

I checked manually with pylint for import errors and corrected a few formatting errors, too.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7992 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
