### PR TITLE
fix: add a check for parent/child relationship

### DIFF
--- a/.github/workflows/test_startcmsproject.yml
+++ b/.github/workflows/test_startcmsproject.yml
@@ -13,12 +13,12 @@ jobs:
       fail-fast: false
       matrix:
         django-version: [
-          '4.2', '5.0', '5.1'
+          '4.2', '5.0', '5.1',
         ]
         python-version: ['3.11']
         requirements-file: ['requirements_base.txt']
         os: [
-          ubuntu-20.04,
+          ubuntu-latest,
         ]
 
     steps:

--- a/cms/plugin_pool.py
+++ b/cms/plugin_pool.py
@@ -18,25 +18,22 @@ from cms.utils.helpers import normalize_name
 
 
 class PluginPool:
-
     def __init__(self):
         self.plugins = {}
         self.discovered = False
         self.global_restrictions_cache = {
             None: {},
-            **{key: {} for key in get_cms_setting('PLACEHOLDER_CONF').keys()},
+            **{key: {} for key in get_cms_setting("PLACEHOLDER_CONF").keys()},
         }
-        self.global_template_restrictions = any(
-            ".htm" in (key or "") for key in self.global_restrictions_cache
-        )
+        self.global_template_restrictions = any(".htm" in (key or "") for key in self.global_restrictions_cache)
 
     def _clear_cached(self):
-        if 'registered_plugins' in self.__dict__:
-            del self.__dict__['registered_plugins']
-        if 'plugins_with_extra_menu' in self.__dict__:
-            del self.__dict__['plugins_with_extra_menu']
-        if 'plugins_with_extra_placeholder_menu' in self.__dict__:
-            del self.__dict__['plugins_with_extra_placeholder_menu']
+        if "registered_plugins" in self.__dict__:
+            del self.__dict__["registered_plugins"]
+        if "plugins_with_extra_menu" in self.__dict__:
+            del self.__dict__["plugins_with_extra_menu"]
+        if "plugins_with_extra_placeholder_menu" in self.__dict__:
+            del self.__dict__["plugins_with_extra_placeholder_menu"]
 
     def discover_plugins(self):
         if self.discovered:
@@ -46,7 +43,7 @@ class PluginPool:
         if get_cms_setting("PAGE_CACHE"):
             invalidate_cms_page_cache()
 
-        autodiscover_modules('cms_plugins')
+        autodiscover_modules("cms_plugins")
         self.discovered = True
 
     def clear(self):
@@ -56,18 +53,20 @@ class PluginPool:
 
     def validate_templates(self, plugin=None):
         """
-        Plugins templates are validated at this stage
-
+        Plugins templates and parent/child classes are validated at this stage
         """
         if plugin:
             plugins = [plugin]
         else:
             plugins = self.plugins.values()
         for plugin_class in plugins:
-            if (plugin_class.render_plugin and type(plugin_class.render_plugin) is not property
-                    or hasattr(plugin_class.model, 'render_template')
-                    or hasattr(plugin_class, 'get_render_template')):
-                if (plugin_class.render_template is None and not hasattr(plugin_class, 'get_render_template')):
+            if (
+                plugin_class.render_plugin
+                and type(plugin_class.render_plugin) is not property
+                or hasattr(plugin_class.model, "render_template")
+                or hasattr(plugin_class, "get_render_template")
+            ):
+                if plugin_class.render_template is None and not hasattr(plugin_class, "get_render_template"):
                     raise ImproperlyConfigured(
                         "CMS Plugins must define a render template, "
                         "a get_render_template method or "
@@ -77,7 +76,7 @@ class PluginPool:
                 # statically check for valid template file as it depends
                 # on plugin configuration and context.
                 # We cannot prevent developer to shoot in the users' feet
-                elif not hasattr(plugin_class, 'get_render_template'):
+                if not hasattr(plugin_class, "get_render_template"):
                     from django.template import loader
 
                     template = plugin_class.render_template
@@ -98,11 +97,28 @@ class PluginPool:
                                 pass
                         except TemplateSyntaxError:
                             pass
+
+                # Validate parent_classes exist
+                if hasattr(plugin_class, "parent_classes") and plugin_class.parent_classes:
+                    for parent_class in plugin_class.parent_classes:
+                        if parent_class != "0" and parent_class not in self.plugins:
+                            raise ImproperlyConfigured(
+                                f"Parent plugin class '{parent_class}' not found. "
+                                f"Please check the parent_classes attribute on plugin '{plugin_class.__name__}'"
+                            )
+
+                # Validate child_classes exist
+                if hasattr(plugin_class, "child_classes") and plugin_class.child_classes:
+                    for child_class in plugin_class.child_classes:
+                        if child_class not in self.plugins:
+                            raise ImproperlyConfigured(
+                                f"Child plugin class '{child_class}' not found. "
+                                f"Please check the child_classes attribute on plugin '{plugin_class.__name__}'"
+                            )
             else:
                 if plugin_class.allow_children:
                     raise ImproperlyConfigured(
-                        "CMS Plugins can not define render_plugin=False and allow_children=True: %s"
-                        % plugin_class
+                        "CMS Plugins can not define render_plugin=False and allow_children=True: %s" % plugin_class
                     )
 
     def register_plugin(self, plugin):
@@ -114,15 +130,11 @@ class PluginPool:
         If a plugin is already registered, this will raise PluginAlreadyRegistered.
         """
         if not issubclass(plugin, CMSPluginBase):
-            raise ImproperlyConfigured(
-                "CMS Plugins must be subclasses of CMSPluginBase, %r is not."
-                % plugin
-            )
+            raise ImproperlyConfigured("CMS Plugins must be subclasses of CMSPluginBase, %r is not." % plugin)
         plugin_name = plugin.__name__
         if plugin_name in self.plugins:
             raise PluginAlreadyRegistered(
-                "Cannot register %r, a plugin with this name (%r) is already "
-                "registered." % (plugin, plugin_name)
+                "Cannot register %r, a plugin with this name (%r) is already " "registered." % (plugin, plugin_name)
             )
 
         plugin.value = plugin_name
@@ -137,9 +149,7 @@ class PluginPool:
         """
         plugin_name = plugin.__name__
         if plugin_name not in self.plugins:
-            raise PluginNotRegistered(
-                'The plugin %r is not registered' % plugin
-            )
+            raise PluginNotRegistered("The plugin %r is not registered" % plugin)
         del self.plugins[plugin_name]
 
     def get_all_plugins(self, placeholder=None, page=None, setting_key="plugins", include_page_only=True):
@@ -147,18 +157,26 @@ class PluginPool:
 
         self.discover_plugins()
         plugins = self.plugins.values()
-        template = lazy(page.get_template, str)() if page else None  # Make template lazy to avoid unnecessary db access
+        template = (
+            lazy(page.get_template, str)() if page else None
+        )  # Make template lazy to avoid unnecessary db access
 
-        allowed_plugins = get_placeholder_conf(
-            setting_key,
-            placeholder,
-            template,
-        ) or ()
-        excluded_plugins = get_placeholder_conf(
-            'excluded_plugins',
-            placeholder,
-            template,
-        ) or ()
+        allowed_plugins = (
+            get_placeholder_conf(
+                setting_key,
+                placeholder,
+                template,
+            )
+            or ()
+        )
+        excluded_plugins = (
+            get_placeholder_conf(
+                "excluded_plugins",
+                placeholder,
+                template,
+            )
+            or ()
+        )
 
         if not include_page_only:
             # Filters out any plugin marked as page only because
@@ -175,15 +193,13 @@ class PluginPool:
 
         if placeholder:
             # Filters out any plugin that requires a parent or has set parent classes
-            plugins = (plugin for plugin in plugins
-                       if not plugin.requires_parent_plugin(placeholder, page))
+            plugins = (plugin for plugin in plugins if not plugin.requires_parent_plugin(placeholder, page))
         return plugins
 
     def get_text_enabled_plugins(self, placeholder, page) -> list[type[CMSPluginBase]]:
         plugins = set(self.get_all_plugins(placeholder, page))
-        plugins.update(self.get_all_plugins(placeholder, page, 'text_only_plugins'))
-        return sorted((p for p in plugins if p.text_enabled),
-                      key=attrgetter('module', 'name'))
+        plugins.update(self.get_all_plugins(placeholder, page, "text_only_plugins"))
+        return sorted((p for p in plugins if p.text_enabled), key=attrgetter("module", "name"))
 
     def get_plugin(self, name) -> type[CMSPluginBase]:
         """
@@ -205,7 +221,7 @@ class PluginPool:
                 p = plugin()
                 slug = slugify(force_str(normalize_name(p.__class__.__name__)))
                 url_patterns += [
-                    re_path(rf'^plugin/{slug}/', include(p.plugin_urls)),
+                    re_path(rf"^plugin/{slug}/", include(p.plugin_urls)),
                 ]
         finally:
             # Reactivate translation
@@ -223,14 +239,12 @@ class PluginPool:
 
     @cached_property
     def plugins_with_extra_menu(self) -> list[type[CMSPluginBase]]:
-        plugin_classes = [cls for cls in self.registered_plugins
-                          if cls._has_extra_plugin_menu_items]
+        plugin_classes = [cls for cls in self.registered_plugins if cls._has_extra_plugin_menu_items]
         return plugin_classes
 
     @cached_property
     def plugins_with_extra_placeholder_menu(self) -> list[type[CMSPluginBase]]:
-        plugin_classes = [cls for cls in self.registered_plugins
-                          if cls._has_extra_placeholder_menu_items]
+        plugin_classes = [cls for cls in self.registered_plugins if cls._has_extra_placeholder_menu_items]
         return plugin_classes
 
     def get_restrictions_cache(self, request_cache: dict, instance: CMSPluginBase, page: Optional[Page] = None):
@@ -285,9 +299,10 @@ class PluginPool:
         Returns:
             bool: True if the restrictions can be cached globally, False otherwise.
         """
-        if not hasattr(plugin_class, '_cache_restrictions_globally'):
+        if not hasattr(plugin_class, "_cache_restrictions_globally"):
             plugin_class._cache_restrictions_globally = all(
-                hasattr(getattr(plugin_class, method_name), "_template_slot_caching") for method_name in self.restriction_methods
+                hasattr(getattr(plugin_class, method_name), "_template_slot_caching")
+                for method_name in self.restriction_methods
             )
         return plugin_class._cache_restrictions_globally
 

--- a/cms/plugin_pool.py
+++ b/cms/plugin_pool.py
@@ -53,7 +53,7 @@ class PluginPool:
 
     def validate_templates(self, plugin=None):
         """
-        Plugins templates and parent/child classes are validated at this stage
+        Plugins templates are validated at this stage
         """
         if plugin:
             plugins = [plugin]
@@ -97,24 +97,6 @@ class PluginPool:
                                 pass
                         except TemplateSyntaxError:
                             pass
-
-                # Validate parent_classes exist
-                if hasattr(plugin_class, "parent_classes") and plugin_class.parent_classes:
-                    for parent_class in plugin_class.parent_classes:
-                        if parent_class != "0" and parent_class not in self.plugins:
-                            raise ImproperlyConfigured(
-                                f"Parent plugin class '{parent_class}' not found. "
-                                f"Please check the parent_classes attribute on plugin '{plugin_class.__name__}'"
-                            )
-
-                # Validate child_classes exist
-                if hasattr(plugin_class, "child_classes") and plugin_class.child_classes:
-                    for child_class in plugin_class.child_classes:
-                        if child_class not in self.plugins:
-                            raise ImproperlyConfigured(
-                                f"Child plugin class '{child_class}' not found. "
-                                f"Please check the child_classes attribute on plugin '{plugin_class.__name__}'"
-                            )
             else:
                 if plugin_class.allow_children:
                     raise ImproperlyConfigured(
@@ -134,7 +116,7 @@ class PluginPool:
         plugin_name = plugin.__name__
         if plugin_name in self.plugins:
             raise PluginAlreadyRegistered(
-                "Cannot register %r, a plugin with this name (%r) is already " "registered." % (plugin, plugin_name)
+                f"Cannot register {plugin!r}, a plugin with this name ({plugin_name!r}) is already registered."
             )
 
         plugin.value = plugin_name

--- a/cms/tests/test_check.py
+++ b/cms/tests/test_check.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from copy import deepcopy
 
 from django.conf import settings
@@ -8,11 +9,22 @@ from djangocms_text_ckeditor.cms_plugins import TextPlugin
 from cms.api import add_plugin
 from cms.models.placeholdermodel import Placeholder
 from cms.models.pluginmodel import CMSPlugin
+from cms.plugin_base import CMSPluginBase
+from cms.plugin_pool import plugin_pool
 from cms.test_utils.project.extensionapp.models import MyPageExtension
-from cms.test_utils.project.pluginapp.plugins.manytomany_rel.models import (
-    ArticlePluginModel,
-)
+from cms.test_utils.project.pluginapp.plugins.manytomany_rel.models import ArticlePluginModel
 from cms.utils.check import FileOutputWrapper, FileSectionWrapper, check
+
+
+@contextmanager
+def register_plugins(*plugins):
+    for plugin in plugins:
+        plugin_pool.register_plugin(plugin)
+    try:
+        yield
+    finally:
+        for plugin in plugins:
+            plugin_pool.unregister_plugin(plugin)
 
 
 class TestOutput(FileOutputWrapper):
@@ -45,9 +57,7 @@ class CheckAssertMixin:
         check(output)
         self.assertEqual(output.successful, successful)
         for key, value in assertions.items():
-            self.assertEqual(
-                getattr(output, key), value, f"{value} {key} expected, got {getattr(output, key)}"
-            )
+            self.assertEqual(getattr(output, key), value, f"{value} {key} expected, got {getattr(output, key)}")
 
 
 class CheckTests(CheckAssertMixin, TestCase):
@@ -56,55 +66,55 @@ class CheckTests(CheckAssertMixin, TestCase):
 
     def test_no_sekizai(self):
         apps = list(settings.INSTALLED_APPS)
-        apps.remove('sekizai')
+        apps.remove("sekizai")
 
         with self.settings(INSTALLED_APPS=apps):
             self.assertCheck(False, errors=1)
 
     def test_no_django_i18n_context_processor(self):
-        override = {'TEMPLATES': deepcopy(settings.TEMPLATES)}
-        override['TEMPLATES'][0]['OPTIONS']['context_processors'] = [
-            'sekizai.context_processors.sekizai',
-            'cms.context_processors.cms_settings'
+        override = {"TEMPLATES": deepcopy(settings.TEMPLATES)}
+        override["TEMPLATES"][0]["OPTIONS"]["context_processors"] = [
+            "sekizai.context_processors.sekizai",
+            "cms.context_processors.cms_settings",
         ]
         with self.settings(**override):
             self.assertCheck(False, errors=1)
 
     def test_no_cms_settings_context_processor(self):
-        override = {'TEMPLATES': deepcopy(settings.TEMPLATES)}
-        override['TEMPLATES'][0]['OPTIONS']['context_processors'] = [
-            'sekizai.context_processors.sekizai',
-            'django.template.context_processors.i18n',
+        override = {"TEMPLATES": deepcopy(settings.TEMPLATES)}
+        override["TEMPLATES"][0]["OPTIONS"]["context_processors"] = [
+            "sekizai.context_processors.sekizai",
+            "django.template.context_processors.i18n",
         ]
         with self.settings(**override):
             self.assertCheck(False, errors=1)
 
     def test_no_sekizai_template_context_processor(self):
-        override = {'TEMPLATES': deepcopy(settings.TEMPLATES)}
-        override['TEMPLATES'][0]['OPTIONS']['context_processors'] = [
-            'cms.context_processors.cms_settings',
-            'django.template.context_processors.i18n',
+        override = {"TEMPLATES": deepcopy(settings.TEMPLATES)}
+        override["TEMPLATES"][0]["OPTIONS"]["context_processors"] = [
+            "cms.context_processors.cms_settings",
+            "django.template.context_processors.i18n",
         ]
         with self.settings(**override):
             self.assertCheck(False, errors=2)
 
     def test_old_style_i18n_settings(self):
-        with self.settings(CMS_LANGUAGES=[('en', 'English')]):
+        with self.settings(CMS_LANGUAGES=[("en", "English")]):
             self.assertRaises(ImproperlyConfigured, self.assertCheck, True, warnings=1, errors=0)
 
     def test_middlewares(self):
         MIDDLEWARE = [
-            'django.middleware.cache.UpdateCacheMiddleware',
-            'django.middleware.http.ConditionalGetMiddleware',
-            'django.contrib.sessions.middleware.SessionMiddleware',
-            'django.contrib.auth.middleware.AuthenticationMiddleware',
-            'django.contrib.messages.middleware.MessageMiddleware',
-            'django.middleware.csrf.CsrfViewMiddleware',
-            'django.middleware.locale.LocaleMiddleware',
-            'django.middleware.common.CommonMiddleware',
-            'cms.middleware.page.CurrentPageMiddleware',
-            'cms.middleware.toolbar.ToolbarMiddleware',
-            'django.middleware.cache.FetchFromCacheMiddleware',
+            "django.middleware.cache.UpdateCacheMiddleware",
+            "django.middleware.http.ConditionalGetMiddleware",
+            "django.contrib.sessions.middleware.SessionMiddleware",
+            "django.contrib.auth.middleware.AuthenticationMiddleware",
+            "django.contrib.messages.middleware.MessageMiddleware",
+            "django.middleware.csrf.CsrfViewMiddleware",
+            "django.middleware.locale.LocaleMiddleware",
+            "django.middleware.common.CommonMiddleware",
+            "cms.middleware.page.CurrentPageMiddleware",
+            "cms.middleware.toolbar.ToolbarMiddleware",
+            "django.middleware.cache.FetchFromCacheMiddleware",
         ]
         self.assertCheck(True, warnings=0, errors=0)
         with self.settings(MIDDLEWARE=MIDDLEWARE):
@@ -132,7 +142,7 @@ class CheckTests(CheckAssertMixin, TestCase):
 
     def test_non_numeric_site_id(self):
         self.assertCheck(True, warnings=0, errors=0)
-        with self.settings(SITE_ID='broken'):
+        with self.settings(SITE_ID="broken"):
             self.assertCheck(False, warnings=0, errors=1)
 
     def test_cmsapps_check(self):
@@ -148,17 +158,61 @@ class CheckTests(CheckAssertMixin, TestCase):
         self.assertCheck(True, warnings=1, errors=0)
         apphook_pool.apps.pop(app.__name__)
 
+    def test_validate_template_invalid_parent_class(self):
+        class ParentPlugin(CMSPluginBase):
+            render_template = "base.html"
+            allow_children = True
+
+        class ChildPlugin(CMSPluginBase):
+            render_template = "base.html"
+            parent_classes = ("NonExistentPlugin",)
+
+        with register_plugins(ParentPlugin, ChildPlugin):
+            self.assertCheck(True, warnings=1)
+
+    def test_validate_template_invalid_child_class(self):
+        class ParentPlugin(CMSPluginBase):
+            render_template = "base.html"
+            allow_children = True
+            child_classes = ("NonExistentPlugin",)
+
+        class ChildPlugin(CMSPluginBase):
+            render_template = "base.html"
+            parent_classes = ("ParentPlugin",)
+
+        with register_plugins(ParentPlugin, ChildPlugin):
+            self.assertCheck(True, warnings=1)
+
+    def test_validate_template_valid_parent_child_classes(self):
+        class ParentPlugin(CMSPluginBase):
+            render_template = "base.html"
+            allow_children = True
+            child_classes = ("ChildPlugin",)
+
+        class ChildPlugin(CMSPluginBase):
+            render_template = "base.html"
+            parent_classes = ("ParentPlugin",)
+
+        with register_plugins(ParentPlugin, ChildPlugin):
+            self.assertCheck(True, warnings=0)
+
+    def test_plugin_parent_child_relations_empty_string(self):
+        class ChildPlugin(CMSPluginBase):
+            render_template = "base.html"
+            parent_classes = ("",)
+
+        with register_plugins(ChildPlugin):
+            self.assertCheck(True, warnings=0)
+
 
 class CheckWithDatabaseTests(CheckAssertMixin, TestCase):
-
     def test_check_plugin_instances(self):
         self.assertCheck(True, warnings=0, errors=0)
 
         placeholder = Placeholder.objects.create(slot="test")
         add_plugin(placeholder, TextPlugin, "en", body="en body")
         add_plugin(placeholder, TextPlugin, "en", body="en body")
-        add_plugin(placeholder, "LinkPlugin", "en",
-                   name="A Link", external_link="https://www.django-cms.org")
+        add_plugin(placeholder, "LinkPlugin", "en", name="A Link", external_link="https://www.django-cms.org")
 
         # create a CMSPlugin with an unsaved instance
         instanceless_plugin = CMSPlugin(language="en", plugin_type="TextPlugin")

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -7,10 +7,7 @@ from unittest import skipIf
 from django import http
 from django.conf import settings
 from django.contrib import admin
-from django.contrib.admin.widgets import (
-    FilteredSelectMultiple,
-    RelatedFieldWidgetWrapper,
-)
+from django.contrib.admin.widgets import FilteredSelectMultiple, RelatedFieldWidgetWrapper
 from django.core.exceptions import ImproperlyConfigured
 from django.forms.widgets import Media
 from django.test.testcases import TestCase
@@ -22,21 +19,13 @@ from djangocms_text_ckeditor.models import Text
 
 from cms import api
 from cms.api import create_page
-from cms.exceptions import (
-    DontUsePageAttributeWarning,
-    PluginAlreadyRegistered,
-    PluginNotRegistered,
-)
+from cms.exceptions import DontUsePageAttributeWarning, PluginAlreadyRegistered, PluginNotRegistered
 from cms.models import Page, Placeholder
 from cms.models.pluginmodel import CMSPlugin
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 from cms.sitemaps.cms_sitemap import CMSSitemap
-from cms.test_utils.project.pluginapp.plugins.manytomany_rel.models import (
-    Article,
-    ArticlePluginModel,
-    Section,
-)
+from cms.test_utils.project.pluginapp.plugins.manytomany_rel.models import Article, ArticlePluginModel, Section
 from cms.test_utils.project.pluginapp.plugins.meta.cms_plugins import (
     TestPlugin,
     TestPlugin2,
@@ -941,56 +930,6 @@ class PluginsTestCase(PluginsTestBaseCase):
 
         self.assertEqual([ancestor.pk for ancestor in ancestors], [plugin.pk for plugin in plugins[:-1]])
 
-    def test_validate_template_invalid_parent_class(self):
-        class ParentPlugin(CMSPluginBase):
-            render_template = "base.html"
-            allow_children = True
-
-        class ChildPlugin(CMSPluginBase):
-            render_template = "base.html"
-            parent_classes = ("NonExistentPlugin",)
-
-        with register_plugins(ParentPlugin, ChildPlugin):
-            from cms.utils.setup import setup
-
-            with self.assertRaises(ImproperlyConfigured) as context:
-                setup()
-
-            self.assertIn("Parent plugin class 'NonExistentPlugin' not found", str(context.exception))
-
-    def test_validate_template_invalid_child_class(self):
-        class ParentPlugin(CMSPluginBase):
-            render_template = "base.html"
-            allow_children = True
-            child_classes = ("NonExistentPlugin",)
-
-        class ChildPlugin(CMSPluginBase):
-            render_template = "base.html"
-            parent_classes = ("ParentPlugin",)
-
-        with register_plugins(ParentPlugin, ChildPlugin):
-            from cms.utils.setup import setup
-
-            with self.assertRaises(ImproperlyConfigured) as context:
-                setup()
-
-            self.assertIn("Child plugin class 'NonExistentPlugin' not found", str(context.exception))
-
-    def test_validate_template_valid_parent_child_classes(self):
-        class ParentPlugin(CMSPluginBase):
-            render_template = "base.html"
-            allow_children = True
-            child_classes = ("ChildPlugin",)
-
-        class ChildPlugin(CMSPluginBase):
-            render_template = "base.html"
-            parent_classes = ("ParentPlugin",)
-
-        with register_plugins(ParentPlugin, ChildPlugin):
-            from cms.utils.setup import setup
-
-            setup()
-
 
 class PluginManyToManyTestCase(PluginsTestBaseCase):
     def setUp(self):
@@ -1255,9 +1194,7 @@ class BrokenPluginTests(TestCase):
 
 class MTIPluginsTestCase(PluginsTestBaseCase):
     def test_add_edit_plugin(self):
-        from cms.test_utils.project.mti_pluginapp.models import (
-            TestPluginBetaModel,
-        )
+        from cms.test_utils.project.mti_pluginapp.models import TestPluginBetaModel
 
         """
         Test that we can instantiate and use a MTI plugin

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -92,7 +92,7 @@ class DumbFixturePluginWithUrls(DumbFixturePlugin):
 
     def get_plugin_urls(self):
         return [
-            re_path(r'^testview/$', admin.site.admin_view(self._test_view), name='dumbfixtureplugin'),
+            re_path(r"^testview/$", admin.site.admin_view(self._test_view), name="dumbfixtureplugin"),
         ]
 
 
@@ -100,7 +100,6 @@ plugin_pool.register_plugin(DumbFixturePluginWithUrls)
 
 
 class PluginsTestBaseCase(CMSTestCase):
-
     def setUp(self):
         plugin_pool._clear_cached()
         self.super_user = self._create_user("test", True, True)
@@ -122,30 +121,29 @@ class PluginsTestBaseCase(CMSTestCase):
         return request
 
     def get_response_pk(self, response):
-        return int(response.content.decode('utf8').split("/edit-plugin/")[1].split("/")[0])
+        return int(response.content.decode("utf8").split("/edit-plugin/")[1].split("/")[0])
 
     def get_placeholder(self):
-        return Placeholder.objects.create(slot='test')
+        return Placeholder.objects.create(slot="test")
 
 
 class PluginsTestCase(PluginsTestBaseCase):
-
-    def _create_link_plugin_on_page(self, page, slot='col_left'):
+    def _create_link_plugin_on_page(self, page, slot="col_left"):
         add_url = self.get_add_plugin_uri(
-            placeholder=page.get_placeholders('en').get(slot=slot),
-            plugin_type='LinkPlugin',
+            placeholder=page.get_placeholders("en").get(slot=slot),
+            plugin_type="LinkPlugin",
             language=settings.LANGUAGES[0][0],
         )
-        data = {'name': 'A Link', 'external_link': 'https://www.django-cms.org'}
+        data = {"name": "A Link", "external_link": "https://www.django-cms.org"}
         response = self.client.post(add_url, data)
         self.assertEqual(response.status_code, 200)
-        return CMSPlugin.objects.latest('pk')
+        return CMSPlugin.objects.latest("pk")
 
     def __edit_link_plugin(self, plugin, text):
         endpoint = self.get_change_plugin_uri(plugin)
         response = self.client.get(endpoint)
         self.assertEqual(response.status_code, 200)
-        data = {'name': text, 'external_link': 'https://www.django-cms.org'}
+        data = {"name": text, "external_link": "https://www.django-cms.org"}
         response = self.client.post(endpoint, data)
         self.assertEqual(response.status_code, 200)
         return CMSPlugin.objects.get(pk=plugin.pk).get_bound_plugin()
@@ -158,7 +156,7 @@ class PluginsTestCase(PluginsTestBaseCase):
         See https://github.com/django-cms/django-cms/issues/7948
         """
         with self.assertRaises(TypeError):
-            TestPlugin[int]  # noqa: F841
+            TestPlugin[int]
 
     def test_add_edit_plugin(self):
         """
@@ -166,7 +164,7 @@ class PluginsTestCase(PluginsTestBaseCase):
         """
         # add a new text plugin
         page_data = self.get_new_page_data()
-        self.client.post(self.get_page_add_uri('en'), page_data)
+        self.client.post(self.get_page_add_uri("en"), page_data)
         page = Page.objects.first()
         created_plugin = self._create_link_plugin_on_page(page)
         # now edit the plugin
@@ -179,7 +177,7 @@ class PluginsTestCase(PluginsTestBaseCase):
         placeholder = self.get_placeholder()
         add_url = self.get_add_plugin_uri(placeholder, plugin_type="ArticlePlugin", language=settings.LANGUAGES[0][0])
         superuser = self.get_superuser()
-        plugin = plugin_pool.get_plugin('ArticlePlugin')
+        plugin = plugin_pool.get_plugin("ArticlePlugin")
 
         with self.login_user_context(superuser):
             request = self.get_request(add_url)
@@ -198,28 +196,28 @@ class PluginsTestCase(PluginsTestBaseCase):
             # Now assert the plugin form has the related field wrapper
             # widget on the sections field.
             self.assertIsInstance(
-                PluginFormClass.base_fields['sections'].widget,
+                PluginFormClass.base_fields["sections"].widget,
                 RelatedFieldWidgetWrapper,
             )
 
             # Now assert the admin form has the related field wrapper
             # widget on the sections field.
             self.assertIsInstance(
-                OriginalFormClass.base_fields['sections'].widget,
+                OriginalFormClass.base_fields["sections"].widget,
                 RelatedFieldWidgetWrapper,
             )
 
             # Now assert the plugin form has the filtered select multiple
             # widget wrapped by the related field wrapper
             self.assertIsInstance(
-                PluginFormClass.base_fields['sections'].widget.widget,
+                PluginFormClass.base_fields["sections"].widget.widget,
                 FilteredSelectMultiple,
             )
 
             # Now assert the admin form has the filtered select multiple
             # widget wrapped by the related field wrapper
             self.assertIsInstance(
-                OriginalFormClass.base_fields['sections'].widget.widget,
+                OriginalFormClass.base_fields["sections"].widget.widget,
                 FilteredSelectMultiple,
             )
 
@@ -228,44 +226,34 @@ class PluginsTestCase(PluginsTestBaseCase):
         Test that you can't add a text plugin
         """
 
-        CMS_PLACEHOLDER_CONF = {
-            'body': {
-                'excluded_plugins': ['TextPlugin']
-            }
-        }
-        add_page_endpoint = self.get_page_add_uri('en')
+        CMS_PLACEHOLDER_CONF = {"body": {"excluded_plugins": ["TextPlugin"]}}
+        add_page_endpoint = self.get_page_add_uri("en")
 
         # try to add a new text plugin
         with self.settings(CMS_PLACEHOLDER_CONF=CMS_PLACEHOLDER_CONF):
             page_data = self.get_new_page_data()
             self.client.post(add_page_endpoint, page_data)
             page = Page.objects.first()
-            installed_plugins = plugin_pool.get_all_plugins('body', page)
+            installed_plugins = plugin_pool.get_all_plugins("body", page)
             installed_plugins = [cls.__name__ for cls in installed_plugins]
-            self.assertNotIn('TextPlugin', installed_plugins)
+            self.assertNotIn("TextPlugin", installed_plugins)
 
-        CMS_PLACEHOLDER_CONF = {
-            'body': {
-                'plugins': ['TextPlugin'],
-                'excluded_plugins': ['TextPlugin']
-            }
-        }
+        CMS_PLACEHOLDER_CONF = {"body": {"plugins": ["TextPlugin"], "excluded_plugins": ["TextPlugin"]}}
 
         # try to add a new text plugin
         with self.settings(CMS_PLACEHOLDER_CONF=CMS_PLACEHOLDER_CONF):
             page_data = self.get_new_page_data()
             self.client.post(add_page_endpoint, page_data)
             page = Page.objects.first()
-            installed_plugins = plugin_pool.get_all_plugins('body', page)
+            installed_plugins = plugin_pool.get_all_plugins("body", page)
             installed_plugins = [cls.__name__ for cls in installed_plugins]
-            self.assertNotIn('TextPlugin', installed_plugins)
+            self.assertNotIn("TextPlugin", installed_plugins)
 
     def test_plugin_order(self):
         """
         Test that plugin position is saved after creation
         """
-        page_en = api.create_page("PluginOrderPage", "col_two.html", "en",
-                                  slug="page1", in_navigation=True)
+        page_en = api.create_page("PluginOrderPage", "col_two.html", "en", slug="page1", in_navigation=True)
         ph_en = page_en.get_placeholders("en").get(slot="col_left")
 
         # We check created objects and objects from the DB to be sure the position value
@@ -302,17 +290,17 @@ class PluginsTestCase(PluginsTestBaseCase):
         text_plugin_1 = api.add_plugin(placeholder, "TextPlugin", "en", body="I'm the first")
 
         data = {
-            'plugin_id': text_plugin_1.id,
-            'plugin_parent': '',
-            'target_language': 'en',
-            'target_position': 1,
+            "plugin_id": text_plugin_1.id,
+            "plugin_parent": "",
+            "target_language": "en",
+            "target_position": 1,
         }
 
         endpoint = self.get_move_plugin_uri(text_plugin_1)
 
         self.client.post(endpoint, data)
 
-        placeholder = cms_page.get_placeholders('en').get(slot="col_left")
+        placeholder = cms_page.get_placeholders("en").get(slot="col_left")
 
         with self.settings(CMS_PERMISSION=False):
             self.assertEqual(CMSPlugin.objects.get(pk=text_plugin_1.pk).position, 1)
@@ -333,13 +321,13 @@ class PluginsTestCase(PluginsTestBaseCase):
         column_2 = api.add_plugin(placeholder, "ColumnPlugin", "en", target=columns)  # ID 3
         text_1 = api.add_plugin(placeholder, "TextPlugin", "en", target=column_1, body="I'm the first")  # ID 4
         text_2 = api.add_plugin(placeholder, "TextPlugin", "en", target=column_1, body="I'm the second")  # ID 5
-        returned_1 = copy_plugins_to_placeholder([text_2], placeholder, 'en', root_plugin=column_1)  # ID 6
-        returned_2 = copy_plugins_to_placeholder([text_2], placeholder_right, 'en')  # ID 7
+        returned_1 = copy_plugins_to_placeholder([text_2], placeholder, "en", root_plugin=column_1)  # ID 6
+        returned_2 = copy_plugins_to_placeholder([text_2], placeholder_right, "en")  # ID 7
 
         # Column #2 position has changed because of the text plugins above
-        column_2.refresh_from_db(fields=['position'])
+        column_2.refresh_from_db(fields=["position"])
         self.assertEqual(column_2.position, 6)
-        returned_3 = copy_plugins_to_placeholder([text_2], placeholder, 'en', root_plugin=column_2)  # ID 8
+        returned_3 = copy_plugins_to_placeholder([text_2], placeholder, "en", root_plugin=column_2)  # ID 8
 
         # STATE AT THIS POINT:
         # placeholder
@@ -379,8 +367,9 @@ class PluginsTestCase(PluginsTestBaseCase):
         self.assertEqual(text_plugin_en.pk, CMSPlugin.objects.all()[0].pk)
 
         # add a *nested* link plugin
-        link_plugin_en = api.add_plugin(ph_en, "LinkPlugin", "en", target=text_plugin_en,
-                                        name="A Link", external_link="https://www.django-cms.org")
+        link_plugin_en = api.add_plugin(
+            ph_en, "LinkPlugin", "en", target=text_plugin_en, name="A Link", external_link="https://www.django-cms.org"
+        )
 
         # the call above to add a child makes a plugin reload required here.
         text_plugin_en = self.reload(text_plugin_en)
@@ -393,7 +382,7 @@ class PluginsTestCase(PluginsTestBaseCase):
         self.assertEqual(CMSPlugin.objects.count(), 2)
 
         # copy the plugins to the german placeholder
-        copy_plugins_to_placeholder(ph_en.get_plugins(), ph_de, language='de')
+        copy_plugins_to_placeholder(ph_en.get_plugins(), ph_de, language="de")
 
         self.assertEqual(ph_de.cmsplugin_set.filter(parent=None).count(), 1)
         text_plugin_de = ph_de.cmsplugin_set.get(parent=None).get_plugin_instance()[0]
@@ -404,8 +393,8 @@ class PluginsTestCase(PluginsTestBaseCase):
         self.assertEqual(CMSPlugin.objects.count(), 4)
 
         # check language plugins
-        self.assertEqual(CMSPlugin.objects.filter(language='de').count(), 2)
-        self.assertEqual(CMSPlugin.objects.filter(language='en').count(), 2)
+        self.assertEqual(CMSPlugin.objects.filter(language="de").count(), 2)
+        self.assertEqual(CMSPlugin.objects.filter(language="en").count(), 2)
 
         text_plugin_en = self.reload(text_plugin_en)
         link_plugin_en = self.reload(link_plugin_en)
@@ -420,7 +409,7 @@ class PluginsTestCase(PluginsTestBaseCase):
         self.assertEqual(text_plugin_de.body, text_plugin_en.body)
 
         # test subplugin copy
-        copy_plugins_to_placeholder([link_plugin_en], ph_de, language='de')
+        copy_plugins_to_placeholder([link_plugin_en], ph_de, language="de")
 
     def test_deep_copy_plugins(self):
         page_en = api.create_page("CopyPluginTestPage (EN)", "nav_playground.html", "en")
@@ -437,12 +426,7 @@ class PluginsTestCase(PluginsTestBaseCase):
 
         # add a *nested* link plugin
         link_plugin_en = api.add_plugin(
-            ph_en,
-            "LinkPlugin",
-            "en",
-            target=col2_en,
-            name="A Link",
-            external_link="https://www.django-cms.org"
+            ph_en, "LinkPlugin", "en", target=col2_en, name="A Link", external_link="https://www.django-cms.org"
         )
 
         old_plugins = [mcol1_en, col1_en, col2_en, link_plugin_en]
@@ -459,7 +443,7 @@ class PluginsTestCase(PluginsTestBaseCase):
         copy_plugins_to_placeholder(
             plugins=[mcol1_en, col1_en, col2_en, link_plugin_en],
             placeholder=ph_de,
-            language='de',
+            language="de",
             root_plugin=col1_de,
         )
 
@@ -475,39 +459,39 @@ class PluginsTestCase(PluginsTestBaseCase):
     def test_copy_plugin_without_custom_model(self):
         page_en = api.create_page("CopyPluginTestPage (EN)", "nav_playground.html", "en")
         page_de = api.create_page("CopyPluginTestPage (DE)", "nav_playground.html", "de")
-        ph_en = page_en.get_placeholders('en').get(slot="body")
-        ph_de = page_de.get_placeholders('de').get(slot="body")
+        ph_en = page_en.get_placeholders("en").get(slot="body")
+        ph_de = page_de.get_placeholders("de").get(slot="body")
         api.add_plugin(ph_en, "NoCustomModel", "en")
 
         # sanity check that so far the data matches expectations
-        self.assertEqual(ph_en.get_plugins('en').count(), 1)
-        self.assertEqual(ph_en.get_plugins('de').count(), 0)
+        self.assertEqual(ph_en.get_plugins("en").count(), 1)
+        self.assertEqual(ph_en.get_plugins("de").count(), 0)
 
         # copy the plugins to the german placeholder
-        new_plugins = copy_plugins_to_placeholder(ph_en.get_plugins_list('en'), ph_de, language='de')
-        new_plugins_qs = [plugin.get_bound_plugin() for plugin in ph_de.get_plugins('de')]
+        new_plugins = copy_plugins_to_placeholder(ph_en.get_plugins_list("en"), ph_de, language="de")
+        new_plugins_qs = [plugin.get_bound_plugin() for plugin in ph_de.get_plugins("de")]
         self.assertEqual(len(new_plugins), 1)
-        self.assertEqual(ph_en.get_plugins('en').count(), 1)
+        self.assertEqual(ph_en.get_plugins("en").count(), 1)
         self.assertSequenceEqual(new_plugins_qs, new_plugins)
 
     def test_copy_nested_plugins_without_custom_model(self):
         page_en = api.create_page("CopyPluginTestPage (EN)", "nav_playground.html", "en")
         page_de = api.create_page("CopyPluginTestPage (DE)", "nav_playground.html", "de")
-        ph_en = page_en.get_placeholders('en').get(slot="body")
-        ph_de = page_de.get_placeholders('de').get(slot="body")
+        ph_en = page_en.get_placeholders("en").get(slot="body")
+        ph_de = page_de.get_placeholders("de").get(slot="body")
         grid_plugin = api.add_plugin(ph_en, "MultiColumnPlugin", "en")
         column_plugin = api.add_plugin(ph_en, "ColumnPlugin", "en", target=grid_plugin)
         api.add_plugin(ph_en, "NoCustomModel", "en", target=column_plugin)
 
         # sanity check that so far the data matches expectations
-        self.assertEqual(ph_en.get_plugins('en').count(), 3)
-        self.assertEqual(ph_en.get_plugins('de').count(), 0)
+        self.assertEqual(ph_en.get_plugins("en").count(), 3)
+        self.assertEqual(ph_en.get_plugins("de").count(), 0)
 
         # copy the plugins to the german placeholder
-        new_plugins = copy_plugins_to_placeholder(ph_en.get_plugins_list('en'), ph_de, language='de')
-        new_plugins_qs = [plugin.get_bound_plugin() for plugin in ph_de.get_plugins('de')]
+        new_plugins = copy_plugins_to_placeholder(ph_en.get_plugins_list("en"), ph_de, language="de")
+        new_plugins_qs = [plugin.get_bound_plugin() for plugin in ph_de.get_plugins("de")]
         self.assertEqual(len(new_plugins), 3)
-        self.assertEqual(ph_en.get_plugins('en').count(), 3)
+        self.assertEqual(ph_en.get_plugins("en").count(), 3)
         self.assertSequenceEqual(new_plugins_qs, new_plugins)
 
     def test_plugin_validation(self):
@@ -521,24 +505,18 @@ class PluginsTestCase(PluginsTestBaseCase):
         When removing a draft plugin we would expect the public copy of the plugin to also be removed
         """
         # add a page
-        page = api.create_page(
-            title='test page',
-            language=settings.LANGUAGES[0][0],
-            template='nav_playground.html'
-        )
+        page = api.create_page(title="test page", language=settings.LANGUAGES[0][0], template="nav_playground.html")
         plugin = api.add_plugin(
-            placeholder=page.get_placeholders(settings.LANGUAGES[0][0]).get(slot='body'),
-            language='en',
-            plugin_type='TextPlugin',
-            body=''
+            placeholder=page.get_placeholders(settings.LANGUAGES[0][0]).get(slot="body"),
+            language="en",
+            plugin_type="TextPlugin",
+            body="",
         )
         # there should be only 1 plugin
         self.assertEqual(CMSPlugin.objects.all().count(), 1)
 
         # delete the plugin
-        plugin_data = {
-            'plugin_id': plugin.pk
-        }
+        plugin_data = {"plugin_id": plugin.pk}
         endpoint = self.get_delete_plugin_uri(plugin)
         response = self.client.post(endpoint, plugin_data)
         self.assertContains(response, '<div class="success"></div>')
@@ -549,17 +527,13 @@ class PluginsTestCase(PluginsTestBaseCase):
         """
         Test case for PlaceholderField
         """
-        page = api.create_page(
-            title='test page',
-            template='nav_playground.html',
-            language='en'
-        )
+        page = api.create_page(title="test page", template="nav_playground.html", language="en")
         # add a plugin
         plugin = api.add_plugin(
-            placeholder=page.get_placeholders('en').get(slot='body'),
-            plugin_type='TextPlugin',
+            placeholder=page.get_placeholders("en").get(slot="body"),
+            plugin_type="TextPlugin",
             language=settings.LANGUAGES[0][0],
-            body=''
+            body="",
         )
         # there should be only 1 plugin
         self.assertEqual(CMSPlugin.objects.all().count(), 1)
@@ -567,12 +541,9 @@ class PluginsTestCase(PluginsTestBaseCase):
         ph = Placeholder(slot="subplugin")
         ph.save()
         add_url = self.get_add_plugin_uri(
-            placeholder=ph,
-            plugin_type="ArticlePlugin",
-            language=settings.LANGUAGES[0][0],
-            parent=plugin
+            placeholder=ph, plugin_type="ArticlePlugin", language=settings.LANGUAGES[0][0], parent=plugin
         )
-        response = self.client.post(add_url, {'body': ''})
+        response = self.client.post(add_url, {"body": ""})
         # no longer allowed for security reasons
         self.assertEqual(response.status_code, 400)
 
@@ -620,7 +591,7 @@ class PluginsTestCase(PluginsTestBaseCase):
         """
         page = api.create_page("page", "nav_playground.html", "en")
 
-        placeholder = page.get_placeholders("en").get(slot='body')
+        placeholder = page.get_placeholders("en").get(slot="body")
         text = Text(body="hello", language="en", placeholder=placeholder, plugin_type="TextPlugin", position=1)
         text.save()
         self.assertEqual(Page.objects.search("hi").count(), 0)
@@ -628,10 +599,10 @@ class PluginsTestCase(PluginsTestBaseCase):
 
     def test_empty_plugin_is_ignored(self):
         page = api.create_page("page", "nav_playground.html", "en")
-        placeholder = page.get_placeholders("en").get(slot='body')
+        placeholder = page.get_placeholders("en").get(slot="body")
 
         CMSPlugin.objects.create(
-            plugin_type='TextPlugin',
+            plugin_type="TextPlugin",
             placeholder=placeholder,
             position=1,
             language=self.FIRST_LANG,
@@ -645,20 +616,20 @@ class PluginsTestCase(PluginsTestBaseCase):
     def test_repr(self):
         non_saved_plugin = CMSPlugin()
         self.assertIsNone(non_saved_plugin.pk)
-        self.assertIn('id=None', repr(non_saved_plugin))
+        self.assertIn("id=None", repr(non_saved_plugin))
         self.assertIn("plugin_type=''", repr(non_saved_plugin))
 
-        saved_plugin = CMSPlugin.objects.create(plugin_type='TextPlugin')
-        self.assertIn(f'id={saved_plugin.pk}', repr(saved_plugin))
+        saved_plugin = CMSPlugin.objects.create(plugin_type="TextPlugin")
+        self.assertIn(f"id={saved_plugin.pk}", repr(saved_plugin))
         self.assertIn(f"plugin_type='{saved_plugin.plugin_type}'", repr(saved_plugin))
 
     def test_pickle(self):
         page = api.create_page("page", "nav_playground.html", "en")
-        placeholder = page.get_placeholders("en").get(slot='body')
+        placeholder = page.get_placeholders("en").get(slot="body")
         text_plugin = api.add_plugin(
             placeholder,
             "TextPlugin",
-            'en',
+            "en",
             body="Hello World",
         )
         cms_plugin = text_plugin.cmsplugin_ptr
@@ -671,18 +642,19 @@ class PluginsTestCase(PluginsTestBaseCase):
 
     def test_defer_pickle(self):
         page = api.create_page("page", "nav_playground.html", "en")
-        placeholder = page.get_placeholders("en").get(slot='body')
-        api.add_plugin(placeholder, "TextPlugin", 'en', body="Hello World")
-        plugins = Text.objects.all().defer('position')
+        placeholder = page.get_placeholders("en").get(slot="body")
+        api.add_plugin(placeholder, "TextPlugin", "en", body="Hello World")
+        plugins = Text.objects.all().defer("position")
         import io
+
         a = io.BytesIO()
         pickle.dump(plugins[0], a)
 
     def test_empty_plugin_description(self):
         page = api.create_page("page", "nav_playground.html", "en")
-        placeholder = page.get_placeholders("en").get(slot='body')
+        placeholder = page.get_placeholders("en").get(slot="body")
         a = CMSPlugin(
-            plugin_type='TextPlugin',
+            plugin_type="TextPlugin",
             placeholder=placeholder,
             position=1,
             language=self.FIRST_LANG,
@@ -693,13 +665,8 @@ class PluginsTestCase(PluginsTestBaseCase):
 
     def test_page_attribute_warns(self):
         page = api.create_page("page", "nav_playground.html", "en")
-        placeholder = page.get_placeholders("en").get(slot='body')
-        a = CMSPlugin(
-            plugin_type='TextPlugin',
-            placeholder=placeholder,
-            position=1,
-            language=self.FIRST_LANG
-        )
+        placeholder = page.get_placeholders("en").get(slot="body")
+        a = CMSPlugin(plugin_type="TextPlugin", placeholder=placeholder, position=1, language=self.FIRST_LANG)
         a.save()
 
         def get_page(plugin):
@@ -709,14 +676,15 @@ class PluginsTestCase(PluginsTestBaseCase):
             DontUsePageAttributeWarning,
             "Don't use the page attribute on CMSPlugins! "
             "CMSPlugins are not guaranteed to have a page associated with them!",
-            get_page, a
+            get_page,
+            a,
         )
 
         with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+            warnings.simplefilter("always")
             a.page
             self.assertEqual(1, len(w))
-            self.assertIn('test_plugins.py', w[0].filename)
+            self.assertIn("test_plugins.py", w[0].filename)
 
     def test_editing_plugin_changes_page_modification_time_in_sitemap(self):
         now = timezone.now()
@@ -725,7 +693,7 @@ class PluginsTestCase(PluginsTestBaseCase):
         page.creation_date = one_day_ago
         page.changed_date = one_day_ago
         page.save()
-        plugin = self._create_link_plugin_on_page(page, slot='body')
+        plugin = self._create_link_plugin_on_page(page, slot="body")
         plugin = self.__edit_link_plugin(plugin, "fnord")
 
         sitemap = CMSSitemap()
@@ -736,28 +704,24 @@ class PluginsTestCase(PluginsTestBaseCase):
 
     def test_moving_plugin_to_different_placeholder(self):
         with register_plugins(DumbFixturePlugin):
-            page = api.create_page(
-                "page",
-                "nav_playground.html",
-                "en"
-            )
+            page = api.create_page("page", "nav_playground.html", "en")
             plugin = api.add_plugin(
-                placeholder=page.get_placeholders("en").get(slot='body'),
-                plugin_type='DumbFixturePlugin',
-                language=settings.LANGUAGES[0][0]
+                placeholder=page.get_placeholders("en").get(slot="body"),
+                plugin_type="DumbFixturePlugin",
+                language=settings.LANGUAGES[0][0],
             )
             child_plugin = api.add_plugin(
-                placeholder=page.get_placeholders("en").get(slot='body'),
-                plugin_type='DumbFixturePlugin',
+                placeholder=page.get_placeholders("en").get(slot="body"),
+                plugin_type="DumbFixturePlugin",
                 language=settings.LANGUAGES[0][0],
-                parent=plugin
+                parent=plugin,
             )
             post = {
-                'plugin_id': child_plugin.pk,
-                'placeholder_id': page.get_placeholders("en").get(slot='right-column').pk,
-                'target_language': 'en',
-                'plugin_parent': '',
-                'target_position': 1,
+                "plugin_id": child_plugin.pk,
+                "placeholder_id": page.get_placeholders("en").get(slot="right-column").pk,
+                "target_language": "en",
+                "plugin_parent": "",
+                "target_position": 1,
             }
 
             endpoint = self.get_move_plugin_uri(child_plugin)
@@ -765,7 +729,7 @@ class PluginsTestCase(PluginsTestBaseCase):
             self.assertEqual(response.status_code, 200)
 
     def test_custom_plugin_urls(self):
-        plugin_url = reverse('admin:dumbfixtureplugin')
+        plugin_url = reverse("admin:dumbfixtureplugin")
 
         response = self.client.get(plugin_url)
         self.assertEqual(response.status_code, 200)
@@ -777,12 +741,12 @@ class PluginsTestCase(PluginsTestBaseCase):
         in the plugin pool when a placeholder is specified
         """
         ParentRequiredPlugin = type(
-            'ParentRequiredPlugin', (CMSPluginBase,), dict(require_parent=True, render_plugin=False)
+            "ParentRequiredPlugin", (CMSPluginBase,), dict(require_parent=True, render_plugin=False)
         )
 
         with register_plugins(ParentRequiredPlugin):
             page = api.create_page("page", "nav_playground.html", "en")
-            placeholder = page.get_placeholders("en").get(slot='body')
+            placeholder = page.get_placeholders("en").get(slot="body")
 
             plugin_list = plugin_pool.get_all_plugins(placeholder=placeholder, page=page)
             self.assertFalse(ParentRequiredPlugin in plugin_list)
@@ -790,20 +754,20 @@ class PluginsTestCase(PluginsTestBaseCase):
     def test_plugin_toolbar_struct(self):
         # Tests that the output of the plugin toolbar structure.
         page = api.create_page("page", "nav_playground.html", "en")
-        placeholder = page.get_placeholders("en").get(slot='body')
+        placeholder = page.get_placeholders("en").get(slot="body")
 
         from cms.utils.placeholder import get_toolbar_plugin_struct
 
         expected_struct_en = {
-            'module': 'Generic',
-            'name': 'Style',
-            'value': 'StylePlugin',
+            "module": "Generic",
+            "name": "Style",
+            "value": "StylePlugin",
         }
 
         expected_struct_de = {
-            'module': 'Generisch',
-            'name': 'Style',
-            'value': 'StylePlugin',
+            "module": "Generisch",
+            "name": "Style",
+            "value": "StylePlugin",
         }
 
         toolbar_struct = get_toolbar_plugin_struct(
@@ -812,121 +776,120 @@ class PluginsTestCase(PluginsTestBaseCase):
             page=page,
         )
 
-        style_config = [config for config in toolbar_struct if config['value'] == 'StylePlugin']
+        style_config = [config for config in toolbar_struct if config["value"] == "StylePlugin"]
 
         self.assertEqual(len(style_config), 1)
 
         style_config = style_config[0]
 
-        with force_language('en'):
-            self.assertEqual(force_str(style_config['module']), expected_struct_en['module'])
-            self.assertEqual(force_str(style_config['name']), expected_struct_en['name'])
+        with force_language("en"):
+            self.assertEqual(force_str(style_config["module"]), expected_struct_en["module"])
+            self.assertEqual(force_str(style_config["name"]), expected_struct_en["name"])
 
-        with force_language('de'):
-            self.assertEqual(force_str(style_config['module']), expected_struct_de['module'])
-            self.assertEqual(force_str(style_config['name']), expected_struct_de['name'])
+        with force_language("de"):
+            self.assertEqual(force_str(style_config["module"]), expected_struct_de["module"])
+            self.assertEqual(force_str(style_config["name"]), expected_struct_de["name"])
 
     def test_plugin_toolbar_struct_permissions(self):
         page = self.get_permissions_test_page()
         page_content = self.get_pagecontent_obj(page)
         page_edit_url = get_object_edit_url(page_content)
         staff_user = self.get_staff_user_with_no_permissions()
-        placeholder = page.get_placeholders('en').get(slot='body')
+        placeholder = page.get_placeholders("en").get(slot="body")
 
-        self.add_permission(staff_user, 'change_page')
-        self.add_permission(staff_user, 'add_text')
+        self.add_permission(staff_user, "change_page")
+        self.add_permission(staff_user, "add_text")
 
         with self.login_user_context(staff_user):
             request = self.get_request(page_edit_url, page=page)
             request.toolbar = CMSToolbar(request)
             renderer = self.get_structure_renderer(request=request)
-            output = renderer.render_placeholder(placeholder, language='en', page=page)
+            output = renderer.render_placeholder(placeholder, language="en", page=page)
             self.assertIn('<a data-rel="add" data-add-form="true" href="TextPlugin">Text</a>', output)
             self.assertNotIn('<a data-rel="add" data-add-form="true" href="LinkPlugin">Link</a>', output)
 
     def test_plugin_child_classes_from_settings(self):
         page = api.create_page("page", "nav_playground.html", "en")
-        placeholder = page.get_placeholders("en").get(slot='body')
+        placeholder = page.get_placeholders("en").get(slot="body")
         ChildClassesPlugin = type(
-            'ChildClassesPlugin', (CMSPluginBase,),
-            dict(child_classes=['TextPlugin'], render_template='allow_children_plugin.html')
+            "ChildClassesPlugin",
+            (CMSPluginBase,),
+            dict(child_classes=["TextPlugin"], render_template="allow_children_plugin.html"),
         )
 
         with register_plugins(ChildClassesPlugin):
             plugin = api.add_plugin(placeholder, ChildClassesPlugin, settings.LANGUAGES[0][0])
             plugin = plugin.get_plugin_class_instance()
             # assert baseline
-            self.assertEqual(['TextPlugin'], plugin.get_child_classes(placeholder.slot, page))
+            self.assertEqual(["TextPlugin"], plugin.get_child_classes(placeholder.slot, page))
 
             CMS_PLACEHOLDER_CONF = {
-                'body': {
-                    'child_classes': {
-                        'ChildClassesPlugin': ['LinkPlugin', 'PicturePlugin'],
+                "body": {
+                    "child_classes": {
+                        "ChildClassesPlugin": ["LinkPlugin", "PicturePlugin"],
                     }
                 }
             }
             with self.settings(CMS_PLACEHOLDER_CONF=CMS_PLACEHOLDER_CONF):
-                self.assertEqual(
-                    ['LinkPlugin', 'PicturePlugin'],
-                    plugin.get_child_classes(placeholder.slot, page)
-                )
+                self.assertEqual(["LinkPlugin", "PicturePlugin"], plugin.get_child_classes(placeholder.slot, page))
 
     def test_plugin_parent_classes_from_settings(self):
         page = api.create_page("page", "nav_playground.html", "en")
-        placeholder = page.get_placeholders("en").get(slot='body')
+        placeholder = page.get_placeholders("en").get(slot="body")
         ParentClassesPlugin = type(
-            'ParentClassesPlugin', (CMSPluginBase,), dict(parent_classes=['TextPlugin'], render_plugin=False)
+            "ParentClassesPlugin", (CMSPluginBase,), dict(parent_classes=["TextPlugin"], render_plugin=False)
         )
 
         with register_plugins(ParentClassesPlugin):
             plugin = api.add_plugin(placeholder, ParentClassesPlugin, settings.LANGUAGES[0][0])
             plugin = plugin.get_plugin_class_instance()
             # assert baseline
-            self.assertEqual(['TextPlugin'], plugin.get_parent_classes(placeholder.slot, page))
+            self.assertEqual(["TextPlugin"], plugin.get_parent_classes(placeholder.slot, page))
 
             CMS_PLACEHOLDER_CONF = {
-                'body': {
-                    'parent_classes': {
-                        'ParentClassesPlugin': ['TestPlugin'],
+                "body": {
+                    "parent_classes": {
+                        "ParentClassesPlugin": ["TestPlugin"],
                     }
                 }
             }
             with self.settings(CMS_PLACEHOLDER_CONF=CMS_PLACEHOLDER_CONF):
-                self.assertEqual(['TestPlugin'], plugin.get_parent_classes(placeholder.slot, page))
+                self.assertEqual(["TestPlugin"], plugin.get_parent_classes(placeholder.slot, page))
 
     def test_plugin_parent_classes_from_object(self):
         page = api.create_page("page", "nav_playground.html", "en")
-        placeholder = page.get_placeholders("en").get(slot='body')
-        ParentPlugin = type('ParentPlugin', (CMSPluginBase,), dict(render_plugin=False))
-        ChildPlugin = type('ChildPlugin', (CMSPluginBase,), dict(parent_classes=['ParentPlugin'], render_plugin=False))
+        placeholder = page.get_placeholders("en").get(slot="body")
+        ParentPlugin = type("ParentPlugin", (CMSPluginBase,), dict(render_plugin=False))
+        ChildPlugin = type("ChildPlugin", (CMSPluginBase,), dict(parent_classes=["ParentPlugin"], render_plugin=False))
 
         with register_plugins(ParentPlugin, ChildPlugin):
             plugin = api.add_plugin(placeholder, ParentPlugin, settings.LANGUAGES[0][0])
             plugin = plugin.get_plugin_class_instance()
             # assert baseline
             child_classes = plugin.get_child_classes(placeholder.slot, page)
-            self.assertIn('ChildPlugin', child_classes)
-            self.assertIn('ParentPlugin', child_classes)
+            self.assertIn("ChildPlugin", child_classes)
+            self.assertIn("ParentPlugin", child_classes)
 
     def test_plugin_require_parent_from_object(self):
         page = api.create_page("page", "nav_playground.html", "en")
-        placeholder = page.get_placeholders("en").get(slot='body')
-        ParentPlugin = type('ParentPlugin', (CMSPluginBase,), dict(render_plugin=False))
-        ChildPlugin = type('ChildPlugin', (CMSPluginBase,), dict(require_parent=True, render_plugin=False))
+        placeholder = page.get_placeholders("en").get(slot="body")
+        ParentPlugin = type("ParentPlugin", (CMSPluginBase,), dict(render_plugin=False))
+        ChildPlugin = type("ChildPlugin", (CMSPluginBase,), dict(require_parent=True, render_plugin=False))
 
         with register_plugins(ParentPlugin, ChildPlugin):
             plugin = api.add_plugin(placeholder, ParentPlugin, settings.LANGUAGES[0][0])
             plugin = plugin.get_plugin_class_instance()
             # assert baseline
             child_classes = plugin.get_child_classes(placeholder.slot, page)
-            self.assertIn('ChildPlugin', child_classes)
-            self.assertIn('ParentPlugin', child_classes)
+            self.assertIn("ChildPlugin", child_classes)
+            self.assertIn("ParentPlugin", child_classes)
 
     def test_plugin_pool_register_returns_plugin_class(self):
         @plugin_pool.register_plugin
         class DecoratorTestPlugin(CMSPluginBase):
             render_plugin = False
             name = "Test Plugin"
+
         self.assertIsNotNone(DecoratorTestPlugin)
 
     def _create_plugin_tree(self, placeholder, n, downcast=False):
@@ -935,8 +898,8 @@ class PluginsTestCase(PluginsTestBaseCase):
         from cms.utils.plugins import downcast_plugins
 
         with register_plugins(CMSPluginBase):
-            # Creat n plugins, shuffle them and then create a linear tree of them
-            plugins = random.sample([api.add_plugin(placeholder, CMSPluginBase, 'en') for _ in range(n)], k=n)
+            # Create n plugins, shuffle them and then create a linear tree of them
+            plugins = random.sample([api.add_plugin(placeholder, CMSPluginBase, "en") for _ in range(n)], k=n)
             for i, plugin in enumerate(plugins):
                 plugin.position = n + i + 1  # order positions, too
                 if i > 0:
@@ -963,7 +926,7 @@ class PluginsTestCase(PluginsTestBaseCase):
         placeholder = self.get_placeholder()
         with register_plugins(CMSPluginBase):
             # Create a single plugin with no parent
-            plugin = api.add_plugin(placeholder, CMSPluginBase, 'en')
+            plugin = api.add_plugin(placeholder, CMSPluginBase, "en")
             plugin.save()
         with self.assertNumQueries(0):
             ancestors = plugin.get_ancestors()
@@ -977,6 +940,56 @@ class PluginsTestCase(PluginsTestBaseCase):
             ancestors = plugins[-1].get_ancestors()
 
         self.assertEqual([ancestor.pk for ancestor in ancestors], [plugin.pk for plugin in plugins[:-1]])
+
+    def test_validate_template_invalid_parent_class(self):
+        class ParentPlugin(CMSPluginBase):
+            render_template = "base.html"
+            allow_children = True
+
+        class ChildPlugin(CMSPluginBase):
+            render_template = "base.html"
+            parent_classes = ("NonExistentPlugin",)
+
+        with register_plugins(ParentPlugin, ChildPlugin):
+            from cms.utils.setup import setup
+
+            with self.assertRaises(ImproperlyConfigured) as context:
+                setup()
+
+            self.assertIn("Parent plugin class 'NonExistentPlugin' not found", str(context.exception))
+
+    def test_validate_template_invalid_child_class(self):
+        class ParentPlugin(CMSPluginBase):
+            render_template = "base.html"
+            allow_children = True
+            child_classes = ("NonExistentPlugin",)
+
+        class ChildPlugin(CMSPluginBase):
+            render_template = "base.html"
+            parent_classes = ("ParentPlugin",)
+
+        with register_plugins(ParentPlugin, ChildPlugin):
+            from cms.utils.setup import setup
+
+            with self.assertRaises(ImproperlyConfigured) as context:
+                setup()
+
+            self.assertIn("Child plugin class 'NonExistentPlugin' not found", str(context.exception))
+
+    def test_validate_template_valid_parent_child_classes(self):
+        class ParentPlugin(CMSPluginBase):
+            render_template = "base.html"
+            allow_children = True
+            child_classes = ("ChildPlugin",)
+
+        class ChildPlugin(CMSPluginBase):
+            render_template = "base.html"
+            parent_classes = ("ParentPlugin",)
+
+        with register_plugins(ParentPlugin, ChildPlugin):
+            from cms.utils.setup import setup
+
+            setup()
 
 
 class PluginManyToManyTestCase(PluginsTestBaseCase):
@@ -998,10 +1011,7 @@ class PluginManyToManyTestCase(PluginsTestBaseCase):
         # create 10 articles by section
         for section in self.sections:
             for j in range(10):
-                Article.objects.create(
-                    title="article %s" % j,
-                    section=section
-                )
+                Article.objects.create(title="article %s" % j, section=section)
         self.FIRST_LANG = settings.LANGUAGES[0][0]
         self.SECOND_LANG = settings.LANGUAGES[1][0]
 
@@ -1011,63 +1021,57 @@ class PluginManyToManyTestCase(PluginsTestBaseCase):
         api.add_plugin(ph_en, "ArticleDynamicTemplatePlugin", "en", title="a title")
         api.add_plugin(ph_en, "ArticleDynamicTemplatePlugin", "en", title="custom template")
         context = self.get_context(path=page_en.get_absolute_url())
-        request = context['request']
+        request = context["request"]
         plugins = get_plugins(request, ph_en, page_en.template)
         content_renderer = self.get_content_renderer()
 
         for plugin in plugins:
-            if plugin.title == 'custom template':
+            if plugin.title == "custom template":
                 content = content_renderer.render_plugin(plugin, context, ph_en)
                 self.assertEqual(
-                    plugin.get_plugin_class_instance().get_render_template({}, plugin, ph_en), 'articles_custom.html'
+                    plugin.get_plugin_class_instance().get_render_template({}, plugin, ph_en), "articles_custom.html"
                 )
-                self.assertTrue('Articles Custom template' in content)
+                self.assertTrue("Articles Custom template" in content)
             else:
                 content = content_renderer.render_plugin(plugin, context, ph_en)
                 self.assertEqual(
-                    plugin.get_plugin_class_instance().get_render_template({}, plugin, ph_en), 'articles.html'
+                    plugin.get_plugin_class_instance().get_render_template({}, plugin, ph_en), "articles.html"
                 )
-                self.assertFalse('Articles Custom template' in content)
+                self.assertFalse("Articles Custom template" in content)
 
     def test_add_plugin_with_m2m(self):
         # add a new text plugin
         self.assertEqual(ArticlePluginModel.objects.count(), 0)
         page_data = self.get_new_page_data()
-        self.client.post(self.get_page_add_uri('en'), page_data)
+        self.client.post(self.get_page_add_uri("en"), page_data)
         page = Page.objects.first()
-        placeholder = page.get_placeholders(self.FIRST_LANG).get(slot='col_left')
+        placeholder = page.get_placeholders(self.FIRST_LANG).get(slot="col_left")
         add_url = self.get_add_plugin_uri(
             placeholder=placeholder,
-            plugin_type='ArticlePlugin',
+            plugin_type="ArticlePlugin",
             language=self.FIRST_LANG,
         )
-        data = {
-            'title': "Articles Plugin 1",
-            "sections": self.section_pks
-        }
+        data = {"title": "Articles Plugin 1", "sections": self.section_pks}
         response = self.client.post(add_url, data)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(ArticlePluginModel.objects.count(), 1)
         plugin = ArticlePluginModel.objects.all()[0]
         self.assertEqual(self.section_count, plugin.sections.count())
-        response = self.client.get('/en/')
+        response = self.client.get("/en/")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(plugin.sections.through._meta.db_table, 'manytomany_rel_articlepluginmodel_sections')
+        self.assertEqual(plugin.sections.through._meta.db_table, "manytomany_rel_articlepluginmodel_sections")
 
     def test_copy_plugin_with_m2m(self):
         page = api.create_page("page", "nav_playground.html", "en")
-        placeholder = page.get_placeholders("en").get(slot='body')
+        placeholder = page.get_placeholders("en").get(slot="body")
         plugin = ArticlePluginModel.objects.create(
-            plugin_type='ArticlePlugin',
+            plugin_type="ArticlePlugin",
             placeholder=placeholder,
             position=1,
             language=self.FIRST_LANG,
         )
         endpoint = self.get_change_plugin_uri(plugin, language=self.FIRST_LANG)
-        data = {
-            'title': "Articles Plugin 1",
-            "sections": self.section_pks
-        }
+        data = {"title": "Articles Plugin 1", "sections": self.section_pks}
         response = self.client.post(endpoint, data)
 
         self.assertEqual(response.status_code, 200)
@@ -1076,10 +1080,12 @@ class PluginManyToManyTestCase(PluginsTestBaseCase):
 
         page_data = self.get_new_page_data()
         # create 2nd language page
-        page_data.update({
-            'title': f"{page.get_title()} {self.SECOND_LANG}",
-            'cms_page': page.pk,
-        })
+        page_data.update(
+            {
+                "title": f"{page.get_title()} {self.SECOND_LANG}",
+                "cms_page": page.pk,
+            }
+        )
         endpoint = self.get_page_add_uri(self.SECOND_LANG, page)
         response = self.client.post(endpoint, page_data)
         self.assertRedirects(response, self.get_pages_admin_list_uri(self.SECOND_LANG))
@@ -1089,16 +1095,16 @@ class PluginManyToManyTestCase(PluginsTestBaseCase):
         self.assertEqual(Page.objects.all().count(), 1)
 
         copy_data = {
-            'source_placeholder_id': placeholder.pk,
-            'target_placeholder_id': placeholder.pk,
-            'target_language': self.SECOND_LANG,
-            'source_language': self.FIRST_LANG,
+            "source_placeholder_id": placeholder.pk,
+            "target_placeholder_id": placeholder.pk,
+            "target_language": self.SECOND_LANG,
+            "source_language": self.FIRST_LANG,
         }
         endpoint = self.get_copy_plugin_uri(plugin, language=self.FIRST_LANG)
         response = self.client.post(endpoint, copy_data)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode('utf8').count('"plugin_type": "ArticlePlugin"'), 1)
+        self.assertEqual(response.content.decode("utf8").count('"plugin_type": "ArticlePlugin"'), 1)
         # assert copy success
         self.assertEqual(CMSPlugin.objects.filter(language=self.FIRST_LANG).count(), 1)
         self.assertEqual(CMSPlugin.objects.filter(language=self.SECOND_LANG).count(), 1)
@@ -1119,17 +1125,17 @@ class PluginCopyRelationsTestCase(PluginsTestBaseCase):
         self._login_context = self.login_user_context(self.super_user)
         self._login_context.__enter__()
         page_data1 = self.get_new_page_data_dbfields()
-        page_data1['published'] = False
+        page_data1["published"] = False
         self.page1 = api.create_page(**page_data1)
         page_data2 = self.get_new_page_data_dbfields()
-        page_data2['published'] = False
+        page_data2["published"] = False
         self.page2 = api.create_page(**page_data2)
-        self.placeholder1 = self.page1.get_placeholders(self.FIRST_LANG).get(slot='body')
-        self.placeholder2 = self.page2.get_placeholders(self.FIRST_LANG).get(slot='body')
+        self.placeholder1 = self.page1.get_placeholders(self.FIRST_LANG).get(slot="body")
+        self.placeholder2 = self.page2.get_placeholders(self.FIRST_LANG).get(slot="body")
 
 
 class PluginsMetaOptionsTests(TestCase):
-    ''' TestCase set for ensuring that bugs like #992 are caught '''
+    """TestCase set for ensuring that bugs like #992 are caught"""
 
     # these plugins are inlined because, due to the nature of the #992
     # ticket, we cannot actually import a single file with all the
@@ -1137,59 +1143,58 @@ class PluginsMetaOptionsTests(TestCase):
     # error with split occurs.
 
     def test_meta_options_as_defaults(self):
-        ''' handling when a CMSPlugin meta options are computed defaults '''
+        """handling when a CMSPlugin meta options are computed defaults"""
         # this plugin relies on the base CMSPlugin and Model classes to
         # decide what the app_label and db_table should be
 
         plugin = TestPlugin.model
-        self.assertEqual(plugin._meta.db_table, 'meta_testpluginmodel')
-        self.assertEqual(plugin._meta.app_label, 'meta')
+        self.assertEqual(plugin._meta.db_table, "meta_testpluginmodel")
+        self.assertEqual(plugin._meta.app_label, "meta")
 
     def test_meta_options_as_declared_defaults(self):
-        ''' handling when a CMSPlugin meta options are declared as per defaults '''
+        """handling when a CMSPlugin meta options are declared as per defaults"""
         # here, we declare the db_table and app_label explicitly, but to the same
         # values as would be computed, thus making sure it's not a problem to
         # supply options.
 
         plugin = TestPlugin2.model
-        self.assertEqual(plugin._meta.db_table, 'meta_testpluginmodel2')
-        self.assertEqual(plugin._meta.app_label, 'meta')
+        self.assertEqual(plugin._meta.db_table, "meta_testpluginmodel2")
+        self.assertEqual(plugin._meta.app_label, "meta")
 
     def test_meta_options_custom_app_label(self):
-        ''' make sure customised meta options on CMSPlugins don't break things '''
+        """make sure customised meta options on CMSPlugins don't break things"""
 
         plugin = TestPlugin3.model
-        self.assertEqual(plugin._meta.db_table, 'one_thing_testpluginmodel3')
-        self.assertEqual(plugin._meta.app_label, 'one_thing')
+        self.assertEqual(plugin._meta.db_table, "one_thing_testpluginmodel3")
+        self.assertEqual(plugin._meta.app_label, "one_thing")
 
     def test_meta_options_custom_db_table(self):
-        ''' make sure custom database table names are OK. '''
+        """make sure custom database table names are OK."""
 
         plugin = TestPlugin4.model
-        self.assertEqual(plugin._meta.db_table, 'or_another_4')
-        self.assertEqual(plugin._meta.app_label, 'meta')
+        self.assertEqual(plugin._meta.db_table, "or_another_4")
+        self.assertEqual(plugin._meta.app_label, "meta")
 
     def test_meta_options_custom_both(self):
-        ''' We should be able to customise app_label and db_table together '''
+        """We should be able to customise app_label and db_table together"""
 
         plugin = TestPlugin5.model
-        self.assertEqual(plugin._meta.db_table, 'or_another_5')
-        self.assertEqual(plugin._meta.app_label, 'one_thing')
+        self.assertEqual(plugin._meta.db_table, "or_another_5")
+        self.assertEqual(plugin._meta.app_label, "one_thing")
 
 
 class NoDatabasePluginTests(TestCase):
-
     def get_plugin_model(self, plugin_type):
         return plugin_pool.get_plugin(plugin_type).model
 
     def test_render_meta_is_unique(self):
-        text = self.get_plugin_model('TextPlugin')
-        link = self.get_plugin_model('LinkPlugin')
+        text = self.get_plugin_model("TextPlugin")
+        link = self.get_plugin_model("LinkPlugin")
         self.assertNotEqual(id(text._render_meta), id(link._render_meta))
 
     def test_render_meta_does_not_leak(self):
-        text = self.get_plugin_model('TextPlugin')
-        link = self.get_plugin_model('LinkPlugin')
+        text = self.get_plugin_model("TextPlugin")
+        link = self.get_plugin_model("LinkPlugin")
 
         text._render_meta.text_enabled = False
         link._render_meta.text_enabled = False
@@ -1205,31 +1210,32 @@ class NoDatabasePluginTests(TestCase):
     def test_db_table_hack(self):
         # Plugin models have been moved away due to Django's AppConfig
         from cms.test_utils.project.bunch_of_plugins.models import TestPlugin1
-        self.assertEqual(TestPlugin1._meta.db_table, 'bunch_of_plugins_testplugin1')
+
+        self.assertEqual(TestPlugin1._meta.db_table, "bunch_of_plugins_testplugin1")
 
     def test_db_table_hack_with_mixin(self):
         # Plugin models have been moved away due to Django's AppConfig
         from cms.test_utils.project.bunch_of_plugins.models import TestPlugin2
-        self.assertEqual(TestPlugin2._meta.db_table, 'bunch_of_plugins_testplugin2')
+
+        self.assertEqual(TestPlugin2._meta.db_table, "bunch_of_plugins_testplugin2")
 
 
 class SimplePluginTests(TestCase):
-
     def test_simple_naming(self):
         class MyPlugin(CMSPluginBase):
-            render_template = 'base.html'
+            render_template = "base.html"
 
-        self.assertEqual(MyPlugin.name, 'My Plugin')
+        self.assertEqual(MyPlugin.name, "My Plugin")
 
     def test_simple_context(self):
         class MyPlugin(CMSPluginBase):
-            render_template = 'base.html'
+            render_template = "base.html"
 
         plugin = MyPlugin(ArticlePluginModel, admin.site)
         context = {}
         out_context = plugin.render(context, 1, 2)
-        self.assertEqual(out_context['instance'], 1)
-        self.assertEqual(out_context['placeholder'], 2)
+        self.assertEqual(out_context["instance"], 1)
+        self.assertEqual(out_context["placeholder"], 2)
         self.assertIs(out_context, context)
 
 
@@ -1241,7 +1247,7 @@ class BrokenPluginTests(TestCase):
         in opposition to the ImportError if the file 'cms_plugins.py' doesn't
         exist.
         """
-        new_apps = ['cms.test_utils.project.brokenpluginapp']
+        new_apps = ["cms.test_utils.project.brokenpluginapp"]
         with self.settings(INSTALLED_APPS=new_apps):
             plugin_pool.discovered = False
             self.assertRaises(ImportError, plugin_pool.discover_plugins)
@@ -1259,19 +1265,16 @@ class MTIPluginsTestCase(PluginsTestBaseCase):
 
         # Create a page
         page = create_page("Test", "nav_playground.html", settings.LANGUAGES[0][0])
-        placeholder = page.get_placeholders(settings.LANGUAGES[0][0]).get(slot='body')
+        placeholder = page.get_placeholders(settings.LANGUAGES[0][0]).get(slot="body")
 
         # Add the MTI plugin
         add_url = self.get_add_plugin_uri(
             placeholder=placeholder,
-            plugin_type='TestPluginBeta',
+            plugin_type="TestPluginBeta",
             language=settings.LANGUAGES[0][0],
         )
 
-        data = {
-            'alpha': 'ALPHA',
-            'beta': 'BETA'
-        }
+        data = {"alpha": "ALPHA", "beta": "BETA"}
         response = self.client.post(add_url, data)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(TestPluginBetaModel.objects.count(), 1)
@@ -1293,49 +1296,51 @@ class MTIPluginsTestCase(PluginsTestBaseCase):
         )
 
         # the first concrete class of the following four plugins is TestPluginAlphaModel
-        self.assertEqual(TestPluginAlphaModel.cmsplugin_ptr.field.remote_field.related_name,
-                         'mti_pluginapp_testpluginalphamodel')
-        self.assertEqual(TestPluginBetaModel.cmsplugin_ptr.field.remote_field.related_name,
-                         'mti_pluginapp_testpluginalphamodel')
-        self.assertEqual(ProxiedAlphaPluginModel.cmsplugin_ptr.field.remote_field.related_name,
-                         'mti_pluginapp_testpluginalphamodel')
-        self.assertEqual(ProxiedBetaPluginModel.cmsplugin_ptr.field.remote_field.related_name,
-                         'mti_pluginapp_testpluginalphamodel')
-        # Abstract plugins will have the dynamic format for related name
         self.assertEqual(
-            AbstractPluginParent.cmsplugin_ptr.field.remote_field.related_name,
-            '%(app_label)s_%(class)s'
+            TestPluginAlphaModel.cmsplugin_ptr.field.remote_field.related_name, "mti_pluginapp_testpluginalphamodel"
         )
+        self.assertEqual(
+            TestPluginBetaModel.cmsplugin_ptr.field.remote_field.related_name, "mti_pluginapp_testpluginalphamodel"
+        )
+        self.assertEqual(
+            ProxiedAlphaPluginModel.cmsplugin_ptr.field.remote_field.related_name, "mti_pluginapp_testpluginalphamodel"
+        )
+        self.assertEqual(
+            ProxiedBetaPluginModel.cmsplugin_ptr.field.remote_field.related_name, "mti_pluginapp_testpluginalphamodel"
+        )
+        # Abstract plugins will have the dynamic format for related name
+        self.assertEqual(AbstractPluginParent.cmsplugin_ptr.field.remote_field.related_name, "%(app_label)s_%(class)s")
         # Concrete plugin of an abstract plugin gets its relatedname
-        self.assertEqual(TestPluginGammaModel.cmsplugin_ptr.field.remote_field.related_name,
-                         'mti_pluginapp_testplugingammamodel')
+        self.assertEqual(
+            TestPluginGammaModel.cmsplugin_ptr.field.remote_field.related_name, "mti_pluginapp_testplugingammamodel"
+        )
         # Child plugin gets it's own related name
-        self.assertEqual(MixedPlugin.cmsplugin_ptr.field.remote_field.related_name,
-                         'mti_pluginapp_mixedplugin')
+        self.assertEqual(MixedPlugin.cmsplugin_ptr.field.remote_field.related_name, "mti_pluginapp_mixedplugin")
         # If the child plugin inherit straight from CMSPlugin, even if composed with
         # other models, gets its own related_name
-        self.assertEqual(LessMixedPlugin.cmsplugin_ptr.field.remote_field.related_name,
-                         'mti_pluginapp_lessmixedplugin')
+        self.assertEqual(
+            LessMixedPlugin.cmsplugin_ptr.field.remote_field.related_name, "mti_pluginapp_lessmixedplugin"
+        )
         # Non plugins are skipped
-        self.assertFalse(hasattr(NonPluginModel, 'cmsplugin_ptr'))
+        self.assertFalse(hasattr(NonPluginModel, "cmsplugin_ptr"))
 
 
 class UserInputValidationPluginTest(PluginsTestBaseCase):
-
     def test_error_response_escapes(self):
-        language = 'en'
+        language = "en"
         superuser = self.get_superuser()
         page = create_page("error page", "nav_playground.html", language=language)
-        placeholder = page.get_placeholders(language).get(slot='body')
+        placeholder = page.get_placeholders(language).get(slot="body")
 
         add_url = self.get_add_plugin_uri(
-            placeholder, plugin_type='TextPlugin"><script>alert("hello world")</script>', language=language)
+            placeholder, plugin_type='TextPlugin"><script>alert("hello world")</script>', language=language
+        )
 
         with self.login_user_context(superuser):
             response = self.client.get(add_url)
 
         self.assertEqual(response.status_code, 400)
         self.assertIn(
-            'TextPlugin&quot;&gt;&lt;script&gt;alert(&quot;hello world&quot;)&lt;/script&gt;',
-            response.content.decode("utf-8")
+            "TextPlugin&quot;&gt;&lt;script&gt;alert(&quot;hello world&quot;)&lt;/script&gt;",
+            response.content.decode("utf-8"),
         )

--- a/cms/utils/check.py
+++ b/cms/utils/check.py
@@ -45,6 +45,7 @@ class FileOutputWrapper:
         section(title): A context manager that starts a new section. For the
             Section API see FileSectionWrapper
     """
+
     def __init__(self, stdout, stderr):
         self.stdout = stdout
         self.stderr = stderr
@@ -57,50 +58,50 @@ class FileOutputWrapper:
     def colorize(self, msg, opts=(), **kwargs):
         return colorize(msg, opts=opts, **kwargs)
 
-    def write_line(self, message=''):
-        self.write('%s\n' % message)
+    def write_line(self, message=""):
+        self.write("%s\n" % message)
 
     def write(self, message):
         self.stdout.write(message)
 
-    def write_stderr_line(self, message=''):
-        self.write_stderr('%s\n' % message)
+    def write_stderr_line(self, message=""):
+        self.write_stderr("%s\n" % message)
 
     def write_stderr(self, message):
         self.stderr.write(message)
 
     def success(self, message):
         self.successes += 1
-        self.write_line('{} {}'.format(message, self.colorize('[OK]', fg='green', opts=['bold'])))
+        self.write_line("{} {}".format(message, self.colorize("[OK]", fg="green", opts=["bold"])))
 
     def error(self, message):
         self.errors += 1
-        self.write_stderr_line('{} {}'.format(message, self.colorize('[ERROR]', fg='red', opts=['bold'])))
+        self.write_stderr_line("{} {}".format(message, self.colorize("[ERROR]", fg="red", opts=["bold"])))
 
     def warn(self, message):
         self.warnings += 1
-        self.write_stderr_line('{} {}'.format(message, self.colorize('[WARNING]', fg='yellow', opts=['bold'])))
+        self.write_stderr_line("{} {}".format(message, self.colorize("[WARNING]", fg="yellow", opts=["bold"])))
 
     def skip(self, message):
         self.skips += 1
-        self.write_line('{} {}'.format(message, self.colorize('[SKIP]', fg='blue', opts=['bold'])))
+        self.write_line("{} {}".format(message, self.colorize("[SKIP]", fg="blue", opts=["bold"])))
 
     @method_decorator(contextmanager)
     def section(self, title):
-        self.write_line(self.colorize(title, opts=['bold']))
-        self.write_line(self.colorize('=' * len(title), opts=['bold']))
+        self.write_line(self.colorize(title, opts=["bold"]))
+        self.write_line(self.colorize("=" * len(title), opts=["bold"]))
         self.write_line()
         wrapper = self.section_wrapper(self)
         try:
             yield wrapper
         except:  # NOQA
-            self.error('Checker failed, see traceback')
+            self.error("Checker failed, see traceback")
             raise
         self.errors += wrapper.errors
         self.successes += wrapper.successes
         self.warnings += wrapper.warnings
         self.skips += wrapper.skips
-        self.write_line('')
+        self.write_line("")
 
     @property
     def successful(self):
@@ -121,15 +122,16 @@ class FileSectionWrapper(FileOutputWrapper):
         finish_warning(message): End this section with a warning
         finish_skip(message): End this (skipped) section
     """
+
     def __init__(self, wrapper):
         super().__init__(wrapper.stdout, wrapper.stderr)
         self.wrapper = wrapper
 
-    def write_line(self, message=''):
-        self.write('  - %s\n' % message)
+    def write_line(self, message=""):
+        self.write("  - %s\n" % message)
 
-    def write_stderr_line(self, message=''):
-        self.write_stderr('  - %s\n' % message)
+    def write_stderr_line(self, message=""):
+        self.write_stderr("  - %s\n" % message)
 
     def finish_success(self, message):
         self.wrapper.write_line()
@@ -159,19 +161,22 @@ def define_check(func):
 @define_check
 def check_sekizai(output):
     with output.section("Sekizai") as section:
-        sekizai_installed = is_installed('sekizai')
+        sekizai_installed = is_installed("sekizai")
 
         if sekizai_installed:
             section.success("Sekizai is installed")
         else:
             section.error("Sekizai is not installed, could not find 'sekizai' in INSTALLED_APPS")
         processors = list(
-            chain(*[template['OPTIONS'].get('context_processors', []) for template in settings.TEMPLATES]))
-        if 'sekizai.context_processors.sekizai' in processors:
+            chain(*[template["OPTIONS"].get("context_processors", []) for template in settings.TEMPLATES])
+        )
+        if "sekizai.context_processors.sekizai" in processors:
             section.success("Sekizai template context processor is installed")
         else:
-            section.error("Sekizai template context processor is not installed, could not find "
-                          "'sekizai.context_processors.sekizai' in TEMPLATES option context_processors")
+            section.error(
+                "Sekizai template context processor is not installed, could not find "
+                "'sekizai.context_processors.sekizai' in TEMPLATES option context_processors"
+            )
 
         if not sekizai_installed:
             # sekizai is not installed.
@@ -179,10 +184,10 @@ def check_sekizai(output):
             # because template loading won't work
             return
 
-        for template, _ in get_cms_setting('TEMPLATES'):
+        for template, _ in get_cms_setting("TEMPLATES"):
             if template == constants.TEMPLATE_INHERITANCE_MAGIC:
                 continue
-            if validate_template(template, ['js', 'css']):
+            if validate_template(template, ["js", "css"]):
                 section.success("Sekizai namespaces 'js' and 'css' found in %r" % template)
             else:
                 section.error("Sekizai namespaces 'js' and 'css' not found in %r" % template)
@@ -195,24 +200,30 @@ def check_sekizai(output):
 @define_check
 def check_i18n(output):
     with output.section("Internationalization") as section:
-        if isinstance(getattr(settings, 'CMS_LANGUAGES', {}), dict):
+        if isinstance(getattr(settings, "CMS_LANGUAGES", {}), dict):
             section.success("New style CMS_LANGUAGES")
         else:
             section.warn("Old style (tuple based) CMS_LANGUAGES, please switch to the new (dictionary based) style")
-        if getattr(settings, 'LANGUAGE_CODE', '').find('_') > -1:
-            section.warn("LANGUAGE_CODE must contain a valid language code, not a locale (e.g.: 'en-us' instead of "
-                         "'en_US'): '%s' provided" % getattr(settings, 'LANGUAGE_CODE', ''))
-        for lang in getattr(settings, 'LANGUAGES', ()):
-            if lang[0].find('_') > -1:
-                section.warn("LANGUAGES must contain valid language codes, not locales (e.g.: 'en-us' instead of "
-                             "'en_US'): '%s' provided" % lang[0])
+        if getattr(settings, "LANGUAGE_CODE", "").find("_") > -1:
+            section.warn(
+                "LANGUAGE_CODE must contain a valid language code, not a locale (e.g.: 'en-us' instead of "
+                "'en_US'): '%s' provided" % getattr(settings, "LANGUAGE_CODE", "")
+            )
+        for lang in getattr(settings, "LANGUAGES", ()):
+            if lang[0].find("_") > -1:
+                section.warn(
+                    "LANGUAGES must contain valid language codes, not locales (e.g.: 'en-us' instead of "
+                    "'en_US'): '%s' provided" % lang[0]
+                )
         if settings.SITE_ID == hash(settings.SITE_ID):
-            for site, items in get_cms_setting('LANGUAGES').items():
+            for site, items in get_cms_setting("LANGUAGES").items():
                 if isinstance(site, int):
                     for lang in items:
-                        if lang['code'].find('_') > -1:
-                            section.warn("CMS_LANGUAGES entries must contain valid language codes, not locales (e.g.: "
-                                         "'en-us' instead of 'en_US'): '%s' provided" % lang['code'])
+                        if lang["code"].find("_") > -1:
+                            section.warn(
+                                "CMS_LANGUAGES entries must contain valid language codes, not locales (e.g.: "
+                                "'en-us' instead of 'en_US'): '%s' provided" % lang["code"]
+                            )
         else:
             section.error("SITE_ID must be an integer, not %r" % settings.SITE_ID)
 
@@ -221,18 +232,18 @@ def check_i18n(output):
 def check_middlewares(output):
     with output.section("Middlewares") as section:
         required_middlewares = (
-            'django.contrib.sessions.middleware.SessionMiddleware',
-            'django.middleware.csrf.CsrfViewMiddleware',
-            'django.contrib.auth.middleware.AuthenticationMiddleware',
-            'django.contrib.messages.middleware.MessageMiddleware',
-            'django.middleware.locale.LocaleMiddleware',
-            'django.middleware.common.CommonMiddleware',
-            'cms.middleware.user.CurrentUserMiddleware',
-            'cms.middleware.page.CurrentPageMiddleware',
-            'cms.middleware.toolbar.ToolbarMiddleware',
-            'cms.middleware.language.LanguageCookieMiddleware',
+            "django.contrib.sessions.middleware.SessionMiddleware",
+            "django.middleware.csrf.CsrfViewMiddleware",
+            "django.contrib.auth.middleware.AuthenticationMiddleware",
+            "django.contrib.messages.middleware.MessageMiddleware",
+            "django.middleware.locale.LocaleMiddleware",
+            "django.middleware.common.CommonMiddleware",
+            "cms.middleware.user.CurrentUserMiddleware",
+            "cms.middleware.page.CurrentPageMiddleware",
+            "cms.middleware.toolbar.ToolbarMiddleware",
+            "cms.middleware.language.LanguageCookieMiddleware",
         )
-        middlewares = getattr(settings, 'MIDDLEWARE', [])
+        middlewares = getattr(settings, "MIDDLEWARE", [])
 
         for middleware in required_middlewares:
             if middleware not in middlewares:
@@ -243,11 +254,9 @@ def check_middlewares(output):
 def check_context_processors(output):
     with output.section("Context processors") as section:
         processors = list(
-            chain(*[template['OPTIONS'].get('context_processors', []) for template in settings.TEMPLATES]))
-        required_processors = (
-            'cms.context_processors.cms_settings',
-            'django.template.context_processors.i18n'
+            chain(*[template["OPTIONS"].get("context_processors", []) for template in settings.TEMPLATES])
         )
+        required_processors = ("cms.context_processors.cms_settings", "django.template.context_processors.i18n")
         for processor in required_processors:
             if processor not in processors:
                 section.error("%s context processor must be in TEMPLATES option context_processors" % processor)
@@ -256,6 +265,7 @@ def check_context_processors(output):
 @define_check
 def check_plugin_instances(output):
     from cms.management.commands.subcommands.list import plugin_report
+
     with output.section("Plugin instances") as section:
         # get the report
         report = plugin_report()
@@ -268,15 +278,18 @@ def check_plugin_instances(output):
             # warn about those that have unsaved instances
             if plugin_type["unsaved_instances"]:
                 section.error(
-                    "{} has {} unsaved instances".format(plugin_type["type"], len(plugin_type["unsaved_instances"])))
+                    "{} has {} unsaved instances".format(plugin_type["type"], len(plugin_type["unsaved_instances"]))
+                )
 
         if section.successful:
             section.finish_success("The plugins in your database are in good order")
         else:
-            section.finish_error("There are potentially serious problems with the plugins in your database. \nEven if "
-                                 "your site works, you should run the 'manage.py cms list plugins' \ncommand and then "
-                                 "the 'manage.py cms delete-orphaned-plugins' command. \nThis will alter your "
-                                 "database; read the documentation before using it.")
+            section.finish_error(
+                "There are potentially serious problems with the plugins in your database. \nEven if "
+                "your site works, you should run the 'manage.py cms list plugins' \ncommand and then "
+                "the 'manage.py cms delete-orphaned-plugins' command. \nThis will alter your "
+                "database; read the documentation before using it."
+            )
 
 
 @define_check
@@ -287,7 +300,7 @@ def check_copy_relations(output):
     from cms.plugin_pool import plugin_pool
 
     def c_to_s(klass):
-        return f'{klass.__module__}.{klass.__name__}'
+        return f"{klass.__module__}.{klass.__name__}"
 
     def get_class(method_name, model):
         for cls in inspect.getmro(model):
@@ -299,41 +312,55 @@ def check_copy_relations(output):
         plugin_pool.discover_plugins()
         for plugin in plugin_pool.plugins.values():
             plugin_class = plugin.model
-            if get_class('copy_relations', plugin_class) is not CMSPlugin or plugin_class is CMSPlugin:
+            if get_class("copy_relations", plugin_class) is not CMSPlugin or plugin_class is CMSPlugin:
                 # this class defines a ``copy_relations`` method, nothing more
                 # to do
                 continue
             for rel in plugin_class._meta.many_to_many:
-                section.warn(f'{c_to_s(plugin_class)} has a many-to-many relation to {c_to_s(rel.model)},\n    but no "copy_relations" method defined.')
+                section.warn(
+                    f'{c_to_s(plugin_class)} has a many-to-many relation to {c_to_s(rel.model)},\n    but no "copy_relations" method defined.'
+                )
             for rel in plugin_class._get_related_objects():
-                if rel.model != CMSPlugin and not issubclass(
-                        rel.model, plugin.model) and rel.model != AliasPluginModel:
-                    section.warn(f'{c_to_s(plugin_class)} has a foreign key from {c_to_s(rel.model)},\n    but no "copy_relations" method defined.')
+                if (
+                    rel.model != CMSPlugin
+                    and not issubclass(rel.model, plugin.model)
+                    and rel.model != AliasPluginModel
+                ):
+                    section.warn(
+                        f'{c_to_s(plugin_class)} has a foreign key from {c_to_s(rel.model)},\n    but no "copy_relations" method defined.'
+                    )
 
         for extension in chain(extension_pool.page_extensions, extension_pool.page_content_extensions):
-            if get_class('copy_relations', extension) is not BaseExtension:
+            if get_class("copy_relations", extension) is not BaseExtension:
                 # OK, looks like there is a 'copy_relations' defined in the
                 # extension... move along...
                 continue
             for rel in extension._meta.many_to_many:
                 section.warn(
-                    '%s has a many-to-many relation to %s,\n    '
-                    'but no "copy_relations" method defined.' % (
+                    "%s has a many-to-many relation to %s,\n    "
+                    'but no "copy_relations" method defined.'
+                    % (
                         c_to_s(extension),
                         c_to_s(rel.remote_field.model),
                     )
                 )
             for rel in extension._get_related_objects():
                 if rel.model != extension:
-                    section.warn(f'{c_to_s(extension)} has a foreign key from {c_to_s(rel.model)},\n    but no "copy_relations" method defined.')
+                    section.warn(
+                        f'{c_to_s(extension)} has a foreign key from {c_to_s(rel.model)},\n    but no "copy_relations" method defined.'
+                    )
 
         if not section.warnings:
-            section.finish_success('All plugins and page/page content extensions have "copy_relations" method if needed.')
+            section.finish_success(
+                'All plugins and page/page content extensions have "copy_relations" method if needed.'
+            )
         else:
-            section.finish_success('Some plugins or page/page content extensions do not define a "copy_relations" method.\n'
-                                   'This might lead to data loss when publishing or copying plugins/extensions.\n'
-                                   'See https://django-cms.readthedocs.io/en/latest/extending_cms/custom_plugins.html#handling-relations or '  # noqa
-                                   'https://django-cms.readthedocs.io/en/latest/extending_cms/extending_page_title.html#handling-relations.')  # noqa
+            section.finish_success(
+                'Some plugins or page/page content extensions do not define a "copy_relations" method.\n'
+                "This might lead to data loss when publishing or copying plugins/extensions.\n"
+                "See https://django-cms.readthedocs.io/en/latest/extending_cms/custom_plugins.html#handling-relations or "  # noqa
+                "https://django-cms.readthedocs.io/en/latest/extending_cms/extending_page_title.html#handling-relations."
+            )
 
 
 @define_check
@@ -360,26 +387,58 @@ def check_template_conf(output):
                     if not isinstance(placeholder, (list, tuple)):
                         section.error("CMS_PLACEHOLDERS setting contains a non-list/tuple entry")
                     elif not isinstance(placeholder[0], str):
-                        section.error(f"CMS_PLACEHOLDERS contains an entry with a non-string identifier: "
-                                      f"{placeholder[0]}")
+                        section.error(
+                            f"CMS_PLACEHOLDERS contains an entry with a non-string identifier: {placeholder[0]}"
+                        )
                     else:
                         section.success("CMS_PLACEHOLDERS setting entry found - CMS will run in headless mode")
             else:
                 section.error("CMS_PLACEHOLDERS setting is not a list or tuple")
         else:
-            section.warn("Both CMS_TEMPLATES and CMS_PLACEHOLDERS settings are missing. "
-                         "Will run in headless mode with one placeholder called \"content\"")
+            section.warn(
+                "Both CMS_TEMPLATES and CMS_PLACEHOLDERS settings are missing. "
+                'Will run in headless mode with one placeholder called "content"'
+            )
 
 
 @define_check
 def check_cmsapps_names(output):
     from cms.apphook_pool import apphook_pool
+
     with output.section("Apphooks") as section:
         for hook, name in apphook_pool.get_apphooks():
             if apphook_pool.get_apphook(hook).name is None:
                 section.warn("CMSApps should define a name. %s doesn't have a name" % name)
         if section.successful:
             section.finish_success("CMSApps configuration is okay")
+
+
+@define_check
+def check_plugin_parent_child_relations(output):
+    from cms.plugin_pool import plugin_pool
+
+    with output.section("Plugin parent/child relations") as section:
+        plugin_pool.discover_plugins()
+        for plugin in plugin_pool.plugins.values():
+            # Check parent_classes
+            if hasattr(plugin, "parent_classes") and plugin.parent_classes:
+                for parent_class in plugin.parent_classes:
+                    if parent_class not in ("0", "") and parent_class not in plugin_pool.plugins:
+                        section.warn(f"Parent plugin class '{parent_class}' not found for plugin '{plugin.__name__}'")
+
+            # Check child_classes
+            if hasattr(plugin, "child_classes") and plugin.child_classes:
+                for child_class in plugin.child_classes:
+                    if child_class not in plugin_pool.plugins:
+                        section.warn(f"Child plugin class '{child_class}' not found for plugin '{plugin.__name__}'")
+
+        if section.successful:
+            section.finish_success("Plugin parent/child relations are valid")
+        else:
+            section.finish_warning(
+                "Some plugins have invalid parent/child class configurations.\n"
+                "This might cause unexpected behavior in the admin interface."
+            )
 
 
 def check(output):
@@ -391,29 +450,31 @@ def check(output):
     Returns whether the configuration/environment are okay (has no errors)
     """
     import cms
+
     title = f"Checking django CMS {cms.__version__} installation"
-    border = '*' * len(title)
-    output.write_line(output.colorize(border, opts=['bold']))
-    output.write_line(output.colorize(title, opts=['bold']))
-    output.write_line(output.colorize(border, opts=['bold']))
+    border = "*" * len(title)
+    output.write_line(output.colorize(border, opts=["bold"]))
+    output.write_line(output.colorize(title, opts=["bold"]))
+    output.write_line(output.colorize(border, opts=["bold"]))
     output.write_line()
     for checker in CHECKERS:
         checker(output)
     output.write_line()
     with output.section("OVERALL RESULTS"):
         if output.errors:
-            output.write_stderr_line(output.colorize("%s errors!" % output.errors, opts=['bold'], fg='red'))
+            output.write_stderr_line(output.colorize("%s errors!" % output.errors, opts=["bold"], fg="red"))
         if output.warnings:
-            output.write_stderr_line(output.colorize("%s warnings!" % output.warnings, opts=['bold'], fg='yellow'))
+            output.write_stderr_line(output.colorize("%s warnings!" % output.warnings, opts=["bold"], fg="yellow"))
         if output.skips:
-            output.write_line(output.colorize("%s checks skipped!" % output.skips, opts=['bold'], fg='blue'))
-        output.write_line(output.colorize("%s checks successful!" % output.successes, opts=['bold'], fg='green'))
+            output.write_line(output.colorize("%s checks skipped!" % output.skips, opts=["bold"], fg="blue"))
+        output.write_line(output.colorize("%s checks successful!" % output.successes, opts=["bold"], fg="green"))
         output.write_line()
         if output.errors:
-            output.write_stderr_line(output.colorize('Please check the errors above', opts=['bold'], fg='red'))
+            output.write_stderr_line(output.colorize("Please check the errors above", opts=["bold"], fg="red"))
         elif output.warnings:
-            output.write_stderr_line(output.colorize('Installation okay, but please check warnings above',
-                                                     opts=['bold'], fg='yellow'))
+            output.write_stderr_line(
+                output.colorize("Installation okay, but please check warnings above", opts=["bold"], fg="yellow")
+            )
         else:
-            output.write_line(output.colorize('Installation okay', opts=['bold'], fg='green'))
+            output.write_line(output.colorize("Installation okay", opts=["bold"], fg="green"))
     return output.successful


### PR DESCRIPTION
## Description

When defining incorrect parent or child classes, raise a warning to avoid side effects. Closes #6849 
I have added a check in the `validate_templates` method, which gets triggered when the cms app is ready in the `setup` method. We need to validate parent/child relationships after all plugins are discovered but before they're used.

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``main``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Validate parent and child plugin classes during setup to prevent incorrect configurations and potential side effects. Refactor test cases for consistency and readability, and add tests to ensure proper validation of plugin class relationships.

Bug Fixes:
- Add validation for parent and child plugin classes during setup to prevent incorrect configurations and potential side effects.

Enhancements:
- Refactor test cases to use consistent string formatting and improve readability.

Tests:
- Add tests to validate the presence of parent and child plugin classes, ensuring that non-existent classes raise an ImproperlyConfigured exception.