### PR TITLE
fix: Placeholder page getter failed for unpublished pages

### DIFF
--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -275,10 +275,11 @@ class Placeholder(models.Model):
 
     def page_getter(self):
         if not hasattr(self, '_page'):
-            from cms.models.pagemodel import Page
+            from cms.models.contentmodels import PageContent
             try:
-                self._page = Page.objects.distinct().get(pagecontent_set__placeholders=self)
-            except (Page.DoesNotExist, Page.MultipleObjectsReturned):
+                self._page = PageContent.admin_manager.filter(placeholders=self).first().page
+                # self._page = Page.objects.distinct().get(pagecontent_set__placeholders=self)
+            except AttributeError:
                 self._page = None
         return self._page
 

--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -278,7 +278,6 @@ class Placeholder(models.Model):
             from cms.models.contentmodels import PageContent
             try:
                 self._page = PageContent.admin_manager.filter(placeholders=self).first().page
-                # self._page = Page.objects.distinct().get(pagecontent_set__placeholders=self)
             except AttributeError:
                 self._page = None
         return self._page

--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -277,7 +277,7 @@ class Placeholder(models.Model):
         if not hasattr(self, '_page'):
             from cms.models.contentmodels import PageContent
             try:
-                self._page = PageContent.admin_manager.filter(placeholders=self).first().page
+                self._page = PageContent.admin_manager.filter(placeholders=self).select_related("page").first().page
             except AttributeError:
                 self._page = None
         return self._page


### PR DESCRIPTION
## Description

`placeholder.page` does not use the admin manager to retrieve a page object. This leads it to being `None` also for placeholders on pages which have no published content. This might lead to page-related placeholder configuration being ignored.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Fix the placeholder page getter to correctly retrieve page objects for placeholders on unpublished pages by using the admin manager.