### PR TITLE
fix: Detect page when getting toolbar for endpoint (#8137)

### DIFF
--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -1506,7 +1506,9 @@ class RequestToolbarForm(forms.Form):
 
         try:
             # Use admin manager if available for the toolbar form
-            if hasattr(model_class, "admin_manager"):
+            if issubclass(model_class, PageContent):
+                generic_obj = model_class.admin_manager.select_related("page").get(pk=obj_id)
+            elif hasattr(model_class, "admin_manager"):
                 generic_obj = model_class.admin_manager.get(pk=obj_id)
             else:
                 generic_obj = model_class.objects.get(pk=obj_id)

--- a/cms/admin/settingsadmin.py
+++ b/cms/admin/settingsadmin.py
@@ -19,6 +19,7 @@ from django.utils.translation import override
 
 from cms.admin.forms import RequestToolbarForm
 from cms.models import UserSettings
+from cms.models.contentmodels import PageContent
 from cms.utils.page import get_page_from_request
 from cms.utils.urlutils import admin_reverse
 
@@ -79,10 +80,10 @@ class SettingsAdmin(ModelAdmin):
         cms_path = form_data.get('cms_path') or request.path_info
         origin_url = urlparse(cms_path)
         attached_obj = form_data.get('attached_obj')
-        current_page = get_page_from_request(request, use_path=origin_url.path, clean_path=True)
-
-        if attached_obj and current_page and not (attached_obj == current_page):
-            return HttpResponseBadRequest('Generic object does not match current page')
+        if isinstance(attached_obj, PageContent):
+            current_page = attached_obj.page
+        else:
+            current_page = get_page_from_request(request, use_path=origin_url.path, clean_path=True)
 
         data = QueryDict(query_string=origin_url.query, mutable=True)
         placeholders = request.GET.getlist("placeholders[]")

--- a/cms/tests/test_placeholder_admin.py
+++ b/cms/tests/test_placeholder_admin.py
@@ -8,21 +8,20 @@ from cms.utils.urlutils import admin_reverse
 
 
 class PlaceholderAdminTestCase(CMSTestCase):
-
     def test_add_plugin_endpoint(self):
         """
         The Placeholder admin add_plugin endpoint works
         """
         superuser = self.get_superuser()
-        placeholder = Placeholder.objects.create(slot='test')
-        plugins = placeholder.get_plugins('en').filter(plugin_type='LinkPlugin')
+        placeholder = Placeholder.objects.create(slot="test")
+        plugins = placeholder.get_plugins("en").filter(plugin_type="LinkPlugin")
         uri = self.get_add_plugin_uri(
             placeholder=placeholder,
-            plugin_type='LinkPlugin',
-            language='en',
+            plugin_type="LinkPlugin",
+            language="en",
         )
         with self.login_user_context(superuser):
-            data = {'name': 'A Link', 'external_link': 'https://www.django-cms.org'}
+            data = {"name": "A Link", "external_link": "https://www.django-cms.org"}
             response = self.client.post(uri, data)
 
         self.assertEqual(response.status_code, 200)
@@ -33,28 +32,23 @@ class PlaceholderAdminTestCase(CMSTestCase):
         User can copy plugins from one placeholder to another
         """
         superuser = self.get_superuser()
-        source_placeholder = Placeholder.objects.create(slot='source')
-        target_placeholder = Placeholder.objects.create(slot='target')
+        source_placeholder = Placeholder.objects.create(slot="source")
+        target_placeholder = Placeholder.objects.create(slot="target")
         source_plugin = self._add_plugin_to_placeholder(source_placeholder)
         endpoint = self.get_copy_plugin_uri(source_plugin)
         with self.login_user_context(superuser):
             data = {
-                'source_language': "en",
-                'source_placeholder_id': source_placeholder.pk,
-                'target_language': "en",
-                'target_placeholder_id': target_placeholder.pk,
+                "source_language": "en",
+                "source_placeholder_id": source_placeholder.pk,
+                "target_language": "en",
+                "target_placeholder_id": target_placeholder.pk,
             }
             response = self.client.post(endpoint, data)
 
         # Test that the target placeholder has the plugin copied from the source placeholder
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(source_placeholder.get_plugins('en').filter(pk=source_plugin.pk).exists())
-        self.assertTrue(
-            target_placeholder
-            .get_plugins('en')
-            .filter(plugin_type=source_plugin.plugin_type)
-            .exists()
-        )
+        self.assertTrue(source_placeholder.get_plugins("en").filter(pk=source_plugin.pk).exists())
+        self.assertTrue(target_placeholder.get_plugins("en").filter(plugin_type=source_plugin.plugin_type).exists())
 
     def test_copy_plugins_to_clipboard(self):
         """
@@ -66,27 +60,24 @@ class PlaceholderAdminTestCase(CMSTestCase):
             user=superuser,
             clipboard=Placeholder.objects.create(),
         )
-        source_placeholder = Placeholder.objects.create(slot='source')
+        source_placeholder = Placeholder.objects.create(slot="source")
         source_plugin = self._add_plugin_to_placeholder(source_placeholder)
         endpoint = self.get_copy_plugin_uri(source_plugin)
         with self.login_user_context(superuser):
             data = {
-                'source_language': "en",
-                'source_placeholder_id': source_placeholder.pk,
-                'source_plugin_id': source_plugin.pk,
-                'target_language': "en",
-                'target_placeholder_id': user_settings.clipboard.pk,
+                "source_language": "en",
+                "source_placeholder_id": source_placeholder.pk,
+                "source_plugin_id": source_plugin.pk,
+                "target_language": "en",
+                "target_placeholder_id": user_settings.clipboard.pk,
             }
             response = self.client.post(endpoint, data)
 
         # Test that the target placeholder has the plugin copied from the source placeholder (clipboard)
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(source_placeholder.get_plugins('en').filter(pk=source_plugin.pk).exists())
+        self.assertTrue(source_placeholder.get_plugins("en").filter(pk=source_plugin.pk).exists())
         self.assertTrue(
-            user_settings.clipboard
-            .get_plugins('en')
-            .filter(plugin_type=source_plugin.plugin_type)
-            .exists()
+            user_settings.clipboard.get_plugins("en").filter(plugin_type=source_plugin.plugin_type).exists()
         )
 
     def test_copy_placeholder_to_clipboard(self):
@@ -99,54 +90,49 @@ class PlaceholderAdminTestCase(CMSTestCase):
             user=superuser,
             clipboard=Placeholder.objects.create(),
         )
-        source_placeholder = Placeholder.objects.create(slot='source')
+        source_placeholder = Placeholder.objects.create(slot="source")
         source_plugin = self._add_plugin_to_placeholder(source_placeholder)
         endpoint = self.get_copy_plugin_uri(source_plugin)
         with self.login_user_context(superuser):
             data = {
-                'source_language': "en",
-                'source_placeholder_id': source_placeholder.pk,
-                'target_language': "en",
-                'target_placeholder_id': user_settings.clipboard.pk,
+                "source_language": "en",
+                "source_placeholder_id": source_placeholder.pk,
+                "target_language": "en",
+                "target_placeholder_id": user_settings.clipboard.pk,
             }
             response = self.client.post(endpoint, data)
 
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(source_placeholder.get_plugins('en').filter(pk=source_plugin.pk).exists())
-        self.assertTrue(
-            user_settings.clipboard
-            .get_plugins('en')
-            .filter(plugin_type='PlaceholderPlugin')
-            .exists()
-        )
+        self.assertTrue(source_placeholder.get_plugins("en").filter(pk=source_plugin.pk).exists())
+        self.assertTrue(user_settings.clipboard.get_plugins("en").filter(plugin_type="PlaceholderPlugin").exists())
 
     def test_edit_plugin_endpoint(self):
         """
         The Placeholder admin edit_plugins endpoint works
         """
         superuser = self.get_superuser()
-        placeholder = Placeholder.objects.create(slot='edit_plugin_placeholder')
+        placeholder = Placeholder.objects.create(slot="edit_plugin_placeholder")
         plugin = self._add_plugin_to_placeholder(placeholder)
         endpoint = self.get_change_plugin_uri(plugin)
         with self.login_user_context(superuser):
-            data = model_to_dict(plugin, fields=['name', 'external_link'])
-            data['name'] = 'Contents modified'
+            data = model_to_dict(plugin, fields=["name", "external_link"])
+            data["name"] = "Contents modified"
             response = self.client.post(endpoint, data)
             plugin.refresh_from_db()
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(plugin.name, data['name'])
+        self.assertEqual(plugin.name, data["name"])
 
     def test_delete_plugin_endpoint(self):
         """
         The Placeholder admin delete_plugin endpoint works
         """
         superuser = self.get_superuser()
-        placeholder = Placeholder.objects.create(slot='source')
+        placeholder = Placeholder.objects.create(slot="source")
         plugin = self._add_plugin_to_placeholder(placeholder)
         endpoint = self.get_delete_plugin_uri(plugin)
         with self.login_user_context(superuser):
-            data = {'post': True}
+            data = {"post": True}
             response = self.client.post(endpoint, data)
 
         self.assertEqual(response.status_code, 302)
@@ -157,14 +143,14 @@ class PlaceholderAdminTestCase(CMSTestCase):
         The Placeholder admin delete_plugin endpoint works
         """
         superuser = self.get_superuser()
-        placeholder = Placeholder.objects.create(slot='source')
+        placeholder = Placeholder.objects.create(slot="source")
         self._add_plugin_to_placeholder(placeholder)
         endpoint = self.get_clear_placeholder_url(placeholder)
         with self.login_user_context(superuser):
-            response = self.client.post(endpoint, {'test': 0})
+            response = self.client.post(endpoint, {"test": 0})
 
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(placeholder.get_plugins('en').count(), 0)
+        self.assertEqual(placeholder.get_plugins("en").count(), 0)
 
     def test_object_edit_endpoint(self):
         page = create_page('Page 1', 'nav_playground.html', 'en')
@@ -176,3 +162,23 @@ class PlaceholderAdminTestCase(CMSTestCase):
             response = self.client.get(endpoint)
 
         self.assertEqual(response.status_code, 200)
+
+    def test_get_toolbar_endpoint(self):
+        """Toolbar endpoint returns the toolbar including the page menu when called from the edit endpoint"""
+        page = create_page("Page 1", "simple.html", "en")
+        content = page.get_content_obj()
+        content_type = ContentType.objects.get(app_label="cms", model="pagecontent")
+        user = self.get_superuser()
+        toolbar_endpoint = admin_reverse("cms_usersettings_get_toolbar")
+        edit_endpoint = admin_reverse(
+            "cms_placeholder_render_object_edit",
+            args=(
+                content_type.pk,
+                content.pk,
+            ),
+        )
+
+        with self.login_user_context(user):
+            response = self.client.get(f"{toolbar_endpoint}?obj_id={content.id}&obj_type=cms.pagecontent&cms_path={edit_endpoint}")
+
+        self.assertContains(response, '<span>Page<span class="cms-icon cms-icon-arrow"></span></span>')  # Contains page menu


### PR DESCRIPTION
## Description

Backport of #8137 

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8137 
* #8136

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Fixed an issue where the toolbar was not correctly detecting the current page when accessed from the edit plugin endpoint.