### PR TITLE
fix: Copy plugins was broken 

### DIFF
--- a/cms/migrations/0038_alter_page_site.py
+++ b/cms/migrations/0038_alter_page_site.py
@@ -3,6 +3,8 @@
 from django.db import migrations, models
 import django.db.models.deletion
 
+import cms.models.settingmodels
+
 
 class Migration(migrations.Migration):
 
@@ -33,5 +35,16 @@ class Migration(migrations.Migration):
         ),
         migrations.DeleteModel(
             name='TreeNode',
+        ),
+        migrations.AlterField(
+            model_name="usersettings",
+            name="clipboard",
+            field=cms.models.settingmodels.PlaceholderForeignKey(
+                blank=True,
+                editable=False,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                to="cms.placeholder",
+            ),
         ),
     ]

--- a/cms/models/settingmodels.py
+++ b/cms/models/settingmodels.py
@@ -7,7 +7,7 @@ from django.utils.translation import gettext_lazy as _
 class ForeignPlaceholderKey(models.ForeignKey):
     def run_checks(self, *args, **kwargs):
         return True
-    
+
 
 class UserSettings(models.Model):
     user = models.OneToOneField(

--- a/cms/models/settingmodels.py
+++ b/cms/models/settingmodels.py
@@ -4,6 +4,11 @@ from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
 
+class ForeignPlaceholderKey(models.ForeignKey):
+    def run_checks(self, *args, **kwargs):
+        return True
+    
+
 class UserSettings(models.Model):
     user = models.OneToOneField(
         settings.AUTH_USER_MODEL,
@@ -13,7 +18,7 @@ class UserSettings(models.Model):
     )
     language = models.CharField(_("Language"), max_length=10, choices=settings.LANGUAGES,
                                 help_text=_("The language for the admin interface and toolbar"))
-    clipboard = models.ForeignKey(
+    clipboard = ForeignPlaceholderKey(
         'cms.Placeholder',
         on_delete=models.CASCADE,
         blank=True,

--- a/cms/models/settingmodels.py
+++ b/cms/models/settingmodels.py
@@ -4,8 +4,9 @@ from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
 
-class ForeignPlaceholderKey(models.ForeignKey):
+class PlaceholderForeignKey(models.ForeignKey):
     def run_checks(self, *args, **kwargs):
+        # User always has permission to change their own clipboard
         return True
 
 
@@ -18,7 +19,7 @@ class UserSettings(models.Model):
     )
     language = models.CharField(_("Language"), max_length=10, choices=settings.LANGUAGES,
                                 help_text=_("The language for the admin interface and toolbar"))
-    clipboard = ForeignPlaceholderKey(
+    clipboard = PlaceholderForeignKey(
         'cms.Placeholder',
         on_delete=models.CASCADE,
         blank=True,
@@ -35,4 +36,5 @@ class UserSettings(models.Model):
         return force_str(self.user)
 
     def has_placeholder_change_permission(self, user):
-        return True
+        # User always has permission to change their own clipboard
+       return True

--- a/cms/tests/test_placeholder_admin.py
+++ b/cms/tests/test_placeholder_admin.py
@@ -103,7 +103,7 @@ class PlaceholderAdminTestCase(CMSTestCase):
         )
         user_settings.clipboard.source = user_settings
         user_settings.clipboard.save()
-        
+
         source_placeholder = Placeholder.objects.create(slot='source')
         source_plugin = self._add_plugin_to_placeholder(source_placeholder)
         endpoint = self.get_copy_plugin_uri(source_plugin)

--- a/cms/tests/test_placeholder_admin.py
+++ b/cms/tests/test_placeholder_admin.py
@@ -101,6 +101,9 @@ class PlaceholderAdminTestCase(CMSTestCase):
             user=superuser,
             clipboard=Placeholder.objects.create(),
         )
+        user_settings.clipboard.source = user_settings
+        user_settings.clipboard.save()
+        
         source_placeholder = Placeholder.objects.create(slot='source')
         source_plugin = self._add_plugin_to_placeholder(source_placeholder)
         endpoint = self.get_copy_plugin_uri(source_plugin)


### PR DESCRIPTION
## Description

This PR fixes a server error when trying to copy plugins in the current develop-4 branch: Since the introduction of the "source" field for the clipboard placeholder, permission checks failed.

This PR fixes the issue and updates the tests.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Fixed a server error that occurred when copying plugins.