### PR TITLE
chore: Replace removed Django API for Django 6.0

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -136,6 +136,11 @@ class PageAdmin(admin.ModelAdmin):
         return page_permissions.user_can_change_page_advanced_settings(request.user, page=obj, site=site)
 
     def log_deletion(self, request, object, object_repr):
+        # DJANGO_42
+        # Block the admin log for deletion. A signal takes care of this!
+        return
+
+    def log_deletions(self, request, queryset):
         # Block the admin log for deletion. A signal takes care of this!
         return
 
@@ -770,6 +775,11 @@ class PageContentAdmin(admin.ModelAdmin):
         return
 
     def log_deletion(self, request, object, object_repr):
+        # DJANGO_42
+        # Block the admin log for deletion. A signal takes care of this!
+        return
+
+    def log_deletions(self, request, queryset):
         # Block the admin log for deletion. A signal takes care of this!
         return
 

--- a/cms/signals/log_entries.py
+++ b/cms/signals/log_entries.py
@@ -82,6 +82,9 @@ _placeholder_operations_map = {
 
 
 def create_log_entry(user_id, content_type_id, object_id, object_repr, action_flag, change_message):
+    if isinstance(change_message, list):
+        change_message = json.dumps(change_message)
+
     LogEntry.objects.create(
             user_id=user_id,
             content_type_id=content_type_id,

--- a/cms/signals/log_entries.py
+++ b/cms/signals/log_entries.py
@@ -81,8 +81,15 @@ _placeholder_operations_map = {
 }
 
 
-create_log_entry = LogEntry.objects.log_action
-
+def create_log_entry(user_id, content_type_id, object_id, object_repr, action_flag, change_message):
+    LogEntry.objects.create(
+            user_id=user_id,
+            content_type_id=content_type_id,
+            object_id=str(object_id),
+            object_repr=object_repr[:200],
+            action_flag=action_flag,
+            change_message=change_message,
+        )
 
 def _is_valid_page_instance(page):
     """

--- a/cms/signals/log_entries.py
+++ b/cms/signals/log_entries.py
@@ -1,3 +1,5 @@
+import json
+
 from django.contrib.admin.models import ADDITION, CHANGE, DELETION, LogEntry
 from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import gettext_lazy as _

--- a/cms/tests/test_admin.py
+++ b/cms/tests/test_admin.py
@@ -484,11 +484,17 @@ class NoDBAdminTests(CMSTestCase):
 
     def test_lookup_allowed_site__exact(self):
         request = self.get_request()
-        self.assertTrue(self.admin_class.lookup_allowed('site__exact', '1', request))
+        if DJANGO_5_1:
+            self.assertTrue(self.admin_class.lookup_allowed('site__exact', '1'))
+        else:
+            self.assertTrue(self.admin_class.lookup_allowed('site__exact', '1', request))
 
     def test_lookup_allowed_published(self):
         request = self.get_request()
-        self.assertTrue(self.admin_class.lookup_allowed('published', '1', request))
+        if DJANGO_5_1:
+            self.assertTrue(self.admin_class.lookup_allowed('site__exact', '1'))
+        else:
+            self.assertTrue(self.admin_class.lookup_allowed('site__exact', '1', request))
 
 
 class PluginPermissionTests(AdminTestsBase):

--- a/cms/tests/test_admin.py
+++ b/cms/tests/test_admin.py
@@ -483,10 +483,12 @@ class NoDBAdminTests(CMSTestCase):
         return site._registry[Page]
 
     def test_lookup_allowed_site__exact(self):
-        self.assertTrue(self.admin_class.lookup_allowed('site__exact', '1'))
+        request = self.get_request()
+        self.assertTrue(self.admin_class.lookup_allowed('site__exact', '1', request))
 
     def test_lookup_allowed_published(self):
-        self.assertTrue(self.admin_class.lookup_allowed('published', value='1'))
+        request = self.get_request()
+        self.assertTrue(self.admin_class.lookup_allowed('published', '1', request))
 
 
 class PluginPermissionTests(AdminTestsBase):

--- a/cms/tests/test_log_entries.py
+++ b/cms/tests/test_log_entries.py
@@ -159,6 +159,7 @@ class LogPageOperationsTests(CMSTestCase):
             endpoint = self.get_admin_url(Page, 'delete', page.pk)
             post_data = {'post': 'yes'}
 
+            self.assertEqual(0, LogEntry.objects.count())
             response = self.client.post(endpoint, post_data)
             # Test that the end point is valid
             self.assertEqual(response.status_code, 302)


### PR DESCRIPTION
## Description

This PR implements updates necessary to run with Django 6.0:
* `create_log_entries`' removed manager method (https://docs.djangoproject.com/en/5.1/releases/5.1/#features-deprecated-in-5-1)
* `request` parameter for `admin.lookup_allowed` (https://docs.djangoproject.com/en/5.1/releases/5.0/#id2)

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Update codebase to be compatible with Django 6.0.

Bug Fixes:
- Replaced removed `create_log_entries` manager method with a function.
- Added `request` parameter to `admin.lookup_allowed`.

## Summary by Sourcery

Update the codebase to support Django 6.0.

Bug Fixes:
- Replaced the removed `create_log_entries` manager method with a function.
- Added the `request` parameter to `admin.lookup_allowed`.