### PR TITLE
chore: Backport the delete translations fix for #8111 to django CMS 4.1

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write
 
 jobs:
   comment:

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -1248,7 +1248,7 @@ class PageContentAdmin(admin.ModelAdmin):
         page_content = self.get_object(request, object_id=object_id)
         page = page_content.page
         language = page_content.language
-        page_contents = PageContent.objects.filter(page=page, langauge=language)
+        page_contents = PageContent.objects.filter(page=page, language=language)
         page_url = page.urls.get(language=page_content.language)
         request_language = get_site_language_from_request(request, site_id=page.node.site_id)
 

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -1248,7 +1248,7 @@ class PageContentAdmin(admin.ModelAdmin):
         page_content = self.get_object(request, object_id=object_id)
         page = page_content.page
         language = page_content.language
-        page_contents = PageContent.objects.filter(page=page, language=language)
+        page_contents = PageContent.admin_manager.filter(page=page, language=language)
         page_url = page.urls.get(language=page_content.language)
         request_language = get_site_language_from_request(request, site_id=page.node.site_id)
 

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -1248,6 +1248,7 @@ class PageContentAdmin(admin.ModelAdmin):
         page_content = self.get_object(request, object_id=object_id)
         page = page_content.page
         language = page_content.language
+        page_contents = PageContent.objects.filter(page=page, langauge=language)
         page_url = page.urls.get(language=page_content.language)
         request_language = get_site_language_from_request(request, site_id=page.node.site_id)
 
@@ -1273,7 +1274,7 @@ class PageContentAdmin(admin.ModelAdmin):
             admin_site=self.admin_site,
         )[:3]
         to_delete_translations, __, perms_needed_translation = get_deleted_objects(
-            [page_content],
+            page_contents,
             request=request,
             admin_site=self.admin_site,
         )[:3]
@@ -1306,7 +1307,7 @@ class PageContentAdmin(admin.ModelAdmin):
             messages.success(request, message)
 
             page_url.delete()
-            page_content.delete()
+            page_contents.delete()
             for p in saved_plugins:
                 p.delete()
 


### PR DESCRIPTION
## Description

This backports parts of #8111: 
* Deleting a language for a page needs to remove **all** of the page's content objects for that language 
* The updated delete message is not backported for consistency reasons.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8111
* https://github.com/django-cms/djangocms-versioning/pull/442
* https://github.com/django-cms/djangocms-versioning/pull/443

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Delete all page content objects for a given language when deleting a page content object.

Bug Fixes:
- Fixed a bug where deleting a language for a page did not remove all of the page's content objects for that language.

Chores:
- Backported the fix for deleting translations to django CMS 4.1.