### PR TITLE
fix: added redirect message when in editing a redirect toolbar object

### DIFF
--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -101,6 +101,28 @@ class ViewTests(CMSTestCase):
             self.assertEqual(response.status_code, 200)
             self.apphook_clear()
 
+    def test_redirect_preview_in_edit_mode(self):
+
+        user = self.get_superuser()
+        page = create_page("page", "nav_playground.html", "fr")
+        page_content = create_page_content("en", "home", page, redirect="https://example.com")
+
+        page.set_as_homepage()
+
+        with self.login_user_context(user), force_language('fr'):
+            edit_url = get_object_edit_url(page_content, language='fr')
+            response = self.client.get(edit_url, follow=True)
+
+            expected = f"""
+                <div class="cms-screenblock">
+                <div class="cms-screenblock-inner">
+                <h1>This page has no preview!</h1>
+                <p>It is being redirected to: <a href="{page_content.redirect}">{page_content.redirect}</a></p>
+                </div>
+                </div>
+            """
+            self.assertContains(response, expected, count=1, html=True)
+
     def test_external_redirect(self):
         # test external redirect
         redirect_one = 'https://www.django-cms.org/'

--- a/cms/views.py
+++ b/cms/views.py
@@ -190,9 +190,7 @@ def details(request, slug):
         redirect_url = _clean_redirect_url(redirect_url, request_language)
 
     if redirect_url:
-        if request.user.is_staff and toolbar.edit_mode_active:
-            toolbar.redirect_url = redirect_url
-        elif redirect_url not in own_urls:
+        if redirect_url not in own_urls:
             if get_cms_setting('REDIRECT_PRESERVE_QUERY_PARAMS'):
                 query_string = request.META.get('QUERY_STRING')
                 if query_string:

--- a/cms/views.py
+++ b/cms/views.py
@@ -85,7 +85,6 @@ def details(request, slug):
     # Get a Page model object from the request
     site = get_current_site()
     page = get_page_from_request(request, use_path=slug)
-    toolbar = get_toolbar_from_request(request)
 
     if not page and not slug and not Page.objects.on_site(site).exists():
         # render the welcome page if the requested path is root "/"

--- a/cms/views.py
+++ b/cms/views.py
@@ -326,6 +326,11 @@ def render_object_endpoint(request, content_type_id, object_id, require_editable
     toolbar = get_toolbar_from_request(request)
     toolbar.set_object(content_type_obj)
 
+    if request.user.is_staff and toolbar.edit_mode_active:
+        redirect = getattr(content_type_obj, "redirect", None)
+        if isinstance(redirect, str):
+            toolbar.redirect_url = redirect
+
     if require_editable and not toolbar.object_is_editable():
         # If not editable, switch from edit to preview endpoint
         return HttpResponseRedirect(get_object_preview_url(content_type_obj))


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->
When in edit mode, if the page is set to redirect to another, it shows the link to which it is redirecting.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8012 

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
