### PR TITLE
fix: Respect ContentAdminManager pattern for frontend-editable models

### DIFF
--- a/.github/workflows/test_startcmsproject.yml
+++ b/.github/workflows/test_startcmsproject.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         django-version: [
-          '4.2', '5.0',
+          '4.2', '5.0', '5.1'
         ]
         python-version: ['3.11']
         requirements-file: ['requirements_base.txt']

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -5,6 +5,7 @@ from urllib.parse import parse_qsl, urlparse
 
 from django import forms
 from django.contrib import admin
+from django.contrib.admin import utils
 from django.contrib.admin.helpers import AdminForm
 from django.contrib.admin.utils import get_deleted_objects
 from django.core.exceptions import PermissionDenied
@@ -104,9 +105,15 @@ class FrontendEditableAdminMixin:
         # Quick and dirty way to retrieve objects for django-hvad
         # Cleaner implementation will extend this method in a child mixin
         try:
-            return self.model.objects.language(language).get(pk=object_id)
+            # First see if the model uses the admin manager pattern from cms.models.manager.ContentAdminManager
+            manager = self.model.admin_manager
         except AttributeError:
-            return self.model.objects.get(pk=object_id)
+            # If not, use the default manager
+            manager = self.model.objects
+        try:
+            return manager.language(language).get(pk=object_id)
+        except AttributeError:
+            return manager.get(pk=object_id)
 
     def edit_field(self, request, object_id, language):
         obj = self._get_object_for_single_field(object_id, language)

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -5,7 +5,6 @@ from urllib.parse import parse_qsl, urlparse
 
 from django import forms
 from django.contrib import admin
-from django.contrib.admin import utils
 from django.contrib.admin.helpers import AdminForm
 from django.contrib.admin.utils import get_deleted_objects
 from django.core.exceptions import PermissionDenied

--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -393,7 +393,7 @@ class PageToolbar(CMSToolbar):
             # Toolbar object already set (e.g., in edit or preview mode)
             return self.obj
         # Get from db
-        page_content = self.page.get_content_obj(language=self.current_lang, fallback=False)
+        page_content = self.page.get_admin_content(language=self.current_lang, fallback=False)
         return page_content or None
 
     def has_page_change_permission(self):

--- a/cms/models/fields.py
+++ b/cms/models/fields.py
@@ -130,9 +130,6 @@ class PlaceholderRelationField(GenericRelation):
             @cached_property
             def content(self):
                 return get_placeholder_from_slot(self.placeholders, "content")  # A specific placeholder
-
-
-
     """
     default_checks = []
 

--- a/cms/templates/admin/cms/page/plugin/error_form.html
+++ b/cms/templates/admin/cms/page/plugin/error_form.html
@@ -2,7 +2,7 @@
 {% load i18n l10n static %}
 
 {% block title %}{% trans "Edit model" %}{% endblock %}
-
+{% block breadcrumbs %}{% endblock %}
 {% block content %}
 <form action="." method="post" id="cmsplugin_form">
 {% csrf_token %}

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -608,7 +608,7 @@ class CMSEditableObject(InclusionTag):
         if not attr_value:
             attr_value = getattr(instance, attribute, '')
         extra_context['content'] = attr_value
-        # This allow the requested item to be a method, a property or an
+        # This allows the requested item to be a method, a property or an
         # attribute
         if callable(extra_context['content']):
             if isinstance(instance, Page):

--- a/cms/test_utils/project/placeholderapp/models.py
+++ b/cms/test_utils/project/placeholderapp/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.urls import reverse
 
+from cms.models import ContentAdminManager
 from cms.models.fields import PlaceholderField
 from cms.utils import get_language_from_request
 from cms.utils.urlutils import admin_reverse
@@ -25,6 +26,9 @@ class Example1(models.Model):
     decimal_field = models.DecimalField(
         max_digits=5, decimal_places=1,
         blank=True, null=True,)
+
+    admin_manager = ContentAdminManager()
+    objects = models.Manager()
 
     static_admin_url = ''
 

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -25,7 +25,7 @@ from cms.cms_toolbars import (
     LANGUAGE_MENU_IDENTIFIER,
     get_user_model,
 )
-from cms.models import ContentAdminManager, PagePermission, UserSettings
+from cms.models import PagePermission, UserSettings
 from cms.test_utils.project.placeholderapp.models import (
     CharPksExample,
     Example1,

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -1734,7 +1734,7 @@ class EditModelTemplateTagTest(ToolbarTestBase):
                 get_mock.return_value = ex1
                 self.client.get(edit_url + "?edit_fields=char_1")
 
-            self.assertEqual(edit_url, "/admin/placeholderapp/example1/edit-field/1/en/")
+            self.assertEqual(edit_url, f"/admin/placeholderapp/example1/edit-field/{ex1.pk}/en/")
             Example1.admin_manager.get.assert_called_once_with(pk=str(ex1.pk))
 
     def test_view_url(self):


### PR DESCRIPTION
## Description

Currently, objects of versioned models cannot be edited from the frontend using `FrontendEditableMixin`.

This PR support for the `ContentAdminManager` mixin introduced in django CMS 4.1.

Fixes #7996. Fixes https://github.com/fsbraun/djangocms-blog/issues/5

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7996 
* https://github.com/fsbraun/djangocms-blog/issues/5

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
