### PR TITLE
fix: Ensure correct placeholder retrieval for PageContent instances

### DIFF
--- a/cms/app_registration.py
+++ b/cms/app_registration.py
@@ -1,5 +1,5 @@
 import inspect
-from functools import lru_cache
+from functools import cache, lru_cache
 from importlib import import_module
 
 from django.apps import apps
@@ -98,7 +98,7 @@ def autodiscover_cms_configs():
                     "CMSAppExtension")
 
 
-@lru_cache(maxsize=None)
+@cache
 def get_cms_extension_apps():
     """
     Returns django app configs of apps with a cms extension
@@ -110,7 +110,7 @@ def get_cms_extension_apps():
     return cms_apps
 
 
-@lru_cache(maxsize=None)
+@cache
 def get_cms_config_apps():
     """
     Returns django app configs of apps with a cms config

--- a/cms/app_registration.py
+++ b/cms/app_registration.py
@@ -1,5 +1,5 @@
 import inspect
-from functools import cache, lru_cache
+from functools import cache
 from importlib import import_module
 
 from django.apps import apps

--- a/cms/context_processors.py
+++ b/cms/context_processors.py
@@ -1,4 +1,4 @@
-from functools import cache, lru_cache
+from functools import cache
 
 from django.utils.functional import lazy
 

--- a/cms/context_processors.py
+++ b/cms/context_processors.py
@@ -1,4 +1,4 @@
-from functools import lru_cache
+from functools import cache, lru_cache
 
 from django.utils.functional import lazy
 
@@ -12,7 +12,7 @@ def cms_settings(request):
     """
     from menus.menu_pool import MenuRenderer
 
-    @lru_cache(maxsize=None)
+    @cache
     def _get_menu_renderer():
         # We use lru_cache to avoid getting the manager
         # every time this function is called.

--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -561,7 +561,7 @@ class ContentRenderer(BaseRenderer):
         toolbar_obj = self.toolbar.get_object()
         if isinstance(toolbar_obj, PageContent) and toolbar_obj.page == page:
             # Current object belongs to the page itself
-            placeholders = Placeholder.objects.get_for_obj(toolbar_obj)
+            return Placeholder.objects.get_for_obj(toolbar_obj)
         elif slots:
             # If looking for inherited placeholders, slots is specified
             if self.toolbar.preview_mode_active or self.toolbar.edit_mode_active:
@@ -569,16 +569,13 @@ class ContentRenderer(BaseRenderer):
                                 .current_content(language=self.request_language).first())
             else:
                 page_content = page.pagecontent_set.filter(language=self.request_language).first()
-            placeholders = Placeholder.objects.get_for_obj(page_content) if page_content else Placeholder.objects.none()
+            return Placeholder.objects.get_for_obj(page_content) if page_content else Placeholder.objects.none()
+        elif page_content := page.get_content_obj(self.request_language, fallback=False):
+            PageContent.page.field.set_cached_value(page_content, page)
+            # Creates any placeholders missing on the page
+            return page_content.rescan_placeholders().values()
         else:
-            page_content = page.get_content_obj(self.request_language, fallback=False)
-            if page_content:
-                PageContent.page.field.set_cached_value(page_content, page)
-                # Creates any placeholders missing on the page
-                placeholders = page_content.rescan_placeholders().values()
-            else:
-                placeholders = Placeholder.objects.none()
-        return placeholders
+            return Placeholder.objects.none()
 
     def _preload_placeholders_for_page(self, page, slots=None, inherit=False):
         """

--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -558,10 +558,10 @@ class ContentRenderer(BaseRenderer):
         return language_cache.get(placeholder.pk)
 
     def _get_content_object(self, page, slots=None):
-        if self.toolbar.get_object() == page:
+        toolbar_obj = self.toolbar.get_object()
+        if isinstance(toolbar_obj, PageContent) and toolbar_obj.page == page:
             # Current object belongs to the page itself
-            page_content = self.toolbar.get_object()
-            placeholders = Placeholder.objects.get_for_obj(page_content)
+            placeholders = Placeholder.objects.get_for_obj(toolbar_obj)
         elif slots:
             # If looking for inherited placeholders, slots is specified
             if self.toolbar.preview_mode_active or self.toolbar.edit_mode_active:
@@ -572,10 +572,12 @@ class ContentRenderer(BaseRenderer):
             placeholders = Placeholder.objects.get_for_obj(page_content) if page_content else Placeholder.objects.none()
         else:
             page_content = page.get_content_obj(self.request_language, fallback=False)
-
-            PageContent.page.field.set_cached_value(page_content, page)
-            # Creates any placeholders missing on the page
-            placeholders = page_content.rescan_placeholders().values()
+            if page_content:
+                PageContent.page.field.set_cached_value(page_content, page)
+                # Creates any placeholders missing on the page
+                placeholders = page_content.rescan_placeholders().values()
+            else:
+                placeholders = Placeholder.objects.none()
         return placeholders
 
     def _preload_placeholders_for_page(self, page, slots=None, inherit=False):

--- a/cms/tests/test_rendering.py
+++ b/cms/tests/test_rendering.py
@@ -295,6 +295,19 @@ class RenderingTestCase(CMSTestCase):
         r = self.strip_rendered(response.content.decode('utf8'))
         self.assertEqual(r, '|' + self.test_data['text_main'] + '|' + self.test_data['text_sub'] + '|')
 
+    def test_getting_placeholders(self):
+        """ContentRenderer._get_content_object uses toolbar to return placeholders of a page"""
+        request = self.get_request(page=self.test_page)
+        request.toolbar = CMSToolbar(request)
+        wrong_content_obj = self.test_page2.get_content_obj("en")
+        wrong_content_obj.page = self.test_page
+        request.toolbar.set_object(wrong_content_obj)
+        content_renderer = self.get_content_renderer(request)
+        placeholders = content_renderer._get_content_object(self.test_page)
+        wrong_content_obj.page = self.test_page2
+
+        self.assertEqual(len(placeholders), 2)
+
     @override_settings(
         CMS_PLUGIN_PROCESSORS=('cms.tests.test_rendering.sample_plugin_processor',),
         CMS_PLUGIN_CONTEXT_PROCESSORS=('cms.tests.test_rendering.sample_plugin_context_processor',),

--- a/cms/utils/plugins.py
+++ b/cms/utils/plugins.py
@@ -2,7 +2,7 @@ import logging
 import sys
 from collections import OrderedDict, defaultdict, deque
 from copy import deepcopy
-from functools import lru_cache
+from functools import cache, lru_cache
 from itertools import starmap
 from operator import itemgetter
 
@@ -20,7 +20,7 @@ from cms.utils.placeholder import get_placeholder_conf
 logger = logging.getLogger(__name__)
 
 
-@lru_cache(maxsize=None)
+@cache
 def get_plugin_class(plugin_type: str) -> CMSPluginBase:
     """Returns the plugin class for a given plugin_type (str)"""
     return plugin_pool.get_plugin(plugin_type)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,11 @@ extend-ignore = [
   "PLW0603",
   "PLW0602",
   "PLW2901",
+  "UP006",  # Use `list` instead of `typing.List` for type annotation
   "UP028",
   "UP030",
   "UP031",
+  "UP035",  # UP035 `typing.List` is deprecated, use `list` instead
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
## Description

Fix placeholder inheritance issue by ensuring correct retrieval of placeholders when the toolbar object is a `PageContent` instance.

After confirming that the fix works, a regression test needs to be added.

Fixes #8087 

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Fix placeholder retrieval for PageContent instances and add a regression test to ensure the fix works. Enhance caching by replacing lru_cache with cache in several functions and update linting rules in pyproject.toml.

Bug Fixes:
- Fix placeholder inheritance issue by ensuring correct retrieval of placeholders when the toolbar object is a PageContent instance.

Enhancements:
- Replace lru_cache with cache for improved caching in various functions.

Tests:
- Add a regression test to verify the correct retrieval of placeholders using the toolbar.

Chores:
- Update pyproject.toml to ignore specific linting rules related to typing annotations.