### PR TITLE
docs: documentation update on PageContent

### DIFF
--- a/docs/how_to/18-extending_page_contents.rst
+++ b/docs/how_to/18-extending_page_contents.rst
@@ -271,12 +271,12 @@ PageContent extensions
 ++++++++++++++++++++++
 
 In order to retrieve a page content extension within a template, get the ``PageContent``
-object using ``request.current_page.get_pagecontent_obj``. Using the example above, we
+object using ``request.current_page.get_content_obj``. Using the example above, we
 could use:
 
 .. code-block::
 
-    {{ request.current_page.get_pagecontent_obj.ratingextension.rating }}
+    {{ request.current_page.get_content_obj.ratingextension.rating }}
 
 With menus
 ~~~~~~~~~~


### PR DESCRIPTION
## Description
- Fixes #8016: Extended PageContent documentation wrong 
   - The issue was a documentation error in a code block which led to an error in retrieving the page content extension in a template. 
- #8016 

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->



<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->



## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
