### PR TITLE
fix: Fall back to class name when app name is None

### DIFF
--- a/cms/apphook_pool.py
+++ b/cms/apphook_pool.py
@@ -73,9 +73,8 @@ class ApphookPool:
 
         for app_name in self.apps:
             app = self.apps[app_name]
-
             if app.get_urls():
-                hooks.append((app_name, app.name))
+                hooks.append((app_name, app.name or app_name))
 
         # Unfortunately, we lose the ordering since we now have a list of
         # tuples. Let's reorder by app_name:

--- a/cms/tests/test_check.py
+++ b/cms/tests/test_check.py
@@ -135,6 +135,17 @@ class CheckTests(CheckAssertMixin, TestCase):
         with self.settings(SITE_ID='broken'):
             self.assertCheck(False, warnings=0, errors=1)
 
+    def test_cmsapps_check(self):
+        from cms.app_base import CMSApp
+        from cms.apphook_pool import apphook_pool
+        class AppWithoutName(CMSApp):
+            def get_urls(self, page=None, language=None, **kwargs):
+                return ["sampleapp.urls"]
+
+        app = apphook_pool.register(AppWithoutName)
+
+        self.assertCheck(True, warnings=1, errors=0)
+        apphook_pool.apps.pop(app.__name__)
 
 class CheckWithDatabaseTests(CheckAssertMixin, TestCase):
 

--- a/cms/utils/check.py
+++ b/cms/utils/check.py
@@ -371,6 +371,18 @@ def check_template_conf(output):
                          "Will run in headless mode with one placeholder called \"content\"")
 
 
+@define_check
+def check_cmsapps_names(output):
+    from cms.apphook_pool import apphook_pool
+    with output.section("Apphooks") as section:
+        for hook, name in apphook_pool.get_apphooks():
+            if apphook_pool.get_apphook(hook).name is None:
+                section.warn("CMSApps should define a name. %s doesn't have a name" % name)
+        if section.successful:
+            section.finish_success("CMSApps configuration is okay")
+
+
+
 def check(output):
     """
     Checks the configuration/environment of this django CMS installation.


### PR DESCRIPTION
## Description
Fall back to class name when the name of a CMSApp is not set.
## Related resources
Fixes #8055 

## Checklist

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
