### PR TITLE
feat: Improved editing response time by global caching of plugin restrictions

### DIFF
--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -213,7 +213,7 @@ class Placeholder(models.Model):
             from cms.models.contentmodels import PageContent
 
             try:
-                # Directly go throug PageContent to avoid having to get the source and the page in separate queries
+                # Directly go through PageContent to avoid having to get the source and the page in separate queries
                 self._page = PageContent.admin_manager.filter(placeholders=self).select_related("page").first().page
             except AttributeError:
                 self._page = None

--- a/cms/models/placeholdermodel.py
+++ b/cms/models/placeholdermodel.py
@@ -213,6 +213,7 @@ class Placeholder(models.Model):
             from cms.models.contentmodels import PageContent
 
             try:
+                # Directly go throug PageContent to avoid having to get the source and the page in separate queries
                 self._page = PageContent.admin_manager.filter(placeholders=self).select_related("page").first().page
             except AttributeError:
                 self._page = None

--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -98,6 +98,23 @@ class CMSPluginBaseMetaclass(forms.MediaDefiningClass):
         return new_plugin
 
 
+def template_slot_caching(method: callable) -> callable:
+    """
+    Decorator that adds a `_template_slot_caching` attribute to the given method.
+
+    This attribute is used to indicate that the method supports global caching based
+    on placeholder slots and templates (see `CMS_PLACEHOLDER_CONF`).
+
+    Args:
+        method (function): The method to be decorated.
+
+    Returns:
+        function: The decorated method with the `_template_slot_caching` attribute set to True.
+    """
+    method._template_slot_caching = True
+    return method
+
+
 class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
     """
     Inherits :class:`django:django.contrib.admin.ModelAdmin` and in most respects behaves like a
@@ -343,6 +360,7 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
             return lazy(instance.placeholder.source.get_template, str)()
         return None
 
+    @template_slot_caching
     @classmethod
     def get_require_parent(cls, slot: str, page: Optional[Page] = None, instance: Optional[CMSPlugin] = None) -> bool:
         from cms.utils.placeholder import get_placeholder_conf
@@ -633,6 +651,7 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
         """
         return gettext('There are no further settings for this plugin. Please press save.')
 
+    @template_slot_caching
     @classmethod
     def get_child_class_overrides(cls, slot: str, page: Optional[Page] = None, instance: Optional[CMSPlugin] = None):
         """
@@ -662,6 +681,7 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
         from cms.plugin_pool import plugin_pool
         return plugin_pool.registered_plugins
 
+    @template_slot_caching
     @classmethod
     def get_child_classes(cls, slot, page: Optional[Page] = None, instance: Optional[CMSPlugin] = None):
         """
@@ -697,6 +717,7 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
 
         return child_classes
 
+    @template_slot_caching
     @classmethod
     def get_parent_classes(cls, slot: str, page: Optional[Page] = None, instance: Optional[CMSPlugin] = None):
         from cms.utils.placeholder import get_placeholder_conf

--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -100,7 +100,7 @@ class CMSPluginBaseMetaclass(forms.MediaDefiningClass):
 
 def template_slot_caching(method: callable) -> callable:
     """
-    Decorator that adds a `_template_slot_caching` attribute to the given method.
+    Decorator that adds a ``_template_slot_caching`` attribute to the given method.
 
     This attribute is used to indicate that the method supports global caching based
     on placeholder slots and templates (see `CMS_PLACEHOLDER_CONF`).
@@ -109,7 +109,7 @@ def template_slot_caching(method: callable) -> callable:
         method (function): The method to be decorated.
 
     Returns:
-        function: The decorated method with the `_template_slot_caching` attribute set to True.
+        function: The decorated method with the ``_template_slot_caching`` attribute set to True.
     """
     method._template_slot_caching = True
     return method
@@ -360,8 +360,8 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
             return lazy(instance.placeholder.source.get_template, str)()
         return None
 
-    @template_slot_caching
     @classmethod
+    @template_slot_caching
     def get_require_parent(cls, slot: str, page: Optional[Page] = None, instance: Optional[CMSPlugin] = None) -> bool:
         from cms.utils.placeholder import get_placeholder_conf
 
@@ -651,8 +651,8 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
         """
         return gettext('There are no further settings for this plugin. Please press save.')
 
-    @template_slot_caching
     @classmethod
+    @template_slot_caching
     def get_child_class_overrides(cls, slot: str, page: Optional[Page] = None, instance: Optional[CMSPlugin] = None):
         """
         Returns a list of plugin types that are allowed
@@ -681,8 +681,8 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
         from cms.plugin_pool import plugin_pool
         return plugin_pool.registered_plugins
 
-    @template_slot_caching
     @classmethod
+    @template_slot_caching
     def get_child_classes(cls, slot, page: Optional[Page] = None, instance: Optional[CMSPlugin] = None):
         """
         Returns a list of plugin types that can be added
@@ -717,8 +717,8 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
 
         return child_classes
 
-    @template_slot_caching
     @classmethod
+    @template_slot_caching
     def get_parent_classes(cls, slot: str, page: Optional[Page] = None, instance: Optional[CMSPlugin] = None):
         from cms.utils.placeholder import get_placeholder_conf
 

--- a/cms/plugin_pool.py
+++ b/cms/plugin_pool.py
@@ -231,7 +231,7 @@ class PluginPool:
                           if cls._has_extra_placeholder_menu_items]
         return plugin_classes
 
-    def get_restricions_cache(self, request_cache: dict, instance: CMSPluginBase, page: Optional[Page] = None):
+    def get_restrictions_cache(self, request_cache: dict, instance: CMSPluginBase, page: Optional[Page] = None):
         """
         Retrieve the restrictions cache for a given plugin instance.
 

--- a/cms/plugin_pool.py
+++ b/cms/plugin_pool.py
@@ -286,7 +286,7 @@ class PluginPool:
             bool: True if the restrictions can be cached globally, False otherwise.
         """
         if not hasattr(plugin_class, '_cache_restrictions_globally'):
-            plugin_class._cache_restrictions_globally = not any(
+            plugin_class._cache_restrictions_globally = all(
                 hasattr(getattr(plugin_class, method_name), "_template_slot_caching") for method_name in self.restriction_methods
             )
         return plugin_class._cache_restrictions_globally

--- a/cms/utils/plugins.py
+++ b/cms/utils/plugins.py
@@ -185,10 +185,11 @@ def get_plugin_restrictions(plugin, page=None, restrictions_cache=None):
     if restrictions_cache is None:
         restrictions_cache = {}
 
+    cache = plugin_pool.get_restricions_cache(restrictions_cache, plugin, page=page)
     plugin_type = plugin.plugin_type
     plugin_class = get_plugin_class(plugin.plugin_type)
-    parents_cache = restrictions_cache.setdefault('plugin_parents', {})
-    children_cache = restrictions_cache.setdefault('plugin_children', {})
+    parents_cache = cache.setdefault('plugin_parents', {})
+    children_cache = cache.setdefault('plugin_children', {})
 
     try:
         parent_classes = parents_cache[plugin_type]

--- a/cms/utils/plugins.py
+++ b/cms/utils/plugins.py
@@ -185,7 +185,7 @@ def get_plugin_restrictions(plugin, page=None, restrictions_cache=None):
     if restrictions_cache is None:
         restrictions_cache = {}
 
-    cache = plugin_pool.get_restricions_cache(restrictions_cache, plugin, page=page)
+    cache = plugin_pool.get_restrictions_cache(restrictions_cache, plugin, page=page)
     plugin_type = plugin.plugin_type
     plugin_class = get_plugin_class(plugin.plugin_type)
     parents_cache = cache.setdefault('plugin_parents', {})


### PR DESCRIPTION
## Description

Plugin restrictions need to be recalculated on every request in edit and structure mode. This is of n² complexity (n: number of plugins). 

While the plugin restrictions can be widely customized, the standard implementation respects the `CMS_PLACEHOLDER_CONF` setting allowing restrictions to depend on template and slot names.

This PR caches these restriction globally in the plugin pool for all plugins that follow the standard implementation.

Request times reduce by 30 to 50% in edit mode.

Logic does not change (only its implementation)- tests remain the same.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Implements global caching of plugin restrictions to improve editing response time. It introduces a cache for plugin restrictions that depend only on the template and placeholder slot, and a decorator to mark methods that support this caching strategy.

New Features:
- Introduces global caching of plugin restrictions based on template and placeholder slot, significantly improving the response time when editing plugins.

Enhancements:
- Adds a decorator `template_slot_caching` to indicate that a plugin's method supports global caching based on placeholder slots and templates.
- Improves the performance of `page_getter` by directly querying `PageContent` to avoid separate queries for source and page.

## Summary by Sourcery

This pull request introduces global caching of plugin restrictions to improve editing response time. It introduces a cache for plugin restrictions that depend only on the template and placeholder slot, and a decorator to mark methods that support this caching strategy.

New Features:
- Implements global caching of plugin restrictions based on template and placeholder slot, which improves the response time when editing plugins.

Enhancements:
- Adds a decorator `template_slot_caching` to indicate that a plugin's method supports global caching based on placeholder slots and templates.
- Improves the performance of `page_getter` by directly querying `PageContent` to avoid separate queries for source and page.