### PR TITLE
fix: Use PageContent.changed_date for sitemap lastmod

### DIFF
--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -275,10 +275,10 @@ class Placeholder(models.Model):
 
     def page_getter(self):
         if not hasattr(self, '_page'):
-            from cms.models.pagemodel import Page
+            from cms.models.contentmodels import PageContent
             try:
-                self._page = Page.objects.distinct().get(pagecontent_set__placeholders=self)
-            except (Page.DoesNotExist, Page.MultipleObjectsReturned):
+                self._page = PageContent.admin_manager.filter(placeholders=self).select_related("page").first().page
+            except AttributeError:
                 self._page = None
         return self._page
 

--- a/cms/sitemaps/cms_sitemap.py
+++ b/cms/sitemaps/cms_sitemap.py
@@ -55,17 +55,17 @@ class CMSSitemap(Sitemap):
             .order_by('page__node__path')
             .select_related("page")
             .annotate(
-                content_pk=Subquery(
+                content_changed_date=Subquery(
                     PageContent.objects.filter(page=OuterRef("page"), language=OuterRef("language"))
                     .filter(Q(redirect="") | Q(redirect=None))
-                    .values_list("pk")[:1]
+                    .values_list("changed_date")[:1]
                 )
             )
-            .filter(content_pk__isnull=False)  # Remove page content with redirects
+            .filter(content_changed_date__isnull=False)  # Remove page content with redirects
         )
 
     def lastmod(self, page_url):
-        return page_url.page.changed_date
+        return page_url.content_changed_date
 
     def location(self, page_url):
         return page_url.get_absolute_url(page_url.language)

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -457,12 +457,12 @@ class PagesTestCase(TransactionCMSTestCase):
         now -= datetime.timedelta(microseconds=now.microsecond)
         one_day_ago = now - datetime.timedelta(days=1)
         page = create_page("page", "nav_playground.html", "en")
-        content = page.get_content_obj('en')
+        page.get_content_obj('en')
         page.creation_date = one_day_ago
         page.changed_date = one_day_ago
         page.save()
         sitemap = CMSSitemap()
-        actual_last_modification_time = sitemap.lastmod(content)
+        actual_last_modification_time = sitemap.lastmod(sitemap.items().first())
         self.assertEqual(actual_last_modification_time.date(), now.date())
 
     def test_templates(self):

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -710,14 +710,14 @@ class PluginsTestCase(PluginsTestBaseCase):
         now = timezone.now()
         one_day_ago = now - datetime.timedelta(days=1)
         page = api.create_page("page", "nav_playground.html", "en")
-        content = page.get_content_obj('en')
         page.creation_date = one_day_ago
         page.changed_date = one_day_ago
         page.save()
         plugin = self._create_link_plugin_on_page(page, slot='body')
         plugin = self.__edit_link_plugin(plugin, "fnord")
 
-        actual_last_modification_time = CMSSitemap().lastmod(content)
+        sitemap = CMSSitemap()
+        actual_last_modification_time = sitemap.lastmod(sitemap.items().first())
         actual_last_modification_time -= datetime.timedelta(microseconds=actual_last_modification_time.microsecond)
         self.assertEqual(plugin.changed_date.date(), actual_last_modification_time.date())
         self.assertEqual(page.changed_date.date(), one_day_ago.date() + datetime.timedelta(days=1))

--- a/test_requirements/databases.txt
+++ b/test_requirements/databases.txt
@@ -1,3 +1,3 @@
 psycopg2==2.9.5
 psycopg>=3.1.8
-mysqlclient==2.0.3
+mysqlclient>=2.2.1


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8122
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
