### PR TITLE
fix: XSS vulnerability for page title

### DIFF
--- a/cms/api.py
+++ b/cms/api.py
@@ -136,7 +136,7 @@ def create_page(title, template, language, menu_title=None, slug=None,
                 xframe_options=constants.X_FRAME_OPTIONS_INHERIT):
     """
     Creates a :class:`cms.models.Page` instance and returns it. Also
-    creates a :class:`cms.models.Title` instance for the specified
+    creates a :class:`cms.models.PageContent` instance for the specified
     language.
 
     .. warning::

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -441,9 +441,7 @@ class PageAttribute(AsTag):
         if page and name in self.valid_attributes:
             func = getattr(page, "get_%s" % name)
             ret_val = func(language=lang, fallback=True)
-            if name == 'page_title':
-                 ret_val = strip_tags(ret_val)
-            elif not isinstance(ret_val, datetime):
+            if not isinstance(ret_val, datetime):
                 ret_val = escape(ret_val)
             return ret_val
         return ''

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -11,11 +11,10 @@ from django.http import HttpResponse
 from django.test import RequestFactory
 from django.test.utils import override_settings
 from django.utils.encoding import force_str
-from django.utils.html import strip_tags, escape
+from django.utils.html import escape
 from django.utils.timezone import now
 from django.utils.translation import override as force_language
 from djangocms_text_ckeditor.cms_plugins import TextPlugin
-from djangocms_text_ckeditor.models import Text
 from sekizai.context import SekizaiContext
 
 import cms


### PR DESCRIPTION
## Description

When used inside an HTML tag `{% page_attribute "page_title" %}` can lead to an XSS vulnerability. This PR fixes it.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
