### PR TITLE
fix: Allow frontend editing of page title fields (#8131)

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -103,6 +103,7 @@ class PageAdmin(admin.ModelAdmin):
     copy_form = CopyPageForm
     move_form = MovePageForm
     inlines = PERMISSION_ADMIN_INLINES
+    title_frontend_editable_fields =  ['title', 'menu_title', 'page_title']
 
     def has_add_permission(self, request):
         return False

--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -275,10 +275,10 @@ class Placeholder(models.Model):
 
     def page_getter(self):
         if not hasattr(self, '_page'):
-            from cms.models.pagemodel import Page
+            from cms.models.contentmodels import PageContent
             try:
-                self._page = Page.objects.distinct().get(pagecontent_set__placeholders=self)
-            except (Page.DoesNotExist, Page.MultipleObjectsReturned):
+                self._page = PageContent.admin_manager.filter(placeholders=self).select_related("page").first().page
+            except AttributeError:
                 self._page = None
         return self._page
 

--- a/cms/tests/test_admin.py
+++ b/cms/tests/test_admin.py
@@ -26,7 +26,7 @@ from cms.test_utils.testcases import (
     URL_CMS_PAGE_PUBLISHED,
     CMSTestCase,
 )
-from cms.utils.compat import DJANGO_2_2
+from cms.utils.compat import DJANGO_2_2, DJANGO_4_2
 from cms.utils.conf import get_cms_setting
 from cms.utils.i18n import get_language_list
 from cms.utils.urlutils import admin_reverse
@@ -460,6 +460,15 @@ class AdminTests(AdminTestsBase):
                 }
                 response = self.client.post(url, data)
                 self.assertEqual(response.status_code, HttpResponseBadRequest.status_code)
+
+    def test_page_edit_field_endpoint(self):
+        endpoint = admin_reverse("cms_page_edit_title_fields", args=(self.page.pk, "en")) + "?language=en&edit_fields=page_title"
+        with self.login_user_context(self.get_superuser()):
+            response = self.client.get(endpoint)
+        if DJANGO_4_2:
+            self.assertContains(response, '<input type="text" name="page_title" maxlength="255" id="id_page_title">')
+        else:
+            self.assertContains(response, '<input type="text" name="page_title" maxlength="255" aria-describedby="id_page_title_helptext" id="id_page_title">')
 
 
 class NoDBAdminTests(CMSTestCase):


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Fix the frontend editing of page title fields.