### PR TITLE
fix: Sitemap: Return a QuerySet in CMSSitemap.items()

### DIFF
--- a/cms/sitemaps/cms_sitemap.py
+++ b/cms/sitemaps/cms_sitemap.py
@@ -1,5 +1,5 @@
 from django.contrib.sitemaps import Sitemap
-from django.db.models import OuterRef, Q, Subquery
+from django.db.models import OuterRef, Q, QuerySet, Subquery
 
 from cms.models import PageContent, PageUrl
 from cms.utils import get_current_site
@@ -15,10 +15,10 @@ def from_iterable(iterables):
 
 
 class CMSSitemap(Sitemap):
-    changefreq = "monthly"
-    priority = 0.5
+    changefreq: str = "monthly"
+    priority: float = 0.5
 
-    def items(self):
+    def items(self) -> QuerySet:
         #
         # It is counter-productive to provide entries for:
         #   > Pages which redirect:
@@ -42,22 +42,25 @@ class CMSSitemap(Sitemap):
         # If, for some reason, you require redirecting pages (PageContent) to be
         # included, simply create a new class inheriting from this one, and
         # supply a new items() method which doesn't filter out the redirects.
+        #
+        # Even though items() can also return a sequence, we should return a
+        # QuerySet in this case in order to be compatible with
+        # djangocms-page-sitemap.
         site = get_current_site()
         languages = get_public_languages(site_id=site.pk)
 
-        return list(
-            PageUrl
-            .objects
-            .get_for_site(site)
+        return (
+            PageUrl.objects.get_for_site(site)
             .filter(language__in=languages, path__isnull=False, page__login_required=False)
-            .order_by('page__path')
+            .order_by("page__path")
             .select_related("page")
-            .annotate(content_pk=Subquery(
-                PageContent.objects
-                .filter(page=OuterRef("page"), language=OuterRef("language"))
-                .filter(Q(redirect="") | Q(redirect=None))
-                .values_list("pk")[:1]
-            ))
+            .annotate(
+                content_pk=Subquery(
+                    PageContent.objects.filter(page=OuterRef("page"), language=OuterRef("language"))
+                    .filter(Q(redirect="") | Q(redirect=None))
+                    .values_list("pk")[:1]
+                )
+            )
             .filter(content_pk__isnull=False)  # Remove page content with redirects
         )
 

--- a/cms/tests/test_sitemap.py
+++ b/cms/tests/test_sitemap.py
@@ -9,6 +9,7 @@ from cms.utils.conf import get_cms_setting
 
 protocol = "http" if DJANGO_4_2 else "https"
 
+
 class SitemapTestCase(CMSTestCase):
     def setUp(self):
         """
@@ -27,41 +28,41 @@ class SitemapTestCase(CMSTestCase):
               + P8 (de, en)
         """
         defaults = {
-            'template': 'nav_playground.html',
-            'language': 'en',
+            "template": "nav_playground.html",
+            "language": "en",
         }
         with self.settings(CMS_PERMISSION=False):
-            p1 = create_page('P1', in_navigation=True, **defaults)
-            create_page_content(language='de', title="other title %s" % p1.get_title('en'), page=p1)
+            p1 = create_page("P1", in_navigation=True, **defaults)
+            create_page_content(language="de", title="other title %s" % p1.get_title("en"), page=p1)
 
-            p4 = create_page('P4', in_navigation=True, **defaults)
-            create_page_content(language='de', title="other title %s" % p4.get_title('en'), page=p4)
+            p4 = create_page("P4", in_navigation=True, **defaults)
+            create_page_content(language="de", title="other title %s" % p4.get_title("en"), page=p4)
 
-            p6 = create_page('P6', in_navigation=False, **defaults)
-            create_page_content(language='de', title="other title %s" % p6.get_title('en'), page=p6)
+            p6 = create_page("P6", in_navigation=False, **defaults)
+            create_page_content(language="de", title="other title %s" % p6.get_title("en"), page=p6)
 
-            p2 = create_page('P2', in_navigation=True, parent=p1, **defaults)
-            create_page_content(language='de', title="other title %s" % p2.get_title('en'), page=p2)
+            p2 = create_page("P2", in_navigation=True, parent=p1, **defaults)
+            create_page_content(language="de", title="other title %s" % p2.get_title("en"), page=p2)
 
-            p3 = create_page('P3', in_navigation=True, parent=p2, **defaults)
-            create_page_content(language='de', title="other title %s" % p3.get_title('en'), page=p3)
+            p3 = create_page("P3", in_navigation=True, parent=p2, **defaults)
+            create_page_content(language="de", title="other title %s" % p3.get_title("en"), page=p3)
 
-            p5 = create_page('P5', in_navigation=True, parent=p4, **defaults)
-            create_page_content(language='de', title="other title %s" % p5.get_title('en'), page=p5)
+            p5 = create_page("P5", in_navigation=True, parent=p4, **defaults)
+            create_page_content(language="de", title="other title %s" % p5.get_title("en"), page=p5)
 
-            p7 = create_page('P7', in_navigation=True, parent=p6, **defaults)
-            create_page_content(language='de', title="other title %s" % p7.get_title('en'), page=p7)
+            p7 = create_page("P7", in_navigation=True, parent=p6, **defaults)
+            create_page_content(language="de", title="other title %s" % p7.get_title("en"), page=p7)
 
-            p8 = create_page('P8', in_navigation=True, parent=p6, **defaults)
-            create_page_content(language='de', title="other title %s" % p8.get_title('en'), page=p8)
+            p8 = create_page("P8", in_navigation=True, parent=p6, **defaults)
+            create_page_content(language="de", title="other title %s" % p8.get_title("en"), page=p8)
 
-            p9 = create_page('P9', in_navigation=True, parent=p1, **defaults)
-            create_page_content(language='de', title="other title %s" % p9.get_title('en'), page=p9)
+            p9 = create_page("P9", in_navigation=True, parent=p1, **defaults)
+            create_page_content(language="de", title="other title %s" % p9.get_title("en"), page=p9)
 
-            p10 = create_page('P10', in_navigation=True, parent=p9, **defaults)
-            create_page_content(language='de', title="other title %s" % p10.get_title('en'), page=p10)
+            p10 = create_page("P10", in_navigation=True, parent=p9, **defaults)
+            create_page_content(language="de", title="other title %s" % p10.get_title("en"), page=p10)
 
-            create_page('P11', in_navigation=True, parent=p9, **defaults)
+            create_page("P11", in_navigation=True, parent=p9, **defaults)
 
     def test_sitemap_count(self):
         """
@@ -79,11 +80,11 @@ class SitemapTestCase(CMSTestCase):
         sitemap = CMSSitemap()
         urlset = sitemap.get_urls()
         for item in urlset:
-            if item['item'].path:
+            if item["item"].path:
                 url = f'{protocol}://example.com/{item["item"].language}/{item["item"].path}/'
             else:
                 url = f'{protocol}://example.com/{item["item"].language}/'
-            self.assertEqual(item['location'], url)
+            self.assertEqual(item["location"], url)
 
     def test_sitemap_urls(self):
         """
@@ -93,28 +94,28 @@ class SitemapTestCase(CMSTestCase):
         locations = []
         urlset = sitemap.get_urls()
         for item in urlset:
-            locations.append(item['location'])
+            locations.append(item["location"])
         for page_url in PageUrl.objects.all():
             if page_url.path:
-                url = f'{protocol}://example.com/{page_url.language}/{page_url.path}/'
+                url = f"{protocol}://example.com/{page_url.language}/{page_url.path}/"
             else:
-                url = f'{protocol}://example.com/{page_url.language}/'
+                url = f"{protocol}://example.com/{page_url.language}/"
             self.assertTrue(url in locations)
 
     def test_sitemap_uses_public_languages_only(self):
         """
         Pages on the sitemap should only show public languages.
         """
-        lang_settings = copy.deepcopy(get_cms_setting('LANGUAGES'))
+        lang_settings = copy.deepcopy(get_cms_setting("LANGUAGES"))
         # sanity check
-        assert lang_settings[1][1]['code'] == 'de'
+        assert lang_settings[1][1]["code"] == "de"
         # set german as private
-        lang_settings[1][1]['public'] = False
+        lang_settings[1][1]["public"] = False
 
         with self.settings(CMS_LANGUAGES=lang_settings):
             for item in CMSSitemap().get_urls():
-                url = f'{protocol}://example.com/en/'
+                url = f"{protocol}://example.com/en/"
 
-                if item['item'].path:
-                    url += item['item'].path + '/'
-                self.assertEqual(item['location'], url)
+                if item["item"].path:
+                    url += item["item"].path + "/"
+                self.assertEqual(item["location"], url)

--- a/cms/tests/test_sitemap.py
+++ b/cms/tests/test_sitemap.py
@@ -1,5 +1,7 @@
 import copy
 
+from django.db.models import QuerySet
+
 from cms.api import create_page, create_page_content
 from cms.models import PageUrl
 from cms.sitemaps import CMSSitemap
@@ -119,3 +121,11 @@ class SitemapTestCase(CMSTestCase):
                 if item["item"].path:
                     url += item["item"].path + "/"
                 self.assertEqual(item["location"], url)
+
+    def test_sitemap_items_type(self):
+        """
+        Ensure that CMSSitemap.items() returns a QuerySet, not a list.
+        """
+        sitemap = CMSSitemap()
+        items = sitemap.items()
+        self.assertIsInstance(items, QuerySet, "CMSSitemap.items() must return a QuerySet.")


### PR DESCRIPTION
## Description

According to the Django docs also a sequence like a list is allowed as the return value type of CMSSitemap.items(),
but djangocms_page_sitemap applies exclude, which only works with `QuerySet`.

This PR changes the type of the return value back to `QuerySet`.

## Related resources

* https://github.com/nephila/djangocms-page-sitemap/blob/5c1a44fa3b1238a5b5d43a7f2f0dd934aa659743/djangocms_page_sitemap/sitemap.py#L14

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
