### PR TITLE
fix: code scanning alert no. 649: Information exposure through an exception

### DIFF
--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -735,10 +735,7 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
                 has_reached_plugin_limit(placeholder, plugin.plugin_type,
                                          target_language, template=template)
             except PluginLimitReached as er:
-                import logging
-                logger = logging.getLogger(__name__)
-                logger.error("Plugin limit reached: %s", er)
-                return HttpResponseBadRequest("A plugin limit has been reached. Please contact the administrator.")
+                return HttpResponseBadRequest(er.args[0])  # Report the end-user message
 
         # True if the plugin is not being moved from the clipboard
         # to a placeholder or from a placeholder to the clipboard.

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -735,7 +735,10 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
                 has_reached_plugin_limit(placeholder, plugin.plugin_type,
                                          target_language, template=template)
             except PluginLimitReached as er:
-                return HttpResponseBadRequest(er)
+                import logging
+                logger = logging.getLogger(__name__)
+                logger.error("Plugin limit reached: %s", er)
+                return HttpResponseBadRequest("A plugin limit has been reached. Please contact the administrator.")
 
         # True if the plugin is not being moved from the clipboard
         # to a placeholder or from a placeholder to the clipboard.


### PR DESCRIPTION
Potential fix for [https://github.com/django-cms/django-cms/security/code-scanning/649](https://github.com/django-cms/django-cms/security/code-scanning/649)

To fix the problem, we need to ensure that the detailed exception message is not exposed to the end user. Instead, we should log the exception message on the server and return a generic error message to the user. This can be achieved by modifying the code to catch the exception, log the detailed message, and return a generic error response.

1. Import the `logging` module to enable logging of the exception message.
2. Modify the exception handling block to log the detailed exception message.
3. Return a generic error message to the user instead of the detailed exception message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent the detailed exception message from being exposed to the end user when a `PluginLimitReached` exception occurs by returning only the end-user message from the exception arguments, and not the full exception object, which might contain sensitive information about the server internals or configuration details.  This addresses a code scanning alert by preventing information exposure through exceptions, thereby improving the security of the application and protecting it from potential vulnerabilities related to information leakage through exception messages or stack traces.