### PR TITLE
docs: Add a note to 18-extending_page_contents.rst in which file to p…

### DIFF
--- a/docs/how_to/18-extending_page_contents.rst
+++ b/docs/how_to/18-extending_page_contents.rst
@@ -78,7 +78,7 @@ To make your extension editable, you must first create an admin class that sub-c
 ``cms.extensions.PageExtensionAdmin``. This admin handles page permissions.
 
 Continuing with the example model above, here's a simple corresponding
-``PageExtensionAdmin`` class:
+``PageExtensionAdmin`` class that should live in the ``admin.py`` file:
 
 .. code-block::
 


### PR DESCRIPTION
Add a note that the PageExtensionAdmin class should go into admin.py. From the flow of the text that might not clear.

@@ -78,7 +78,7 @@ To make your extension editable, you must first create an admin class that sub-c
``cms.extensions.PageExtensionAdmin``. This admin handles page permissions.

Continuing with the example model above, here's a simple corresponding
``PageExtensionAdmin`` class:
``PageExtensionAdmin`` class that should live in the ``admin.py`` file:

.. code-block::


## Checklist

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst)
* [ ] I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Documentation:
- Add a note about placing the PageExtensionAdmin class in admin.py.