### PR TITLE
fix: Django 6 tried to adding object tools to the page tree throwing an error

### DIFF
--- a/cms/templates/admin/cms/page/tree/base.html
+++ b/cms/templates/admin/cms/page/tree/base.html
@@ -33,6 +33,7 @@
 
 {% block content_title %}{% endblock %}
 
+{% block object-tools-items %}{% endblock %}
 {% block content %}
     {% spaceless %}
     <div id="content-main">

--- a/cms/templates/admin/cms/page/tree/base.html
+++ b/cms/templates/admin/cms/page/tree/base.html
@@ -30,10 +30,9 @@
         </div>
     {% endblock %}
 {% endif %}
-
 {% block content_title %}{% endblock %}
-
 {% block object-tools-items %}{% endblock %}
+
 {% block content %}
     {% spaceless %}
     <div id="content-main">


### PR DESCRIPTION
## Description

This PR explicitly removes the object tools for the page content change list, also known as the page tree.

Django 6 tests started throwing an error. 

The page tree has an add page button and this object tools are not needed.
<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Fix Django 6 error when adding a page through the object tools.