### PR TITLE
fix: Adjust tests for updated django 5.2 admin templates

### DIFF
--- a/cms/utils/compat/__init__.py
+++ b/cms/utils/compat/__init__.py
@@ -7,5 +7,11 @@ DJANGO_VERSION = get_version()
 PYTHON_VERSION = python_version()
 
 # These means "less than or equal to DJANGO_FOO_BAR"
+DJANGO_2_2 = Version(DJANGO_VERSION) < Version('3.0')
+DJANGO_3_0 = Version(DJANGO_VERSION) < Version('3.1')
+DJANGO_3_1 = Version(DJANGO_VERSION) < Version('3.2')
+DJANGO_3_2 = Version(DJANGO_VERSION) < Version('3.3')
+DJANGO_3 = Version(DJANGO_VERSION) < Version('4.0')
+DJANGO_4_1 = Version(DJANGO_VERSION) < Version('4.2')
 DJANGO_4_2 = Version(DJANGO_VERSION) < Version('4.3')
 DJANGO_5_1 = Version(DJANGO_VERSION) < Version('5.2.dev')  # To allow testing against django's main branch

--- a/cms/utils/compat/__init__.py
+++ b/cms/utils/compat/__init__.py
@@ -7,11 +7,5 @@ DJANGO_VERSION = get_version()
 PYTHON_VERSION = python_version()
 
 # These means "less than or equal to DJANGO_FOO_BAR"
-DJANGO_2_2 = Version(DJANGO_VERSION) < Version('3.0')
-DJANGO_3_0 = Version(DJANGO_VERSION) < Version('3.1')
-DJANGO_3_1 = Version(DJANGO_VERSION) < Version('3.2')
-DJANGO_3_2 = Version(DJANGO_VERSION) < Version('3.3')
-DJANGO_3 = Version(DJANGO_VERSION) < Version('4.0')
-DJANGO_4_1 = Version(DJANGO_VERSION) < Version('4.2')
 DJANGO_4_2 = Version(DJANGO_VERSION) < Version('4.3')
-DJANGO_5_1 = Version(DJANGO_VERSION) < Version('5.2')
+DJANGO_5_1 = Version(DJANGO_VERSION) < Version('5.2.dev')  # To allow testing against django's main branch


### PR DESCRIPTION
## Description

Update test cases to align with changes in Django 5.2 admin templates, ensuring compatibility with new error message structures and improving test organization using subTest.

Bug Fixes:
- Adjust tests to accommodate changes in Django 5.2 admin templates, ensuring compatibility with updated error message structures.

Tests:
- Refactor test cases to use subTest for better organization and clarity, particularly in scenarios involving slug collisions and redirect validations.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.