### PR TITLE
fix: Plugin tree update incomplete after move plugin action

### DIFF
--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -144,7 +144,7 @@ class BaseEditableAdminMixin:
             return TemplateResponse(request, 'admin/cms/page/plugin/confirm_form.html', context)
         if not cancel_clicked and request.method == 'POST' and saved_successfully and isinstance(admin_obj, CMSPluginBase):
             # Update the structure board by populating the data bridge
-            return admin_obj.render_close_frame(request, obj, add=False)
+            return admin_obj.render_close_frame(request, obj, action="change")
         return TemplateResponse(request, 'admin/cms/page/plugin/change_form.html', context)
 
 

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -802,13 +802,13 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
             root = (new_plugin.parent or new_plugin)
             new_plugins = [root] + list(root.get_descendants())
         data = get_plugin_tree(request, new_plugins, target_plugin=new_plugins[0])
-        if old_parent and old_parent not in new_plugins:
+        if old_parent and old_parent not in new_plugins and "content" in data:
             # Update previous parent and its children
             old_parent_plugins = list(downcast_plugins([old_parent] + list(old_parent.get_descendants()), select_placeholder=True))
             create_child_plugin_references(old_parent_plugins)
             data["content"] += get_plugin_content(request, old_parent_plugins[0])
         # Pass the target_position
-        if len(data["content"]) > 0:
+        if "content" in data and len(data["content"]) > 0:
             data["content"][0]["insert"] = new_plugins[0].pk == plugin.pk  # Insert the content (old_parent is always only updated)
             if move_to_clipboard:
                 data["content"].pop(0)

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -36,7 +36,7 @@ from cms.models.pluginmodel import CMSPlugin
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 from cms.signals import post_placeholder_operation, pre_placeholder_operation
-from cms.toolbar.utils import get_plugin_content, get_plugin_tree
+from cms.toolbar.utils import create_child_plugin_references, get_plugin_content, get_plugin_tree
 from cms.utils import get_current_site
 from cms.utils.compat.warnings import RemovedInDjangoCMS51Warning
 from cms.utils.conf import get_cms_setting
@@ -804,8 +804,9 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
         data = get_plugin_tree(request, new_plugins, target_plugin=new_plugins[0])
         if old_parent and old_parent not in new_plugins:
             # Update previous parent and its children
-            old_parent_plugins = downcast_plugins([old_parent] + list(old_parent.get_descendants()), select_placeholder=True)
-            data["content"] += get_plugin_content(request, next(old_parent_plugins, None))
+            old_parent_plugins = list(downcast_plugins([old_parent] + list(old_parent.get_descendants()), select_placeholder=True))
+            create_child_plugin_references(old_parent_plugins)
+            data["content"] += get_plugin_content(request, old_parent_plugins[0])
         # Pass the target_position
         if len(data["content"]) > 0:
             data["content"][0]["insert"] = new_plugins[0].pk == plugin.pk  # Insert the content (old_parent is always only updated)

--- a/cms/toolbar/utils.py
+++ b/cms/toolbar/utils.py
@@ -77,6 +77,7 @@ def get_plugin_tree_as_json(request: HttpRequest, plugins: list[CMSPlugin]) -> s
 
 
 def create_child_plugin_references(plugins: list[CMSPlugin]) -> deque[CMSPlugin]:
+    """Creates the ``child_plugin_instances`` attribute on each plugin instance after downcasting."""
     plugin_children = defaultdict(deque)
     root_plugins = deque()
 

--- a/cms/toolbar/utils.py
+++ b/cms/toolbar/utils.py
@@ -76,6 +76,22 @@ def get_plugin_tree_as_json(request: HttpRequest, plugins: list[CMSPlugin]) -> s
     return json.dumps(get_plugin_tree(request, plugins)[0])
 
 
+def create_child_plugin_references(plugins: list[CMSPlugin]) -> deque[CMSPlugin]:
+    plugin_children = defaultdict(deque)
+    root_plugins = deque()
+
+    plugin_ids = frozenset(plugin.pk for plugin in plugins)
+
+    for plugin in reversed(plugins):
+        plugin.child_plugin_instances = plugin_children[plugin.pk]
+
+        if plugin.parent_id in plugin_ids:
+            plugin_children[plugin.parent_id].appendleft(plugin)
+        else:
+            root_plugins.appendleft(plugin)
+    return root_plugins
+
+
 def get_plugin_tree(
     request: HttpRequest,
     plugins: list[CMSPlugin],
@@ -105,23 +121,13 @@ def get_plugin_tree(
     tree_data = []
     tree_structure = []
     restrictions = restrictions or {}
-    root_plugins = deque()
-    plugin_children = defaultdict(deque)
     toolbar = get_toolbar_from_request(request)
     template = toolbar.templates.drag_item_template
     get_plugin_info = get_plugin_toolbar_info
     placeholder = plugins[0].placeholder
     copy_to_clipboard = placeholder.pk == toolbar.clipboard.pk
     plugins = list(downcast_plugins(plugins, select_placeholder=True))
-    plugin_ids = frozenset(plugin.pk for plugin in plugins)
-
-    for plugin in reversed(plugins):
-        plugin.child_plugin_instances = plugin_children[plugin.pk]
-
-        if plugin.parent_id in plugin_ids:
-            plugin_children[plugin.parent_id].appendleft(plugin)
-        else:
-            root_plugins.appendleft(plugin)
+    root_plugins = create_child_plugin_references(plugins)
 
     def collect_plugin_data(plugin):
         child_classes, parent_classes = get_plugin_restrictions(

--- a/cms/views.py
+++ b/cms/views.py
@@ -297,7 +297,7 @@ def render_object_endpoint(request, content_type_id, object_id, require_editable
             content_type_obj = model.admin_manager.select_related("page").get(pk=object_id)
             request.current_page = content_type_obj.page
             if (
-                content_type_obj.page.application_urls and  # noqa: W504
+                content_type_obj.page.application_urls and
                 content_type_obj.page.application_urls in dict(apphook_pool.get_apphooks())
             ):
                 try:


### PR DESCRIPTION
## Description

After moving a plugin to another branch of the plugin tree not all children of the source position were redrawn.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Fixes an issue where moving a plugin to another branch in the plugin tree did not fully redraw all children of the source position. It also updates the old parent and its children after a plugin move.

Bug Fixes:
- Fixes an issue where not all children of the source position were redrawn after moving a plugin to another branch of the plugin tree.
- Updates the old parent and its children after a plugin move to ensure the plugin tree is correctly updated.