### PR TITLE
fix: Fallback page names were not escaped (#8113)

### DIFF
--- a/cms/templatetags/cms_admin.py
+++ b/cms/templatetags/cms_admin.py
@@ -7,7 +7,7 @@ from django.contrib import admin
 from django.contrib.admin.views.main import ERROR_FLAG
 from django.template.loader import render_to_string
 from django.utils.encoding import force_str
-from django.utils.html import format_html
+from django.utils.html import escape, format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import get_language, gettext_lazy as _
 
@@ -98,8 +98,8 @@ def get_page_display_name(cms_page):
     page_content = cms_page.get_admin_content(language, fallback="force")
     title = page_content.title or page_content.page_title or page_content.menu_title
     if not title:
-        title = cms_page.get_slug(language)
-    return title if page_content.language == language else mark_safe(f"<em>{title} ({page_content.language})</em>")
+        title = cms_page.get_slug(language) or _("Empty")
+    return title if page_content.language == language else mark_safe(f"<em>{escape(title)} ({page_content.language})</em>")
 
 
 class TreePublishRow(Tag):


### PR DESCRIPTION
## Description

Backports #8113 
<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8113 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Fix an issue where fallback page names were not escaped in the admin, which could lead to XSS vulnerabilities.