### PR TITLE
fix: Accept legacy action names for page permission check

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -571,7 +571,7 @@ class PageAdmin(admin.ModelAdmin):
             if can_change_global_permissions:
                 can_change = True
             else:
-                page_path = permission.page.node.path
+                page_path = permission.page.path
                 can_change = any(perm_tuple.contains(page_path) for perm_tuple in allowed_pages)
 
             row = PermissionRow(

--- a/cms/models/permissionmodels.py
+++ b/cms/models/permissionmodels.py
@@ -277,8 +277,7 @@ class PagePermission(AbstractPagePermission):
             raise ValidationError(message)
 
     def get_page_permission_tuple(self):
-        node = self.page.node
-        return PermissionTuple((self.grant_on, node.path))
+        return PermissionTuple((self.grant_on, self.page.path))
 
     def get_page_ids(self):
         import warnings

--- a/cms/test_utils/testcases.py
+++ b/cms/test_utils/testcases.py
@@ -476,8 +476,6 @@ class BaseCMSTestCase:
             self.fail(f"Warning {message} not given.")
         return result
 
-    assertWarns = failUnlessWarns
-
     def load_template_from_string(self, template):
         return engines['django'].from_string(template)
 

--- a/cms/tests/test_extensions.py
+++ b/cms/tests/test_extensions.py
@@ -435,7 +435,7 @@ class ExtensionAdminTestCase(CMSTestCase):
 
         message = "get_title_extension_admin has been deprecated and replaced by get_page_content_extension_admin"
         with self.login_user_context(self.admin):
-            self.assertWarns(
+            self.failUnlessWarns(
                 RemovedInDjangoCMS43Warning,
                 message,
                 lambda: self.client.get(self.page.get_absolute_url()),

--- a/cms/tests/test_permissions.py
+++ b/cms/tests/test_permissions.py
@@ -9,6 +9,7 @@ from cms.cache.permissions import (
 )
 from cms.models.permissionmodels import ACCESS_PAGE_AND_DESCENDANTS, GlobalPagePermission
 from cms.test_utils.testcases import CMSTestCase
+from cms.utils.compat.warnings import RemovedInDjangoCMS43Warning
 from cms.utils.page_permissions import (
     get_change_perm_tuples,
     has_generic_permission,
@@ -91,6 +92,8 @@ class PermissionCacheTests(CMSTestCase):
         self.assertTrue(can_publish)
 
     def test_has_generic_permissions_compatibiltiy(self):
+        from cms.utils.permissions import has_page_permission
+
         page_b = create_page("page_b", "nav_playground.html", "en",
                              created_by=self.user_super)
         assign_user_to_page(page_b, self.user_normal, can_view=True,
@@ -99,6 +102,12 @@ class PermissionCacheTests(CMSTestCase):
         self.assertTrue(has_generic_permission(page_b, self.user_normal, "change_page"))
         self.assertFalse(has_generic_permission(page_b, self.user_normal, "publish_page"))
 
+        message = ("has_page_permission is deprecated and will be removed in django CMS 4.3. "
+                   "Use cms.utils.page_permissions.has_generic_permission instead.")
         # Backwards compatibility: check if the old permission names work
-        self.assertTrue(has_generic_permission(page_b, self.user_normal, "change"))
-        self.assertFalse(has_generic_permission(page_b, self.user_normal, "publish"))
+        with self.assertWarns(RemovedInDjangoCMS43Warning) as w:
+            self.assertTrue(has_page_permission(self.user_normal, page_b, "change"))
+        self.assertEqual(str(w.warning), message)
+        with self.assertWarns(RemovedInDjangoCMS43Warning) as w:
+            self.assertFalse(has_page_permission(self.user_normal, page_b, "publish"))
+        self.assertEqual(str(w.warning), message)

--- a/cms/tests/test_permissions.py
+++ b/cms/tests/test_permissions.py
@@ -11,6 +11,7 @@ from cms.models.permissionmodels import ACCESS_PAGE_AND_DESCENDANTS, GlobalPageP
 from cms.test_utils.testcases import CMSTestCase
 from cms.utils.page_permissions import (
     get_change_perm_tuples,
+    has_generic_permission,
     user_can_publish_page,
 )
 
@@ -88,3 +89,16 @@ class PermissionCacheTests(CMSTestCase):
             Site.objects.get_current(),
         )
         self.assertTrue(can_publish)
+
+    def test_has_generic_permissions_compatibiltiy(self):
+        page_b = create_page("page_b", "nav_playground.html", "en",
+                             created_by=self.user_super)
+        assign_user_to_page(page_b, self.user_normal, can_view=True,
+                            can_change=True)
+
+        self.assertTrue(has_generic_permission(page_b, self.user_normal, "change_page"))
+        self.assertFalse(has_generic_permission(page_b, self.user_normal, "publish_page"))
+
+        # Backwards compatibility: check if the old permission names work
+        self.assertTrue(has_generic_permission(page_b, self.user_normal, "change"))
+        self.assertFalse(has_generic_permission(page_b, self.user_normal, "publish"))

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -109,7 +109,7 @@ class PlaceholderTestCase(TransactionCMSTestCase):
         self.assertEqual(sorted(placeholders), sorted(['new_one', 'new_two', 'new_three']))
 
     def test_placeholder_scanning_duplicate(self):
-        placeholders = self.assertWarns(
+        placeholders = self.failUnlessWarns(
             DuplicatePlaceholderWarning,
             'Duplicate {% placeholder "one" %} in template placeholder_tests/test_seven.html.',
             _get_placeholder_slots, 'placeholder_tests/test_seven.html'

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -693,7 +693,7 @@ class PluginsTestCase(PluginsTestBaseCase):
         def get_page(plugin):
             return plugin.page
 
-        self.assertWarns(
+        self.failUnlessWarns(
             DontUsePageAttributeWarning,
             "Don't use the page attribute on CMSPlugins! "
             "CMSPlugins are not guaranteed to have a page associated with them!",

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -406,6 +406,7 @@ class ContextTests(CMSTestCase):
                 template = Variable('CMS_TEMPLATE').resolve(response.context)
                 self.assertEqual(template, page_template)
 
+
 class EndpointTests(CMSTestCase):
 
     def setUp(self) -> None:
@@ -437,7 +438,7 @@ class EndpointTests(CMSTestCase):
         self._add_plugin_to_placeholder(placeholder, "TextPlugin", language="fr")
         with force_language("fr"):
             setting, _ = UserSettings.objects.get_or_create(user=self.get_superuser())
-            setting.language="fr"
+            setting.language = "fr"
             setting.save()
             structure_endpoint_url = admin_reverse(
                 "cms_placeholder_render_object_structure",

--- a/cms/utils/page_permissions.py
+++ b/cms/utils/page_permissions.py
@@ -540,14 +540,19 @@ def has_generic_permission(page, user, action, site=None, check_global=True, use
     page_path = page.node.path
     actions_map = {
         'add_page': get_add_perm_tuples,
+        'add': get_add_perm_tuples,
         'change_page': get_change_perm_tuples,
+        'change': get_change_perm_tuples,
         'change_page_advanced_settings': get_change_advanced_settings_perm_tuples,
         'change_page_permissions': get_change_permissions_perm_tuples,
         'delete_page': get_delete_perm_tuples,
+        'delete': get_delete_perm_tuples,
         'delete_page_translation': get_delete_perm_tuples,
         'publish_page': get_publish_perm_tuples,
+        'publish': get_publish_perm_tuples,
         'move_page': get_move_page_perm_tuples,
         'view_page': get_view_perm_tuples,
+        'view': get_view_perm_tuples,
     }
 
     func = actions_map[action]

--- a/cms/utils/page_permissions.py
+++ b/cms/utils/page_permissions.py
@@ -537,22 +537,17 @@ def has_generic_permission(page, user, action, site=None, check_global=True, use
     if site is None:
         site = get_current_site()
 
-    page_path = page.node.path
+    page_path = page.path
     actions_map = {
         'add_page': get_add_perm_tuples,
-        'add': get_add_perm_tuples,
         'change_page': get_change_perm_tuples,
-        'change': get_change_perm_tuples,
         'change_page_advanced_settings': get_change_advanced_settings_perm_tuples,
         'change_page_permissions': get_change_permissions_perm_tuples,
         'delete_page': get_delete_perm_tuples,
-        'delete': get_delete_perm_tuples,
         'delete_page_translation': get_delete_perm_tuples,
         'publish_page': get_publish_perm_tuples,
-        'publish': get_publish_perm_tuples,
         'move_page': get_move_page_perm_tuples,
         'view_page': get_view_perm_tuples,
-        'view': get_view_perm_tuples,
     }
 
     func = actions_map[action]

--- a/cms/utils/permissions.py
+++ b/cms/utils/permissions.py
@@ -223,6 +223,17 @@ def has_page_permission(user, page, action, use_cache=True):
                   "Use cms.utils.page_permissions.has_generic_permission instead.",
                   RemovedInDjangoCMS43Warning, stacklevel=2)
 
+    action_map = {
+        "change": "change_page",
+        "add": "add_page",
+        "move": "move_page",
+        "publish": "publish_page",
+        "delete": "delete_page",
+        "view": "view_page",
+    }
+    if action in action_map:
+        action = action_map[action]
+
     return has_generic_permission(page, user, action, site=page.site, check_global=False, use_cache=use_cache)
 
 

--- a/docs/upgrade/4.2.0.rst
+++ b/docs/upgrade/4.2.0.rst
@@ -95,6 +95,13 @@ Miscellaneous
   on page content objects. Use ``cms.cms_menus.get_visible_page_contents``
   instead.
 
+* The ``cms.test_utils.testcases.CMSTestCase`` class's ``assertWarns`` has been
+  removed since it was an alias of ``CMSTestCase.failUnlessWarns`` and shadows
+  Python's ``assertWarns``. In your test cases, use
+  Python's ``assertWarns`` instead, or use the ``failUnlessWarns`` method
+  of ``CMSTestCase`` which retains the syntax of the original method.
+
+
 Features deprecated in 4.2.0
 ============================
 


### PR DESCRIPTION
## Description

Some 3rd party apps use outdated action names for checking page permissions. This PR adds those names.

Fixes #8020 for v4

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8020 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
