### PR TITLE
fix: backward migration flattened page tree

### DIFF
--- a/cms/migrations/0038_alter_page_site.py
+++ b/cms/migrations/0038_alter_page_site.py
@@ -17,6 +17,7 @@ def separate_page_treenode(apps, schema_editor):
             path=page.path,
             site=page.site,
             numchild=page.numchild
+            parent=page.parent.node_deprecated if page.parent else None,
         )
         page.save()
 

--- a/cms/migrations/0038_alter_page_site.py
+++ b/cms/migrations/0038_alter_page_site.py
@@ -16,7 +16,7 @@ def separate_page_treenode(apps, schema_editor):
             depth=page.depth,
             path=page.path,
             site=page.site,
-            numchild=page.numchild
+            numchild=page.numchild,
             parent=page.parent.node_deprecated if page.parent else None,
         )
         page.save()


### PR DESCRIPTION
## Description

This is a fix for django CMS 5.0.0a1.

The backward migration did not preserve the tree structure of the page tree.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Fixes a bug in the backward migration that caused the page tree structure to be lost.