### PR TITLE
fix: Language tabs didn't show existing content due to caching issue

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -740,11 +740,7 @@ class PageContentAdmin(admin.ModelAdmin):
         key is used if no field is provided. Return ``None`` if no match is
         found or the object_id fails validation.
         """
-        obj = super().get_object(request, object_id, from_field)
-
-        if obj:
-            obj.page.admin_content_cache[obj.language] = obj
-        return obj
+        return super().get_object(request, object_id, from_field)
 
     def get_admin_url(self, action, *args):
         url_name = f"{self.opts.app_label}_{self.opts.model_name}_{action}"

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -734,14 +734,6 @@ class PageContentAdmin(admin.ModelAdmin):
         # Block the admin log for change. A signal takes care of this!
         return
 
-    def get_object(self, request, object_id, from_field=None):
-        """
-        Return an instance matching the field and value provided, the primary
-        key is used if no field is provided. Return ``None`` if no match is
-        found or the object_id fails validation.
-        """
-        return super().get_object(request, object_id, from_field)
-
     def get_admin_url(self, action, *args):
         url_name = f"{self.opts.app_label}_{self.opts.model_name}_{action}"
         return admin_reverse(url_name, args=args)

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -28,6 +28,12 @@ from menus.menu_pool import menu_pool
 logger = getLogger(__name__)
 
 
+class AdminCacheDict(dict):
+    """Dictionary that disallows setting individual items to prevent accidental cache corruption."""
+    def __setitem__(self, key, value):
+        raise ValueError("Do not set individual items in the admin cache dict. Use the clear_cache method instead.")
+
+
 class Page(MP_Node):
     """
     A ``Page`` is the basic unit of site structure in django CMS. The CMS uses a hierarchical page model: each page
@@ -139,7 +145,7 @@ class Page(MP_Node):
         self.urls_cache = {}
         self.page_content_cache = {}
         #: Internal cache for page content objects visible publicly
-        self.admin_content_cache = {}
+        self.admin_content_cache = AdminCacheDict()
         #: Internal cache for page content objects visible in the admin (i.e. to staff users.)
         #: Might be larger than the page_content_cache
 
@@ -203,7 +209,7 @@ class Page(MP_Node):
     def _clear_internal_cache(self):
         self.urls_cache = {}
         self.page_content_cache = {}
-        self.admin_content_cache = {}
+        self.admin_content_cache = AdminCacheDict()
 
         if hasattr(self, '_prefetched_objects_cache'):
             del self._prefetched_objects_cache
@@ -722,6 +728,7 @@ class Page(MP_Node):
             self.page_content_cache.setdefault(translation.language, translation)
 
     def set_admin_content_cache(self):
+        self.admin_conent_cache = AdminCacheDict()
         for translation in self.pagecontent_set(manager="admin_manager").latest_content().all():
             self.admin_content_cache.setdefault(translation.language, translation)
 


### PR DESCRIPTION
## Description

This PR resolves issue #8044 by not setting the `admin_content_cache` when calling `get_object`. Doing so resulted in partial caches being present for only the currently selected language, meaning that any use of the cache would yield an `EmptyPageContent` object instead of the actual content.

This breaks the language tabs inside the page edit form. Not setting the cache partially now triggers the `set_admin_content_cache` method and resolves this issue.

## Related resources

#8044 

## Checklist

* [x] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
