### PR TITLE
fix: Use correct `changed_date` of page content in sitemap

### DIFF
--- a/cms/sitemaps/cms_sitemap.py
+++ b/cms/sitemaps/cms_sitemap.py
@@ -54,19 +54,18 @@ class CMSSitemap(Sitemap):
             .filter(language__in=languages, path__isnull=False, page__login_required=False)
             .order_by("page__path")
             .select_related("page")
-            .prefetch_related("page__pagecontent_set")
             .annotate(
-                content_pk=Subquery(
+                content_changed_date=Subquery(
                     PageContent.objects.filter(page=OuterRef("page"), language=OuterRef("language"))
                     .filter(Q(redirect="") | Q(redirect=None))
-                    .values_list("pk")[:1]
+                    .values_list("changed_date")[:1]
                 )
             )
-            .filter(content_pk__isnull=False)  # Remove page content with redirects
+            .filter(content_changed_date__isnull=False)  # Remove page content with redirects
         )
 
     def lastmod(self, page_url):
-        return page_url.page.get_content_obj(page_url.language).changed_date
+        return page_url.content_changed_date
 
     def location(self, page_url):
         return page_url.get_absolute_url(page_url.language)

--- a/cms/sitemaps/cms_sitemap.py
+++ b/cms/sitemaps/cms_sitemap.py
@@ -54,6 +54,7 @@ class CMSSitemap(Sitemap):
             .filter(language__in=languages, path__isnull=False, page__login_required=False)
             .order_by("page__path")
             .select_related("page")
+            .prefetch_related("page__pagecontent_set")
             .annotate(
                 content_pk=Subquery(
                     PageContent.objects.filter(page=OuterRef("page"), language=OuterRef("language"))
@@ -65,7 +66,7 @@ class CMSSitemap(Sitemap):
         )
 
     def lastmod(self, page_url):
-        return page_url.page.changed_date
+        return page_url.page.get_content_obj(page_url.language).changed_date
 
     def location(self, page_url):
         return page_url.get_absolute_url(page_url.language)

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -457,12 +457,12 @@ class PagesTestCase(TransactionCMSTestCase):
         now -= datetime.timedelta(microseconds=now.microsecond)
         one_day_ago = now - datetime.timedelta(days=1)
         page = create_page("page", "nav_playground.html", "en")
-        content = page.get_content_obj('en')
+        page.get_content_obj('en')
         page.creation_date = one_day_ago
         page.changed_date = one_day_ago
         page.save()
         sitemap = CMSSitemap()
-        actual_last_modification_time = sitemap.lastmod(content)
+        actual_last_modification_time = sitemap.lastmod(sitemap.items().first())
         self.assertEqual(actual_last_modification_time.date(), now.date())
 
     def test_templates(self):

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -722,7 +722,6 @@ class PluginsTestCase(PluginsTestBaseCase):
         now = timezone.now()
         one_day_ago = now - datetime.timedelta(days=1)
         page = api.create_page("page", "nav_playground.html", "en")
-        content = page.get_content_obj('en')
         page.creation_date = one_day_ago
         page.changed_date = one_day_ago
         page.save()

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -729,7 +729,8 @@ class PluginsTestCase(PluginsTestBaseCase):
         plugin = self._create_link_plugin_on_page(page, slot='body')
         plugin = self.__edit_link_plugin(plugin, "fnord")
 
-        actual_last_modification_time = CMSSitemap().lastmod(content)
+        sitemap = CMSSitemap()
+        actual_last_modification_time = sitemap.lastmod(sitemap.items().first())
         actual_last_modification_time -= datetime.timedelta(microseconds=actual_last_modification_time.microsecond)
         self.assertEqual(plugin.changed_date.date(), actual_last_modification_time.date())
         self.assertEqual(page.changed_date.date(), one_day_ago.date() + datetime.timedelta(days=1))


### PR DESCRIPTION
## Description

Check #8121 for details.

* [x] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Fixed a bug where the sitemap was returning the `changed_date` of the page object instead of the page content object.