### PR TITLE
fix: Replaced `languages` field from `Page` which used to become inconsistent

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -1227,13 +1227,15 @@ class PageContentAdmin(admin.ModelAdmin):
                 'language': force_str(get_language_object(language)['name'])
             }
             messages.success(request, message)
+            if language in page.admin_content_cache:
+                del page.admin_content_cache[language]
+            if language in page.page_content_cache:
+                del page.page_content_cache[language]
 
             page_url.delete()
             page_content.delete()
             for p in saved_plugins:
                 p.delete()
-
-            page.remove_language(language)
 
             send_post_page_operation(
                 request=request,

--- a/cms/api.py
+++ b/cms/api.py
@@ -313,12 +313,10 @@ def create_page_content(language, title, page, menu_title=None, slug=None,
         _thread_locals.user = created_by
         created_by = get_clean_username(created_by)
 
-    page.urls.create(
-        slug=slug,
-        path=path,
+    page.urls.update_or_create(
         page=page,
-        managed=not bool(overwrite_url),
         language=language,
+        defaults=dict(slug=slug, path=path,  managed=not bool(overwrite_url)),
     )
 
     # E.g., djangocms-versioning needs an User object to be passed when creating a versioned Object
@@ -340,11 +338,8 @@ def create_page_content(language, title, page, menu_title=None, slug=None,
         xframe_options=xframe_options,
     )
     page_content.rescan_placeholders()
+    page._clear_internal_cache()
 
-    page_languages = page.get_languages()
-
-    if language not in page_languages:
-        page.update_languages(page_languages + [language])
     return page_content
 
 

--- a/cms/cms_menus.py
+++ b/cms/cms_menus.py
@@ -333,7 +333,6 @@ class CMSMenu(Menu):
                 "soft_root",
                 "in_navigation",
                 "page__site_id",
-                "page__languages",
                 "page__parent_id",
                 "page__is_home",
                 "page__login_required",
@@ -352,7 +351,7 @@ class CMSMenu(Menu):
         else:
             preview_url = None  # No short-cut here
             prefetched_urls = PageUrl.objects.filter(
-                language__in=self.languages,
+                language__in=(page_content.language for page_content in page_contents),
                 page_id__in=(page_content.page.pk for page_content in page_contents),
             )  # Fetch the PageUrl objects
             # Prepare for filling urls_cache

--- a/cms/management/commands/subcommands/copy.py
+++ b/cms/management/commands/subcommands/copy.py
@@ -89,9 +89,6 @@ class CopyLangCommand(SubcommandsCommand):
                     new_title["page"] = page
                     PageContent.objects.with_user(user).create(**new_title)
 
-                    if to_lang not in page.get_languages():
-                        page.update_languages(page.get_languages() + [to_lang])
-
                 if copy_content:
                     # copy plugins using API
                     if verbose:

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -16,12 +16,11 @@ from django.utils.translation import get_language, gettext_lazy as _, override a
 from treebeard.mp_tree import MP_Node
 
 from cms import constants
-from cms.exceptions import LanguageError
 from cms.models.managers import PageManager, PageUrlManager
 from cms.utils import i18n
 from cms.utils.compat.warnings import RemovedInDjangoCMS43Warning
 from cms.utils.conf import get_cms_setting
-from cms.utils.i18n import get_current_language, get_fallback_languages
+from cms.utils.i18n import get_current_language
 from cms.utils.page import get_clean_username
 from menus.menu_pool import menu_pool
 
@@ -114,12 +113,6 @@ class Page(MP_Node):
         blank=True,
         null=True,
     )
-    languages = models.CharField(
-        max_length=255,
-        editable=False,
-        blank=True,
-        null=True,
-    )
     is_page_type = models.BooleanField(
         default=False,
         help_text=_("Mark this page as a page type"),
@@ -143,6 +136,7 @@ class Page(MP_Node):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.urls_cache = {}
+        #: Internal cache for page urls
         self.page_content_cache = {}
         #: Internal cache for page content objects visible publicly
         self.admin_content_cache = AdminCacheDict()
@@ -438,7 +432,6 @@ class Page(MP_Node):
         languages = (
             self
             .urls
-            .filter(language__in=self.get_languages())
             .values_list('language', flat=True)
         )
 
@@ -524,7 +517,6 @@ class Page(MP_Node):
                 )
                 placeholder.copy_plugins(new_placeholder, language=new_title.language)
             new_page.page_content_cache[new_title.language] = new_title
-        new_page.update_languages([trans.language for trans in translations])
 
         if extensions:
             from cms.extensions import extension_pool
@@ -692,30 +684,46 @@ class Page(MP_Node):
         )
         return self.parent
 
-    def get_languages(self):
-        if self.languages:
-            return sorted(self.languages.split(','))
-        else:
-            return []
+    @property
+    def languages(self):
+        warnings.warn(
+            "Attribute `languages` is deprecated. Use `get_languages` instead.",
+            RemovedInDjangoCMS43Warning,
+            stacklevel=2
+        )
+        return ",".join(self.get_languages())
+
+    def get_languages(self, admin_manager=True):
+        """Returns available languages for the page. This is potentially costly."""
+        if admin_manager:
+            if not self.admin_content_cache:
+                self.set_admin_content_cache()
+            return list(self.admin_content_cache.keys())
+        if not self.page_content_cache:
+            self._get_page_content_cache(get_language(), fallback=False, force_reload=False)
+        return list(self.page_content_cache.keys())
 
     def remove_language(self, language):
-        page_languages = self.get_languages()
-
-        if language in page_languages:
-            page_languages.remove(language)
-            self.update_languages(page_languages)
+        warnings.warn(
+            "Method `remove_language` is deprecated and has no effect any more.",
+            RemovedInDjangoCMS43Warning,
+            stacklevel=2
+        )
 
     def update_languages(self, languages):
-        languages = ",".join(set(languages))
-        # Update current instance
-        self.languages = languages
-        # Commit. It's important to not call save()
-        # we'd like to commit only the languages field and without
-        # any kind of signals.
-        self.update(languages=languages)
+        warnings.warn(
+            "Method `update_languages` is deprecated and has no effect any more.",
+            RemovedInDjangoCMS43Warning,
+            stacklevel=2
+        )
 
     def get_published_languages(self):
-        return self.get_languages()
+        warnings.warn(
+            "Method `get_published_languages` is deprecated. Use `get_languages(admin_manager=False)` instead.",
+            RemovedInDjangoCMS43Warning,
+            stacklevel=2,
+        )
+        return self.get_languages(admin_manager=False)
 
     def set_translations_cache(self):
         warnings.warn(
@@ -800,58 +808,42 @@ class Page(MP_Node):
         except AttributeError:
             return None
 
-    def get_path(self, language, fallback=True):
+    def get_url_obj(self, language, fallback=True):
         """Get the path of the page depending on the given language"""
         languages = [language]
 
         if fallback:
             languages.extend(self.get_fallbacks(language))
 
-        page_languages = self.get_languages()
-
         for _language in languages:
-            if _language in page_languages:
+            if _language in self.urls_cache:
                 language = _language
                 break
-
-        if language not in self.urls_cache:
-            self.urls_cache.update({
-                url.language: url for url in self.urls.all() if url.language in languages # TODO: overwrites multiple urls
-            })
-
+        else:
+            # `get_page_from_request` will fill the cache only for the current language
+            # Here, we fully fill it and try again
+            self.urls_cache ={
+                url.language: url for url in self.urls.all() if url.language in languages
+            }
             for _language in languages:
-                self.urls_cache.setdefault(_language, None)
+                if _language in self.urls_cache:
+                    language = _language
+                    break
 
-        try:
-            return self.urls_cache[language].path
-        except (AttributeError, KeyError):
-            return None
+        return self.urls_cache.get(language)
+
+    def get_path(self, language, fallback=True):
+        url = self.get_url_obj(language, fallback)
+        if url:
+            return url.path
+        return None
 
     def get_slug(self, language, fallback=True):
-        languages = [language]
+        url = self.get_url_obj(language, fallback)
+        if url:
+            return url.slug
+        return None
 
-        if fallback:
-            languages.extend(self.get_fallbacks(language))
-
-        page_languages = self.get_languages()
-
-        for _language in languages:
-            if _language in page_languages:
-                language = _language
-                break
-
-        if language not in self.urls_cache:
-            self.urls_cache.update({
-                url.language: url for url in self.urls.filter(language__in=languages)
-            })
-
-            for _language in languages:
-                self.urls_cache.setdefault(_language, None)
-
-        try:
-            return self.urls_cache[language].slug
-        except (AttributeError, KeyError):
-            return None
 
     def get_title(self, language=None, fallback=True, force_reload=False):
         """
@@ -1099,6 +1091,7 @@ class PageUrl(models.Model):
     class Meta:
         app_label = 'cms'
         default_permissions = []
+        unique_together = ('language', 'page')
 
     def __str__(self):
         return f"{self.path or self.slug} ({self.language})"

--- a/cms/templatetags/cms_admin.py
+++ b/cms/templatetags/cms_admin.py
@@ -98,7 +98,7 @@ def get_page_display_name(cms_page):
     page_content = cms_page.get_admin_content(language, fallback="force")
     title = page_content.title or page_content.page_title or page_content.menu_title
     if not title:
-        title = cms_page.get_slug(language)
+        title = cms_page.get_slug(language) or _("Empty")
     return title if page_content.language == language else mark_safe(f"<em>{title} ({page_content.language})</em>")
 
 

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -533,6 +533,7 @@ class ToolbarTests(ToolbarTestBase):
         page = create_page("english-page", "nav_playground.html", "en")
         german_content = create_page_content("de", "german content", page)
         english_content = page.get_content_obj('en')
+        page_languages = page.get_languages()
         edit_url = get_object_edit_url(english_content)
         staff = self.get_staff()
         self.client.force_login(staff)
@@ -541,8 +542,8 @@ class ToolbarTests(ToolbarTestBase):
         menus = response.context['cms_toolbar'].menus
         language_menu = menus['language-menu']
         delete = language_menu.items[-2]
-        german_delete = delete.items[0]
-        english_delete = delete.items[1]
+        german_delete = delete.items[page_languages.index("de")]
+        english_delete = delete.items[page_languages.index("en")]
 
         copy = language_menu.items[-1]
         copy_german = copy.items[0]

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -366,6 +366,18 @@ class ViewTests(CMSTestCase):
 
         self.assertNotIn(response.url, "<script>alert('Attack')</script>")
 
+    def test_queries(self):
+        create_page("home", "simple.html", "en")
+        cms_page = create_page("dreinhardt", "simple.html", "en")
+        url = cms_page.get_absolute_url()
+        with self.assertNumQueries(5):
+            # 1. get_page_from_request: checks PageUrl
+            # 2. get page contents: PageContent
+            # 3. Check permissions
+            # 4. Get placeholders
+            # 5. Get plugins
+            self.client.get(url)
+
 
 @override_settings(ROOT_URLCONF='cms.test_utils.project.urls')
 class ContextTests(CMSTestCase):

--- a/cms/utils/page.py
+++ b/cms/utils/page.py
@@ -2,9 +2,10 @@ import re
 
 from django.urls import NoReverseMatch, reverse
 from django.utils.encoding import force_str
+from django.utils.translation.trans_null import get_language
 
 from cms.constants import PAGE_USERNAME_MAX_LENGTH
-from cms.utils import get_current_site
+from cms.utils import get_current_site, get_language_from_request
 from cms.utils.conf import get_cms_setting
 
 SUFFIX_REGEX = re.compile(r'^(.*)-(\d+)$')
@@ -105,10 +106,10 @@ def get_page_from_request(request, use_path=None, clean_path=None):
     page_urls = list(page_urls)  # force queryset evaluation to save 1 query
     try:
         page = page_urls[0].page
+        if page_urls[0].language == get_language_from_request(request):
+            page.urls_cache = {url.language: url for url in page_urls}
     except IndexError:
         page = None
-    else:
-        page.urls_cache = {url.language: url for url in page_urls}
     return page
 
 

--- a/menus/utils.py
+++ b/menus/utils.py
@@ -207,10 +207,9 @@ class DefaultLanguageChanger:
         if not page:
             return '/%s/' % lang if settings.USE_I18N else '/'
 
-        page_languages = page.get_languages()
-
-        if lang in page_languages:
-            return page.get_absolute_url(lang, fallback=False)
+        url = page.get_absolute_url(lang, fallback=False)
+        if url:
+            return url
 
         site = get_current_site()
 
@@ -226,14 +225,16 @@ class DefaultLanguageChanger:
 
         default_language = get_default_language_for_site(site.pk)
 
-        if not _valid_language and default_language in page_languages:
+        if not _valid_language:
             # The request language is not configured for the current site.
             # Fallback to the default language configured for the current site.
-            return page.get_absolute_url(default_language, fallback=False)
+            url = page.get_absolute_url(default_language, fallback=False)
+            if url:
+                return url
 
         if _valid_language:
             fallbacks = get_fallback_languages(lang, site_id=site.pk) or []
-            fallbacks = [_lang for _lang in fallbacks if _lang in page_languages]
+            fallbacks = [_lang for _lang in fallbacks if _lang in page.get_languages()]
         else:
             fallbacks = []
 


### PR DESCRIPTION
## Description

This PR removes the ambiguous `languages` field from the `Page` model:
* Together with djangocms-versioning the field's content becomes ambiguous
* It tends to become inconsistent over time (#8019)
* It's size limit effectively but unnecessarily restricts the number of languages usable.

Originally, it contained a chained string of available `Title` objects (which is of course redundant) and was maintained to save database hits. With django CMS 4 its use does not save database hits any more.

Fixes #8019 

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8019
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
