### PR TITLE
fix: Grouper admin raised AttributeError when used outside the admin views

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -104,6 +104,7 @@ class PageAdmin(admin.ModelAdmin):
     copy_form = CopyPageForm
     move_form = MovePageForm
     inlines = PERMISSION_ADMIN_INLINES
+    search_fields = ('=id', 'urls__slug', 'pagecontent_set__title', 'reverse_id')
 
     def has_add_permission(self, request):
         return False

--- a/cms/forms/validators.py
+++ b/cms/forms/validators.py
@@ -48,11 +48,15 @@ def validate_url_uniqueness(site, path, language, user_language=None, exclude_pa
     if user_language:
         change_url += f'?language={user_language}'
 
-    conflict_url = f'<a href="{change_url}" target="_blank">{force_str(conflict_page)}</a>'
+    conflict_url = f'<a href="{change_url}" target="_blank">{str(conflict_translation.title)}</a>'
 
     if exclude_page:
         message = gettext('Page %(conflict_page)s has the same url \'%(url)s\' as current page "%(instance)s".')
     else:
         message = gettext('Page %(conflict_page)s has the same url \'%(url)s\' as current page.')
-    message = message % {'conflict_page': conflict_url, 'url': path, 'instance': exclude_page}
+    message = message % {
+        'conflict_page': conflict_url,
+        'url': path,
+        'instance': exclude_page.get_title(language) if exclude_page else ''
+    }
     raise ValidationError(mark_safe(message))

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -156,8 +156,7 @@ class Page(MP_Node):
         else:
             title = _("No available title")
         path = self.get_path(get_language(), fallback=True)
-        path = f" (/{path}/)" if path else ""
-        return force_str(title) + path
+        return force_str(title) + ("" if path is None else f" (/{path})")
 
     def __repr__(self):
         display = f'<{self.__module__}.{self.__class__.__name__} id={self.pk} object at {hex(id(self))}>'

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -150,8 +150,7 @@ class Page(MP_Node):
         #: Might be larger than the page_content_cache
 
     def __str__(self):
-        lang = self._get_page_content_cache(get_language(), fallback=True, force_reload=False)
-        page_content = self.page_content_cache.get(lang)
+        page_content = self.get_admin_content(get_language(), fallback=True)
         if page_content:
             title = page_content.menu_title or page_content.title
         else:
@@ -728,7 +727,7 @@ class Page(MP_Node):
             self.page_content_cache.setdefault(translation.language, translation)
 
     def set_admin_content_cache(self):
-        self.admin_conent_cache = AdminCacheDict()
+        self.admin_content_cache = AdminCacheDict()
         for translation in self.pagecontent_set(manager="admin_manager").latest_content().all():
             self.admin_content_cache.setdefault(translation.language, translation)
 

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -150,12 +150,14 @@ class Page(MP_Node):
         #: Might be larger than the page_content_cache
 
     def __str__(self):
-        page_content = self.get_admin_content(get_language(), fallback=True)
+        page_content = self.get_content_obj(get_language(), fallback=True)
         if page_content:
             title = page_content.menu_title or page_content.title
         else:
-            title = _("Empty")
-        return force_str(title)
+            title = _("No available title")
+        path = self.get_path(get_language(), fallback=True)
+        path = f" (/{path}/)" if path else ""
+        return force_str(title) + path
 
     def __repr__(self):
         display = f'<{self.__module__}.{self.__class__.__name__} id={self.pk} object at {hex(id(self))}>'

--- a/cms/tests/test_admin.py
+++ b/cms/tests/test_admin.py
@@ -165,7 +165,7 @@ class AdminTestCase(AdminTestsBase):
                 if not admin_instance.search_fields:
                     continue
                 url = admin_reverse('cms_%s_changelist' % model._meta.model_name)
-                response = self.client.get('%s?q=1' % url)
+                response = self.client.get('%s?q=1' % url, follow=True)  # Page redirects to PageContent
                 errmsg = response.content
                 self.assertEqual(response.status_code, 200, errmsg)
 

--- a/cms/tests/test_grouper_admin.py
+++ b/cms/tests/test_grouper_admin.py
@@ -1,6 +1,7 @@
 from django.contrib.admin import site
 from django.templatetags.static import static
 from django.utils.crypto import get_random_string
+from django.utils.translation import get_language, override as force_language
 
 from cms.admin.utils import CONTENT_PREFIX
 from cms.test_utils.project.sampleapp.models import (
@@ -125,6 +126,29 @@ class GrouperModelAdminTestCase(SetupMixin, CMSTestCase):
         # Assert
         admin = site._registry[GrouperModel]
         self.assertEqual(admin.content_model, GrouperModelContent)
+
+    def test_extra_grouping_field_fixed(self):
+        """Extra grouping fields are retrieved correctly"""
+        with force_language("en"):
+            expected_language = "zh"
+            self.admin.language = expected_language
+
+            admin_language = self.admin.get_language()
+            current_content_filters = self.admin.current_content_filters
+
+            self.assertEqual(admin_language, expected_language)
+            self.assertEqual(current_content_filters["language"],  expected_language)
+
+    def test_extra_grouping_field_current(self):
+        """Extra grouping fields (language) when not set return current default correctly"""
+        del self.admin.language  # No pre-set language
+        expected_language = get_language()
+
+        admin_language = self.admin.get_language()
+        current_content_filters = self.admin.current_content_filters
+
+        self.assertEqual(admin_language, expected_language)
+        self.assertEqual(current_content_filters["language"], expected_language)
 
 
 class GrouperChangeListTestCase(SetupMixin, CMSTestCase):

--- a/cms/tests/test_log_entries.py
+++ b/cms/tests/test_log_entries.py
@@ -7,6 +7,7 @@ from cms.forms.wizards import CreateCMSPageForm
 from cms.models import Page, Placeholder, UserSettings
 from cms.test_utils.testcases import URL_CMS_PAGE_MOVE, CMSTestCase
 from cms.utils import get_current_site
+from cms.utils.i18n import force_language
 from cms.wizards.forms import WizardStep2BaseForm, step2_form_factory
 
 # Snippet to create wizard page taken from: test_wizards.py
@@ -214,6 +215,8 @@ class LogPageOperationsTests(CMSTestCase):
             title_en = "page_a"
             page = create_page(title_en, "nav_playground.html", "en")
             create_page_content(language='de', title="other title %s" % title_en, page=page)
+            with force_language("de"):  # The remaining language
+                expected_entry = str(page)
             endpoint = self.get_page_delete_translation_uri('en', page)
             post_data = {'post': 'yes', 'language': 'en'}
 
@@ -233,7 +236,7 @@ class LogPageOperationsTests(CMSTestCase):
             # Check the object id is set correctly
             self.assertEqual(str(page.pk), log_entry.object_id)
             # Check the object_repr is set correctly
-            self.assertEqual(str(page), log_entry.object_repr)
+            self.assertEqual(expected_entry, log_entry.object_repr)
             # Check that the correct user created the log
             self.assertEqual(self._admin_user.pk, log_entry.user_id)
 

--- a/cms/utils/placeholder.py
+++ b/cms/utils/placeholder.py
@@ -21,7 +21,7 @@ from django.template.loader_tags import BlockNode, ExtendsNode, IncludeNode
 from sekizai.helpers import get_varname
 
 from cms.exceptions import DuplicatePlaceholderWarning
-from cms.models import Placeholder
+from cms.models import EmptyPageContent, Placeholder
 from cms.utils.conf import get_cms_setting
 
 RANGE_START = 128
@@ -407,7 +407,7 @@ def rescan_placeholders_for_obj(obj):
     return existing
 
 
-def get_declared_placeholders_for_obj(obj: Union[models.Model, None]) -> list[Placeholder]:
+def get_declared_placeholders_for_obj(obj: Union[models.Model, EmptyPageContent, None]) -> list[Placeholder]:
     """Returns declared placeholders for an object. The object is supposed to either have a method
     ``get_placeholder_slots`` which returns the list of placeholders or a method ``get_template``
     which returns the template path as a string that renders the object. ``get_declared_placeholders`` returns


### PR DESCRIPTION
## Description

This PR adds fallback methods to `GrouperModelAdmin` to allow for fallback methods if not all grouping fields are set. This allows to use `GrouperModelAdmin` outside the admin views, e.g., as a target for the `AutocompleteSelect` widget.

It makes pages searchable by adding search fields. Also, the page's __str__ method is updated for search fields: This way pages are consistently represented in the admin by (`str(page)`) in the form of "My page title (/path/to/page)" in the current or a fallback language.

Finally, a type hint error is fixed.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
