### PR TITLE
chore: Fixed randomly failing Postgres tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,134 +63,134 @@ jobs:
         DATABASE_URL: postgres://postgres:postgres@127.0.0.1/postgres
 
 
-#  mysql:
-#    runs-on: ${{ matrix.os }}
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        python-version: [3.9, '3.10', '3.11', '3.12', '3.13.0-rc.2']  # latest release minus two
-#        requirements-file: [
-#          django-4.2.txt,
-#          django-5.0.txt,
-#          django-5.1.txt,
-#        ]
-#        os: [
-#          ubuntu-latest,
-#        ]
-#        exclude:
-#          - requirements-file: django-5.0.txt
-#            python-version: 3.9
-#          - requirements-file: django-5.1.txt
-#            python-version: 3.9
-#
-#    services:
-#      mysql:
-#        image: mysql:9.0.1
-#        env:
-#          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-#          MYSQL_DATABASE: djangocms_test
-#        ports:
-#          - 3306:3306
-#        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-#
-#
-#    steps:
-#    - uses: actions/checkout@v4
-#    - name: Set up Python ${{ matrix.python-version }}
-#
-#      uses: actions/setup-python@v5
-#      with:
-#        python-version: ${{ matrix.python-version }}
-#        cache: 'pip'
-#    - name: Install dependencies
-#      run: |
-#        sudo apt install gettext gcc -y
-#        python -m pip install --upgrade pip
-#        pip install pytest uv
-#        uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
-#        uv pip install --system -r test_requirements/databases.txt
-#        python setup.py install
-#
-#
-#    - name: Test with django test runner
-#      run: |
-#        python manage.py test
-#      env:
-#        DATABASE_URL: mysql://root@127.0.0.1/djangocms_test
-#
-#  sqlite:
-#    runs-on: ${{ matrix.os }}
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        python-version: [3.9, '3.10', '3.11', '3.12', '3.13.0-rc.2']  # latest release minus two
-#        requirements-file: [
-#          django-4.2.txt,
-#          django-5.0.txt,
-#          django-5.1.txt,
-#        ]
-#        os: [
-#          ubuntu-latest,
-#        ]
-#        exclude:
-#          - requirements-file: django-5.0.txt
-#            python-version: 3.9
-#          - requirements-file: django-5.1.txt
-#            python-version: 3.9
-#
-#    steps:
-#    - uses: actions/checkout@v4
-#    - name: Set up Python ${{ matrix.python-version }}
-#
-#      uses: actions/setup-python@v5
-#      with:
-#        python-version: ${{ matrix.python-version }}
-#        cache: 'pip'
-#    - name: Install dependencies
-#      run: |
-#        sudo apt install gettext gcc -y
-#        python -m pip install --upgrade pip
-#        pip install pytest uv
-#        uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
-#        python setup.py install
-#
-#    - name: Test with django test runner
-#      run: python manage.py test
-#      env:
-#        DATABASE_URL: sqlite://localhost/testdb.sqlite
-#
-#  django-main-sqlite:
-#    runs-on: ${{ matrix.os }}
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        python-version: ['3.12']
-#        requirements-file: ['requirement_base_django_main.txt']
-#        os: [
-#          ubuntu-latest,
-#        ]
-#
-#    steps:
-#    - uses: actions/checkout@v4
-#    - name: Set up Python ${{ matrix.python-version }}
-#
-#      uses: actions/setup-python@v5
-#      with:
-#        python-version: ${{ matrix.python-version }}
-#    - name: Install dependencies
-#      run: |
-#        sudo apt install gettext gcc -y
-#        python -m pip install --upgrade pip
-#        pip install uv
-#        uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
-#        uv pip install --system pytest
-#        python setup.py install
-#
-#    - name: Test with django test runner
-#      run: python manage.py test
-#      continue-on-error: true
-#      env:
-#        DATABASE_URL: sqlite://localhost/testdb.sqlite
+  mysql:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.9, '3.10', '3.11', '3.12', '3.13.0-rc.2']  # latest release minus two
+        requirements-file: [
+          django-4.2.txt,
+          django-5.0.txt,
+          django-5.1.txt,
+        ]
+        os: [
+          ubuntu-latest,
+        ]
+        exclude:
+          - requirements-file: django-5.0.txt
+            python-version: 3.9
+          - requirements-file: django-5.1.txt
+            python-version: 3.9
+
+    services:
+      mysql:
+        image: mysql:9.0.1
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE: djangocms_test
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+    - name: Install dependencies
+      run: |
+        sudo apt install gettext gcc -y
+        python -m pip install --upgrade pip
+        pip install pytest uv
+        uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
+        uv pip install --system -r test_requirements/databases.txt
+        python setup.py install
+
+
+    - name: Test with django test runner
+      run: |
+        python manage.py test
+      env:
+        DATABASE_URL: mysql://root@127.0.0.1/djangocms_test
+
+  sqlite:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.9, '3.10', '3.11', '3.12', '3.13.0-rc.2']  # latest release minus two
+        requirements-file: [
+          django-4.2.txt,
+          django-5.0.txt,
+          django-5.1.txt,
+        ]
+        os: [
+          ubuntu-latest,
+        ]
+        exclude:
+          - requirements-file: django-5.0.txt
+            python-version: 3.9
+          - requirements-file: django-5.1.txt
+            python-version: 3.9
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+    - name: Install dependencies
+      run: |
+        sudo apt install gettext gcc -y
+        python -m pip install --upgrade pip
+        pip install pytest uv
+        uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
+        python setup.py install
+
+    - name: Test with django test runner
+      run: python manage.py test
+      env:
+        DATABASE_URL: sqlite://localhost/testdb.sqlite
+
+  django-main-sqlite:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.12']
+        requirements-file: ['requirement_base_django_main.txt']
+        os: [
+          ubuntu-latest,
+        ]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        sudo apt install gettext gcc -y
+        python -m pip install --upgrade pip
+        pip install uv
+        uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
+        uv pip install --system pytest
+        python setup.py install
+
+    - name: Test with django test runner
+      run: python manage.py test
+      continue-on-error: true
+      env:
+        DATABASE_URL: sqlite://localhost/testdb.sqlite
 
   django-main-postgres:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:17
+        image: postgres:latest
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -63,134 +63,134 @@ jobs:
         DATABASE_URL: postgres://postgres:postgres@127.0.0.1/postgres
 
 
-  mysql:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.9, '3.10', '3.11', '3.12', '3.13.0-rc.2']  # latest release minus two
-        requirements-file: [
-          django-4.2.txt,
-          django-5.0.txt,
-          django-5.1.txt,
-        ]
-        os: [
-          ubuntu-latest,
-        ]
-        exclude:
-          - requirements-file: django-5.0.txt
-            python-version: 3.9
-          - requirements-file: django-5.1.txt
-            python-version: 3.9
-
-    services:
-      mysql:
-        image: mysql:9.0.1
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_DATABASE: djangocms_test
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-    - name: Install dependencies
-      run: |
-        sudo apt install gettext gcc -y
-        python -m pip install --upgrade pip
-        pip install pytest uv
-        uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
-        uv pip install --system -r test_requirements/databases.txt
-        python setup.py install
-
-
-    - name: Test with django test runner
-      run: |
-        python manage.py test
-      env:
-        DATABASE_URL: mysql://root@127.0.0.1/djangocms_test
-
-  sqlite:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.9, '3.10', '3.11', '3.12', '3.13.0-rc.2']  # latest release minus two
-        requirements-file: [
-          django-4.2.txt,
-          django-5.0.txt,
-          django-5.1.txt,
-        ]
-        os: [
-          ubuntu-latest,
-        ]
-        exclude:
-          - requirements-file: django-5.0.txt
-            python-version: 3.9
-          - requirements-file: django-5.1.txt
-            python-version: 3.9
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-    - name: Install dependencies
-      run: |
-        sudo apt install gettext gcc -y
-        python -m pip install --upgrade pip
-        pip install pytest uv
-        uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
-        python setup.py install
-
-    - name: Test with django test runner
-      run: python manage.py test
-      env:
-        DATABASE_URL: sqlite://localhost/testdb.sqlite
-
-  django-main-sqlite:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.12']
-        requirements-file: ['requirement_base_django_main.txt']
-        os: [
-          ubuntu-latest,
-        ]
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        sudo apt install gettext gcc -y
-        python -m pip install --upgrade pip
-        pip install uv
-        uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
-        uv pip install --system pytest
-        python setup.py install
-
-    - name: Test with django test runner
-      run: python manage.py test
-      continue-on-error: true
-      env:
-        DATABASE_URL: sqlite://localhost/testdb.sqlite
+#  mysql:
+#    runs-on: ${{ matrix.os }}
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        python-version: [3.9, '3.10', '3.11', '3.12', '3.13.0-rc.2']  # latest release minus two
+#        requirements-file: [
+#          django-4.2.txt,
+#          django-5.0.txt,
+#          django-5.1.txt,
+#        ]
+#        os: [
+#          ubuntu-latest,
+#        ]
+#        exclude:
+#          - requirements-file: django-5.0.txt
+#            python-version: 3.9
+#          - requirements-file: django-5.1.txt
+#            python-version: 3.9
+#
+#    services:
+#      mysql:
+#        image: mysql:9.0.1
+#        env:
+#          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+#          MYSQL_DATABASE: djangocms_test
+#        ports:
+#          - 3306:3306
+#        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+#
+#
+#    steps:
+#    - uses: actions/checkout@v4
+#    - name: Set up Python ${{ matrix.python-version }}
+#
+#      uses: actions/setup-python@v5
+#      with:
+#        python-version: ${{ matrix.python-version }}
+#        cache: 'pip'
+#    - name: Install dependencies
+#      run: |
+#        sudo apt install gettext gcc -y
+#        python -m pip install --upgrade pip
+#        pip install pytest uv
+#        uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
+#        uv pip install --system -r test_requirements/databases.txt
+#        python setup.py install
+#
+#
+#    - name: Test with django test runner
+#      run: |
+#        python manage.py test
+#      env:
+#        DATABASE_URL: mysql://root@127.0.0.1/djangocms_test
+#
+#  sqlite:
+#    runs-on: ${{ matrix.os }}
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        python-version: [3.9, '3.10', '3.11', '3.12', '3.13.0-rc.2']  # latest release minus two
+#        requirements-file: [
+#          django-4.2.txt,
+#          django-5.0.txt,
+#          django-5.1.txt,
+#        ]
+#        os: [
+#          ubuntu-latest,
+#        ]
+#        exclude:
+#          - requirements-file: django-5.0.txt
+#            python-version: 3.9
+#          - requirements-file: django-5.1.txt
+#            python-version: 3.9
+#
+#    steps:
+#    - uses: actions/checkout@v4
+#    - name: Set up Python ${{ matrix.python-version }}
+#
+#      uses: actions/setup-python@v5
+#      with:
+#        python-version: ${{ matrix.python-version }}
+#        cache: 'pip'
+#    - name: Install dependencies
+#      run: |
+#        sudo apt install gettext gcc -y
+#        python -m pip install --upgrade pip
+#        pip install pytest uv
+#        uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
+#        python setup.py install
+#
+#    - name: Test with django test runner
+#      run: python manage.py test
+#      env:
+#        DATABASE_URL: sqlite://localhost/testdb.sqlite
+#
+#  django-main-sqlite:
+#    runs-on: ${{ matrix.os }}
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        python-version: ['3.12']
+#        requirements-file: ['requirement_base_django_main.txt']
+#        os: [
+#          ubuntu-latest,
+#        ]
+#
+#    steps:
+#    - uses: actions/checkout@v4
+#    - name: Set up Python ${{ matrix.python-version }}
+#
+#      uses: actions/setup-python@v5
+#      with:
+#        python-version: ${{ matrix.python-version }}
+#    - name: Install dependencies
+#      run: |
+#        sudo apt install gettext gcc -y
+#        python -m pip install --upgrade pip
+#        pip install uv
+#        uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
+#        uv pip install --system pytest
+#        python setup.py install
+#
+#    - name: Test with django test runner
+#      run: python manage.py test
+#      continue-on-error: true
+#      env:
+#        DATABASE_URL: sqlite://localhost/testdb.sqlite
 
   django-main-postgres:
     runs-on: ${{ matrix.os }}

--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -693,11 +693,11 @@ class Placeholder(models.Model):
 
             if last_position < plugins:
                 # Close the gap in the plugin tree
-                # self._shift_plugin_positions(
-                #     instance.language,
-                #     start=instance.position,
-                #     offset=plugins,
-                # )
+                self._shift_plugin_positions(
+                    instance.language,
+                    start=instance.position,
+                    offset=plugins,
+                )
                 self._recalculate_plugin_positions(instance.language)  #4th hit: Recalculate positions
 
     def get_last_plugin(self, language):

--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -756,38 +756,14 @@ class Placeholder(models.Model):
         cursor = _get_database_cursor('write')
         db_vendor = _get_database_vendor('write')
 
-        if db_vendor == 'sqlite':
-            sql = (
-                'CREATE TEMPORARY TABLE temp AS '
-                'SELECT ID, ('
-                'SELECT COUNT(*)+1 FROM {0} t WHERE '
-                'placeholder_id={0}.placeholder_id AND language={0}.language '
-                'AND {0}.position > t.position'
-                ') AS new_position '
-                'FROM {0} WHERE placeholder_id=%s AND language=%s'
-            )
-            sql = sql.format(connection.ops.quote_name(CMSPlugin._meta.db_table))
-            cursor.execute(sql, [self.pk, language])
-
-            sql = (
-                'UPDATE {0} '
-                'SET position = (SELECT new_position FROM temp WHERE id={0}.id) '
-                'WHERE placeholder_id=%s AND language=%s'
-            )
-            sql = sql.format(connection.ops.quote_name(CMSPlugin._meta.db_table))
-            cursor.execute(sql, [self.pk, language])
-
-            sql = 'DROP TABLE temp'
-            sql = sql.format(connection.ops.quote_name(CMSPlugin._meta.db_table))
-            cursor.execute(sql)
-        elif db_vendor == 'postgresql':
+        if db_vendor == 'sqlite' or db_vendor == 'postgresql' or db_vendor == 'mysql':
             sql = (
                 'UPDATE {0} '
                 'SET position = RowNbrs.RowNbr '
                 'FROM ('
                 'SELECT  ID, ROW_NUMBER() OVER (ORDER BY position) AS RowNbr '
                 'FROM {0} WHERE placeholder_id=%s AND language=%s '
-                ') RowNbrs '
+                ') AS RowNbrs '
                 'WHERE {0}.id=RowNbrs.id'
             )
             sql = sql.format(connection.ops.quote_name(CMSPlugin._meta.db_table))

--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -2,7 +2,7 @@ import json
 import os
 import warnings
 from datetime import date
-from functools import lru_cache
+from functools import cache
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import connection, connections, models, router
@@ -19,7 +19,7 @@ from cms.utils.conf import get_cms_setting
 from cms.utils.urlutils import admin_reverse
 
 
-@lru_cache(maxsize=None)
+@cache
 def _get_descendants_cte():
     db_vendor = _get_database_vendor('read')
     if db_vendor == 'oracle':
@@ -60,7 +60,7 @@ def _get_database_cursor(action):
     return _get_database_connection(action).cursor()
 
 
-@lru_cache(maxsize=None)
+@cache
 def plugin_supports_cte():
     # This has to be as function because when it's a var it evaluates before
     # db is connected and we get OperationalError. MySQL version is retrieved

--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -186,7 +186,7 @@ class CMSPlugin(models.Model, metaclass=PluginModelBase):
         return force_str(self.pk)
 
     def __repr__(self):
-        display = f"<{self.__module__}.{self.__class__.__name__} id={self.pk} position={self.position} plugin_type='{self.plugin_type}'>"
+        display = f"<{self.__module__}.{self.__class__.__name__} id={self.pk} plugin_type='{self.plugin_type}' object at {hex(id(self))}>"
         return display
 
     def get_plugin_name(self):

--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -186,7 +186,7 @@ class CMSPlugin(models.Model, metaclass=PluginModelBase):
         return force_str(self.pk)
 
     def __repr__(self):
-        display = f"<{self.__module__}.{self.__class__.__name__} id={self.pk} plugin_type='{self.plugin_type}' object at {hex(id(self))}>"
+        display = f"<{self.__module__}.{self.__class__.__name__} id={self.pk} position={self.position} plugin_type='{self.plugin_type}'>"
         return display
 
     def get_plugin_name(self):

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -1378,7 +1378,12 @@ class PlaceholderFlatPluginTests(PlaceholderPluginTestsBase):
         for plugin in self.get_plugins().filter(parent__isnull=True):
             for plugin_id in [plugin.pk] + tree[plugin.pk]:
                 plugin_tree_all.remove(plugin_id)
-            self.placeholder.delete_plugin(plugin)
+            from django.db import DatabaseError
+            try:
+                self.placeholder.delete_plugin(plugin)
+            except DatabaseError as e:
+                print(f"{self.placeholder.cmsplugin_set.filter(language='en').all()=}")
+                raise e
             new_tree = self.get_plugins().values_list('pk', 'position')
             expected = [(pk, pos) for pos, pk in enumerate(plugin_tree_all, 1)]
             self.assertSequenceEqual(new_tree, expected)

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -1378,18 +1378,10 @@ class PlaceholderFlatPluginTests(PlaceholderPluginTestsBase):
         for plugin in self.get_plugins().filter(parent__isnull=True):
             for plugin_id in [plugin.pk] + tree[plugin.pk]:
                 plugin_tree_all.remove(plugin_id)
-            from django.db import DatabaseError
-            try:
-                prev_count = self.placeholder.get_plugins(language='en').count()
-                plugin.refresh_from_db()
-                self.placeholder.delete_plugin(plugin)
-            except DatabaseError as e:
-                print("After")
-                print(f"{plugin_id=} {self.placeholder.cmsplugin_set.get(pk=plugin_id).position=}")
-                print("Previous count", prev_count)
-                print(f"{self.placeholder.get_plugins(language='en').count()=}")
-                print(f"{max(self.placeholder.get_plugins(language='en').values_list('position', flat=True))=}")
-                raise e
+
+            plugin.refresh_from_db()
+            self.placeholder.delete_plugin(plugin)
+
             new_tree = self.get_plugins().values_list('pk', 'position')
             expected = [(pk, pos) for pos, pk in enumerate(plugin_tree_all, 1)]
             self.assertSequenceEqual(new_tree, expected)
@@ -1680,8 +1672,10 @@ class PlaceholderNestedPluginTests(PlaceholderFlatPluginTests):
         for plugin in self.get_plugins().filter(parent__isnull=True):
             for plugin_id in [plugin.pk] + tree[plugin.pk]:
                 plugin_tree_all.remove(plugin_id)
+
             plugin.refresh_from_db()
             self.placeholder.delete_plugin(plugin)
+
             new_tree = self.get_plugins().values_list('pk', 'position')
             expected = [(pk, pos) for pos, pk in enumerate(plugin_tree_all, 1)]
             self.assertSequenceEqual(new_tree, expected, f"Failed for {plugin.pk}")

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -1613,20 +1613,23 @@ class PlaceholderFlatPluginTests(PlaceholderPluginTestsBase):
 
 
 class PlaceholderNestedPluginTests(PlaceholderFlatPluginTests):
-    """Same tests as before but now with a different plugin tree:
+    """
+    Same tests as for PlaceholderFlatPluginTests but now with a different plugin tree:
 
-    Parent 1
-      Parent 2
-        Child
-    Parent 1
-      Parent 2
-        Child
-    Parent 1
-      Parent 2
-        Child
-    Parent 1
-      Parent 2
-        Child
+    ::
+
+        Parent 1
+          Parent 2
+            Child
+        Parent 1
+          Parent 2
+            Child
+        Parent 1
+          Parent 2
+            Child
+        Parent 1
+          Parent 2
+            Child
     """
 
     def create_plugins(self, placeholder):
@@ -1678,4 +1681,4 @@ class PlaceholderNestedPluginTests(PlaceholderFlatPluginTests):
 
             new_tree = self.get_plugins().values_list('pk', 'position')
             expected = [(pk, pos) for pos, pk in enumerate(plugin_tree_all, 1)]
-            self.assertSequenceEqual(new_tree, expected, f"Failed for {plugin.pk}")
+            self.assertSequenceEqual(new_tree, expected)


### PR DESCRIPTION
## Description

This PR fixes randomly failing postgres tests by

1. Encapsulating `placeholder.delete_plugin()` in an atomic transaction
2. Recalculating plugin positions only if necessary after deleting a plugin (and its descendants)
3. Ensuring during tests, that the plugin object is in sync with the database

Also, as a positive side effect, this PR 
* Reduces the number of DB queries `placeholder.delete_plugin()` by one
* Improves the raw SQL code for recalculating the plugin positions for SQLite databases which since 2018 accept the same subqueries with `ROW_NUMBER ` as Postgres.

This PR will make PR management significantly easier, since failing Postgres tests do not have restarted multiple times  for each PR any more.

I am not fully sure what the underlying root cause for the randomness of the failures is, but I speculate that it is a combination of postgres' optimizer and the recalculation of plugin positions occasionally being called despite it would be a no-op.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
