### PR TITLE
feat: Don't show plugin selector if only one plugin can be selected

### DIFF
--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -6,7 +6,7 @@ from urllib.parse import parse_qsl, urlparse
 from django import forms
 from django.contrib import admin
 from django.contrib.admin.helpers import AdminForm
-from django.contrib.admin.utils import get_deleted_objects, flatten_fieldsets
+from django.contrib.admin.utils import flatten_fieldsets, get_deleted_objects
 from django.core.exceptions import PermissionDenied
 from django.db import models, transaction
 from django.http import (

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -84,7 +84,7 @@ def _instance_overrides_method(base, instance, method_name):
 
 class BaseEditableAdminMixin:
     """
-    Base class for FrontendEditableAdminMixin to be re-used by
+    Base class for FrontendEditableAdminMixin to be reused by
     PlaceholderAdmin
     """
     @xframe_options_sameorigin

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -447,7 +447,7 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
             fields = flatten_fieldsets(fieldsets)
             # Instantiate the add form for all fields
             initial_form = plugin_instance.get_form(request, None, change=False, fields=fields)()
-            # Turn the inital values in a multi-value dict. In a multi-value dict each value is a list.
+            # Turn the initial values in a multi-value dict. In a multi-value dict each value is a list.
             # Hence, if the initial value is not a list, it is turned into a list.
             query_dict = MultiValueDict({
                 name: field.initial if isinstance(field.initial, (tuple, list)) else [field.initial]

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -6,7 +6,7 @@ from urllib.parse import parse_qsl, urlparse
 from django import forms
 from django.contrib import admin
 from django.contrib.admin.helpers import AdminForm
-from django.contrib.admin.utils import get_deleted_objects
+from django.contrib.admin.utils import get_deleted_objects, flatten_fieldsets
 from django.core.exceptions import PermissionDenied
 from django.db import models, transaction
 from django.http import (
@@ -19,6 +19,7 @@ from django.http import (
 from django.shortcuts import get_list_or_404, get_object_or_404, render
 from django.template.response import TemplateResponse
 from django.urls import include, re_path
+from django.utils.datastructures import MultiValueDict
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_str
 from django.utils.html import conditional_escape
@@ -436,8 +437,29 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
             'position': plugin_data['plugin_position'],
         }
 
-        response = plugin_instance.add_view(request)
+        if request.method == 'POST':
+            # If the plugin has show_add_plugin_form set to False,
+            # the post data is missing the initial values of the plugin form
+            # Get the fields, the form and the initial values from the plugin instance
+            # Replace the POST parameters by those initial values plus any concrete changes
+            # the form.
+            fieldsets = plugin_instance.get_fieldsets(request, obj=None)
+            fields = flatten_fieldsets(fieldsets)
+            # Instantiate the add form for all fields
+            initial_form = plugin_instance.get_form(request, None, change=False, fields=fields)()
+            # Turn the inital values in a multi-value dict. In a multi-value dict each value is a list.
+            # Hence, if the initial value is not a list, it is turned into a list.
+            query_dict = MultiValueDict({
+                name: field.initial if isinstance(field.initial, (tuple, list)) else [field.initial]
+                for name, field in initial_form.fields.items()
+                if getattr(field, "initial", None) is not None and name not in request.POST
+            })
+            # Add the actual post parameters
+            query_dict.update(request.POST)
+            # Use the QueryDict as the POST data
+            request.POST = query_dict
 
+        response = plugin_instance.add_view(request)
         plugin = getattr(plugin_instance, 'saved_object', None)
 
         if plugin_instance._operation_token:

--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -205,10 +205,10 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
     #: not open the plugin edit dialog. The user will not have a direct way to change the plugin instance.
     #:
     #: Moving or adding child plugins are not affected.
-    edit_disabled = False
+    disable_edit = False
 
-    #: Determines if the add plugin modal is shown for this plugin (default: yes). Useful for plugins which,have now
-    #: fields to fill, or which have valid default values for all fields.
+    #: Determines if the add plugin modal is shown for this plugin (default: yes). Useful for plugins which,have no
+    #: fields to fill, or which have valid default values for *all* fields.
     #: If the plugin's form will not validate with the default values the add plugin modal is shown with the form
     #: errors
     show_plugin_add_form = True

--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -207,15 +207,6 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
     #: Moving or adding child plugins are not affected.
     edit_disabled = False
 
-    #: Disables *moving* of children of this plugin in structure mode. Useful for plugins which, for example, manage
-    #: their child plugins.
-    #:
-    #: If moving is disabled, the plugin will not be draggable in structure mode. The user will not have a direct way
-    #: to change the order of the child plugins.
-    #:
-    #: Editing or adding child plugins are not affected.
-    moving_children_disabled = False
-
     #: Determines if the add plugin modal is shown for this plugin (default: yes). Useful for plugins which,have now
     #: fields to fill, or which have valid default values for all fields.
     #: If the plugin's form will not validate with the default values the add plugin modal is shown with the form
@@ -540,15 +531,15 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
         pass
 
     def icon_src(self, instance):
-        """By default, this returns an empty string, which, if left un-overridden would result in no icon
+        """Deprecated: Since djangocms-text-ckeditor introduced inline previews of plugins, the icon will not be
+        rendered in TextPlugins anymore.
+
+        By default, this returns an empty string, which, if left un-overridden would result in no icon
         rendered at all, which, in turn, would render the plugin un-editable by the operator inside a parent
         text plugin.
 
         Therefore, this should be overridden when the plugin has text_enabled set to True to return the path
         to an icon to display in the text of the text plugin.
-
-        Since djangocms-text-ckeditor introduced inline previews of plugins, the icon will not be
-        rendered in TextPlugins anymore.
 
         :param instance: The instance of the plugin model.
         :type instance: :class:`cms.models.pluginmodel.CMSPlugin` instance
@@ -556,7 +547,7 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
         Example::
 
             def icon_src(self, instance):
-                return settings.STATIC_URL + "cms/img/icons/plugins/link.png"
+                return static("cms/img/icons/plugins/link.png")
 
         See also: :attr:`text_enabled`, :meth:`icon_alt`
         """
@@ -572,7 +563,7 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
             for the 'alt' text.
         :type instance: :class:`cms.models.pluginmodel.CMSPlugin` instance
 
-        By default :meth:`icon_alt` will return a string of the form: "[plugin type] -
+        By default, :meth:`icon_alt` will return a string of the form: "[plugin type] -
         [instance]", but can be modified to return anything you like.
 
         This function accepts the ``instance`` as a parameter and returns a string to be

--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -79,15 +79,6 @@ class CMSPluginBaseMetaclass(forms.MediaDefiningClass):
                         }
                     )
                 ]
-            if not basic_fields and not advanced_fields:
-                # No need for editing of plugin without fields
-                # Plugins with a get_fieldsets method are assumed to provide non-empty fieldsets
-                new_plugin.edit_disabled = new_plugin.edit_disabled or not hasattr(new_plugin, "get_fieldsets")
-        else:
-            if not flatten_fieldsets(new_plugin.fieldsets):
-                # No need for editing of plugin without fields
-                new_plugin.edit_disabled = new_plugin.edit_disabled or not hasattr(new_plugin, "get_fieldsets")
-
         # Set default name
         if not new_plugin.name:
             new_plugin.name = re.sub("([a-z])([A-Z])", "\\g<1> \\g<2>", name)

--- a/cms/static/cms/js/modules/cms.modal.js
+++ b/cms/static/cms/js/modules/cms.modal.js
@@ -169,7 +169,7 @@ class Modal {
         this.ui.minimizeButton.toggle(this.options.minimizable);
         this.ui.maximizeButton.toggle(this.options.maximizable);
 
-        var position = this._calculateNewPosition(opts);
+        const position = this._calculateNewPosition(opts);
 
         this.ui.maximizeButton.removeClass('cms-modal-maximize-active');
         this.maximized = false;
@@ -912,12 +912,15 @@ class Modal {
             }
 
             // check if we are redirected - should only happen after successful form submission
-            var redirect = body.find('a.cms-view-new-object').attr('href');
+            const redirect = body.find('a.cms-view-new-object').attr('href');
 
             if (redirect) {
                 Helpers.reloadBrowser(redirect, false);
                 return true;
             }
+
+            // If the resopnse contains the data bridge, the form was saved successfully
+            that.saved = that.saved || body.find('script#data-bridge').length;
 
             // tabindex is required for keyboard navigation
             // body.attr('tabindex', '0');
@@ -1034,6 +1037,10 @@ class Modal {
                     }, 150); // eslint-disable-line
                 }
             } else {
+                if (that.ui.modal.hasClass('cms-modal-open')) {
+                    // show modal if hidden
+                    that.ui.modal.show();
+                }
                 iframe.show();
                 // set title of not provided
                 innerTitle = contents.find('#content h1:eq(0)');

--- a/cms/static/cms/js/modules/cms.plugins.js
+++ b/cms/static/cms/js/modules/cms.plugins.js
@@ -494,7 +494,7 @@ var Plugin = new Class({
      * @param {Number} position (optional) position of the plugin
      */
     // eslint-disable-next-line max-params
-    addPlugin: function(type, name, parent, showAddForm=true, position) {
+    addPlugin: function(type, name, parent, showAddForm = true, position) {
         var params = {
             placeholder_id: this.options.placeholder_id,
             plugin_type: type,
@@ -530,6 +530,7 @@ var Plugin = new Class({
             }
             const contents = modal.ui.frame.find('iframe').contents();
             const body = contents.find('body');
+
             body.append(`<form method="post" action="${url}" style="display: none;">
                 <input type="hidden" name="csrfmiddlewaretoken" value="${CMS.config.csrf}"></form>`);
             body.find('form').submit();
@@ -537,7 +538,7 @@ var Plugin = new Class({
         this.modal = modal;
 
         Helpers.removeEventListener('modal-closed.add-plugin');
-        Helpers.addEventListener('modal-closed.add-plugin', (e, {instance}) => {
+        Helpers.addEventListener('modal-closed.add-plugin', (e, { instance }) => {
             if (instance !== modal) {
                 return;
             }
@@ -1157,6 +1158,7 @@ var Plugin = new Class({
                     const pluginType = el.attr('href').replace('#', '');
                     const showAddForm = el.data('addForm');
                     const parentId = that._getId(nav.closest('.cms-draggable'));
+
                     that.addPlugin(pluginType, el.text(), parentId, showAddForm);
                 }
             });

--- a/cms/static/cms/js/modules/cms.plugins.js
+++ b/cms/static/cms/js/modules/cms.plugins.js
@@ -490,10 +490,11 @@ var Plugin = new Class({
      * @param {String} type type of the plugin, e.g "Bootstrap3ColumnCMSPlugin"
      * @param {String} name name of the plugin, e.g. "Column"
      * @param {String} parent id of a parent plugin
+     * @param {Boolean} showAddForm if false, will NOT show the add form
      * @param {Number} position (optional) position of the plugin
      */
     // eslint-disable-next-line max-params
-    addPlugin: function(type, name, parent, position) {
+    addPlugin: function(type, name, parent, showAddForm, position) {
         var params = {
             placeholder_id: this.options.placeholder_id,
             plugin_type: type,
@@ -506,25 +507,73 @@ var Plugin = new Class({
             params.plugin_parent = parent;
         }
         var url = this.options.urls.add_plugin + '?' + $.param(params);
-        var modal = new Modal({
+
+        const modal = new Modal({
             onClose: this.options.onClose || false,
             redirectOnClose: this.options.redirectOnClose || false
         });
 
-        modal.open({
-            url: url,
-            title: name
-        });
-
+        if (showAddForm) {
+            modal.open({
+                url: url,
+                title: name
+            });
+        } else {
+            // Also open the modal but without the content. Instead create a form and immediately submit it.
+            modal.open({
+                url: '#',
+                title: name
+            });
+            modal.ui.modal.hide();
+            const contents = modal.ui.frame.find('iframe').contents();
+            const body = contents.find('body');
+            body.append(`<form method="post" action="${url}" style="display: none;">
+                <input type="hidden" name="csrfmiddlewaretoken" value="${CMS.config.csrf}"></form>`);
+            body.find('form').submit();
+        }
         this.modal = modal;
 
         Helpers.removeEventListener('modal-closed.add-plugin');
-        Helpers.addEventListener('modal-closed.add-plugin', (e, { instance }) => {
+        Helpers.addEventListener('modal-closed.add-plugin', (e, {instance}) => {
             if (instance !== modal) {
                 return;
             }
             Plugin._removeAddPluginPlaceholder();
         });
+    },
+
+    _postAddRequest: function (url) {
+        showLoader();
+        Plugin._removeAddPluginPlaceholder();
+        new Modal().close();  // Don't have access to a potentially open modal, just create a new one and close it
+
+        const iframe = $(document.body)
+            .append(`<iframe name="cms-add-plugin" style="display: none;"></iframe>`)
+            .find('iframe[target="cms-add-plugin"]').last();
+        const form = $(document.body)
+            .append(`<form method="post" target="cms-add-plugin" action="${url}" style="display: none;">
+<input type="hidden" name="csrfmiddlewaretoken" value="${CMS.config.csrf}"></form>`)
+            .find('form[target="cms-add-plugin"]').last();
+
+        iframe.on('load', () => {
+            console.log("iframe onLoad");
+            const contents = iframe.contents();
+
+            // show messages in toolbar if provided
+            const messages = contents.find('.messagelist li.error');
+            if (messages.length) {
+                CMS.API.Messages.open({
+                    message: messages.eq(0).html()
+                });
+            }
+
+            iframe.remove();
+            hideLoader();
+        });
+
+        form.submit();
+        form.remove();
+        console.log("submitted", form);
     },
 
     _getPluginAddPosition: function() {
@@ -1137,9 +1186,9 @@ var Plugin = new Class({
                     // instead directly add the single plugin
                     const el = possibleChildClasses.find('a');  // only one result
                     const pluginType = el.attr('href').replace('#', '');
+                    const showAddForm = el.data('addForm');
                     const parentId = that._getId(nav.closest('.cms-draggable'));
-
-                    that.addPlugin(pluginType, el.text(), parentId);
+                    that.addPlugin(pluginType, el.text(), parentId, showAddForm);
                 }
             });
 
@@ -1352,9 +1401,10 @@ var Plugin = new Class({
             // eslint-disable-next-line no-case-declarations
             case 'add':
                 const pluginType = el.attr('href').replace('#', '');
+                const showAddForm = el.data('addForm');
 
                 Plugin._updateUsageCount(pluginType);
-                that.addPlugin(pluginType, el.text(), el.closest('.cms-plugin-picker').data('parentId'));
+                that.addPlugin(pluginType, el.text(), el.closest('.cms-plugin-picker').data('parentId'), showAddForm);
                 break;
             case 'ajax_add':
                 CMS.API.Toolbar.openAjax({

--- a/cms/static/cms/js/modules/cms.plugins.js
+++ b/cms/static/cms/js/modules/cms.plugins.js
@@ -490,7 +490,9 @@ var Plugin = new Class({
      * @param {String} type type of the plugin, e.g "Bootstrap3ColumnCMSPlugin"
      * @param {String} name name of the plugin, e.g. "Column"
      * @param {String} parent id of a parent plugin
+     * @param {Number} position (optional) position of the plugin
      */
+    // eslint-disable-next-line max-params
     addPlugin: function(type, name, parent, position) {
         var params = {
             placeholder_id: this.options.placeholder_id,
@@ -1136,6 +1138,7 @@ var Plugin = new Class({
                     const el = possibleChildClasses.find('a');  // only one result
                     const pluginType = el.attr('href').replace('#', '');
                     const parentId = that._getId(nav.closest('.cms-draggable'));
+
                     that.addPlugin(pluginType, el.text(), parentId);
                 }
             });

--- a/cms/static/cms/js/modules/cms.plugins.js
+++ b/cms/static/cms/js/modules/cms.plugins.js
@@ -1032,11 +1032,9 @@ var Plugin = new Class({
         }
         var that = this;
         var modal;
+        var possibleChildClasses;
         var isTouching;
         var plugins;
-
-        var possibleChildClasses = this._getPossibleChildClasses();
-        var selectionNeeded = possibleChildClasses.filter(':not(.cms-submenu-item-title)').length !== 1;
 
         var initModal = once(function initModal() {
             var placeholder = $(
@@ -1110,6 +1108,9 @@ var Plugin = new Class({
                 e.stopPropagation();
 
                 Plugin._hideSettingsMenu();
+
+                possibleChildClasses = that._getPossibleChildClasses();
+                var selectionNeeded = possibleChildClasses.filter(':not(.cms-submenu-item-title)').length !== 1;
 
                 if (selectionNeeded) {
                     initModal();

--- a/cms/static/cms/js/modules/cms.plugins.js
+++ b/cms/static/cms/js/modules/cms.plugins.js
@@ -494,7 +494,7 @@ var Plugin = new Class({
      * @param {Number} position (optional) position of the plugin
      */
     // eslint-disable-next-line max-params
-    addPlugin: function(type, name, parent, showAddForm, position) {
+    addPlugin: function(type, name, parent, showAddForm=true, position) {
         var params = {
             placeholder_id: this.options.placeholder_id,
             plugin_type: type,
@@ -524,7 +524,10 @@ var Plugin = new Class({
                 url: '#',
                 title: name
             });
-            modal.ui.modal.hide();
+            if (modal.ui) {
+                // Hide the plugin type selector modal if it's open
+                modal.ui.modal.hide();
+            }
             const contents = modal.ui.frame.find('iframe').contents();
             const body = contents.find('body');
             body.append(`<form method="post" action="${url}" style="display: none;">
@@ -540,40 +543,6 @@ var Plugin = new Class({
             }
             Plugin._removeAddPluginPlaceholder();
         });
-    },
-
-    _postAddRequest: function (url) {
-        showLoader();
-        Plugin._removeAddPluginPlaceholder();
-        new Modal().close();  // Don't have access to a potentially open modal, just create a new one and close it
-
-        const iframe = $(document.body)
-            .append(`<iframe name="cms-add-plugin" style="display: none;"></iframe>`)
-            .find('iframe[target="cms-add-plugin"]').last();
-        const form = $(document.body)
-            .append(`<form method="post" target="cms-add-plugin" action="${url}" style="display: none;">
-<input type="hidden" name="csrfmiddlewaretoken" value="${CMS.config.csrf}"></form>`)
-            .find('form[target="cms-add-plugin"]').last();
-
-        iframe.on('load', () => {
-            console.log("iframe onLoad");
-            const contents = iframe.contents();
-
-            // show messages in toolbar if provided
-            const messages = contents.find('.messagelist li.error');
-            if (messages.length) {
-                CMS.API.Messages.open({
-                    message: messages.eq(0).html()
-                });
-            }
-
-            iframe.remove();
-            hideLoader();
-        });
-
-        form.submit();
-        form.remove();
-        console.log("submitted", form);
     },
 
     _getPluginAddPosition: function() {

--- a/cms/templates/cms/toolbar/dragitem_menu.html
+++ b/cms/templates/cms/toolbar/dragitem_menu.html
@@ -4,7 +4,7 @@
     <div class="cms-submenu-item cms-submenu-item-title"><span>{% if module.grouper %}{{ module.grouper|capfirst }}{% else %}{% trans "Available plugins" %}{% endif %}</span></div>
     {% for p in module.list %}
         {% if p.value != 'AliasPlugin' and p.value != 'PlaceholderPlugin' %}
-            <div class="cms-submenu-item"><a data-rel="add" href="{{ p.value }}">{{ p.name }}</a></div>
+            <div class="cms-submenu-item"><a data-rel="add" data-add-form="{{ p.add_form|yesno:'true,false' }}" href="{{ p.value }}">{{ p.name }}</a></div>
         {% endif %}
     {% endfor %}
 {% endfor %}

--- a/cms/tests/frontend/unit/cms.plugins.test.js
+++ b/cms/tests/frontend/unit/cms.plugins.test.js
@@ -324,7 +324,7 @@ describe('CMS.Plugin', function() {
             jasmine.clock().uninstall();
         });
 
-        it('removes the temlpate tags around the plugin markup', function() {
+        it('removes the template tags around the plugin markup', function() {
             expect($('template')).not.toBeInDOM();
         });
 
@@ -496,6 +496,10 @@ describe('CMS.Plugin', function() {
         class FakeModal {
             constructor(...args) {
                 modalConstructor(...args);
+                this.ui = {
+                    frame: $('.cms-modal-frame'),
+                    modal: $('.cms-modal')
+                };
             }
         }
 
@@ -543,8 +547,8 @@ describe('CMS.Plugin', function() {
             fixture.cleanup();
         });
 
-        it('opens the modal with correct url', function() {
-            plugin.addPlugin('TextPlugin', 'Text plugin', 12);
+        it('opens the edit modal with correct url', function() {
+            plugin.addPlugin('TextPlugin', 'Text plugin', 12, true);
 
             expect(modalConstructor).toHaveBeenCalledWith({
                 onClose: false,
@@ -563,6 +567,19 @@ describe('CMS.Plugin', function() {
             expect(FakeModal.prototype.open.calls.mostRecent().args[0].url).toMatch('plugin_parent=12');
             expect(FakeModal.prototype.open.calls.mostRecent().args[0].url).toMatch('plugin_position=42');
             expect(FakeModal.prototype.open.calls.mostRecent().args[0].url).toMatch('cms_path=');
+        });
+
+        it('skips the edit modal when configured', function() {
+            plugin.addPlugin('TextPlugin', 'Text plugin', 12, false);
+            expect(modalConstructor).toHaveBeenCalledWith({
+                onClose: false,
+                redirectOnClose: false
+            });
+
+            expect(FakeModal.prototype.open).toHaveBeenCalledWith({
+                url: '#',
+                title: 'Text plugin'
+            });
         });
 
         it('opens the modal with correct url', function() {

--- a/cms/tests/frontend/unit/cms.plugins.test.js
+++ b/cms/tests/frontend/unit/cms.plugins.test.js
@@ -1687,7 +1687,7 @@ describe('CMS.Plugin', function() {
         var plugin;
         var tmpl =
             '<div class="cms-plugin-picker" data-parent-id="mock"><div class="cms-submenu-item {1}">' +
-            '<a href="{2}">Submenu item</a>' +
+            '<a href="{2}" data-add-form="{3}">Submenu item</a>' +
             '</div></div>';
 
         beforeEach(function(done) {
@@ -1771,13 +1771,15 @@ describe('CMS.Plugin', function() {
 
         it('delegates to add plugin', function() {
             spyOn(plugin, 'addPlugin');
-            var nav = $(tmpl.replace('{1}', '').replace('{2}', '#shmock')).find('> div');
+            var nav = $(tmpl.replace('{1}', '')
+                .replace('{2}', '#shmock')
+                .replace('{3}', 'perhaps')).find('> div');
             var link = nav.find('a');
             link.attr('data-rel', 'add');
             plugin._setupActions(nav);
             link.trigger(Plugin.click);
             expect(plugin.addPlugin).toHaveBeenCalledTimes(1);
-            expect(plugin.addPlugin).toHaveBeenCalledWith('shmock', 'Submenu item', 'mock');
+            expect(plugin.addPlugin).toHaveBeenCalledWith('shmock', 'Submenu item', 'mock', 'perhaps');
         });
 
         it('delegates to add ajax plugin', function() {

--- a/cms/tests/frontend/unit/fixtures/plugins.html
+++ b/cms/tests/frontend/unit/fixtures/plugins.html
@@ -241,4 +241,25 @@
             </div>
         </div>
     </div>
+
+    <div class="cms-modal" data-touch-action="none">
+        <div class="cms-modal-head" data-touch-action="none">
+            <span class="cms-modal-title" data-touch-action="none">
+                <span class="cms-modal-title-prefix"></span>
+                <span class="cms-modal-title-suffix"></span>
+            </span>
+            <span class="cms-modal-minimize cms-icon cms-icon-minus" title="Minimize"></span>
+            <span class="cms-modal-maximize cms-icon cms-icon-window" title="Maximize"></span>
+            <span class="cms-modal-close cms-icon cms-icon-close" title="Close"></span>
+        </div>
+        <div class="cms-modal-breadcrumb" data-touch-action="pan-x"></div>
+        <div class="cms-modal-body">
+            <div class="cms-modal-shim"></div>
+            <div class="cms-modal-frame"></div>
+        </div>
+        <div class="cms-modal-foot">
+            <div class="cms-modal-buttons"></div>
+            <div class="cms-modal-resize"><span class="cms-icon cms-icon-handler"></span></div>
+        </div>
+    </div>
 </div>

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -841,8 +841,8 @@ class PluginsTestCase(PluginsTestBaseCase):
             request.toolbar = CMSToolbar(request)
             renderer = self.get_structure_renderer(request=request)
             output = renderer.render_placeholder(placeholder, language='en', page=page)
-            self.assertIn('<a data-rel="add" href="TextPlugin">Text</a>', output)
-            self.assertNotIn('<a data-rel="add" href="LinkPlugin">Link</a>', output)
+            self.assertIn('<a data-rel="add" data-add-form="true" href="TextPlugin">Text</a>', output)
+            self.assertNotIn('<a data-rel="add" data-add-form="true" href="LinkPlugin">Link</a>', output)
 
     def test_plugin_child_classes_from_settings(self):
         page = api.create_page("page", "nav_playground.html", "en")

--- a/cms/utils/placeholder.py
+++ b/cms/utils/placeholder.py
@@ -122,6 +122,7 @@ def get_toolbar_plugin_struct(plugins, slot=None, page=None):
                 "value": plugin.value,
                 "name": names.get(plugin.value, plugin.name),
                 "module": modules.get(plugin.value, plugin.module),
+                "add_form": plugin.show_plugin_add_form
             }
         )
     return sorted(main_list, key=operator.itemgetter("module"))

--- a/cms/utils/placeholder.py
+++ b/cms/utils/placeholder.py
@@ -122,7 +122,7 @@ def get_toolbar_plugin_struct(plugins, slot=None, page=None):
                 "value": plugin.value,
                 "name": names.get(plugin.value, plugin.name),
                 "module": modules.get(plugin.value, plugin.module),
-                "add_form": plugin.show_plugin_add_form and not plugin.edit_disabled,
+                "add_form": plugin.show_plugin_add_form and not plugin.disable_edit,
             }
         )
     return sorted(main_list, key=operator.itemgetter("module"))

--- a/cms/utils/placeholder.py
+++ b/cms/utils/placeholder.py
@@ -122,7 +122,7 @@ def get_toolbar_plugin_struct(plugins, slot=None, page=None):
                 "value": plugin.value,
                 "name": names.get(plugin.value, plugin.name),
                 "module": modules.get(plugin.value, plugin.module),
-                "add_form": plugin.show_plugin_add_form
+                "add_form": plugin.show_plugin_add_form and not plugin.edit_disabled,
             }
         )
     return sorted(main_list, key=operator.itemgetter("module"))

--- a/docs/introduction/02-templates_placeholders.rst
+++ b/docs/introduction/02-templates_placeholders.rst
@@ -56,7 +56,7 @@ first one listed in the project's ``settings.py`` ``CMS_TEMPLATES`` tuple:
 
 If you've installed django CMS by hand or used the ``djangocms`` command you
 will not have templates pre-installed. The ``djangocms`` command installs an
-empty template that re-uses a minimal template from the djangocms-frontend
+empty template that reuses a minimal template from the djangocms-frontend
 package using Bootstrap 5. For this tutorial, you can check out and copy the
 `quickstart templates on github <https://github.com/django-cms/django-cms-quickstart/tree/main/backend/templates>`_.
 


### PR DESCRIPTION
## Description

As suggested by @CarwynNelson in #7982:
* when adding a plugin to a placeholder, there is no need for a plugin selector modal if only one plugin is available.
* when the plugin form contains no fields to edit, a plugin can be created without the form.

This PR skips the plugin selector modal when adding a plugin if only one plugin can be selected. Typical use cases include "nested" plugins such as accordions, rows with columns, ... 

![one-click-add-new](https://github.com/user-attachments/assets/c862e531-bf06-4219-b06d-6aa17cef84ee)

Also, it introduces a new attribute for the plugin in class (`show_plugin_add_form`). If set to `False`, adding the plugin will not show the add plugin form. Instead, a plugin will be created with the plugin's default values for all fields in the plugin's form. (If the form does not validate, the form errors are shown in the modal.)

Both features aim at reducing the number of clicks to add content in specific situations where these do not add value. Plugin defaults can also be used to provide instructive content for a plugin (such as, "Enter section title here") for further editing.

Here's an example from a tailwind text block / container which only provides styling and does not have any fields and an accordion where items can be added with a default title.

![one-click-add-new-2](https://github.com/user-attachments/assets/955dd230-21b0-443b-8808-d5d776e7cbc9)

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7982
* #7989 

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

New Features:
- Skip showing the plugin selector modal if only one plugin is available.