### PR TITLE
chore: Improve pagecontent caching in page admin (esp. page tree)

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -1400,7 +1400,7 @@ class PageContentAdmin(admin.ModelAdmin):
             Prefetch(
                 'pagecontent_set',
                 to_attr='filtered_translations',
-                queryset=self.get_queryset(request),
+                queryset=PageContent.admin_manager.get_queryset()   ,
             ),
         )
         rows = self.get_tree_rows(
@@ -1429,7 +1429,7 @@ class PageContentAdmin(admin.ModelAdmin):
         user_can_change_advanced = page_permissions.user_can_change_page_advanced_settings
 
         def render_page_row(page):
-            page.admin_content_cache = {trans.language: trans for trans in page.filtered_translations if trans}
+            page.admin_content_cache = {trans.language: trans for trans in page.filtered_translations}
             has_move_page_permission = page_permissions.user_can_move_page(request.user, page, site=site)
 
             if permissions_on and not has_move_page_permission:

--- a/cms/models/managers.py
+++ b/cms/models/managers.py
@@ -296,7 +296,7 @@ class PagePermissionManager(BasicPagePermissionManager):
         from cms.models import PermissionTuple
         allow_list = Q()
         for perm_tuple in get_change_permissions_perm_tuples(user, site, check_global=False):
-           allow_list |= PermissionTuple(perm_tuple).allow_list("page")
+            allow_list |= PermissionTuple(perm_tuple).allow_list("page")
 
         # get permission set, but without objects targeting user, or any group
         # in which he can be

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -736,6 +736,7 @@ class Page(MP_Node):
                 page_content = self.admin_content_cache.get(lang)
                 if page_content:
                     return page_content
+            page_content = EmptyPageContent(language=language, page=self)
             if fallback == "force":
                 # Try any page content object
                 for item in self.admin_content_cache.values():

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -21,7 +21,7 @@ from cms.models.managers import PageManager, PageUrlManager
 from cms.utils import i18n
 from cms.utils.compat.warnings import RemovedInDjangoCMS43Warning
 from cms.utils.conf import get_cms_setting
-from cms.utils.i18n import get_current_language
+from cms.utils.i18n import get_current_language, get_fallback_languages
 from cms.utils.page import get_clean_username
 from menus.menu_pool import menu_pool
 
@@ -144,13 +144,11 @@ class Page(MP_Node):
         #: Might be larger than the page_content_cache
 
     def __str__(self):
-        try:
-            title = self.get_menu_title(fallback=True)
-        except LanguageError:
-            title = self.pagecontent_set(manager="admin_manager").current_content().first()
-            if title:
-                title = title.title
-        if title is None:
+        lang = self._get_page_content_cache(get_language(), fallback=True, force_reload=False)
+        page_content = self.page_content_cache.get(lang)
+        if page_content:
+            title = page_content.menu_title or page_content.title
+        else:
             title = _("Empty")
         return force_str(title)
 
@@ -205,6 +203,7 @@ class Page(MP_Node):
     def _clear_internal_cache(self):
         self.urls_cache = {}
         self.page_content_cache = {}
+        self.admin_content_cache = {}
 
         if hasattr(self, '_prefetched_objects_cache'):
             del self._prefetched_objects_cache
@@ -726,12 +725,23 @@ class Page(MP_Node):
         for translation in self.pagecontent_set(manager="admin_manager").current_content().all():
             self.admin_content_cache.setdefault(translation.language, translation)
 
-    def get_admin_content(self, language):
+    def get_admin_content(self, language, fallback=False):
         from cms.models.contentmodels import EmptyPageContent
 
         if not self.admin_content_cache:
             self.set_admin_content_cache()
-        return self.admin_content_cache.get(language, EmptyPageContent(language=language, page=self))
+        page_content = self.admin_content_cache.get(language, EmptyPageContent(language=language, page=self))
+        if not page_content and fallback:
+            for lang in i18n.get_fallback_languages(language):
+                page_content = self.admin_content_cache.get(lang)
+                if page_content:
+                    return page_content
+            if fallback == "force":
+                # Try any page content object
+                for item in self.admin_content_cache.values():
+                    if item:
+                        return item
+        return page_content
 
     def get_path_for_slug(self, slug, language):
         if self.is_home:

--- a/cms/templatetags/cms_admin.py
+++ b/cms/templatetags/cms_admin.py
@@ -106,7 +106,7 @@ def get_page_display_name(cms_page):
                 language = lang
                 break
         else:
-            for lang, item in cms_page.admin_content_cache.items():  # The content wass filled in the previous if
+            for lang, item in cms_page.admin_content_cache.items():  # The content was filled in the previous if clause
                 if not isinstance(item, EmptyPageContent):
                     language = lang
                     page_content = item

--- a/cms/templatetags/cms_admin.py
+++ b/cms/templatetags/cms_admin.py
@@ -93,35 +93,13 @@ def show_admin_menu_for_pages(context, descendants, depth=1):
 
 @register.simple_tag(takes_context=False)
 def get_page_display_name(cms_page):
-    from cms.models import EmptyPageContent
     language = get_language()
 
-    fallback_found = False
-    page_content = cms_page.get_admin_content(language)
-    if not page_content:
-        fallback_found = True
-        fallback_langs = i18n.get_fallback_languages(language)
-        for lang in fallback_langs:
-            if cms_page.get_admin_content(lang):
-                language = lang
-                break
-        else:
-            for lang, item in cms_page.admin_content_cache.items():  # The content was filled in the previous if clause
-                if not isinstance(item, EmptyPageContent):
-                    language = lang
-                    page_content = item
-                    break
-            else:
-                return _("Empty")
-    if page_content.title:
-        title = page_content.title
-    elif page_content.page_title:
-        title = page_content.page_title
-    elif page_content.menu_title:
-        title = page_content.menu_title
-    else:
+    page_content = cms_page.get_admin_content(language, fallback="force")
+    title = page_content.title or page_content.page_title or page_content.menu_title
+    if not title:
         title = cms_page.get_slug(language)
-    return mark_safe(f"<em>{title} ({language})</em>") if fallback_found else title
+    return title if page_content.language == language else mark_safe(f"<em>{title} ({page_content.language})</em>")
 
 
 class TreePublishRow(Tag):

--- a/cms/tests/test_log_entries.py
+++ b/cms/tests/test_log_entries.py
@@ -211,12 +211,15 @@ class LogPageOperationsTests(CMSTestCase):
         When a pages translation is deleted a log entry is created.
         """
         with self.login_user_context(self._admin_user):
-            page = create_page("page_a", "nav_playground.html", "en")
-            create_page_content(language='de', title="other title %s" % page.get_title('en'), page=page)
+            title_en = "page_a"
+            page = create_page(title_en, "nav_playground.html", "en")
+            create_page_content(language='de', title="other title %s" % title_en, page=page)
             endpoint = self.get_page_delete_translation_uri('en', page)
             post_data = {'post': 'yes', 'language': 'en'}
 
             response = self.client.post(endpoint, post_data)
+            page.page_content_cache = {}  # Reset cache of local object after translation is deleted
+
             # Test that the end point is valid
             self.assertEqual(response.status_code, 302)
             # Test that the log count is correct

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -79,16 +79,16 @@ class TemplatetagTests(CMSTestCase):
         }
         with self.settings(CMS_LANGUAGES=languages):
             with force_language('fr'):
-                page.page_content_cache = {'en': PageContent(page_title="test2", title="test2")}
+                page.admin_content_cache = {'en': PageContent(page_title="test2", title="test2", language="en")}
                 self.assertEqual('<em>test2 (en)</em>', force_str(get_page_display_name(page)))
-                page.page_content_cache = {'en': PageContent(page_title="test2")}
+                page.admin_content_cache = {'en': PageContent(page_title="test2", language="en")}
                 self.assertEqual('<em>test2 (en)</em>', force_str(get_page_display_name(page)))
-                page.page_content_cache = {'en': PageContent(menu_title="menu test2")}
+                page.admin_content_cache = {'en': PageContent(menu_title="menu test2", language="en")}
                 self.assertEqual('<em>menu test2 (en)</em>', force_str(get_page_display_name(page)))
-                page.page_content_cache = {'en': PageContent()}
+                page.admin_content_cache = {'en': PageContent(language="en")}
                 page.urls_cache = {'en': PageUrl(slug='slug-test2')}
                 self.assertEqual('<em>slug-test2 (en)</em>', force_str(get_page_display_name(page)))
-                page.page_content_cache = {'en': PageContent(), 'fr': EmptyPageContent('fr')}
+                page.admin_content_cache = {'en': PageContent(language="en"), 'fr': EmptyPageContent('fr')}
                 self.assertEqual('<em>slug-test2 (en)</em>', force_str(get_page_display_name(page)))
 
     def test_get_site_id_from_nothing(self):


### PR DESCRIPTION
## Description

Historically, django CMS has used a python cache on model level for page content objects: `page.page_content_cache`.

Since django CMS 4., this cache is filled either with user-visible objects (using the default `objects` manager) or with admin-visible objects, using the `admin_manager` manager. Since each request is, either from the user side or the admin side, this same cache can be used to hold different sets of page content objects. A side effect, however, lead to some page titles in fallback languages not to be shown in the page tree.

It turns out, however, that this was not consistently done, leading to unnecessary cache misses. 

This PR splits the caches into `page_content_cache`(traditional, user-facing) and `admin_content_cache` for the page admin, to make sure no side effects can happen.

This improves the cache hits and reduces the number of database hits for the page tree effectively removing a hidden N+1 issue. The response time should improve by 20%+ (tested with local sqlite).

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
