### PR TITLE
fix: Allow frontend editing of page title fields

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -156,7 +156,7 @@ class PageAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
     move_form = MovePageForm
     inlines = PERMISSION_ADMIN_INLINES
     search_fields = ('=id', 'urls__slug', 'pagecontent_set__title', 'reverse_id')
-    title_frontend_editable_fields =  ['title', 'menu_title', 'page_title'] 
+    title_frontend_editable_fields =  ['title', 'menu_title', 'page_title']
 
     def has_module_permission(self, request):
         return False  # Hides page model from the admin index

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -156,6 +156,7 @@ class PageAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
     move_form = MovePageForm
     inlines = PERMISSION_ADMIN_INLINES
     search_fields = ('=id', 'urls__slug', 'pagecontent_set__title', 'reverse_id')
+    title_frontend_editable_fields =  ['title', 'menu_title', 'page_title'] 
 
     def has_module_permission(self, request):
         return False  # Hides page model from the admin index

--- a/cms/tests/test_admin.py
+++ b/cms/tests/test_admin.py
@@ -487,6 +487,13 @@ class AdminTests(AdminTestsBase):
                 response = self.client.post(url, data)
                 self.assertEqual(response.status_code, HttpResponseBadRequest.status_code)
 
+    def test_page_edit_field_endpoint(self):
+        endpoint = admin_reverse("cms_page_edit_title_fields", args=(self.page.pk, "en")) + "?language=en&edit_fields=page_title"
+        with self.login_user_context(self.get_superuser()):
+            response = self.client.get(endpoint)
+        self.assertContains(response, '<input type="text" name="page_title" maxlength="255" aria-describedby="id_page_title_helptext" id="id_page_title">')
+
+
 
 class NoDBAdminTests(CMSTestCase):
     @property

--- a/cms/tests/test_admin.py
+++ b/cms/tests/test_admin.py
@@ -26,7 +26,7 @@ from cms.test_utils.testcases import (
     URL_CMS_PAGE_PUBLISHED,
     CMSTestCase,
 )
-from cms.utils.compat import DJANGO_5_1
+from cms.utils.compat import DJANGO_4_2, DJANGO_5_1
 from cms.utils.conf import get_cms_setting
 from cms.utils.i18n import get_language_list
 from cms.utils.urlutils import admin_reverse
@@ -491,8 +491,10 @@ class AdminTests(AdminTestsBase):
         endpoint = admin_reverse("cms_page_edit_title_fields", args=(self.page.pk, "en")) + "?language=en&edit_fields=page_title"
         with self.login_user_context(self.get_superuser()):
             response = self.client.get(endpoint)
-        self.assertContains(response, '<input type="text" name="page_title" maxlength="255" aria-describedby="id_page_title_helptext" id="id_page_title">')
-
+        if DJANGO_4_2:
+            self.assertContains(response, '<input type="text" name="page_title" maxlength="255" id="id_page_title">')
+        else:
+            self.assertContains(response, '<input type="text" name="page_title" maxlength="255" aria-describedby="id_page_title_helptext" id="id_page_title">')
 
 
 class NoDBAdminTests(CMSTestCase):


### PR DESCRIPTION
## Description

This PR fixes #7689 by adding the missing class property `title_frontend_editable_fields` to `PageAdmin`.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7689 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Fix the frontend editing capability for page title fields by introducing the `title_frontend_editable_fields` property in `PageAdmin` and add a corresponding test to ensure the functionality works as expected.

Bug Fixes:
- Fix the issue allowing frontend editing of page title fields by adding the missing class property `title_frontend_editable_fields` to `PageAdmin`.

Tests:
- Add a test to verify the page edit field endpoint for frontend editing of page title fields.