### PR TITLE
fix: ensures page content translations are created with the same temp…

### DIFF
--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -81,11 +81,7 @@ def get_page_changed_by_filter_choices():
     # This is not site-aware
     # Been like this forever
     # Would be nice for it to filter out by site
-    values = (
-        Page.objects.distinct()
-        .order_by("changed_by")
-        .values_list("changed_by", flat=True)
-    )
+    values = Page.objects.distinct().order_by("changed_by").values_list("changed_by", flat=True)
 
     yield ("", _("All"))
 
@@ -118,9 +114,7 @@ def save_permissions(data, obj):
         for key in ("add", "change", "delete"):
             # add permission `key` for model `model`
             codename = get_permission_codename(key, model._meta)
-            permission = Permission.objects.get(
-                content_type=content_type, codename=codename
-            )
+            permission = Permission.objects.get(content_type=content_type, codename=codename)
             field = f"can_{key}_{name}"
 
             if data.get(field):
@@ -282,9 +276,7 @@ class AddPageForm(BasePageContentForm):
         if root_page:
             # Set the choicefield's choices to the various page_types
             descendants = root_page.get_descendant_pages().filter(is_page_type=True)
-            titles = PageContent.objects.filter(
-                page__in=descendants, language=self._language
-            )
+            titles = PageContent.objects.filter(page__in=descendants, language=self._language)
             choices = [("", "---------")]
             choices.extend((title.page_id, title.title) for title in titles)
             source_field.choices = choices
@@ -330,7 +322,7 @@ class AddPageForm(BasePageContentForm):
             raise ValidationError("Site doesn't match the parent's page site")
         return parent_page
 
-    def create_translation(self, page):
+    def create_translation(self, page, og_page_content_template=None):
         data = self.cleaned_data
         title_kwargs = {
             "page": page,
@@ -351,6 +343,10 @@ class AddPageForm(BasePageContentForm):
 
         if "meta_description" in data:
             title_kwargs["meta_description"] = data["meta_description"]
+
+        if og_page_content_template:
+            title_kwargs["template"] = og_page_content_template
+
         return api.create_page_content(**title_kwargs)
 
     def from_source(self, source, parent=None):
@@ -389,10 +385,26 @@ class AddPageForm(BasePageContentForm):
             new_page = self.from_source(source, parent=parent)
         else:
             new_page = Page(site=self._site, parent=parent)
-            new_page.add_to_tree(position='last-child')
+            new_page.add_to_tree(position="last-child")
             new_page.save()
 
-        translation = self.create_translation(new_page)
+        # If you have djangocms-versioning installed, this will get the latest version of the page content, and ignore drafts.
+        # Get the original page content template if available
+        og_page_content_template = None
+        if new_page:
+            try:
+                main_language = new_page.get_languages()[0]
+                og_page_content = (
+                    PageContent.objects.filter(page_id=new_page.pk, language=main_language).only("template").first()
+                )
+                if og_page_content:
+                    og_page_content_template = og_page_content.template
+            except (IndexError, AttributeError):
+                # Handle cases where get_languages() returns empty list
+                # or if there's any attribute access error
+                pass
+
+        translation = self.create_translation(new_page, og_page_content_template=og_page_content_template)
         new_page.page_content_cache[translation.language] = translation
 
         if source:
@@ -408,15 +420,9 @@ class AddPageForm(BasePageContentForm):
                     slot=source_placeholder.slot,
                     default_width=source_placeholder.default_width,
                 )
-                source_placeholder.copy_plugins(
-                    target_placeholder, language=translation.language
-                )
+                source_placeholder.copy_plugins(target_placeholder, language=translation.language)
 
-        is_first = not (
-            Page.objects.on_site(self._site)
-            .exclude(pk=new_page.id)
-            .exists()
-        )
+        is_first = not (Page.objects.on_site(self._site).exclude(pk=new_page.id).exists())
 
         if is_first and not new_page.is_page_type:
             # it's the first page. Make it the homepage
@@ -579,7 +585,7 @@ class ChangePageForm(BasePageContentForm):
             {
                 "fields": ("xframe_options",),
                 "classes": ["collapse"],
-            }
+            },
         ),
     )
 
@@ -622,7 +628,7 @@ class ChangePageForm(BasePageContentForm):
                 path = slug
             else:
                 base_path = page.parent.get_path(self._language)
-                path = f'{base_path}/{slug}' if base_path else None
+                path = f"{base_path}/{slug}" if base_path else None
         else:
             path = slug
 
@@ -630,9 +636,7 @@ class ChangePageForm(BasePageContentForm):
             data["path"] = None
             return data
 
-        user_language = get_site_language_from_request(
-            self._request, site_id=self._site.pk
-        )
+        user_language = get_site_language_from_request(self._request, site_id=self._site.pk)
 
         try:
             # Validate the url
@@ -734,9 +738,7 @@ class AdvancedSettingsForm(forms.ModelForm):
 
         if "navigation_extenders" in self.fields:
             navigation_extenders = self.get_navigation_extenders()
-            self.fields["navigation_extenders"].widget = forms.Select(
-                {}, [("", "---------")] + navigation_extenders
-            )
+            self.fields["navigation_extenders"].widget = forms.Select({}, [("", "---------")] + navigation_extenders)
         if "application_urls" in self.fields:
             # Prepare a dict mapping the apps by class name ('PollApp') to
             # their app_name attribute ('polls'), if any.
@@ -752,9 +754,7 @@ class AdvancedSettingsForm(forms.ModelForm):
             self.fields["application_urls"].widget = AppHookSelect(
                 attrs={"id": "application_urls"}, app_namespaces=app_namespaces
             )
-            self.fields["application_urls"].choices = [
-                ("", "---------")
-            ] + apphook_pool.get_apphooks()
+            self.fields["application_urls"].choices = [("", "---------")] + apphook_pool.get_apphooks()
 
             page_data = self.data if self.data else self.initial
             if app_configs:
@@ -763,19 +763,14 @@ class AdvancedSettingsForm(forms.ModelForm):
                     app_configs=app_configs,
                 )
 
-                if (
-                    page_data.get("application_urls", False)
-                    and page_data["application_urls"] in app_configs
-                ):
+                if page_data.get("application_urls", False) and page_data["application_urls"] in app_configs:
                     configs = app_configs[page_data["application_urls"]].get_configs()
                     self.fields["application_configs"].widget.choices = [
                         (config.pk, force_str(config)) for config in configs
                     ]
 
                     try:
-                        config = configs.get(
-                            namespace=self.initial["application_namespace"]
-                        )
+                        config = configs.get(namespace=self.initial["application_namespace"])
                         self.fields["application_configs"].initial = config.pk
                     except ObjectDoesNotExist:
                         # Provided apphook configuration doesn't exist (anymore),
@@ -817,34 +812,22 @@ class AdvancedSettingsForm(forms.ModelForm):
                 # the 'usual' namespace field to be backward compatible
                 # with existing apphooks
                 try:
-                    appconfig_pk = forms.IntegerField(required=True).to_python(
-                        application_config
-                    )
+                    appconfig_pk = forms.IntegerField(required=True).to_python(application_config)
                 except ValidationError:
-                    self._errors["application_configs"] = ErrorList(
-                        [_("Invalid application config value")]
-                    )
+                    self._errors["application_configs"] = ErrorList([_("Invalid application config value")])
                     return self.cleaned_data
 
                 try:
-                    config = (
-                        apphooks_with_config[apphook].get_configs().get(pk=appconfig_pk)
-                    )
+                    config = apphooks_with_config[apphook].get_configs().get(pk=appconfig_pk)
                 except ObjectDoesNotExist:
-                    self._errors["application_configs"] = ErrorList(
-                        [_("Invalid application config value")]
-                    )
+                    self._errors["application_configs"] = ErrorList([_("Invalid application config value")])
                     return self.cleaned_data
 
                 if self._check_unique_namespace_instance(config.namespace):
                     # Looks like there's already one with the default instance
                     # namespace defined.
                     self._errors["application_configs"] = ErrorList(
-                        [
-                            _(
-                                "An application instance using this configuration already exists."
-                            )
-                        ]
+                        [_("An application instance using this configuration already exists.")]
                     )
                 else:
                     self.cleaned_data["application_namespace"] = config.namespace
@@ -852,11 +835,7 @@ class AdvancedSettingsForm(forms.ModelForm):
                 if instance_namespace:
                     if self._check_unique_namespace_instance(instance_namespace):
                         self._errors["application_namespace"] = ErrorList(
-                            [
-                                _(
-                                    "An application instance with this name already exists."
-                                )
-                            ]
+                            [_("An application instance with this name already exists.")]
                         )
                 else:
                     # The attribute on the apps 'app_name' is a misnomer, it should be
@@ -867,22 +846,16 @@ class AdvancedSettingsForm(forms.ModelForm):
                             # Looks like there's already one with the default instance
                             # namespace defined.
                             self._errors["application_namespace"] = ErrorList(
-                                [
-                                    _(
-                                        "An application instance with this name already exists."
-                                    )
-                                ]
+                                [_("An application instance with this name already exists.")]
                             )
                         else:
                             # OK, there are zero instances of THIS app that use the
                             # default instance namespace, so, since the user didn't
                             # provide one, we'll use the default. NOTE: The following
                             # line is really setting the "instance namespace" of the
-                            # new app to the app’s "application namespace", which is
+                            # new app to the app's "application namespace", which is
                             # the default instance namespace.
-                            self.cleaned_data["application_namespace"] = (
-                                application_namespace
-                            )
+                            self.cleaned_data["application_namespace"] = application_namespace
 
         if instance_namespace and not apphook:
             self.cleaned_data["application_namespace"] = None
@@ -927,7 +900,6 @@ class AdvancedSettingsForm(forms.ModelForm):
 
 
 class PageTreeForm(forms.Form):
-
     position = forms.IntegerField(initial=0, required=True)
     target = forms.ModelChoiceField(queryset=Page.objects.none(), required=False)
 
@@ -948,7 +920,7 @@ class PageTreeForm(forms.Form):
         warnings.warn(
             "Method `get_root_nodes()` is deprecated. Instead use method `get_root_pages`.",
             RemovedInDjangoCMS43Warning,
-            stacklevel=2
+            stacklevel=2,
         )
         return self.get_root_pages()
 
@@ -961,28 +933,27 @@ class PageTreeForm(forms.Form):
     def _get_tree_options_for_root(self, position):
         siblings = Page.get_root_nodes().filter(site=self._site)
         try:
-            return siblings[position], 'left'
+            return siblings[position], "left"
         except IndexError:
             # The position requested is not occupied.
             # Add the node as the last root node,
             # relative to the current site.
-            return siblings.reverse()[0], 'right'
+            return siblings.reverse()[0], "right"
 
     def _get_tree_options_for_parent(self, parent_page, position):
         if position == 0:
-            return parent_page, 'first-child'
+            return parent_page, "first-child"
 
         siblings = parent_page.get_children().filter(site=self._site)
         try:
-            return siblings[position], 'left'
+            return siblings[position], "left"
         except IndexError:
             # The position requested is not occupied.
             # Add the node to be the parent's first child
-            return parent_page, 'last-child'
+            return parent_page, "last-child"
 
 
 class MovePageForm(PageTreeForm):
-
     def clean(self):
         cleaned_data = super().clean()
 
@@ -995,22 +966,22 @@ class MovePageForm(PageTreeForm):
 
     def get_tree_options(self):
         target_page, target_page_position = super().get_tree_options()
-        if target_page_position != 'left':
+        if target_page_position != "left":
             return target_page, target_page_position
 
         if self.page.path < target_page.path:
             if self.page.is_sibling_of(target_page):
                 # The page being moved appears before the target page and is a sibling of the target node.
                 # The user is moving from left to right.
-                return target_page, 'right'
+                return target_page, "right"
 
             # The node being moved appears before the target node but is not a sibling of the target node.
             # The user is moving from right to left.
-            return target_page, 'left'
+            return target_page, "left"
 
         # The node being moved appears after the target node.
         # The user is moving from right to left.
-        return target_page, 'left'
+        return target_page, "left"
 
     def move_page(self):
         self.page.move_page(*self.get_tree_options())
@@ -1082,7 +1053,6 @@ class ChangeListForm(forms.Form):
 
 
 class BasePermissionAdminForm(forms.ModelForm):
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         permission_fields = self._meta.model.get_all_permissions()
@@ -1199,7 +1169,6 @@ class ViewRestrictionInlineAdminForm(BasePermissionAdminForm):
 
 
 class GlobalPagePermissionAdminForm(BasePermissionAdminForm):
-
     class Meta:
         fields = [
             "user",
@@ -1223,9 +1192,7 @@ class GenericCmsPermissionForm(forms.ModelForm):
     _current_user = None
 
     can_add_page = forms.BooleanField(label=_("Add"), required=False, initial=True)
-    can_change_page = forms.BooleanField(
-        label=_("Change"), required=False, initial=True
-    )
+    can_change_page = forms.BooleanField(label=_("Change"), required=False, initial=True)
     can_delete_page = forms.BooleanField(label=_("Delete"), required=False)
 
     # pageuser is for pageuser & group - they are combined together,
@@ -1262,8 +1229,7 @@ class GenericCmsPermissionForm(forms.ModelForm):
 
             if data.get("can_delete_page"):
                 message = _(
-                    "Users can't delete a page without permissions "
-                    "to change the page. Edit permissions required."
+                    "Users can't delete a page without permissions " "to change the page. Edit permissions required."
                 )
                 raise ValidationError(message)
 
@@ -1305,9 +1271,7 @@ class GenericCmsPermissionForm(forms.ModelForm):
         for model in (Page, PageUser, PagePermission):
             name = model.__name__.lower()
             content_type = ContentType.objects.get_for_model(model)
-            permissions = permission_accessor.filter(
-                content_type=content_type
-            ).values_list("codename", flat=True)
+            permissions = permission_accessor.filter(content_type=content_type).values_list("codename", flat=True)
             for key in ("add", "change", "delete"):
                 codename = get_permission_codename(key, model._meta)
                 initials[f"can_{key}_{name}"] = codename in permissions
@@ -1354,7 +1318,6 @@ class PageUserAddForm(forms.ModelForm):
 
 
 class PageUserChangeForm(UserChangeForm):
-
     _current_user = None
 
     class Meta:
@@ -1384,7 +1347,6 @@ class PageUserChangeForm(UserChangeForm):
 
 
 class PageUserGroupForm(GenericCmsPermissionForm):
-
     class Meta:
         model = PageUserGroup
         fields = ("name",)
@@ -1443,33 +1405,26 @@ class PluginAddValidationForm(forms.Form):
                 return self.cleaned_data
 
             if parent_plugin.placeholder_id != placeholder.pk:
-                message = gettext(
-                    "Parent plugin placeholder must be same as placeholder!"
-                )
+                message = gettext("Parent plugin placeholder must be same as placeholder!")
                 self.add_error("placeholder_id", message)
                 return self.cleaned_data
 
             if position <= parent_plugin.position:
                 message = gettext("Plugin position must be greater than %(position)d")
-                self.add_error(
-                    "placeholder_id", message % {"position": parent_plugin.position}
-                )
+                self.add_error("placeholder_id", message % {"position": parent_plugin.position})
                 return self.cleaned_data
 
         page = placeholder.page
         template = page.get_template() if page else None
 
         try:
-            has_reached_plugin_limit(
-                placeholder, data["plugin_type"], language, template=template
-            )
+            has_reached_plugin_limit(placeholder, data["plugin_type"], language, template=template)
         except PluginLimitReached as error:
             self.add_error(None, force_str(error))
         return self.cleaned_data
 
 
 class RequestToolbarForm(forms.Form):
-
     obj_id = forms.CharField(required=False)
     obj_type = forms.CharField(required=False)
     cms_path = forms.CharField(required=False)

--- a/cms/tests/test_admin.py
+++ b/cms/tests/test_admin.py
@@ -223,6 +223,29 @@ class AdminTestCase(AdminTestsBase):
             self.assertRedirects(response, self.get_pages_admin_list_uri("de"))
             self.assertEqual(page.get_content_obj("de").template, TEMPLATE_INHERITANCE_MAGIC)
 
+    def test_create_translation_always_copies_template_from_default_language_regardless_of_amount_of_languages(self):
+        admin_user = self.get_superuser()
+        # Create a page in default language ("fr")
+        page = create_page("create-translation", "nav_playground.html", "fr", created_by=admin_user)
+        with self.login_user_context(admin_user):
+            data = {
+                "title": "create-translation-de",
+                "slug": "create-translation-de",
+                "cms_page": page.pk,
+                "template": "col_two.html",
+            }
+            response = self.client.post(
+                self.get_page_add_uri("de", page),
+                data=data,
+            )
+            data = {"title": "create-translation-en", "slug": "create-translation-en", "cms_page": page.pk}
+            response = self.client.post(
+                self.get_page_add_uri("en", page),
+                data=data,
+            )
+            self.assertRedirects(response, self.get_pages_admin_list_uri("en"))
+            self.assertEqual(page.get_content_obj("en").template, "nav_playground.html")
+
     def test_delete_translation(self):
         admin_user = self.get_superuser()
         page = create_page("delete-page-translation", "nav_playground.html", "en", created_by=admin_user)

--- a/cms/tests/test_admin.py
+++ b/cms/tests/test_admin.py
@@ -33,7 +33,6 @@ from cms.utils.urlutils import admin_reverse
 
 
 class AdminTestsBase(CMSTestCase):
-
     @property
     def page_admin_class(self):
         return site._registry[Page]
@@ -51,17 +50,17 @@ class AdminTestsBase(CMSTestCase):
         return admin_user, staff_user
 
     def _get_staff_user(self, use_global_permissions=True):
-        USERNAME = 'test'
+        USERNAME = "test"
 
-        if get_user_model().USERNAME_FIELD == 'email':
-            normal_guy = get_user_model().objects.create_user(USERNAME, 'test@test.com', 'test@test.com')
+        if get_user_model().USERNAME_FIELD == "email":
+            normal_guy = get_user_model().objects.create_user(USERNAME, "test@test.com", "test@test.com")
         else:
-            normal_guy = get_user_model().objects.create_user(USERNAME, 'test@test.com', USERNAME)
+            normal_guy = get_user_model().objects.create_user(USERNAME, "test@test.com", USERNAME)
 
         normal_guy.is_staff = True
         normal_guy.is_active = True
         perms = Permission.objects.filter(
-            codename__in=['change_page', 'change_title', 'add_page', 'add_title', 'delete_page', 'delete_title']
+            codename__in=["change_page", "change_title", "add_page", "add_title", "delete_page", "delete_title"]
         )
         normal_guy.save()
         normal_guy.user_permissions.set(perms)
@@ -80,30 +79,27 @@ class AdminTestsBase(CMSTestCase):
 
 
 class AdminTestCase(AdminTestsBase):
-
     def test_extension_not_in_admin(self):
         admin_user, staff = self._get_guys()
         with self.login_user_context(admin_user):
-            request = self.get_request(self.get_pages_admin_list_uri('en'))
+            request = self.get_request(self.get_pages_admin_list_uri("en"))
             response = site.index(request)
-            self.assertNotContains(response, '/mytitleextension/')
-            self.assertNotContains(response, '/mypageextension/')
+            self.assertNotContains(response, "/mytitleextension/")
+            self.assertNotContains(response, "/mypageextension/")
 
     @override_settings(CMS_PERMISSION=False)
     def test_2apphooks_with_same_namespace(self):
-        PAGE1 = 'Test Page'
-        PAGE2 = 'Test page 2'
-        APPLICATION_URLS = 'project.sampleapp.urls'
+        PAGE1 = "Test Page"
+        PAGE2 = "Test page 2"
+        APPLICATION_URLS = "project.sampleapp.urls"
 
         admin_user, normal_guy = self._get_guys()
 
         current_site = Site.objects.get(pk=1)
 
         # The admin creates the page
-        page = create_page(PAGE1, "nav_playground.html", "en",
-                           site=current_site, created_by=admin_user)
-        page2 = create_page(PAGE2, "nav_playground.html", "en",
-                            site=current_site, created_by=admin_user)
+        page = create_page(PAGE1, "nav_playground.html", "en", site=current_site, created_by=admin_user)
+        page2 = create_page(PAGE2, "nav_playground.html", "en", site=current_site, created_by=admin_user)
 
         page.application_urls = APPLICATION_URLS
         page.application_namespace = "space1"
@@ -113,11 +109,11 @@ class AdminTestCase(AdminTestsBase):
 
         # The admin edits the page (change the page name for ex.)
         page_data = {
-            'title': PAGE2,
-            'slug': page2.get_slug('en'),
-            'template': page2.template,
-            'application_urls': 'SampleApp',
-            'application_namespace': 'space1',
+            "title": PAGE2,
+            "slug": page2.get_slug("en"),
+            "template": page2.template,
+            "application_urls": "SampleApp",
+            "application_namespace": "space1",
         }
 
         with self.login_user_context(admin_user):
@@ -126,7 +122,7 @@ class AdminTestCase(AdminTestsBase):
             self.assertEqual(Page.objects.filter(application_namespace="space1").count(), 1)
             resp = self.client.post(base.URL_CMS_PAGE_ADVANCED_CHANGE % page2.pk, page_data)
             self.assertEqual(resp.status_code, 200)
-            page_data['application_namespace'] = 'space2'
+            page_data["application_namespace"] = "space2"
             resp = self.client.post(base.URL_CMS_PAGE_ADVANCED_CHANGE % page2.pk, page_data)
             self.assertEqual(resp.status_code, 302)
 
@@ -134,26 +130,26 @@ class AdminTestCase(AdminTestsBase):
         admin_user = self.get_superuser()
         create_page("home", "nav_playground.html", "en", created_by=admin_user)
         page = create_page("delete-page", "nav_playground.html", "en", created_by=admin_user)
-        create_page('child-page', "nav_playground.html", "en", created_by=admin_user, parent=page)
-        body = page.get_placeholders("en").get(slot='body')
-        add_plugin(body, 'TextPlugin', 'en', body='text')
+        create_page("child-page", "nav_playground.html", "en", created_by=admin_user, parent=page)
+        body = page.get_placeholders("en").get(slot="body")
+        add_plugin(body, "TextPlugin", "en", body="text")
         with self.login_user_context(admin_user):
-            data = {'post': 'yes'}
+            data = {"post": "yes"}
             response = self.client.post(URL_CMS_PAGE_DELETE % page.pk, data, follow=True)
-            self.assertRedirects(response, self.get_pages_admin_list_uri('en'))
+            self.assertRedirects(response, self.get_pages_admin_list_uri("en"))
 
     def test_delete_diff_language(self):
         admin_user = self.get_superuser()
         create_page("home", "nav_playground.html", "en", created_by=admin_user)
         page = create_page("delete-page", "nav_playground.html", "en", created_by=admin_user)
-        create_page('child-page', "nav_playground.html", "de", created_by=admin_user, parent=page)
-        body = page.get_placeholders("en").get(slot='body')
-        add_plugin(body, 'TextPlugin', 'en', body='text')
+        create_page("child-page", "nav_playground.html", "de", created_by=admin_user, parent=page)
+        body = page.get_placeholders("en").get(slot="body")
+        add_plugin(body, "TextPlugin", "en", body="text")
         with self.login_user_context(admin_user):
-            data = {'post': 'yes'}
+            data = {"post": "yes"}
             response = self.client.post(URL_CMS_PAGE_DELETE % page.pk, data, follow=True)
             # follow=True, since page changelist redirects to page content changelist
-            self.assertRedirects(response, self.get_pages_admin_list_uri('en'))
+            self.assertRedirects(response, self.get_pages_admin_list_uri("en"))
 
     def test_search_fields(self):
         superuser = self.get_superuser()
@@ -161,12 +157,12 @@ class AdminTestCase(AdminTestsBase):
 
         with self.login_user_context(superuser):
             for model, admin_instance in site._registry.items():
-                if model._meta.app_label != 'cms':
+                if model._meta.app_label != "cms":
                     continue
                 if not admin_instance.search_fields:
                     continue
-                url = admin_reverse('cms_%s_changelist' % model._meta.model_name)
-                response = self.client.get('%s?q=1' % url, follow=True)  # Page redirects to PageContent
+                url = admin_reverse("cms_%s_changelist" % model._meta.model_name)
+                response = self.client.get("%s?q=1" % url, follow=True)  # Page redirects to PageContent
                 errmsg = response.content
                 self.assertEqual(response.status_code, 200, errmsg)
 
@@ -174,87 +170,127 @@ class AdminTestCase(AdminTestsBase):
         superuser = self.get_superuser()
         create_page("root-page", "nav_playground.html", "en", created_by=superuser)
         with self.login_user_context(superuser):
-            url = admin_reverse('cms_pagecontent_changelist')
-            response = self.client.get('%s?template__exact=nav_playground.html' % url)
+            url = admin_reverse("cms_pagecontent_changelist")
+            response = self.client.get("%s?template__exact=nav_playground.html" % url)
             errmsg = response.content
             self.assertEqual(response.status_code, 200, errmsg)
 
+    def test_create_translation_copies_template(self):
+        admin_user = self.get_superuser()
+        page = create_page("create-translation", "col_two.html", "de", created_by=admin_user)
+        with self.login_user_context(admin_user):
+            response = self.client.post(
+                self.get_page_add_uri("en", page),
+                data={"title": "create-translation-en", "slug": "create-translation-en", "cms_page": page.pk},
+            )
+            self.assertRedirects(response, self.get_pages_admin_list_uri("en"))
+            self.assertEqual(page.get_content_obj("en").template, "col_two.html")
+
+    def test_create_translation_copies_template_on_default_page_language_update(self):
+        admin_user = self.get_superuser()
+        page = create_page("create-translation", "nav_playground.html", "en", created_by=admin_user)
+        with self.login_user_context(admin_user):
+            data = {"title": "test page 2", "slug": "page-test-2", "template": "col_two.html"}
+            self.client.post(
+                self.get_page_change_uri("en", page),
+                data=data,
+            )
+            response = self.client.post(
+                self.get_page_add_uri("de", page),
+                data={"title": "create-translation-de", "slug": "create-translation-de", "cms_page": page.pk},
+            )
+            self.assertRedirects(response, self.get_pages_admin_list_uri("de"))
+            self.assertEqual(page.get_content_obj("de").template, "col_two.html")
+
+    def test_create_translation_copies_template_with_inheritance(self):
+        """
+        Test that template inheritance flag is properly copied when creating translations
+        """
+        admin_user = self.get_superuser()
+        page = create_page("inherit-template", "nav_playground.html", "en", created_by=admin_user)
+
+        with self.login_user_context(admin_user):
+            data = {"title": "test page", "slug": "test-page", "template": TEMPLATE_INHERITANCE_MAGIC}
+            self.client.post(
+                self.get_page_change_uri("en", page),
+                data=data,
+            )
+
+            response = self.client.post(
+                self.get_page_add_uri("de", page),
+                data={"title": "inherit-de", "slug": "inherit-de", "cms_page": page.pk},
+            )
+            self.assertRedirects(response, self.get_pages_admin_list_uri("de"))
+            self.assertEqual(page.get_content_obj("de").template, TEMPLATE_INHERITANCE_MAGIC)
+
     def test_delete_translation(self):
         admin_user = self.get_superuser()
-        page = create_page("delete-page-translation", "nav_playground.html", "en",
-                           created_by=admin_user)
+        page = create_page("delete-page-translation", "nav_playground.html", "en", created_by=admin_user)
         create_page_content("de", "delete-page-translation-2", page, slug="delete-page-translation-2")
         create_page_content("es-mx", "delete-page-translation-es", page, slug="delete-page-translation-es")
         data = {"post": "yes"}
         with self.login_user_context(admin_user):
-            response = self.client.get(self.get_page_delete_translation_uri('de', page))
+            response = self.client.get(self.get_page_delete_translation_uri("de", page))
             self.assertEqual(response.status_code, 200)
-            response = self.client.post(self.get_page_delete_translation_uri('de', page), data=data)
-            self.assertRedirects(response, self.get_pages_admin_list_uri('de'))
-            response = self.client.get(self.get_page_delete_translation_uri('es-mx', page))
+            response = self.client.post(self.get_page_delete_translation_uri("de", page), data=data)
+            self.assertRedirects(response, self.get_pages_admin_list_uri("de"))
+            response = self.client.get(self.get_page_delete_translation_uri("es-mx", page))
             self.assertEqual(response.status_code, 200)
             self.assertContains(
-                response,
-                '<p>Are you sure you want to delete the page content "delete-page-translation-es (es-mx)"?'
+                response, '<p>Are you sure you want to delete the page content "delete-page-translation-es (es-mx)"?'
             )
-            response = self.client.post(self.get_page_delete_translation_uri('es-mx', page), data=data)
-            self.assertRedirects(response, self.get_pages_admin_list_uri('es-mx'))
+            response = self.client.post(self.get_page_delete_translation_uri("es-mx", page), data=data)
+            self.assertRedirects(response, self.get_pages_admin_list_uri("es-mx"))
 
-        self.assertTrue(PageContent.objects.filter(page=page, language='en').exists())
-        self.assertFalse(PageContent.objects.filter(page=page, language='de').exists())
-        self.assertFalse(PageContent.objects.filter(page=page, language='es-mx').exists())
-        self.assertFalse(PageUrl.objects.filter(page=page, language='de').exists())
-        self.assertFalse(PageUrl.objects.filter(page=page, language='es-mx').exists())
+        self.assertTrue(PageContent.objects.filter(page=page, language="en").exists())
+        self.assertFalse(PageContent.objects.filter(page=page, language="de").exists())
+        self.assertFalse(PageContent.objects.filter(page=page, language="es-mx").exists())
+        self.assertFalse(PageUrl.objects.filter(page=page, language="de").exists())
+        self.assertFalse(PageUrl.objects.filter(page=page, language="es-mx").exists())
 
     def test_change_template(self):
-        template = get_cms_setting('TEMPLATES')[0][0]
+        template = get_cms_setting("TEMPLATES")[0][0]
         admin_user, staff = (self.get_superuser(), self.get_staff_user_with_no_permissions())
 
         with self.login_user_context(admin_user):
-            response = self.client.post(
-                self.get_admin_url(PageContent, 'change_template', 1),
-                {'template': template}
-            )
+            response = self.client.post(self.get_admin_url(PageContent, "change_template", 1), {"template": template})
             self.assertEqual(response.status_code, 404)
 
         with self.login_user_context(staff):
-            response = self.client.post(
-                self.get_admin_url(PageContent, 'change_template', 1),
-                {'template': template}
-            )
+            response = self.client.post(self.get_admin_url(PageContent, "change_template", 1), {"template": template})
             self.assertEqual(response.status_code, 403)
 
-        page = create_page('test-page', template, 'en')
-        endpoint = self.get_page_change_template_uri('en', page)
+        page = create_page("test-page", template, "en")
+        endpoint = self.get_page_change_template_uri("en", page)
 
         with self.login_user_context(staff):
-            response = self.client.post(endpoint, {'template': template})
+            response = self.client.post(endpoint, {"template": template})
             self.assertEqual(response.status_code, 403)
 
         with self.login_user_context(admin_user):
-            response = self.client.post(endpoint, {'template': 'doesntexist'})
+            response = self.client.post(endpoint, {"template": "doesntexist"})
             self.assertEqual(response.status_code, 400)
-            response = self.client.post(endpoint, {'template': template})
+            response = self.client.post(endpoint, {"template": template})
             self.assertEqual(response.status_code, 200)
 
     def test_changelist_items(self):
         admin_user = self.get_superuser()
-        first_level_page = create_page('level1', 'nav_playground.html', 'en')
+        first_level_page = create_page("level1", "nav_playground.html", "en")
         second_level_page_top = create_page(
-            'level21', "nav_playground.html", "en", created_by=admin_user, parent=first_level_page
+            "level21", "nav_playground.html", "en", created_by=admin_user, parent=first_level_page
         )
         first_level_page.refresh_from_db()
         second_level_page_bottom = create_page(
-            'level22', "nav_playground.html", "en", created_by=admin_user, parent=first_level_page
+            "level22", "nav_playground.html", "en", created_by=admin_user, parent=first_level_page
         )
         third_level_page = create_page(
-            'level3', "nav_playground.html", "en", created_by=admin_user, parent=second_level_page_top
+            "level3", "nav_playground.html", "en", created_by=admin_user, parent=second_level_page_top
         )
         self.assertEqual(Page.objects.all().count(), 4)
 
         with self.login_user_context(admin_user):
-            response = self.client.get(self.get_pages_admin_list_uri('en'))
-            cms_page_nodes = response.context_data['tree']['items']
+            response = self.client.get(self.get_pages_admin_list_uri("en"))
+            cms_page_nodes = response.context_data["tree"]["items"]
             self.assertEqual(cms_page_nodes[0], first_level_page)
             self.assertEqual(cms_page_nodes[1], second_level_page_top)
             self.assertEqual(cms_page_nodes[2], third_level_page)
@@ -262,31 +298,31 @@ class AdminTestCase(AdminTestsBase):
 
     def test_changelist_get_results(self):
         admin_user = self.get_superuser()
-        first_level_page = create_page('level1', 'nav_playground.html', 'en')
+        first_level_page = create_page("level1", "nav_playground.html", "en")
         second_level_page_top = create_page(
-            'level21', "nav_playground.html", "en", created_by=admin_user, parent=first_level_page
+            "level21", "nav_playground.html", "en", created_by=admin_user, parent=first_level_page
         )
         create_page(
-            'level22', "nav_playground.html", "en", created_by=admin_user, parent=self.reload(first_level_page)
+            "level22", "nav_playground.html", "en", created_by=admin_user, parent=self.reload(first_level_page)
         )
-        create_page('level3', "nav_playground.html", "en", created_by=admin_user, parent=second_level_page_top)
+        create_page("level3", "nav_playground.html", "en", created_by=admin_user, parent=second_level_page_top)
         create_page(
-            'level23', "nav_playground.html", "en", created_by=admin_user, parent=self.reload(first_level_page)
+            "level23", "nav_playground.html", "en", created_by=admin_user, parent=self.reload(first_level_page)
         )
         self.assertEqual(Page.objects.all().count(), 5)
         endpoint = self.get_pages_admin_list_uri()
 
         with self.login_user_context(admin_user):
             response = self.client.get(endpoint)
-            self.assertEqual(response.context_data['tree']['items'].count(), 5)
+            self.assertEqual(response.context_data["tree"]["items"].count(), 5)
 
         with self.login_user_context(admin_user):
-            response = self.client.get(endpoint + '&q=level23')
-            self.assertEqual(response.context_data['tree']['items'].count(), 1)
+            response = self.client.get(endpoint + "&q=level23")
+            self.assertEqual(response.context_data["tree"]["items"].count(), 1)
 
         with self.login_user_context(admin_user):
-            response = self.client.get(endpoint + '&q=level2')
-            self.assertEqual(response.context_data['tree']['items'].count(), 3)
+            response = self.client.get(endpoint + "&q=level2")
+            self.assertEqual(response.context_data["tree"]["items"].count(), 3)
 
     def test_empty_placeholder_with_nested_plugins(self):
         # It's important that this test clears a placeholder
@@ -302,18 +338,18 @@ class AdminTestCase(AdminTestsBase):
         add_plugin(ph, "ColumnPlugin", "en", parent=column_wrapper)
 
         # before cleaning the de placeholder
-        self.assertEqual(ph.get_plugins('en').count(), 3)
+        self.assertEqual(ph.get_plugins("en").count(), 3)
 
         admin_user, staff = self._get_guys()
-        endpoint = self.get_clear_placeholder_url(ph, language='en')
+        endpoint = self.get_clear_placeholder_url(ph, language="en")
 
         with self.login_user_context(admin_user):
-            response = self.client.post(endpoint, {'test': 0})
+            response = self.client.post(endpoint, {"test": 0})
 
         self.assertEqual(response.status_code, 302)
 
         # After cleaning the de placeholder, en placeholder must still have all the plugins
-        self.assertEqual(ph.get_plugins('en').count(), 0)
+        self.assertEqual(ph.get_plugins("en").count(), 0)
 
     def test_empty_placeholder_in_correct_language(self):
         """
@@ -328,26 +364,26 @@ class AdminTestCase(AdminTestsBase):
         add_plugin(ph, "TextPlugin", "en", body="Hello World EN 2")
 
         # creating a de title of the page and adding plugins to it
-        create_page_content("de", page_en.get_title(), page_en, slug=page_en.get_slug('en'))
+        create_page_content("de", page_en.get_title(), page_en, slug=page_en.get_slug("en"))
         add_plugin(ph, "TextPlugin", "de", body="Hello World DE")
         add_plugin(ph, "TextPlugin", "de", body="Hello World DE 2")
         add_plugin(ph, "TextPlugin", "de", body="Hello World DE 3")
 
         # before cleaning the de placeholder
-        self.assertEqual(ph.get_plugins('en').count(), 2)
-        self.assertEqual(ph.get_plugins('de').count(), 3)
+        self.assertEqual(ph.get_plugins("en").count(), 2)
+        self.assertEqual(ph.get_plugins("de").count(), 3)
 
         admin_user, staff = self._get_guys()
-        endpoint = self.get_clear_placeholder_url(ph, language='de')
+        endpoint = self.get_clear_placeholder_url(ph, language="de")
 
         with self.login_user_context(admin_user):
-            response = self.client.post(endpoint, {'test': 0})
+            response = self.client.post(endpoint, {"test": 0})
 
         self.assertEqual(response.status_code, 302)
 
         # After cleaning the de placeholder, en placeholder must still have all the plugins
-        self.assertEqual(ph.get_plugins('en').count(), 2)
-        self.assertEqual(ph.get_plugins('de').count(), 0)
+        self.assertEqual(ph.get_plugins("en").count(), 2)
+        self.assertEqual(ph.get_plugins("de").count(), 0)
 
 
 class AdminTests(AdminTestsBase):
@@ -361,7 +397,7 @@ class AdminTests(AdminTestsBase):
 
         fields = dict(email="admin@django-cms.org", is_staff=True, is_superuser=True)
 
-        if (User.USERNAME_FIELD != 'email'):
+        if User.USERNAME_FIELD != "email":
             fields[User.USERNAME_FIELD] = "admin"
 
         usr = User(**fields)
@@ -374,7 +410,7 @@ class AdminTests(AdminTestsBase):
 
         fields = dict(email="permless@django-cms.org", is_staff=True)
 
-        if (User.USERNAME_FIELD != 'email'):
+        if User.USERNAME_FIELD != "email":
             fields[User.USERNAME_FIELD] = "permless"
 
         usr = User(**fields)
@@ -400,7 +436,7 @@ class AdminTests(AdminTestsBase):
 
     def test_change_innavigation(self):
         page = self.get_page()
-        content = self.get_pagecontent_obj(page, 'en')
+        content = self.get_pagecontent_obj(page, "en")
         permless = self.get_permless()
         admin_user = self.get_admin()
         pagecontent_admin = self.pagecontent_admin_class
@@ -409,22 +445,21 @@ class AdminTests(AdminTestsBase):
             response = pagecontent_admin.change_innavigation(request, content.pk)
             self.assertEqual(response.status_code, 405)
         with self.login_user_context(permless):
-            request = self.get_request(post_data={'no': 'data'})
+            request = self.get_request(post_data={"no": "data"})
             response = pagecontent_admin.change_innavigation(request, content.pk)
             self.assertEqual(response.status_code, 403)
         with self.login_user_context(permless):
-            request = self.get_request(post_data={'no': 'data'})
+            request = self.get_request(post_data={"no": "data"})
             self.assertEqual(response.status_code, 403)
         with self.login_user_context(admin_user):
-            request = self.get_request(post_data={'no': 'data'})
-            self.assertRaises(Http404, pagecontent_admin.change_innavigation,
-                              request, content.pk + 100)
+            request = self.get_request(post_data={"no": "data"})
+            self.assertRaises(Http404, pagecontent_admin.change_innavigation, request, content.pk + 100)
         with self.login_user_context(permless):
-            request = self.get_request(post_data={'no': 'data'})
+            request = self.get_request(post_data={"no": "data"})
             response = pagecontent_admin.change_innavigation(request, content.pk)
             self.assertEqual(response.status_code, 403)
         with self.login_user_context(admin_user):
-            request = self.get_request(post_data={'no': 'data'})
+            request = self.get_request(post_data={"no": "data"})
             old = page.get_in_navigation()
             response = pagecontent_admin.change_innavigation(request, content.pk)
             self.assertEqual(response.status_code, 204)
@@ -432,8 +467,8 @@ class AdminTests(AdminTestsBase):
             self.assertEqual(old, not page.get_in_navigation())
 
     def test_remove_plugin_requires_post(self):
-        ph = self.page.get_placeholders('en')[0]
-        plugin = add_plugin(ph, 'TextPlugin', 'en', body='test')
+        ph = self.page.get_placeholders("en")[0]
+        plugin = add_plugin(ph, "TextPlugin", "en", body="test")
         admin_user = self.get_admin()
         with self.login_user_context(admin_user):
             endpoint = self.get_delete_plugin_uri(plugin)
@@ -442,59 +477,65 @@ class AdminTests(AdminTestsBase):
 
     def test_too_many_plugins_global(self):
         conf = {
-            'body': {
-                'limits': {
-                    'global': 1,
+            "body": {
+                "limits": {
+                    "global": 1,
                 },
             },
         }
         admin_user = self.get_admin()
-        url = admin_reverse('cms_placeholder_add_plugin')
+        url = admin_reverse("cms_placeholder_add_plugin")
         with self.settings(CMS_PERMISSION=False, CMS_PLACEHOLDER_CONF=conf):
-            page = create_page('somepage', 'nav_playground.html', 'en')
-            body = page.get_placeholders("en").get(slot='body')
-            add_plugin(body, 'TextPlugin', 'en', body='text')
+            page = create_page("somepage", "nav_playground.html", "en")
+            body = page.get_placeholders("en").get(slot="body")
+            add_plugin(body, "TextPlugin", "en", body="text")
             with self.login_user_context(admin_user):
                 data = {
-                    'plugin_type': 'TextPlugin',
-                    'placeholder_id': body.pk,
-                    'target_language': 'en',
+                    "plugin_type": "TextPlugin",
+                    "placeholder_id": body.pk,
+                    "target_language": "en",
                 }
                 response = self.client.post(url, data)
                 self.assertEqual(response.status_code, HttpResponseBadRequest.status_code)
 
     def test_too_many_plugins_type(self):
         conf = {
-            'body': {
-                'limits': {
-                    'TextPlugin': 1,
+            "body": {
+                "limits": {
+                    "TextPlugin": 1,
                 },
             },
         }
         admin_user = self.get_admin()
-        url = admin_reverse('cms_placeholder_add_plugin')
+        url = admin_reverse("cms_placeholder_add_plugin")
         with self.settings(CMS_PERMISSION=False, CMS_PLACEHOLDER_CONF=conf):
-            page = create_page('somepage', 'nav_playground.html', 'en')
-            body = page.get_placeholders("en").get(slot='body')
-            add_plugin(body, 'TextPlugin', 'en', body='text')
+            page = create_page("somepage", "nav_playground.html", "en")
+            body = page.get_placeholders("en").get(slot="body")
+            add_plugin(body, "TextPlugin", "en", body="text")
             with self.login_user_context(admin_user):
                 data = {
-                    'plugin_type': 'TextPlugin',
-                    'placeholder_id': body.pk,
-                    'target_language': 'en',
-                    'plugin_parent': '',
+                    "plugin_type": "TextPlugin",
+                    "placeholder_id": body.pk,
+                    "target_language": "en",
+                    "plugin_parent": "",
                 }
                 response = self.client.post(url, data)
                 self.assertEqual(response.status_code, HttpResponseBadRequest.status_code)
 
     def test_page_edit_field_endpoint(self):
-        endpoint = admin_reverse("cms_page_edit_title_fields", args=(self.page.pk, "en")) + "?language=en&edit_fields=page_title"
+        endpoint = (
+            admin_reverse("cms_page_edit_title_fields", args=(self.page.pk, "en"))
+            + "?language=en&edit_fields=page_title"
+        )
         with self.login_user_context(self.get_superuser()):
             response = self.client.get(endpoint)
         if DJANGO_4_2:
             self.assertContains(response, '<input type="text" name="page_title" maxlength="255" id="id_page_title">')
         else:
-            self.assertContains(response, '<input type="text" name="page_title" maxlength="255" aria-describedby="id_page_title_helptext" id="id_page_title">')
+            self.assertContains(
+                response,
+                '<input type="text" name="page_title" maxlength="255" aria-describedby="id_page_title_helptext" id="id_page_title">',
+            )
 
 
 class NoDBAdminTests(CMSTestCase):
@@ -505,34 +546,34 @@ class NoDBAdminTests(CMSTestCase):
     def test_lookup_allowed_site__exact(self):
         request = self.get_request()
         if DJANGO_5_1:
-            self.assertTrue(self.admin_class.lookup_allowed('site__exact', '1'))
+            self.assertTrue(self.admin_class.lookup_allowed("site__exact", "1"))
         else:
-            self.assertTrue(self.admin_class.lookup_allowed('site__exact', '1', request=request))
+            self.assertTrue(self.admin_class.lookup_allowed("site__exact", "1", request=request))
 
     def test_lookup_allowed_published(self):
         request = self.get_request()
         if DJANGO_5_1:
-            self.assertTrue(self.admin_class.lookup_allowed('site__exact', '1'))
+            self.assertTrue(self.admin_class.lookup_allowed("site__exact", "1"))
         else:
-            self.assertTrue(self.admin_class.lookup_allowed('site__exact', '1', request=request))
+            self.assertTrue(self.admin_class.lookup_allowed("site__exact", "1", request=request))
 
 
 class PluginPermissionTests(AdminTestsBase):
     def setUp(self):
-        self._page = create_page('test page', 'nav_playground.html', 'en')
-        self._placeholder = self._page.get_placeholders('en')[0]
+        self._page = create_page("test page", "nav_playground.html", "en")
+        self._placeholder = self._page.get_placeholders("en")[0]
 
     def _get_admin(self):
         User = get_user_model()
 
         fields = dict(email="admin@django-cms.org", is_staff=True, is_active=True)
 
-        if (User.USERNAME_FIELD != 'email'):
+        if User.USERNAME_FIELD != "email":
             fields[User.USERNAME_FIELD] = "admin"
 
         admin_user = User(**fields)
 
-        admin_user.set_password('admin')
+        admin_user.set_password("admin")
         admin_user.save()
         return admin_user
 
@@ -540,22 +581,19 @@ class PluginPermissionTests(AdminTestsBase):
         return admin.site._registry[Page]
 
     def _give_permission(self, user, model, permission_type, save=True):
-        codename = f'{permission_type}_{model._meta.object_name.lower()}'
+        codename = f"{permission_type}_{model._meta.object_name.lower()}"
         user.user_permissions.add(Permission.objects.get(codename=codename))
 
     def _give_page_permission_rights(self, user):
-        self._give_permission(user, PagePermission, 'add')
-        self._give_permission(user, PagePermission, 'change')
-        self._give_permission(user, PagePermission, 'delete')
+        self._give_permission(user, PagePermission, "add")
+        self._give_permission(user, PagePermission, "change")
+        self._give_permission(user, PagePermission, "delete")
 
     def _get_change_page_request(self, user, page):
-        return type('Request', (object,), {
-            'user': user,
-            'path': self.get_page_change_uri('en', page)
-        })
+        return type("Request", (object,), {"user": user, "path": self.get_page_change_uri("en", page)})
 
     def _give_cms_permissions(self, user, save=True):
-        for perm_type in ['add', 'change', 'delete']:
+        for perm_type in ["add", "change", "delete"]:
             for model in [Page, PageContent]:
                 self._give_permission(user, model, perm_type, False)
         gpp = GlobalPagePermission.objects.create(
@@ -572,7 +610,7 @@ class PluginPermissionTests(AdminTestsBase):
             user.save()
 
     def _create_plugin(self):
-        plugin = add_plugin(self._placeholder, 'TextPlugin', 'en')
+        plugin = add_plugin(self._placeholder, "TextPlugin", "en")
         return plugin
 
     def test_plugin_edit_wrong_url(self):
@@ -580,14 +618,16 @@ class PluginPermissionTests(AdminTestsBase):
         plugin = self._create_plugin()
         _, normal_guy = self._get_guys()
 
-        if get_user_model().USERNAME_FIELD == 'email':
-            self.client.login(username='test@test.com', password='test@test.com')
+        if get_user_model().USERNAME_FIELD == "email":
+            self.client.login(username="test@test.com", password="test@test.com")
         else:
-            self.client.login(username='test', password='test')
+            self.client.login(username="test", password="test")
 
-        self._give_permission(normal_guy, Text, 'change')
-        endpoint = '{}edit-plugin/{}/'.format(admin_reverse('cms_placeholder_edit_plugin', args=[plugin.id]), plugin.id)
-        endpoint += '?cms_path=/en/'
+        self._give_permission(normal_guy, Text, "change")
+        endpoint = "{}edit-plugin/{}/".format(
+            admin_reverse("cms_placeholder_edit_plugin", args=[plugin.id]), plugin.id
+        )
+        endpoint += "?cms_path=/en/"
         response = self.client.post(endpoint, dict())
 
         self.assertEqual(response.status_code, HttpResponseNotFound.status_code)
@@ -595,87 +635,84 @@ class PluginPermissionTests(AdminTestsBase):
 
 
 class AdminFormsTests(AdminTestsBase):
-
     def test_clean_overwrite_url(self):
         """
         A manual path needs to be stripped from leading and trailing slashes.
         """
         superuser = self.get_superuser()
-        cms_page = create_page('test page', 'nav_playground.html', 'en')
+        cms_page = create_page("test page", "nav_playground.html", "en")
         page_data = {
-            'title': 'test page',
-            'slug': 'test-page',
-            'overwrite_url': '/overwrite/url/',
-            'template': cms_page.get_template('en'),
+            "title": "test page",
+            "slug": "test-page",
+            "overwrite_url": "/overwrite/url/",
+            "template": cms_page.get_template("en"),
         }
-        endpoint = self.get_page_change_uri('en', cms_page)
+        endpoint = self.get_page_change_uri("en", cms_page)
 
         with self.login_user_context(superuser):
             response = self.client.post(endpoint, page_data)
-            self.assertRedirects(response, self.get_pages_admin_list_uri('en'))
+            self.assertRedirects(response, self.get_pages_admin_list_uri("en"))
             self.assertSequenceEqual(
-                cms_page.urls.values_list('path', 'managed'),
-                [('overwrite/url', False)],
+                cms_page.urls.values_list("path", "managed"),
+                [("overwrite/url", False)],
             )
 
     def test_missmatching_site_parent_dotsite(self):
         superuser = self.get_superuser()
-        new_site = Site.objects.create(id=2, domain='foo.com', name='foo.com')
-        parent_page = api.create_page("test", get_cms_setting('TEMPLATES')[0][0], "fr", site=new_site)
+        new_site = Site.objects.create(id=2, domain="foo.com", name="foo.com")
+        parent_page = api.create_page("test", get_cms_setting("TEMPLATES")[0][0], "fr", site=new_site)
         new_page_data = {
-            'title': 'Title',
-            'slug': 'slug',
-            'parent_page': parent_page.pk,
+            "title": "Title",
+            "slug": "slug",
+            "parent_page": parent_page.pk,
         }
         with self.login_user_context(superuser):
             # Invalid parent
-            endpoint = self.get_page_add_uri('en')
+            endpoint = self.get_page_add_uri("en")
             response = self.client.post(endpoint, new_page_data)
             if DJANGO_5_1:
                 expected_error = (
-                    '<ul class="errorlist">'
-                    '<li>Site doesn&#39;t match the parent&#39;s page site</li></ul>'
+                    '<ul class="errorlist">' "<li>Site doesn&#39;t match the parent&#39;s page site</li></ul>"
                 )
             else:
                 expected_error = (
                     '<ul class="errorlist" id="id_parent_page_error">'
-                    '<li>Site doesn&#x27;t match the parent&#x27;s page site</li></ul>'
+                    "<li>Site doesn&#x27;t match the parent&#x27;s page site</li></ul>"
                 )
             self.assertEqual(response.status_code, 200)
             self.assertContains(response, expected_error, html=True)
 
     def test_form_errors(self):
         superuser = self.get_superuser()
-        site0 = Site.objects.create(id=2, domain='foo.com', name='foo.com')
-        page1 = api.create_page("test", get_cms_setting('TEMPLATES')[0][0], "fr", site=site0)
+        site0 = Site.objects.create(id=2, domain="foo.com", name="foo.com")
+        page1 = api.create_page("test", get_cms_setting("TEMPLATES")[0][0], "fr", site=site0)
 
         new_page_data = {
-            'title': 'Title',
-            'slug': 'home',
-            'parent_page': page1.pk,
+            "title": "Title",
+            "slug": "home",
+            "parent_page": page1.pk,
         }
-        endpoint = self.get_page_add_uri('en')
+        endpoint = self.get_page_add_uri("en")
 
         with self.login_user_context(superuser):
             # Invalid parent
             response = self.client.post(endpoint, new_page_data)
             if DJANGO_5_1:
                 expected_error = (
-                    '<ul class="errorlist">'
-                    '<li>Site doesn&#39;t match the parent&#39;s page site</li></ul>'
+                    '<ul class="errorlist">' "<li>Site doesn&#39;t match the parent&#39;s page site</li></ul>"
                 )
             else:
                 expected_error = (
                     '<ul class="errorlist" id="id_parent_page_error">'
-                    '<li>Site doesn&#x27;t match the parent&#x27;s page site</li></ul>'
+                    "<li>Site doesn&#x27;t match the parent&#x27;s page site</li></ul>"
                 )
 
             self.assertEqual(response.status_code, 200)
             self.assertContains(response, expected_error, html=True)
 
         new_page_data = {
-            'title': 'Title',
-            'slug': '#',
+            "title": "Title",
+            "slug": "#",
         }
 
         with self.subTest("Invalid slug"):
@@ -683,19 +720,23 @@ class AdminFormsTests(AdminTestsBase):
                 # Invalid slug
                 response = self.client.post(endpoint, new_page_data)
                 if DJANGO_5_1:
-                    expected_error = ('<ul class="errorlist"><li>Enter a valid “slug” consisting of letters, numbers, '
-                                      'underscores or hyphens.</li></ul>')
+                    expected_error = (
+                        '<ul class="errorlist"><li>Enter a valid “slug” consisting of letters, numbers, '
+                        "underscores or hyphens.</li></ul>"
+                    )
                 else:
-                    expected_error = ('<ul class="errorlist" id="id_slug_error"><li>Enter a valid “slug” consisting of '
-                                      'letters, numbers, underscores or hyphens.</li></ul>')
+                    expected_error = (
+                        '<ul class="errorlist" id="id_slug_error"><li>Enter a valid “slug” consisting of '
+                        "letters, numbers, underscores or hyphens.</li></ul>"
+                    )
 
                 self.assertEqual(response.status_code, 200)
                 self.assertContains(response, expected_error, html=True)
 
-        page2 = api.create_page("test", get_cms_setting('TEMPLATES')[0][0], "en")
+        page2 = api.create_page("test", get_cms_setting("TEMPLATES")[0][0], "en")
         new_page_data = {
-            'title': 'Title',
-            'slug': 'test',
+            "title": "Title",
+            "slug": "test",
         }
 
         with self.login_user_context(superuser):
@@ -705,14 +746,14 @@ class AdminFormsTests(AdminTestsBase):
                     expected_error = (
                         '<ul class="errorlist"><li>Page '
                         '<a href="{}" target="_blank">test</a> '
-                        'has the same url \'test\' as current page.</li></ul>'
-                    ).format(self.get_page_change_uri('en', page2))
+                        "has the same url 'test' as current page.</li></ul>"
+                    ).format(self.get_page_change_uri("en", page2))
                 else:
                     expected_error = (
                         '<ul class="errorlist" id="id_slug_error"><li>Page '
                         '<a href="{}" target="_blank">test</a> '
-                        'has the same url \'test\' as current page.</li></ul>'
-                    ).format(self.get_page_change_uri('en', page2))
+                        "has the same url 'test' as current page.</li></ul>"
+                    ).format(self.get_page_change_uri("en", page2))
 
                 self.assertEqual(response.status_code, 200)
                 self.assertContains(response, expected_error, html=True)
@@ -720,34 +761,31 @@ class AdminFormsTests(AdminTestsBase):
     @override_settings(CMS_PERMISSION=False)
     def test_reverse_id_error_location(self):
         superuser = self.get_superuser()
-        create_page('Page 1', 'nav_playground.html', 'en', reverse_id='p1')
-        page2 = create_page('Page 2', 'nav_playground.html', 'en')
-        page2_endpoint = self.get_admin_url(Page, 'advanced', page2.pk)
+        create_page("Page 1", "nav_playground.html", "en", reverse_id="p1")
+        page2 = create_page("Page 2", "nav_playground.html", "en")
+        page2_endpoint = self.get_admin_url(Page, "advanced", page2.pk)
 
         # Assemble a bunch of data to test the page form
         page2_data = {
-            'reverse_id': 'p1',
-            'template': 'col_two.html',
+            "reverse_id": "p1",
+            "template": "col_two.html",
         }
 
         with self.login_user_context(superuser):
             response = self.client.post(page2_endpoint, page2_data)
-            expected_error = (
-                '<ul class="errorlist">'
-                '<li>A page with this reverse URL id exists already.</li></ul>'
-            )
+            expected_error = '<ul class="errorlist">' "<li>A page with this reverse URL id exists already.</li></ul>"
             self.assertEqual(response.status_code, 200)
             self.assertContains(response, expected_error.format(page2.pk), html=True)
 
     @override_settings(CMS_PERMISSION=False)
     def test_advanced_settings_endpoint_fails_gracefully(self):
         admin_user = self.get_superuser()
-        page = create_page('Page 1', 'nav_playground.html', 'en')
+        page = create_page("Page 1", "nav_playground.html", "en")
         page_data = {
-            'language': 'en',
-            'template': 'col_two.html',
+            "language": "en",
+            "template": "col_two.html",
         }
-        path = admin_reverse('cms_page_advanced', args=(page.pk,))
+        path = admin_reverse("cms_page_advanced", args=(page.pk,))
 
         # It's important to test fields that are validated
         # automatically by Django vs fields that are validated
@@ -757,7 +795,7 @@ class AdminFormsTests(AdminTestsBase):
         # method then an error will be raised.
 
         # So test that the form short circuits if there's errors.
-        page_data['application_urls'] = 'TestApp'
+        page_data["application_urls"] = "TestApp"
 
         with self.login_user_context(admin_user):
             response = self.client.post(path, page_data)
@@ -773,53 +811,49 @@ class AdminFormsTests(AdminTestsBase):
 
         cache.clear()
 
-        homepage = create_page('Test', 'static.html', 'en')
+        homepage = create_page("Test", "static.html", "en")
         homepage.set_as_homepage()
 
-        for placeholder in homepage.get_placeholders('en'):
-            add_plugin(placeholder, TextPlugin, 'en', body='<b>Test</b>')
+        for placeholder in homepage.get_placeholders("en"):
+            add_plugin(placeholder, TextPlugin, "en", body="<b>Test</b>")
 
         user = self.get_superuser()
-        self.assertEqual(homepage.get_placeholders('en').count(), 2)
+        self.assertEqual(homepage.get_placeholders("en").count(), 2)
         with self.login_user_context(user):
-            output = force_str(
-                self.client.get('/en/').content
-            )
-            self.assertIn('<b>Test</b>', output)
+            output = force_str(self.client.get("/en/").content)
+            self.assertIn("<b>Test</b>", output)
             self.assertEqual(StaticPlaceholder.objects.count(), 2)
-            for placeholder in homepage.get_placeholders('en'):
-                add_plugin(placeholder, TextPlugin, 'en', body='<b>Test</b>')
-            output = force_str(
-                self.client.get('/en/').content
-            )
-            self.assertIn('<b>Test</b>', output)
+            for placeholder in homepage.get_placeholders("en"):
+                add_plugin(placeholder, TextPlugin, "en", body="<b>Test</b>")
+            output = force_str(self.client.get("/en/").content)
+            self.assertIn("<b>Test</b>", output)
 
     def test_tree_view_queries(self):
         from django.core.cache import cache
 
         cache.clear()
         for i in range(10):
-            create_page('Test%s' % i, 'col_two.html', 'en')
+            create_page("Test%s" % i, "col_two.html", "en")
         for placeholder in Placeholder.objects.all():
-            add_plugin(placeholder, TextPlugin, 'en', body='<b>Test</b>')
+            add_plugin(placeholder, TextPlugin, "en", body="<b>Test</b>")
 
         user = self.get_superuser()
         with self.login_user_context(user):
             with self.assertNumQueries(8):
-                force_str(self.client.get(self.get_pages_admin_list_uri('en')))
+                force_str(self.client.get(self.get_pages_admin_list_uri("en")))
 
     def test_smart_link_pages(self):
         admin, staff_guy = self._get_guys()
         page_url = URL_CMS_PAGE_PUBLISHED  # Not sure how to achieve this with reverse...
-        create_page('home', 'col_two.html', 'en')
+        create_page("home", "col_two.html", "en")
 
         with self.login_user_context(staff_guy):
-            multi_title_page = create_page('main_title', 'col_two.html', 'en',
-                                           overwrite_url='overwritten_url',
-                                           menu_title='menu_title')
+            multi_title_page = create_page(
+                "main_title", "col_two.html", "en", overwrite_url="overwritten_url", menu_title="menu_title"
+            )
 
             title = multi_title_page.get_content_obj()
-            title.page_title = 'page_title'
+            title.page_title = "page_title"
             title.save()
 
             multi_title_page.save()
@@ -827,60 +861,65 @@ class AdminFormsTests(AdminTestsBase):
             # Non ajax call should return a 403 as this page shouldn't be accessed by anything else but ajax queries
             self.assertEqual(403, self.client.get(page_url).status_code)
 
-            self.assertEqual(
-                200, self.client.get(page_url, HTTP_X_REQUESTED_WITH='XMLHttpRequest').status_code
-            )
+            self.assertEqual(200, self.client.get(page_url, HTTP_X_REQUESTED_WITH="XMLHttpRequest").status_code)
 
             # Test that the query param is working as expected.
             self.assertEqual(
-                1, len(json.loads(
-                    self.client.get(
-                        page_url, {'q': 'main_title'},
-                        HTTP_X_REQUESTED_WITH='XMLHttpRequest'
-                    ).content.decode("utf-8")
-                ))
+                1,
+                len(
+                    json.loads(
+                        self.client.get(
+                            page_url, {"q": "main_title"}, HTTP_X_REQUESTED_WITH="XMLHttpRequest"
+                        ).content.decode("utf-8")
+                    )
+                ),
             )
 
             self.assertEqual(
-                1, len(json.loads(
-                    self.client.get(
-                        page_url, {'q': 'menu_title'},
-                        HTTP_X_REQUESTED_WITH='XMLHttpRequest'
-                    ).content.decode("utf-8")
-                ))
+                1,
+                len(
+                    json.loads(
+                        self.client.get(
+                            page_url, {"q": "menu_title"}, HTTP_X_REQUESTED_WITH="XMLHttpRequest"
+                        ).content.decode("utf-8")
+                    )
+                ),
             )
 
             self.assertEqual(
-                1, len(json.loads(
-                    self.client.get(
-                        page_url, {'q': 'overwritten_url'},
-                        HTTP_X_REQUESTED_WITH='XMLHttpRequest'
-                    ).content.decode("utf-8")
-                ))
+                1,
+                len(
+                    json.loads(
+                        self.client.get(
+                            page_url, {"q": "overwritten_url"}, HTTP_X_REQUESTED_WITH="XMLHttpRequest"
+                        ).content.decode("utf-8")
+                    )
+                ),
             )
 
             self.assertEqual(
-                1, len(json.loads(
-                    self.client.get(
-                        page_url, {'q': 'page_title'},
-                        HTTP_X_REQUESTED_WITH='XMLHttpRequest'
-                    ).content.decode("utf-8")
-                ))
+                1,
+                len(
+                    json.loads(
+                        self.client.get(
+                            page_url, {"q": "page_title"}, HTTP_X_REQUESTED_WITH="XMLHttpRequest"
+                        ).content.decode("utf-8")
+                    )
+                ),
             )
 
 
 class PagePropsMovedToPageContentTests(CMSTestCase):
-
     def test_moved_fields(self):
         non_editables = [
-            'id',
-            'changed_by',
-            'changed_date',
-            'created_by',
-            'creation_date',
-            'page_id',
-            'in_navigation',
-            'language'
+            "id",
+            "changed_by",
+            "changed_date",
+            "created_by",
+            "creation_date",
+            "page_id",
+            "in_navigation",
+            "language",
         ]
 
         change_page_form_fieldsets = flatten_fieldsets(ChangePageForm.fieldsets)
@@ -909,8 +948,8 @@ class AdminPageEditContentSizeTests(AdminTestsBase):
         """
         with self.settings(CMS_PERMISSION=True):
             admin_user = self.get_superuser()
-            PAGE_NAME = 'TestPage'
-            USER_NAME = 'test_size_user_0'
+            PAGE_NAME = "TestPage"
+            USER_NAME = "test_size_user_0"
             current_site = Site.objects.get(pk=1)
             page = create_page(PAGE_NAME, "nav_playground.html", "en", site=current_site, created_by=admin_user)
             page.save()
@@ -922,8 +961,9 @@ class AdminPageEditContentSizeTests(AdminTestsBase):
                 old_response_size = len(response.content)
                 old_user_count = get_user_model().objects.count()
                 # create additional user and reload the page
-                get_user_model().objects.create_user(username=USER_NAME, email=USER_NAME + '@django-cms.org',
-                                                     password=USER_NAME)
+                get_user_model().objects.create_user(
+                    username=USER_NAME, email=USER_NAME + "@django-cms.org", password=USER_NAME
+                )
                 user_count = get_user_model().objects.count()
                 more_users_in_db = old_user_count < user_count
                 # we have more users
@@ -937,20 +977,22 @@ class AdminPageEditContentSizeTests(AdminTestsBase):
                 text = smart_str(response.content, response.charset)
                 foundcount = text.count(USER_NAME)
                 # 2 forms contain usernames as options
-                self.assertEqual(foundcount, 2,
-                                 f"Username {USER_NAME} appeared {foundcount} times in response.content, expected 2 times")
+                self.assertEqual(
+                    foundcount,
+                    2,
+                    f"Username {USER_NAME} appeared {foundcount} times in response.content, expected 2 times",
+                )
 
 
 class AdminPageTreeTests(AdminTestsBase):
-
     def test_move_node(self):
         admin_user, staff = self._get_guys()
         page_admin = self.page_admin_class
 
-        alpha = create_page('Alpha', 'nav_playground.html', 'en')
-        beta = create_page('Beta', TEMPLATE_INHERITANCE_MAGIC, 'en')
-        gamma = create_page('Gamma', TEMPLATE_INHERITANCE_MAGIC, 'en')
-        delta = create_page('Delta', TEMPLATE_INHERITANCE_MAGIC, 'en')
+        alpha = create_page("Alpha", "nav_playground.html", "en")
+        beta = create_page("Beta", TEMPLATE_INHERITANCE_MAGIC, "en")
+        gamma = create_page("Gamma", TEMPLATE_INHERITANCE_MAGIC, "en")
+        delta = create_page("Delta", TEMPLATE_INHERITANCE_MAGIC, "en")
 
         # Current structure:
         #   <root>
@@ -961,18 +1003,18 @@ class AdminPageTreeTests(AdminTestsBase):
 
         # Move Beta to be a child of Alpha
         data = {
-            'id': beta.pk,
-            'position': 0,
-            'target': alpha.pk,
+            "id": beta.pk,
+            "position": 0,
+            "target": alpha.pk,
         }
 
         with self.login_user_context(admin_user):
             request = self.get_request(post_data=data)
             response = page_admin.move_page(request, page_id=beta.pk)
-            data = json.loads(response.content.decode('utf8'))
+            data = json.loads(response.content.decode("utf8"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(data['status'], 200)
+        self.assertEqual(data["status"], 200)
         alpha.refresh_from_db()
         self.assertEqual(alpha.get_descendants().count(), 1)
 
@@ -985,18 +1027,18 @@ class AdminPageTreeTests(AdminTestsBase):
 
         # Move Gamma to be a child of Beta
         data = {
-            'id': gamma.pk,
-            'position': 0,
-            'target': beta.pk,
+            "id": gamma.pk,
+            "position": 0,
+            "target": beta.pk,
         }
 
         with self.login_user_context(admin_user):
             request = self.get_request(post_data=data)
             response = page_admin.move_page(request, page_id=gamma.pk)
-            data = json.loads(response.content.decode('utf8'))
+            data = json.loads(response.content.decode("utf8"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(data['status'], 200)
+        self.assertEqual(data["status"], 200)
         alpha.refresh_from_db()
         self.assertEqual(alpha.get_descendants().count(), 2)
         beta.refresh_from_db()
@@ -1011,18 +1053,18 @@ class AdminPageTreeTests(AdminTestsBase):
 
         # Move Delta to be a child of Beta
         data = {
-            'id': delta.pk,
-            'position': 0,
-            'target': gamma.pk,
+            "id": delta.pk,
+            "position": 0,
+            "target": gamma.pk,
         }
 
         with self.login_user_context(admin_user):
             request = self.get_request(post_data=data)
             response = page_admin.move_page(request, page_id=delta.pk)
-            data = json.loads(response.content.decode('utf8'))
+            data = json.loads(response.content.decode("utf8"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(data['status'], 200)
+        self.assertEqual(data["status"], 200)
         alpha.refresh_from_db()
         self.assertEqual(alpha.get_descendants().count(), 3)
         beta.refresh_from_db()
@@ -1039,17 +1081,17 @@ class AdminPageTreeTests(AdminTestsBase):
 
         # Move Beta to the root as node #1 (positions are 0-indexed)
         data = {
-            'id': beta.pk,
-            'position': 1,
+            "id": beta.pk,
+            "position": 1,
         }
 
         with self.login_user_context(admin_user):
             request = self.get_request(post_data=data)
             response = page_admin.move_page(request, page_id=beta.pk)
-            data = json.loads(response.content.decode('utf8'))
+            data = json.loads(response.content.decode("utf8"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(data['status'], 200)
+        self.assertEqual(data["status"], 200)
         alpha.refresh_from_db()
         self.assertEqual(alpha.get_descendants().count(), 0)
         beta.refresh_from_db()
@@ -1066,18 +1108,18 @@ class AdminPageTreeTests(AdminTestsBase):
 
         # Move Beta to be a child of Alpha again
         data = {
-            'id': beta.pk,
-            'position': 0,
-            'target': alpha.pk,
+            "id": beta.pk,
+            "position": 0,
+            "target": alpha.pk,
         }
 
         with self.login_user_context(admin_user):
             request = self.get_request(post_data=data)
             response = page_admin.move_page(request, page_id=beta.pk)
-            data = json.loads(response.content.decode('utf8'))
+            data = json.loads(response.content.decode("utf8"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(data['status'], 200)
+        self.assertEqual(data["status"], 200)
         alpha.refresh_from_db()
         self.assertEqual(alpha.get_descendants().count(), 3)
         beta.refresh_from_db()
@@ -1094,17 +1136,17 @@ class AdminPageTreeTests(AdminTestsBase):
 
         # Move Gamma to the root as node #1 (positions are 0-indexed)
         data = {
-            'id': gamma.pk,
-            'position': 1,
+            "id": gamma.pk,
+            "position": 1,
         }
 
         with self.login_user_context(admin_user):
             request = self.get_request(post_data=data)
             response = page_admin.move_page(request, page_id=gamma.pk)
-            data = json.loads(response.content.decode('utf8'))
+            data = json.loads(response.content.decode("utf8"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(data['status'], 200)
+        self.assertEqual(data["status"], 200)
         alpha.refresh_from_db()
         self.assertEqual(alpha.get_descendants().count(), 1)
         beta.refresh_from_db()
@@ -1121,17 +1163,17 @@ class AdminPageTreeTests(AdminTestsBase):
 
         # Move Delta to the root as node #1 (positions are 0-indexed)
         data = {
-            'id': delta.pk,
-            'position': 1,
+            "id": delta.pk,
+            "position": 1,
         }
 
         with self.login_user_context(admin_user):
             request = self.get_request(post_data=data)
             response = page_admin.move_page(request, page_id=delta.pk)
-            data = json.loads(response.content.decode('utf8'))
+            data = json.loads(response.content.decode("utf8"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(data['status'], 200)
+        self.assertEqual(data["status"], 200)
         alpha.refresh_from_db()
         self.assertEqual(alpha.get_descendants().count(), 1)
         beta.refresh_from_db()
@@ -1148,18 +1190,18 @@ class AdminPageTreeTests(AdminTestsBase):
 
         # Move Gamma to be a child of Delta
         data = {
-            'id': gamma.pk,
-            'position': 1,
-            'target': delta.pk,
+            "id": gamma.pk,
+            "position": 1,
+            "target": delta.pk,
         }
 
         with self.login_user_context(admin_user):
             request = self.get_request(post_data=data)
             response = page_admin.move_page(request, page_id=gamma.pk)
-            data = json.loads(response.content.decode('utf8'))
+            data = json.loads(response.content.decode("utf8"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(data['status'], 200)
+        self.assertEqual(data["status"], 200)
         alpha.refresh_from_db()
         self.assertEqual(alpha.get_descendants().count(), 1)
         beta.refresh_from_db()
@@ -1201,7 +1243,7 @@ class AdminPageTreeTests(AdminTestsBase):
             # Create pages in all languages
             page = {}
             for language in languages:
-                page[language] = create_page('Alpha', 'nav_playground.html', language)
+                page[language] = create_page("Alpha", "nav_playground.html", language)
 
             # Get the page tree and see if the href triggers an add page content for the
             # selected language
@@ -1209,14 +1251,10 @@ class AdminPageTreeTests(AdminTestsBase):
             for language in languages:
                 request = self.get_request(path=f"{url}?language={language}")
                 response = pagecontent_admin.get_tree(request)
-                self.assertContains(
-                    response,
-                    f'href="{add_url}?parent_page={page[language].id}&language={language}"'
-                )
+                self.assertContains(response, f'href="{add_url}?parent_page={page[language].id}&language={language}"')
 
 
 class AdminInputSanitationTests(AdminTestsBase):
-
     @property
     def settings_admin_class(self):
         return site._registry[UserSettings]
@@ -1229,9 +1267,11 @@ class AdminInputSanitationTests(AdminTestsBase):
 
         with self.login_user_context(admin_user):
             request = self.get_request(
-                self.settings_admin_class.urls[0], post_data={
-                    "settings": "<script>alert(\"hello world\")</script>",
-                })
+                self.settings_admin_class.urls[0],
+                post_data={
+                    "settings": '<script>alert("hello world")</script>',
+                },
+            )
             response = self.settings_admin_class.session_store(request)
 
             self.assertEqual(response.content, b'"&lt;script&gt;alert(&quot;hello world&quot;)&lt;/script&gt;"')

--- a/docs/how_to/04-templates.rst
+++ b/docs/how_to/04-templates.rst
@@ -228,3 +228,23 @@ Example: application template
 
 ``CMS_TEMPLATE`` memorises the path of the cms template so the application
 template can dynamically import it.
+
+Template Inheritance in Page Content Translations
+=================================================
+
+Default Behavior (without versioning)
+-------------------------------------
+
+In django CMS (version 4 and above), when creating page content translations, all content is immediately published. When creating a translation of an existing page, the template from the original page content is copied to the new translation.
+This behavior can be seen in the `create_translation` method. The template is explicitly copied from the original page content to ensure consistent layout across languages.
+
+Behavior with djangocms-versioning
+------------------------------------
+
+When using djangocms-versioning, pages and their content can exist in different states (draft, published, etc.). This introduces some nuances in template inheritance:
+
+1. When you create a page and publish it, the template is set and published
+2. If you create a new page content in another language and modify its template but don't publish it, that template change remains in draft state
+3. When creating a translation of that page content, the new translation will inherit the template from the last published version, not from any unpublished drafts
+
+This is because djangocms-versioning maintains strict separation between published and draft content to prevent unpublished changes from becoming visible. This behavior ensures that new translations are based on stable, published content rather than draft changes that may still be in progress.

--- a/docs/how_to/04-templates.rst
+++ b/docs/how_to/04-templates.rst
@@ -235,16 +235,29 @@ Template Inheritance in Page Content Translations
 Default Behavior (without versioning)
 -------------------------------------
 
-In django CMS (version 4 and above), when creating page content translations, all content is immediately published. When creating a translation of an existing page, the template from the original page content is copied to the new translation.
-This behavior can be seen in the `create_translation` method. The template is explicitly copied from the original page content to ensure consistent layout across languages.
+In django CMS (version 4 and above), when creating page content translations, all content is immediately 
+published. When creating a translation of an existing page, the template from the original page content is 
+copied to the new translation. This behavior can be seen in the `create_translation` method. The template 
+is explicitly copied from the original page content to ensure consistent layout across languages.
+
+Note for django CMS versions prior to 4.2:
+
+In older versions of django CMS (prior to 4.2), when creating page content translations, the template is not 
+automatically copied from the original page content. Instead, the default site template (or the template 
+from the last published version) is applied, and manual adjustments may be necessary to ensure consistency.
 
 Behavior with djangocms-versioning
 ------------------------------------
 
-When using djangocms-versioning, pages and their content can exist in different states (draft, published, etc.). This introduces some nuances in template inheritance:
+When using djangocms-versioning, pages and their content can exist in different states (draft, published,
+etc.). This introduces some nuances in template inheritance:
 
 1. When you create a page and publish it, the template is set and published
-2. If you create a new page content in another language and modify its template but don't publish it, that template change remains in draft state
-3. When creating a translation of that page content, the new translation will inherit the template from the last published version, not from any unpublished drafts
+2. When creating a translation of a page content, the new translation will inherit the template from the
+   draft version of the main language page content if one exists
+3. If no draft version exists in the main language, the template will be inherited from the published
+   version instead
 
-This is because djangocms-versioning maintains strict separation between published and draft content to prevent unpublished changes from becoming visible. This behavior ensures that new translations are based on stable, published content rather than draft changes that may still be in progress.
+This behavior ensures that new translations automatically pick up any template changes that are in progress
+(draft state) in the main language, maintaining consistency across translations even before changes are
+published.


### PR DESCRIPTION
## Description

Fixes the issue reported in https://github.com/django-cms/django-cms/issues/8081, in which subsequent created translations did not use the project's default language's template by default, and instead had the "Inherit the template of the nearest ancestor" setting.

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [X] I have opened this pull request against ``develop-4``
* [X] I have added or modified the tests when changing logic
* [X] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [X] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
