### PR TITLE
feat: Add `FrontendEditableAdminMixin` endpoint to plugins

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -53,7 +53,6 @@ from cms.cache.permissions import clear_permission_cache
 from cms.constants import MODAL_HTML_REDIRECT
 from cms.models import (
     CMSPlugin,
-    EmptyPageContent,
     GlobalPagePermission,
     Page,
     PageContent,
@@ -169,6 +168,7 @@ class PageAdmin(admin.ModelAdmin):
         """Get the admin urls
         """
         info = f"{self.model._meta.app_label}_{self.model._meta.model_name}"
+
         def pat(regex, fn):
             return re_path(regex, self.admin_site.admin_view(fn), name=f'{info}_{fn.__name__}')
 
@@ -763,6 +763,7 @@ class PageContentAdmin(admin.ModelAdmin):
         """Get the admin urls
         """
         info = f"{self.model._meta.app_label}_{self.model._meta.model_name}"
+
         def pat(regex, fn):
             return re_path(regex, self.admin_site.admin_view(fn), name=f'{info}_{fn.__name__}')
 
@@ -915,7 +916,6 @@ class PageContentAdmin(admin.ModelAdmin):
             url = get_object_edit_url(obj)  # Redirects to preview if necessary
             return HttpResponse(MODAL_HTML_REDIRECT.format(url=url))
         return super().response_add(request, obj)
-
 
     def get_filled_languages(self, request, page):
         site_id = get_site(request).pk
@@ -1121,7 +1121,6 @@ class PageContentAdmin(admin.ModelAdmin):
         else:
             if to_template not in (placeholder_set[0] for placeholder_set in get_cms_setting('PLACEHOLDERS')):
                 return HttpResponseBadRequest(_("Placeholder selection not valid"))
-
 
         page_content.template = to_template
         page_content.save()

--- a/cms/admin/settingsadmin.py
+++ b/cms/admin/settingsadmin.py
@@ -136,5 +136,3 @@ class SettingsAdmin(ModelAdmin):
         Return empty perms dict thus hiding the model from admin index.
         """
         return {}
-
-

--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -21,7 +21,6 @@ from cms.toolbar.utils import (
 from cms.toolbar_base import CMSToolbar
 from cms.toolbar_pool import toolbar_pool
 from cms.utils import get_language_from_request, page_permissions
-from cms.utils.compat import DJANGO_4_2
 from cms.utils.compat.warnings import RemovedInDjangoCMS43Warning
 from cms.utils.conf import get_cms_setting
 from cms.utils.i18n import get_language_dict, get_language_tuple
@@ -631,24 +630,16 @@ class PageToolbar(CMSToolbar):
             # first break
             current_page_menu.add_break(PAGE_MENU_FIRST_BREAK)
 
-            # page edit
-            with force_language(self.current_lang):
-                disabled = (
-                    edit_mode or not self.toolbar.object_is_editable()
-                )
-                page_edit_url = get_object_edit_url(self.page_content) if self.page_content else ''
-                current_page_menu.add_link_item(_('Edit this Page'), disabled=disabled, url=page_edit_url)
-
             # page settings
             page_settings_url = add_url_parameters(page_settings_url, language=self.toolbar.request_language)
-            settings_disabled = not edit_mode or not can_change
+            settings_disabled = not can_change
             current_page_menu.add_modal_item(_('Page settings'), url=page_settings_url, disabled=settings_disabled,
                                              on_close=refresh)
 
             # advanced settings
             advanced_url = add_url_parameters(advanced_url, language=self.toolbar.request_language)
             can_change_advanced = self.page.has_advanced_settings_permission(self.request.user)
-            advanced_disabled = not edit_mode or not can_change_advanced
+            advanced_disabled = not can_change_advanced
             current_page_menu.add_modal_item(_('Advanced settings'), url=advanced_url, disabled=advanced_disabled)
 
             # templates menu

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -573,7 +573,7 @@ class CMSEditableObject(InclusionTag):
                     if not view_url:
                         if isinstance(instance, CMSPlugin):
                             # Plugins do not have a registered admin. They are managed by the placeholder admin.
-                            view_url = f'admin:cms_placeholder_edit_field'
+                            view_url = 'admin:cms_placeholder_edit_field'
                         else:
                             view_url = f'admin:{opts.app_label}_{opts.model_name}_edit_field'
                     if view_url.endswith('_changelist'):

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -866,29 +866,6 @@ class CMSEditableObjectBlock(CMSEditableObject):
         return extra_context
 
 
-class CMSInlineField(CMSEditableObject):
-    name = 'render_inline_field'
-    options = Options(
-        Argument('instance'),
-        Argument('attribute'),
-        Argument('language', default=None, required=False),
-        Argument('filters', default=None, required=False),
-        Argument('view_url', default=None, required=False),
-        Argument('view_method', default=None, required=False),
-        'as',
-        Argument('varname', required=False, resolve=False),
-    )
-
-    def render_tag(self, context, **kwargs):
-        if context["request"].session.get("inline_editing", True) and isinstance(kwargs["instance"], CMSPlugin):
-            # Only allow inline field to be rendered if inline editing is active and the instance is a CMSPlugin
-            # DummyPlugins of the ``plugin`` tag are cannot be edited
-            kwargs["edit_fields"] = kwargs["attribute"]
-            return super().render_tag(context, **kwargs)
-        else:
-            return getattr(kwargs["instance"], kwargs["attribute"], "")
-
-
 class StaticPlaceholderNode(Tag):
     name = 'static_placeholder'
     options = PlaceholderOptions(

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -1014,7 +1014,6 @@ register.tag('render_model_add_block', CMSEditableObjectAddBlock)
 register.tag('render_model_add', CMSEditableObjectAdd)
 register.tag('render_model_icon', CMSEditableObjectIcon)
 register.tag('render_model', CMSEditableObject)
-register.tag('render_inline_field', CMSInlineField)
 register.simple_tag(
     _show_placeholder_by_id,
     takes_context=True,

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -15,9 +15,7 @@ from classytags.utils import flatten_context
 from classytags.values import ListValue, StringValue
 from django import template
 from django.conf import settings
-from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
-from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.core.mail import mail_managers
 from django.db.models import Model
 from django.template.loader import render_to_string
@@ -531,25 +529,20 @@ class CMSEditableObject(InclusionTag):
         else:
             lang = get_language()
         opts = instance._meta
-        # Django < 1.10 creates dynamic proxy model subclasses when fields are
-        # deferred using .only()/.exclude(). Make sure to use the underlying
-        # model options when it's the case.
-        if getattr(instance, '_deferred', False):
-            opts = opts.proxy_for_model._meta
         with force_language(lang):
             extra_context = {}
             if edit_fields == 'changelist':
-                instance.get_plugin_name = "{} {} list".format(smart_str(_('Edit')), smart_str(opts.verbose_name))
+                instance.get_plugin_name = lambda: f"{smart_str(_('Edit'))} {smart_str(opts.verbose_name)} list"
                 extra_context['attribute_name'] = 'changelist'
             elif editmode:
-                instance.get_plugin_name = "{} {}".format(smart_str(_('Edit')), smart_str(opts.verbose_name))
+                instance.get_plugin_name = lambda: f"{smart_str(_('Edit'))} {smart_str(opts.verbose_name)}"
                 if not context.get('attribute_name', None):
                     # Make sure CMS.Plugin object will not clash in the frontend.
                     extra_context['attribute_name'] = '-'.join(
                         edit_fields
                     ) if not isinstance('edit_fields', str) else edit_fields
             else:
-                instance.get_plugin_name = "{} {}".format(smart_str(_('Add')), smart_str(opts.verbose_name))
+                instance.get_plugin_name = lambda: f"{smart_str(_('Add'))} {smart_str(opts.verbose_name)}"
                 extra_context['attribute_name'] = 'add'
             extra_context['instance'] = instance
             extra_context['generic'] = opts
@@ -578,7 +571,10 @@ class CMSEditableObject(InclusionTag):
                         url_base = reverse(view_url, args=(instance.pk,))
                 else:
                     if not view_url:
-                        view_url = f'admin:{opts.app_label}_{opts.model_name}_edit_field'
+                        if isinstance(instance, CMSPlugin):
+                            view_url = f'admin:{opts.app_label}_{opts.model_name}_edit_field'  # TODO: Correct endpoint
+                        else:
+                            view_url = f'admin:{opts.app_label}_{opts.model_name}_edit_field'
                     if view_url.endswith('_changelist'):
                         url_base = reverse(view_url)
                     else:

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -703,9 +703,9 @@ class EditablePluginsTemplateTags(CMSTestCase):
         template = """{% load cms_tags %}{% render_model plugin "body" "body" %}"""
         # The template html tags will render the object editable in the frontend
         expectation = (
-            f'<template class="cms-plugin cms-plugin-start cms-plugin-djangocms_text_ckeditor-text-body-{{ self.plugin_pk }} cms-render-model"></template>'
+            f'<template class="cms-plugin cms-plugin-start cms-plugin-djangocms_text_ckeditor-text-body-{ self.plugin.pk } cms-render-model"></template>'
             '&lt;b&gt;Test&lt;/b&gt;'
-            f'<template class="cms-plugin cms-plugin-end cms-plugin-djangocms_text_ckeditor-text-body-{{ self.plugin_pk }} cms-render-model"></template>'
+            f'<template class="cms-plugin cms-plugin-end cms-plugin-djangocms_text_ckeditor-text-body-{ self.plugin.pk } cms-render-model"></template>'
         )
 
         endpoint = get_object_edit_url(self.page.get_content_obj("en"))  # view in edit mode

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -699,6 +699,7 @@ class EditablePluginsTemplateTags(CMSTestCase):
         self.plugin = add_plugin(self.placeholder, TextPlugin, 'en', body='<b>Test</b>')
 
     def test_render_model_plugin(self):
+        """The render_model template tags also works with a plugin."""
         template = """{% load cms_tags %}{% render_model plugin "body" "body" %}"""
         # The template html tags will render the object editable in the frontend
         expectation = (

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -703,9 +703,9 @@ class EditablePluginsTemplateTags(CMSTestCase):
         template = """{% load cms_tags %}{% render_model plugin "body" "body" %}"""
         # The template html tags will render the object editable in the frontend
         expectation = (
-            '<template class="cms-plugin cms-plugin-start cms-plugin-djangocms_text_ckeditor-text-body-1 cms-render-model"></template>'
+            f'<template class="cms-plugin cms-plugin-start cms-plugin-djangocms_text_ckeditor-text-body-{{ self.plugin_pk }} cms-render-model"></template>'
             '&lt;b&gt;Test&lt;/b&gt;'
-            '<template class="cms-plugin cms-plugin-end cms-plugin-djangocms_text_ckeditor-text-body-1 cms-render-model"></template>'
+            f'<template class="cms-plugin cms-plugin-end cms-plugin-djangocms_text_ckeditor-text-body-{{ self.plugin_pk }} cms-render-model"></template>'
         )
 
         endpoint = get_object_edit_url(self.page.get_content_obj("en"))  # view in edit mode

--- a/docs/how_to/06-frontend_models.rst
+++ b/docs/how_to/06-frontend_models.rst
@@ -62,7 +62,7 @@ All three titles::
 
 
 You can always customise the editable fields by providing the
-`edit_field` parameter::
+``edit_field`` parameter::
 
     {% render_model request.current_page "title" "page_title,menu_title" %}
 
@@ -281,4 +281,44 @@ the standard ``as`` syntax:
     <h1>{{ variable }}</h1>
 
     {% endblock content %}
+
+
+*******
+Plugins
+*******
+
+.. versionadded:: 4.2
+
+    Exposing plugins for frontend editing is a new feature in django CMS 4.2.
+
+
+The frontend editing feature is also available for plugins. While by definition
+plugins are frontend-editable, you can still use the template tags to expose
+only selected fields for editing.
+
+Say, you have a header plugin that contains a section header and a summary
+of the section content. You can expose only the header for editing::
+
+    {% load cms_tags %}
+
+    {% block content %}
+    <h1>{% render_model instance "header" "header" %}</h1>
+    {% endblock content %}
+
+This will render ``{{ instance.header }}`` and double-clicking on it will open
+a pop-up window with the change form for the plugin instance with the header field
+only.
+
+An alternative is to use the ``render_model_block`` template tag::
+
+    {% load cms_tags %}
+
+    {% block content %}
+    <h1>{% render_model_block instance "header" %}
+      {{ instance.header }}
+    {% endrender_model_block %}</h1>
+    {% endblock content %}
+
+Third party packages such as djangocms-text use this feature to allow inline
+editing of single fields in the frontend.
 

--- a/manage.py
+++ b/manage.py
@@ -8,6 +8,7 @@ import warnings
 import dj_database_url
 
 from cms.exceptions import DontUsePageAttributeWarning
+from cms.utils.conf import default
 from docs.django_settings import SECRET_KEY
 
 gettext = lambda s: s
@@ -50,9 +51,8 @@ def main(argv: list[str], **full_settings):
     ]
 
     if (
-        len(argv) >= 2
+        len(argv) - sum((arg.startswith("-") for arg in argv[2:]), start=0) < 3
         and argv[1] in local_commands
-        and all(not arg.startswith("-") for arg in argv[2:])
     ):
         argv.append("cms")
         argv.append("menus")


### PR DESCRIPTION
## Description

django CMS provides editing endpoints and frontend support for general models through `FrontendEditableAdminMixin`. Specifically, it supports editing a subset of fields only.

This PR extends this feature to plugin models which have no model admin registered for themselves, but are managed by the `PlaceholderAdmin` class. Literally, a few lines of code allow us to have partial editing endpoints for plugins. These can be used for inline editing, for example.

### This PR
* Splits the `FrontendEditableAdminMixin` into two classes, a base class (`BaseEditableAdminMixin`) which provides the endpoint, and a specific class (`FrontendEditableAdmin`) that provides the interface to the model admin.
* The `BaseEditableAdminMixin` is added to the `PlaceholderAdmin` along with the appropriate methods to 
  * retrieve the object being edited
  * find its admin instance (which is its plugin class)
* Tweaks some tricks in the existing `FrontendEditableAdminMixin`:
  * Replaces `get_plugin_name` attributes by callables (makes no difference for the template engine, but does for the plugin class)
  * When changing a plugin, the response does not trigger a page reload but just a local update of the plugin through the data bridge
  * Finally, it provides the placeholder endpoints for plugin models instead of the model admin endpoint (which does not exist for placeholders) in all template tags based on `{% render_model %}

### Usage
With this PR, partial edit can be included by replacing `{{ instance.field }}` in a plugin's template by `{% render_model instance "field" "field,other_field" %}`. Upon double-click this will open a modal with two input fields: `field` and `other_fields`.

Especially interesting is the use of `{% render_model instance "field" "field" %}` which will render the field and allow editing just itself. djangocms-text will take this to inline editing if it is active. See this short demo here on an unstyled blog title field and content fields (**not plugins**):

![inlnie-fields](https://github.com/user-attachments/assets/e59537bf-e5b7-48ca-a879-ac375b713806)

Any field type can be edited inline if there is an apps (such as djangocms-text) supporting it for that field type. djangocms-text supports `HTMLField` and `CharField`.

### Docs and tests

... are here now.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
