### PR TITLE
fix: Remove need for timeout to close modal

### DIFF
--- a/cms/static/cms/js/admin.base.js
+++ b/cms/static/cms/js/admin.base.js
@@ -18,20 +18,3 @@ const CMS = {
 // in case some data is already attached to the global CMS
 // we must not override it
 window.CMS = CMS.$.extend(window.CMS || {}, CMS);
-
-// Serve the data bridge:
-// We have a special case here cause the CMS namespace
-// can be either inside the current window or the parent
-if (document.querySelector('body.cms-close-frame script#data-bridge')) {
-    (function (Window) {
-        // the dataBridge is used to access plugin information from different resources
-        // Do NOT move this!!!
-        Window.CMS.API.Helpers.dataBridge = JSON.parse(document.getElementById('data-bridge').textContent);
-        // make sure we're doing after the "modal" mechanism kicked in
-        setTimeout(function () {
-            // save current plugin
-            Window.CMS.API.Helpers.onPluginSave();
-        }, 100); // eslint-disable-line no-magic-numbers
-    })(window.parent || window);
-}
-

--- a/cms/static/cms/js/modules/cms.modal.js
+++ b/cms/static/cms/js/modules/cms.modal.js
@@ -1019,22 +1019,19 @@ class Modal {
                         true
                     );
                 } else {
-                    setTimeout(function() {
-                        if (that.justDeleted && (that.justDeletedPlugin || that.justDeletedPlaceholder)) {
-                            CMS.API.StructureBoard.invalidateState(
-                                that.justDeletedPlaceholder ? 'CLEAR_PLACEHOLDER' : 'DELETE',
-                                {
-                                    plugin_id: that.justDeletedPlugin,
-                                    placeholder_id: that.justDeletedPlaceholder,
-                                    deleted: true
-                                }
-                            );
-                        }
+                    // Serve the data bridge:
+                    // We have a special case here cause the CMS namespace
+                    // can be either inside the current window or the parent
+                    const dataBridge = body[0].querySelector('script#data-bridge');
+                    if (dataBridge) {
                         // hello ckeditor
                         Helpers.removeEventListener('modal-close.text-plugin');
                         that.close();
-                    // must be more than 100ms
-                    }, 150); // eslint-disable-line
+                        // the dataBridge is used to access plugin information from different resources
+                        // Do NOT move this!!!
+                        CMS.API.Helpers.dataBridge = JSON.parse(dataBridge.textContent);
+                        CMS.API.Helpers.onPluginSave();
+                    }
                 }
             } else {
                 if (that.ui.modal.hasClass('cms-modal-open')) {

--- a/cms/templates/admin/cms/page/close_frame.html
+++ b/cms/templates/admin/cms/page/close_frame.html
@@ -5,10 +5,7 @@
         <div class="messagelist">
             <div class="success"></div>
         </div>
-        {% if data_bridge %}
-            {{ data_bridge|json_script:"data-bridge" }}
-            <script src="{% static_with_version "cms/js/dist/bundle.admin.base.min.js" %}" type="text/javascript"></script>
-        {% endif %}
+        {% if data_bridge %}{{ data_bridge|json_script:"data-bridge" }}{% endif %}
     </body>
 </html>
 {% endspaceless %}


### PR DESCRIPTION
## Description

This PR takes 100 to 150ms out of the closing time of the modal by eliminating the need for a timeout.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
