### PR TITLE
fix: Handle cms command raising error

### DIFF
--- a/cms/management/commands/subcommands/base.py
+++ b/cms/management/commands/subcommands/base.py
@@ -60,6 +60,8 @@ class SubcommandsCommand(BaseCommand):
         parser = CommandParser(
             prog=f"{os.path.basename(prog_name)} {subcommand}",
             description=self.help or None,
+            missing_args_message=getattr(self, "missing_args_message", None),
+            called_from_command_line=getattr(self, "_called_from_command_line", None),
             **kwargs
         )
         self.add_arguments(parser)

--- a/cms/tests/test_management.py
+++ b/cms/tests/test_management.py
@@ -304,6 +304,10 @@ class ManagementTestCase(CMSTestCase):
         self.assertEqual(out.getvalue(), "1 'TextPlugin' plugins uninstalled\n")
         self.assertEqual(CMSPlugin.objects.filter(plugin_type=PLUGIN).count(), 0)
 
+    def test_for_running_only_cms_command(self):
+        with self.assertRaises(CommandError) as e:
+            management.call_command('cms')
+        self.assertEqual(str(e.exception), 'Error: one of the available sub commands must be provided')
 
 class PageFixtureManagementTestCase(NavextendersFixture, CMSTestCase):
 


### PR DESCRIPTION
When "python manage.py cms" is run on the CLI;
it should not raise AttributeError, rather it
should be caught and a nice error message should be printed

Fixes #8045

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
