### PR TITLE
fix: Creation of text plugins failed

### DIFF
--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -437,12 +437,14 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
             'position': plugin_data['plugin_position'],
         }
 
-        if request.method == 'POST':
-            # If the plugin has show_add_plugin_form set to False,
+        if request.method == 'POST' and not plugin_class.show_plugin_add_form:
+            # If the plugin has show_plugin_add_form set to False,
             # the post data is missing the initial values of the plugin form
             # Get the fields, the form and the initial values from the plugin instance
             # Replace the POST parameters by those initial values plus any concrete changes
             # the form.
+            # TODO: Make this work with Text plugins which use ghost plugins and have to
+            # have show_plugin_add_form=True
             fieldsets = plugin_instance.get_fieldsets(request, obj=None)
             fields = flatten_fieldsets(fieldsets)
             # Instantiate the add form for all fields

--- a/cms/tests/test_placeholder_admin.py
+++ b/cms/tests/test_placeholder_admin.py
@@ -29,6 +29,23 @@ class PlaceholderAdminTestCase(CMSTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(plugins.count(), 1)
 
+    def test_add_plugin_with_ghost(self):
+        """Adding a text plugin works. Text plugins create a ghost plugin."""
+        superuser = self.get_superuser()
+        placeholder = Placeholder.objects.create(slot="test")
+        plugins = placeholder.get_plugins("en").filter(plugin_type="TextPlugin")
+        uri = self.get_add_plugin_uri(
+            placeholder=placeholder,
+            plugin_type="TextPlugin",
+            language="en",
+        )
+        with self.login_user_context(superuser):
+            data = {"body": "<p>Some markup</p>"}
+            response = self.client.post(uri, data, follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(plugins.count(), 1)
+
     def test_add_plugins_from_placeholder(self):
         """
         User can copy plugins from one placeholder to another


### PR DESCRIPTION
## Description

This fixes a regression introduced in #8105. Creation of text plugins failed since, they require a ghost plugin to be created to run their add form.

The PR only tries to idetify defaults from a plugin's form if it has `show_plugin_add_form` set to `False`.


## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8143 
* #8105

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Fix the issue where text plugins were failing to be created. Only attempt to identify default values from a plugin's form if `show_plugin_add_form` is set to `False`. Add a test to verify the fix.

Bug Fixes:
- Fix the creation of text plugins, which was failing due to a regression introduced in #8105. The creation of text plugins now works correctly by only trying to identify defaults from a plugin's form if it has `show_plugin_add_form` set to `False`

Tests:
- Add a test case to verify that text plugins, which create a ghost plugin, can be added successfully.