### PR TITLE
feat: add placeholder-level error handling

### DIFF
--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -2,8 +2,9 @@ import contextlib
 import logging
 import sys
 from collections import OrderedDict
+from collections.abc import Generator
 from functools import partial
-from typing import Generator, Optional, Union
+from typing import Optional, Union
 
 from classytags.utils import flatten_context
 from django.conf import settings
@@ -18,7 +19,7 @@ from django.views.debug import ExceptionReporter
 
 from cms.cache.placeholder import get_placeholder_cache, set_placeholder_cache
 from cms.exceptions import PlaceholderNotFound
-from cms.models import PageContent, Placeholder, Page, CMSPlugin, StaticPlaceholder
+from cms.models import CMSPlugin, Page, PageContent, Placeholder, StaticPlaceholder
 from cms.plugin_pool import PluginPool
 from cms.toolbar.toolbar import CMSToolbar
 from cms.toolbar.utils import (

--- a/cms/static/cms/sass/components/_general.scss
+++ b/cms/static/cms/sass/components/_general.scss
@@ -17,3 +17,29 @@
         overflow: hidden !important;
     }
 }
+
+// Render exceptions in edit mode
+.cms-rendering-exception {
+    display: inline-block;
+    border: none;
+    background: #ffc;
+    padding: 0.6em 1.3em;
+    cursor: not-allowed;
+    min-height: 2em;
+    width:100%;
+    vertical-align:middle;
+
+    .cms-rendering-exception-title {
+        font-weight: bold;
+        color: darkred;
+    }
+    header#summary {
+        h1, pre {
+            display: none;
+        }
+    }
+
+    main#info {
+        font-size: 0.8rem;
+    }
+}

--- a/cms/static/cms/sass/components/_general.scss
+++ b/cms/static/cms/sass/components/_general.scss
@@ -24,14 +24,16 @@
     border: none;
     background: #ffc;
     padding: 0.6em 1.3em;
-    cursor: not-allowed;
     min-height: 2em;
-    width:100%;
-    vertical-align:middle;
+    width: 100%;
+    vertical-align: middle;
 
     .cms-rendering-exception-title {
         font-weight: bold;
         color: darkred;
+        &:not(.cms-plugin) {
+            cursor: not-allowed;
+        }
     }
     header#summary {
         h1, pre {
@@ -41,5 +43,11 @@
 
     main#info {
         font-size: 0.8rem;
+        h2 {
+            font-size: 1.6rem;
+        }
+        h3 {
+            font-size: 1.2rem;
+        }
     }
 }

--- a/cms/static/cms/sass/components/_general.scss
+++ b/cms/static/cms/sass/components/_general.scss
@@ -49,5 +49,8 @@
         h3 {
             font-size: 1.2rem;
         }
+        h4 {
+            font-size: 1rem;
+        }
     }
 }

--- a/cms/tests/test_plugin_renderers.py
+++ b/cms/tests/test_plugin_renderers.py
@@ -12,8 +12,8 @@ from cms.plugin_rendering import (
     StructureRenderer,
 )
 from cms.test_utils.testcases import CMSTestCase
-from cms.toolbar.utils import get_object_edit_url, get_toolbar_from_request
 from cms.toolbar.toolbar import CMSToolbar
+from cms.toolbar.utils import get_object_edit_url, get_toolbar_from_request
 
 
 class TestStructureRenderer(CMSTestCase):

--- a/cms/tests/test_plugin_renderers.py
+++ b/cms/tests/test_plugin_renderers.py
@@ -1,6 +1,5 @@
 from collections import deque
 
-import kolo
 from django.template import Context
 from django.test.utils import override_settings
 

--- a/cms/utils/conf.py
+++ b/cms/utils/conf.py
@@ -91,6 +91,7 @@ DEFAULTS = {
     'HIDE_LEGACY_FEATURES': True,
     'COLOR_SCHEME': 'auto',
     'COLOR_SCHEME_TOGGLE': True,
+    'CATCH_PLUGIN_500_EXCEPTION': True,
 }
 
 

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -1186,6 +1186,20 @@ This indicates to the CMS that it should redirect requests with an non-lowercase
 slug to its lowercase version if no page with that slug is found.
 
 
+CMS_CATCH_PLUGIN_500_EXCEPTION
+==============================
+
+default
+    ``True``
+
+Should rendering plugins cause an exception, they are caught by default.
+In edit mode the exception is shown in the placeholder, in preview mode and
+on public content the placeholder remains empty.
+
+If ``CMS_CATCH_PLUGIN_500_EXCEPTION`` is set to ``False``, viewing public
+content will cause a server error (http error code 500). This can, for example,
+be used for regular health checking.
+
 CMS_CONFIRM_VERSION4
 ====================
 

--- a/docs/upgrade/4.2.0.rst
+++ b/docs/upgrade/4.2.0.rst
@@ -42,16 +42,16 @@ Exception handling
 ==================
 
 Since django CMS 4, exceptions that happen during plugin rendering have been
-caught and displayed a message at the plugin's position.
-
-After feedback from the community, django CMS 4.2 refactored exception handling.
+caught and displayed a message at the plugin's position. After feedback from
+the community, django CMS 4.2 refactored exception handling.
 
 * Exceptions are now caught on placeholder level.
 
 * In edit mode, a message about the exception is shown for the placeholder. If
   ``settings.DEBUG == True`` this message includes the full Django trace.
 
-* Editors still can edit plugins causing the exception.
+* Editors still can edit plugins causing the exception. It can be edited by
+  double-clicking the error message or through the structure board.
 
 * In preview mode and on site, the placeholder containing the plugin will
   render empty.
@@ -59,7 +59,6 @@ After feedback from the community, django CMS 4.2 refactored exception handling.
 * If ``settings.CMS_CATCH_PLUGIN_500_EXCEPTION`` is set to ``False``, trying
   to view content that raises an exception will trigger a server error
   (http 500). Preview and edit modes will still work.
-
 
 
 Minor features

--- a/docs/upgrade/4.2.0.rst
+++ b/docs/upgrade/4.2.0.rst
@@ -4,7 +4,7 @@
 4.2.0 release notes
 ###################
 
-*October 31, 2024*
+*March 31, 2025*
 
 Welcome to django CMS 4.2.0!
 
@@ -38,14 +38,29 @@ Feature 1
 
 Empty sections are to be removed before release.
 
-Feature 2
-=========
+Exception handling
+==================
 
-Empty sections are to be removed before release.
+Since django CMS 4, exceptions that happen during plugin rendering have been
+caught and displayed a message at the plugin's position.
+
+After feedback from the community, django CMS 4.2 refactored exception handling.
+
+* Exceptions are now caught on placeholder level.
+
+* In edit mode, a message about the exception is shown for the placeholder. If
+  ``settings.DEBUG == True`` this message includes the full Django trace.
+
+* Editors still can edit plugins causing the exception.
+
+* In preview mode and on site, the placeholder containing the plugin will
+  render empty.
+
+* If ``settings.CMS_CATCH_PLUGIN_500_EXCEPTION`` is set to ``False``, trying
+  to view content that raises an exception will trigger a server error
+  (http 500). Preview and edit modes will still work.
 
 
-Feature 3
-=========
 
 Minor features
 ==============


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->
fixes #7974 

Since django CMS 4, exceptions that happen during plugin rendering have been caught and displayed a message at the plugin's position.

After [feedback from the community](https://github.com/django-cms/django-cms/discussions/7953), this PR refactors error handling when rendering placeholders.
.

* Exceptions are now caught on placeholder level.

* In edit mode, a message about the exception is shown for the placeholder. If  `settings.DEBUG == True` this message includes the full Django trace.

* Editors still can edit plugins causing the exception. It can be edited by  double-clicking the error message or through the structure board.

* In preview mode and on site, the placeholder containing the plugin will  render empty.

* If `settings.CMS_CATCH_PLUGIN_500_EXCEPTION` is set to `False`, trying  to view content that raises an exception will trigger a server error   (http 500). Preview and edit modes will still work.

## Screenshot

This is a full error message in edit mode and with `DEBUG = True`. The plugin with pk 35 caused a division by zero exception. It can be edited by double-clicking the red error message. Toolbar and structure board are available.

<img width="1101" alt="image" src="https://github.com/user-attachments/assets/a2afe094-10ff-4faf-9c89-c246997c9175" />

The same warning message on a production system is shorter:
<img width="1101" alt="image" src="https://github.com/user-attachments/assets/e6f0141c-c84f-4a01-8bc5-b8c1ee8eb59f" />


## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7974 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Fix error handling when rendering placeholders.