### PR TITLE
fix: Async support and middleware update for django CMS 4.2+

### DIFF
--- a/cms/middleware/language.py
+++ b/cms/middleware/language.py
@@ -4,6 +4,8 @@ from django.utils.translation import get_language
 
 
 class LanguageCookieMiddleware(MiddlewareMixin):
+    async_capable = False
+
     def __init__(self, get_response):
         super().__init__(get_response)
 

--- a/cms/middleware/language.py
+++ b/cms/middleware/language.py
@@ -1,16 +1,21 @@
 from django.conf import settings
-from django.utils.deprecation import MiddlewareMixin
 from django.utils.translation import get_language
 
 
-class LanguageCookieMiddleware(MiddlewareMixin):
-    async_capable = False
-
+class LanguageCookieMiddleware:
     def __init__(self, get_response):
-        super().__init__(get_response)
+        self.get_response = get_response
+        super().__init__()
 
     def __call__(self, request):
         response = self.get_response(request)
+        return self.process_response(request, response)
+
+    async def __acall__(self, request):
+        response = await self.get_response(request)
+        return self.process_response(request, response)
+
+    def process_response(self, request, response):
         language = get_language()
         if (
             settings.LANGUAGE_COOKIE_NAME in request.COOKIES  # noqa: W503

--- a/cms/middleware/page.py
+++ b/cms/middleware/page.py
@@ -1,4 +1,3 @@
-from django.utils.deprecation import MiddlewareMixin
 from django.utils.functional import SimpleLazyObject
 
 
@@ -15,6 +14,14 @@ def get_page(request):
     return request._current_page_cache
 
 
-class CurrentPageMiddleware(MiddlewareMixin):
-    def process_request(self, request):
+class CurrentPageMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
         request.current_page = SimpleLazyObject(lambda: get_page(request))
+        return self.get_response(request)
+
+    async def __acall__(self, request):
+        request.current_page = SimpleLazyObject(lambda: get_page(request))
+        return await self.get_response(request)

--- a/cms/middleware/user.py
+++ b/cms/middleware/user.py
@@ -3,13 +3,15 @@ permission system.
 
 This middleware is required only when CMS_PERMISSION = True.
 """
-from django.utils.deprecation import MiddlewareMixin
 
-
-class CurrentUserMiddleware(MiddlewareMixin):
+class CurrentUserMiddleware:
     async_capable = False
 
-    def process_request(self, request):
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
         from cms.utils.permissions import set_current_user
 
         set_current_user(getattr(request, 'user', None))
+        return self.get_response(request)

--- a/cms/middleware/user.py
+++ b/cms/middleware/user.py
@@ -5,8 +5,6 @@ This middleware is required only when CMS_PERMISSION = True.
 """
 
 class CurrentUserMiddleware:
-    async_capable = False
-
     def __init__(self, get_response):
         self.get_response = get_response
 

--- a/cms/middleware/user.py
+++ b/cms/middleware/user.py
@@ -7,6 +7,8 @@ from django.utils.deprecation import MiddlewareMixin
 
 
 class CurrentUserMiddleware(MiddlewareMixin):
+    async_capable = False
+
     def process_request(self, request):
         from cms.utils.permissions import set_current_user
 

--- a/cms/middleware/utils.py
+++ b/cms/middleware/utils.py
@@ -1,11 +1,18 @@
-from django.utils.deprecation import MiddlewareMixin
-
 from cms.utils import apphook_reload
 
 
-class ApphookReloadMiddleware(MiddlewareMixin):
+class ApphookReloadMiddleware:
     """
     If the URLs are stale, reload them.
     """
-    def process_request(self, request):
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
         apphook_reload.ensure_urlconf_is_up_to_date()
+        return self.get_response(request)
+
+    async def __acall__(self, request):
+        apphook_reload.ensure_urlconf_is_up_to_date()
+        return await self.get_response(request)
+


### PR DESCRIPTION
## Description

This PR removes the use of the compatibility `MiddlewareMixin` which is a tool to migrate old-style middleware to new-style middleware.

Except user middleware (which sets affects the current thread) all middlewares should in principle support async calls.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7985 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
