### PR TITLE
fix: Menus crashed when unexpected page content was present

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           django-5.1.txt,
         ]
         os: [
-          ubuntu-20.04,
+          ubuntu-latest,
         ]
         exclude:
           - requirements-file: django-5.0.txt
@@ -225,7 +225,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15
+        image: postgres:17
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -1390,7 +1390,7 @@ class PageContentAdmin(admin.ModelAdmin):
             Prefetch(
                 'pagecontent_set',
                 to_attr='filtered_translations',
-                queryset=PageContent.admin_manager.get_queryset(),
+                queryset=PageContent.admin_manager.get_queryset().latest_content(),
             ),
         )
         rows = self.get_tree_rows(

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -813,18 +813,6 @@ class PageContentAdmin(admin.ModelAdmin):
         # Block the admin log for change. A signal takes care of this!
         return
 
-    def get_object(self, request, object_id, from_field=None):
-        """
-        Return an instance matching the field and value provided, the primary
-        key is used if no field is provided. Return ``None`` if no match is
-        found or the object_id fails validation.
-        """
-        obj = super().get_object(request, object_id, from_field)
-
-        if obj:
-            obj.page.admin_content_cache[obj.language] = obj
-        return obj
-
     def get_admin_url(self, action, *args):
         url_name = f"{self.opts.app_label}_{self.opts.model_name}_{action}"
         return admin_reverse(url_name, args=args)

--- a/cms/cms_menus.py
+++ b/cms/cms_menus.py
@@ -140,8 +140,8 @@ def get_menu_node_for_page(renderer, page, language, fallbacks=None, endpoint=Fa
     for lang in [language] + fallbacks:
         translation = page.page_content_cache.get(lang)
 
-        if translation:
-            page_url = page.urls_cache[translation.language]
+        if translation and lang in page.urls_cache:
+            page_url = page.urls_cache[lang]
             # Do we have a redirectURL?
             attr["redirect_url"] = translation.redirect  # save redirect URL if any
 

--- a/cms/cms_menus.py
+++ b/cms/cms_menus.py
@@ -141,7 +141,7 @@ def get_menu_node_for_page(renderer, page, language, fallbacks=None, endpoint=Fa
         translation = page.page_content_cache.get(lang)
 
         if translation:
-            page_url = page.urls_cache[lang]
+            page_url = page.urls_cache[translation.language]
             # Do we have a redirectURL?
             attr["redirect_url"] = translation.redirect  # save redirect URL if any
 

--- a/cms/models/managers.py
+++ b/cms/models/managers.py
@@ -310,7 +310,7 @@ class PagePermissionManager(BasicPagePermissionManager):
         from cms.models import PermissionTuple
         allow_list = Q()
         for perm_tuple in get_change_permissions_perm_tuples(user, site, check_global=False):
-           allow_list |= PermissionTuple(perm_tuple).allow_list("page__node")
+            allow_list |= PermissionTuple(perm_tuple).allow_list("page__node")
 
         # get permission set, but without objects targeting user, or any group
         # in which he can be

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -21,7 +21,7 @@ from cms.models.managers import PageManager, PageNodeManager, PageUrlManager
 from cms.utils import i18n
 from cms.utils.compat.warnings import RemovedInDjangoCMS43Warning
 from cms.utils.conf import get_cms_setting
-from cms.utils.i18n import get_current_language, get_fallback_languages
+from cms.utils.i18n import get_current_language
 from cms.utils.page import get_clean_username
 from menus.menu_pool import menu_pool
 

--- a/cms/models/permissionmodels.py
+++ b/cms/models/permissionmodels.py
@@ -231,7 +231,7 @@ class PermissionTuple(tuple):
         return False
 
     def allow_list(self, filter: str = "", steplen: int = TreeNode.steplen) -> Q:
-        if filter !="":
+        if filter != "":
             filter = f"{filter}__"
         grant_on, path = self
         if grant_on == ACCESS_PAGE:

--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -741,7 +741,7 @@ class Placeholder(models.Model):
     def _shift_plugin_positions(self, language, start, offset=None):
         if offset is None:
             offset = self.get_last_plugin_position(language) or 0
-    
+
         self.get_plugins(language).filter(
             position__gte=start
         ).update(position=models.F('position') + offset)

--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -784,6 +784,15 @@ class Placeholder(models.Model):
             cursor.execute(sql)
         elif db_vendor == 'postgresql':
             sql = (
+                'WITH RowNbrs AS ('
+                '    SELECT ID, ROW_NUMBER() OVER (ORDER BY position, id) AS RowNbr'
+                '    FROM table'
+                '    WHERE placeholder_id=%s AND language=%s'
+                '）UPDATE table'
+                'SET position = RowNbrs.RowNbr'
+                'FROM RowNbrs WHERE table.id = RowNbrs.id'
+            )
+            (
                 'UPDATE {0} '
                 'SET position = RowNbrs.RowNbr '
                 'FROM ('

--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -692,7 +692,7 @@ class Placeholder(models.Model):
             self._shift_plugin_positions(
                 instance.language,
                 start=instance.position,
-                offset=last_plugin.position,
+                offset=last_plugin.position + 1,
             )
             self._recalculate_plugin_positions(instance.language)
 
@@ -740,8 +740,10 @@ class Placeholder(models.Model):
 
     def _shift_plugin_positions(self, language, start, offset=None):
         if offset is None:
-            offset = self.get_last_plugin_position(language) or 0
-
+            offset = self.get_last_plugin_position(language)
+            if offset is None:
+                return
+            offset += 1
         self.get_plugins(language).filter(
             position__gte=start
         ).update(position=models.F('position') + offset)

--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -741,6 +741,7 @@ class Placeholder(models.Model):
     def _shift_plugin_positions(self, language, start, offset=None):
         if offset is None:
             offset = self.get_last_plugin_position(language) or 0
+    
         self.get_plugins(language).filter(
             position__gte=start
         ).update(position=models.F('position') + offset)

--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -692,7 +692,7 @@ class Placeholder(models.Model):
             self._shift_plugin_positions(
                 instance.language,
                 start=instance.position,
-                offset=last_plugin.position + 1,
+                offset=last_plugin.position,
             )
             self._recalculate_plugin_positions(instance.language)
 
@@ -740,10 +740,7 @@ class Placeholder(models.Model):
 
     def _shift_plugin_positions(self, language, start, offset=None):
         if offset is None:
-            offset = self.get_last_plugin_position(language)
-            if offset is None:
-                return
-            offset += 1
+            offset = self.get_last_plugin_position(language) or 0
         self.get_plugins(language).filter(
             position__gte=start
         ).update(position=models.F('position') + offset)

--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -784,13 +784,6 @@ class Placeholder(models.Model):
             cursor.execute(sql)
         elif db_vendor == 'postgresql':
             sql = (
-                'WITH RowNbrs AS ('
-                '    SELECT ID, ROW_NUMBER() OVER (ORDER BY position) AS RowNbr'
-                '    FROM {0} WHERE placeholder_id=%s AND language=%s '
-                ') UPDATE {0} SET position = RowNbrs.RowNbr '
-                'FROM RowNbrs WHERE {0}.id = RowNbrs.id'
-            )
-            (
                 'UPDATE {0} '
                 'SET position = RowNbrs.RowNbr '
                 'FROM ('

--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -785,12 +785,10 @@ class Placeholder(models.Model):
         elif db_vendor == 'postgresql':
             sql = (
                 'WITH RowNbrs AS ('
-                '    SELECT ID, ROW_NUMBER() OVER (ORDER BY position, id) AS RowNbr'
-                '    FROM table'
-                '    WHERE placeholder_id=%s AND language=%s'
-                '）UPDATE table'
-                'SET position = RowNbrs.RowNbr'
-                'FROM RowNbrs WHERE table.id = RowNbrs.id'
+                '    SELECT ID, ROW_NUMBER() OVER (ORDER BY position) AS RowNbr'
+                '    FROM {0} WHERE placeholder_id=%s AND language=%s '
+                ') UPDATE {0} SET position = RowNbrs.RowNbr '
+                'FROM RowNbrs WHERE {0}.id = RowNbrs.id'
             )
             (
                 'UPDATE {0} '

--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -557,7 +557,6 @@ class ContentRenderer(BaseRenderer):
                 language_cache[placeholder.pk] = cached_value
         return language_cache.get(placeholder.pk)
 
-
     def _get_content_object(self, page, slots=None):
         if self.toolbar.get_object() == page:
             # Current object belongs to the page itself

--- a/cms/templates/cms/welcome.html
+++ b/cms/templates/cms/welcome.html
@@ -40,7 +40,7 @@
 
         <section class="cms-welcome-cards">
             <div class="cms-welcome-section">
-                {% blocktranslate %}
+                {% blocktrans %}
                     <h2>Help Funding</h2>
                     <p>
                         Your funding directly benefits the product, mainly through the
@@ -50,10 +50,10 @@
                         A quick way for yourself or your organisation to donate is on
                         <a href="https://github.com/sponsors/django-cms">Github Sponsors</a>.
                     </p>
-                {% endblocktranslate %}
+                {% endblocktrans %}
             </div>
             <div class="cms-welcome-section">
-                {% blocktranslate %}
+                {% blocktrans %}
                     <h2>Join Us</h2>
                     <p>
                         The django CMS Association is a non-profit organisation that funds and steers the development of
@@ -63,10 +63,10 @@
                         You can <a href="https://www.django-cms.org/en/memberships/">join both as an individual or as an
                         organisation</a>.
                     </p>
-                {% endblocktranslate %}
+                {% endblocktrans %}
             </div>
             <div class="cms-welcome-section">
-                {% blocktranslate %}
+                {% blocktrans %}
                     <h2>Contribute</h2>
                     <ul>
                         <li><a href="https://www.django-cms.org/en/contribute/">Contribute code:</a> fix a bug or
@@ -76,7 +76,7 @@
                         <li><a href="https://www.django-cms.org/en/repositories-plugins/">Open-source your work:</a>
                             Make the ecosystem strong.</li>
                     </ul>
-                {% endblocktranslate %}
+                {% endblocktrans %}
             </div>
         </section>
 

--- a/cms/templatetags/cms_admin.py
+++ b/cms/templatetags/cms_admin.py
@@ -202,6 +202,7 @@ def boolean_icon(value):
         mapped_icon,
     )
 
+
 @register.tag(name="page_submit_row")
 class PageSubmitRow(InclusionTag):
     name = 'page_submit_row'

--- a/cms/tests/test_admin.py
+++ b/cms/tests/test_admin.py
@@ -800,6 +800,7 @@ class AdminFormsTests(AdminTestsBase):
                 ))
             )
 
+
 class PagePropsMovedToPageContentTests(CMSTestCase):
 
     def test_moved_fields(self):
@@ -822,6 +823,7 @@ class PagePropsMovedToPageContentTests(CMSTestCase):
 
         for field in filtered_page_content_fields:
             self.assertIn(field, change_page_form_fieldsets)
+
 
 class AdminPageEditContentSizeTests(AdminTestsBase):
     """

--- a/cms/tests/test_extensions.py
+++ b/cms/tests/test_extensions.py
@@ -16,7 +16,7 @@ from cms.test_utils.project.extensionapp.models import (
 )
 from cms.test_utils.testcases import CMSTestCase
 from cms.toolbar_pool import toolbar_pool
-from cms.utils.compat.warnings import RemovedInDjangoCMS42Warning, RemovedInDjangoCMS43Warning
+from cms.utils.compat.warnings import RemovedInDjangoCMS43Warning
 from cms.utils.urlutils import admin_reverse
 
 
@@ -427,6 +427,7 @@ class ExtensionAdminTestCase(CMSTestCase):
 
         class SampleExtensionToolbar2(ExtensionToolbar):
             model = MyPageContentExtension
+
             def populate(self):
                 nonlocal urls
                 urls = self.get_title_extension_admin()

--- a/cms/tests/test_i18n.py
+++ b/cms/tests/test_i18n.py
@@ -1,4 +1,3 @@
-from collections import deque
 from importlib import import_module
 from unittest.mock import patch
 
@@ -7,11 +6,6 @@ from django.template.context import Context
 from django.test.utils import override_settings
 
 from cms import api
-from cms.plugin_rendering import (
-    ContentRenderer,
-    LegacyRenderer,
-    StructureRenderer,
-)
 from cms.test_utils.testcases import CMSTestCase
 from cms.utils import get_language_from_request, i18n
 from cms.utils.compat import DJANGO_2_2
@@ -518,6 +512,7 @@ class TestLanguageFallbacks(CMSTestCase):
         self.assertEqual(response_fr.status_code, 200)
         response_en = self.client.get(page.get_absolute_url(language="en"))
         self.assertRedirects(response_en, page.get_absolute_url(language="fr"))
+
 
 @override_settings(
     LANGUAGE_CODE='en',

--- a/cms/tests/test_management.py
+++ b/cms/tests/test_management.py
@@ -288,7 +288,6 @@ class ManagementTestCase(CMSTestCase):
         max_positon = placeholder.cmsplugin_set.aggregate(models.Max('position'))['position__max']
         self.assertEqual(max_positon, 3)
 
-
     def test_uninstall_plugins_without_plugin(self):
         out = StringIO()
         management.call_command('cms', 'uninstall', 'plugins', PLUGIN, interactive=False, stdout=out)

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -1604,6 +1604,7 @@ class PageActionsTestCase(PageTestBase):
             self.assertRedirects(response, redirect_url)
             self.assertEqual(Page.objects.all().count(), 2)
 
+
 class PermissionsTestCase(PageTestBase):
     def assertContainsPermissions(self, response):
         try:
@@ -2695,7 +2696,6 @@ class PermissionsOnGlobalTest(PermissionsTestCase):
 
         self.assertIsNone(get_permission_cache(staff_user, "change_page"))
 
-
     def test_permission_cache_invalidation_on_group_remove(self):
         """
         Permissions cache is invalidated if the group relationship of a user is changed
@@ -2713,7 +2713,6 @@ class PermissionsOnGlobalTest(PermissionsTestCase):
         group.user_set.remove(staff_user)
 
         self.assertIsNone(get_permission_cache(staff_user, "change_page"))
-
 
     def test_user_can_copy_page(self):
         """

--- a/cms/tests/test_permmod.py
+++ b/cms/tests/test_permmod.py
@@ -165,7 +165,6 @@ class PermissionModeratorTests(CMSTestCase):
             self.assertEqual(response.status_code, 200)
             self.assertEqual(CMSPlugin.objects.count(), 1)
 
-
     def test_super_can_add_plugin(self):
         self._add_plugin(self.user_super, page=self.slave_page)
 

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -1376,6 +1376,10 @@ class PlaceholderFlatPluginTests(PlaceholderPluginTestsBase):
             .values_list('pk', flat=True)
         )
 
+        new_tree = self.get_plugins().values_list('pk', 'position')
+        expected = [(pk, pos) for pos, pk in enumerate(plugin_tree_all, 1)]
+        self.assertSequenceEqual(new_tree, expected)
+
         for plugin in self.get_plugins().filter(parent__isnull=True):
             for plugin_id in [plugin.pk] + tree[plugin.pk]:
                 plugin_tree_all.remove(plugin_id)

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -761,14 +761,14 @@ class PlaceholderTestCase(TransactionCMSTestCase):
 
         conf = {
             'col_left': {
-                'default_plugins' : [
+                'default_plugins': [
                     {
-                        'plugin_type':'TextPlugin',
-                        'values':{'body':'<p>en default body 1</p>'},
+                        'plugin_type': 'TextPlugin',
+                        'values': {'body': '<p>en default body 1</p>'},
                     },
                     {
-                        'plugin_type':'TextPlugin',
-                        'values':{'body':'<p>en default body 2</p>'},
+                        'plugin_type': 'TextPlugin',
+                        'values': {'body': '<p>en default body 2</p>'},
                     },
                 ]
             },

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -51,7 +51,7 @@ from cms.test_utils.project.pluginapp.plugins.validation.cms_plugins import (
 )
 from cms.test_utils.testcases import CMSTestCase
 from cms.toolbar.toolbar import CMSToolbar
-from cms.toolbar.utils import get_object_edit_url, get_toolbar_from_request
+from cms.toolbar.utils import get_object_edit_url
 from cms.utils.plugins import copy_plugins_to_placeholder, get_plugins
 
 

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -57,7 +57,6 @@ class TemplatetagTests(CMSTestCase):
         self.assertIn("/en", page_preview_url)
         self.assertIn("/de/", german_content_preview_url)
 
-
     def test_get_admin_tree_title(self):
         page = create_page("page_a", "nav_playground.html", "en")
         self.assertEqual(get_page_display_name(page), 'page_a')

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -12,7 +12,6 @@ from django.test.utils import override_settings
 from django.urls import clear_url_caches, reverse
 from django.utils.translation import override as force_language
 
-from cms import api
 from cms.api import create_page, create_page_content
 from cms.middleware.toolbar import ToolbarMiddleware
 from cms.models import PageContent, PagePermission, Placeholder, UserSettings
@@ -432,6 +431,7 @@ class ContextTests(CMSTestCase):
                 template = Variable('CMS_TEMPLATE').resolve(response.context)
                 self.assertEqual(template, page_template)
 
+
 class EndpointTests(CMSTestCase):
 
     def setUp(self) -> None:
@@ -463,7 +463,7 @@ class EndpointTests(CMSTestCase):
         self._add_plugin_to_placeholder(placeholder, "TextPlugin", language="fr")
         with force_language("fr"):
             setting, _ = UserSettings.objects.get_or_create(user=self.get_superuser())
-            setting.language="fr"
+            setting.language = "fr"
             setting.save()
             structure_endpoint_url = admin_reverse(
                 "cms_placeholder_render_object_structure",

--- a/cms/toolbar/utils.py
+++ b/cms/toolbar/utils.py
@@ -14,7 +14,6 @@ from django.utils.translation import (
 )
 
 from cms.constants import PLACEHOLDER_TOOLBAR_JS, PLUGIN_TOOLBAR_JS
-from cms.models import PageContent
 from cms.utils import get_language_list
 from cms.utils.conf import get_cms_setting
 from cms.utils.urlutils import admin_reverse
@@ -170,7 +169,7 @@ def get_object_edit_url(obj: models.Model, language: str = None) -> str:
     return url
 
 
-def get_object_preview_url(obj:models.Model, language: str = None) -> str:
+def get_object_preview_url(obj: models.Model, language: str = None) -> str:
     """
     Returns the url of the preview endpoint for the given object. The object must be frontend-editable
     and registered as such with cms.
@@ -206,6 +205,7 @@ def get_object_structure_url(obj: models.Model, language: str = None) -> str:
 
     with force_language(language):
         return admin_reverse('cms_placeholder_render_object_structure', args=[content_type.pk, obj.pk])
+
 
 def get_object_for_language(obj: models.Model, language: str, latest: bool = False) -> Optional[models.Model]:
     """

--- a/cms/utils/permissions.py
+++ b/cms/utils/permissions.py
@@ -10,7 +10,7 @@ from django.db.models import Q
 
 from cms.constants import ROOT_USER_LEVEL, SCRIPT_USERNAME
 from cms.exceptions import NoPermissionsException
-from cms.models import GlobalPagePermission, Page, PagePermission
+from cms.models import GlobalPagePermission, PagePermission
 from cms.utils.compat.dj import available_attrs
 from cms.utils.conf import get_cms_setting
 from cms.utils.page import get_clean_username

--- a/cms/views.py
+++ b/cms/views.py
@@ -94,7 +94,6 @@ def details(request, slug):
     # Get a Page model object from the request
     site = get_current_site()
     page = get_page_from_request(request, use_path=slug)
-    toolbar = get_toolbar_from_request(request)
     tree_nodes = TreeNode.objects.get_for_site(site)
 
     if not page and not slug and not tree_nodes.exists():


### PR DESCRIPTION
## Description

This PR fixes two issues with correct page content retrieval (fixes #8040 and #8037). Menus raised an exception if a page content for a non-configured language was present, but no page URL.

Due to the new menu system in 4.2 (https://github.com/django-cms/django-cms/pull/7956), this bug is not present in `develop-4`.


## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8040 
* #8050 
* https://github.com/django-cms/django-cms/pull/7956

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
