### PR TITLE
chore: Django 5.2-compatible test fixtures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,8 @@ jobs:
         exclude:
           - requirements-file: django-5.0.txt
             python-version: 3.9
+          - requirements-file: django-5.1.txt
+            python-version: 3.9
 
     services:
       postgres:
@@ -78,6 +80,8 @@ jobs:
         exclude:
           - requirements-file: django-5.0.txt
             python-version: 3.9
+          - requirements-file: django-5.1.txt
+            python-version: 3.9
 
     services:
       mysql:
@@ -130,6 +134,8 @@ jobs:
         ]
         exclude:
           - requirements-file: django-5.0.txt
+            python-version: 3.9
+          - requirements-file: django-5.1.txt
             python-version: 3.9
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres
+        image: postgres:15
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -205,7 +205,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres
+        image: postgres:15
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
         requirements-file: [
           django-4.2.txt,
           django-5.0.txt,
+          django-5.1.txt,
         ]
         os: [
           ubuntu-20.04,
@@ -26,7 +27,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12
+        image: postgres
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -69,6 +70,7 @@ jobs:
         requirements-file: [
           django-4.2.txt,
           django-5.0.txt,
+          django-5.1.txt,
         ]
         os: [
           ubuntu-20.04,
@@ -121,6 +123,7 @@ jobs:
         requirements-file: [
           django-4.2.txt,
           django-5.0.txt,
+          django-5.1.txt,
         ]
         os: [
           ubuntu-20.04,
@@ -196,7 +199,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13
+        image: postgres
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/cms/test_utils/testcases.py
+++ b/cms/test_utils/testcases.py
@@ -91,8 +91,8 @@ def _collectWarnings(observeWarning, f, *args, **kwargs):
 class BaseCMSTestCase:
     counter = 1
 
-    def _fixture_setup(self):
-        super()._fixture_setup()
+    def _pre_setup(self):
+        super()._pre_setup()
         self.create_fixtures()
         activate("en")
 

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -1609,6 +1609,29 @@ class PageActionsTestCase(PageTestBase):
             self.assertEqual(Page.objects.all().count(), 2)
 
 class PermissionsTestCase(PageTestBase):
+    def assertContainsPermissions(self, response):
+        try:
+            # Django >= 5.1
+            self.assertContains(
+                response,
+                '<h2 id="pagepermission_set-2-heading" class="inline-heading">Page permissions</h2>',
+                html=True,
+            )
+        except AssertionError:
+            # Django < 5.1
+            self.assertContains(response, '<h2>Page permissions</h2>', html=True)
+
+    def assertNotContainsPermissions(self, response):
+        try:
+            # Django >= 5.1
+            self.assertNotContains(
+                response,
+                '<h2 id="pagepermission_set-1-heading" class="inline-heading">Page permissions</h2>',
+                html=True,
+            )
+        except AssertionError:
+            # Django < 5.1
+            self.assertNotContains(response, '<h2>Page permissions</h2>', html=True)
 
     def _add_translation_to_page(self, page):
         translation = create_page_content(
@@ -2186,7 +2209,7 @@ class PermissionsOnGlobalTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertContainsPermissions(response)
             response = self.client.post(endpoint, data)
             self.assertEqual(response.status_code, 302)
             self.assertRedirects(response, endpoint)
@@ -2223,7 +2246,7 @@ class PermissionsOnGlobalTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertNotContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertNotContainsPermissions(response)
             self.client.post(endpoint, data)
             self.assertFalse(self._page_permission_exists(user=staff_user_2))
 
@@ -2265,7 +2288,7 @@ class PermissionsOnGlobalTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertContainsPermissions(response)
             response = self.client.post(endpoint, data)
             self.assertEqual(response.status_code, 302)
             self.assertRedirects(response, endpoint)
@@ -2315,7 +2338,7 @@ class PermissionsOnGlobalTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertNotContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertNotContainsPermissions(response)
             self.client.post(endpoint, data)
             self.assertFalse(
                 self._page_permission_exists(
@@ -2357,7 +2380,7 @@ class PermissionsOnGlobalTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertContainsPermissions(response)
             response = self.client.post(endpoint, data)
             self.assertEqual(response.status_code, 302)
             self.assertRedirects(response, endpoint)
@@ -2397,7 +2420,7 @@ class PermissionsOnGlobalTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertNotContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertNotContainsPermissions(response)
             self.client.post(endpoint, data)
             self.assertTrue(self._page_permission_exists(user=staff_user_2))
 
@@ -2431,7 +2454,7 @@ class PermissionsOnGlobalTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertContainsPermissions(response)
             response = self.client.post(endpoint, data)
             self.assertEqual(response.status_code, 302)
             self.assertRedirects(response, endpoint)
@@ -2468,7 +2491,7 @@ class PermissionsOnGlobalTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertNotContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertNotContainsPermissions(response)
             self.client.post(endpoint, data)
             self.assertFalse(self._page_permission_exists(user=staff_user_2, can_view=True))
 
@@ -2509,7 +2532,7 @@ class PermissionsOnGlobalTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertContainsPermissions(response)
             response = self.client.post(endpoint, data)
             self.assertEqual(response.status_code, 302)
             self.assertRedirects(response, endpoint)
@@ -2557,7 +2580,7 @@ class PermissionsOnGlobalTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertNotContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertNotContainsPermissions(response)
             self.client.post(endpoint, data)
             self.assertFalse(
                 self._page_permission_exists(
@@ -2601,7 +2624,7 @@ class PermissionsOnGlobalTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertContainsPermissions(response)
             response = self.client.post(endpoint, data)
             self.assertEqual(response.status_code, 302)
             self.assertRedirects(response, endpoint)
@@ -2643,7 +2666,7 @@ class PermissionsOnGlobalTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertNotContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertNotContainsPermissions(response)
             self.client.post(endpoint, data)
             self.assertTrue(self._page_permission_exists(user=staff_user_2, can_view=True))
 
@@ -3630,7 +3653,7 @@ class PermissionsOnPageTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertContainsPermissions(response)
             response = self.client.post(endpoint, data)
             self.assertEqual(response.status_code, 302)
             self.assertRedirects(response, endpoint)
@@ -3667,7 +3690,7 @@ class PermissionsOnPageTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertNotContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertNotContainsPermissions(response)
             self.client.post(endpoint, data)
             self.assertFalse(self._page_permission_exists(user=staff_user_2))
 
@@ -3709,7 +3732,7 @@ class PermissionsOnPageTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertContainsPermissions(response)
             response = self.client.post(endpoint, data)
             self.assertEqual(response.status_code, 302)
             self.assertRedirects(response, endpoint)
@@ -3759,7 +3782,7 @@ class PermissionsOnPageTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertNotContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertNotContainsPermissions(response)
             self.client.post(endpoint, data)
             self.assertFalse(
                 self._page_permission_exists(
@@ -3801,7 +3824,7 @@ class PermissionsOnPageTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertContainsPermissions(response)
             response = self.client.post(endpoint, data)
             self.assertEqual(response.status_code, 302)
             self.assertRedirects(response, endpoint)
@@ -3841,7 +3864,7 @@ class PermissionsOnPageTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertNotContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertNotContainsPermissions(response)
             self.client.post(endpoint, data)
             self.assertTrue(self._page_permission_exists(user=staff_user_2))
 
@@ -3875,7 +3898,7 @@ class PermissionsOnPageTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertContainsPermissions(response)
             response = self.client.post(endpoint, data)
             self.assertEqual(response.status_code, 302)
             self.assertRedirects(response, endpoint)
@@ -3912,7 +3935,7 @@ class PermissionsOnPageTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertNotContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertNotContainsPermissions(response)
             self.client.post(endpoint, data)
             self.assertFalse(self._page_permission_exists(user=staff_user_2, can_view=True))
 
@@ -3953,7 +3976,7 @@ class PermissionsOnPageTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertContainsPermissions(response)
             response = self.client.post(endpoint, data)
             self.assertEqual(response.status_code, 302)
             self.assertRedirects(response, endpoint)
@@ -4001,7 +4024,7 @@ class PermissionsOnPageTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertNotContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertNotContainsPermissions(response)
             self.client.post(endpoint, data)
             self.assertFalse(
                 self._page_permission_exists(
@@ -4045,7 +4068,7 @@ class PermissionsOnPageTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertContainsPermissions(response)
             response = self.client.post(endpoint, data)
             self.assertEqual(response.status_code, 302)
             self.assertRedirects(response, endpoint)
@@ -4087,7 +4110,7 @@ class PermissionsOnPageTest(PermissionsTestCase):
 
         with self.login_user_context(staff_user):
             response = self.client.get(endpoint)
-            self.assertNotContains(response, '<h2>Page permissions</h2>', html=True)
+            self.assertNotContainsPermissions(response)
             self.client.post(endpoint, data)
             self.assertTrue(self._page_permission_exists(user=staff_user_2, can_view=True))
 

--- a/test_requirements/databases.txt
+++ b/test_requirements/databases.txt
@@ -1,2 +1,2 @@
-psycopg2==2.9.5
+psycopg>=3.1.8
 mysqlclient==2.0.3

--- a/test_requirements/django-5.1.txt
+++ b/test_requirements/django-5.1.txt
@@ -1,2 +1,2 @@
 -r requirements_base.txt
-Django>=5.0,<5.1
+Django>=5.1,<5.2


### PR DESCRIPTION
## Description

This PR fixes the `CMSBaseTestCase` to stay compatible with Django 5.2. (Fixes #8006 )

Fixtures were loaded in `_fixture_setup()` which will turn into a classmethod in Django 5.2. Since the `CMSBaseTestCase` API expects the fixtures to be in a regular method, they are now loaded in `_pre_setup()`.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8006 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
