### PR TITLE
fix: Browser reloaded when clearing placeholder

### DIFF
--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -251,12 +251,11 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
             pat(r'^copy-plugins/$', self.copy_plugins),
             pat(r'^add-plugin/$', self.add_plugin),
             pat(r'^edit-plugin/([0-9]+)/$', self.edit_plugin),
-            pat(r'^edit-plugin/([0-9]+)/([a-z\-]+)/$', self.edit_field),
+            pat(r'^edit-field/([0-9]+)/([a-z\-]+)/$', self.edit_field),
             pat(r'^delete-plugin/([0-9]+)/$', self.delete_plugin),
             pat(r'^clear-placeholder/([0-9]+)/$', self.clear_placeholder),
             pat(r'^move-plugin/$', self.move_plugin),
             # Register object edit/structure/preview endpoints.
-            # pat(r'^object/(?P<content_type_id>\d+)/structure/(?P<object_id>.+)$', render_object_structure),
             pat(r'^object/([0-9]+)/edit/([0-9]+)/$', render_object_edit),
             pat(r'^object/([0-9]+)/structure/([0-9]+)/$', render_object_structure),
             pat(r'^object/([0-9]+)/preview/([0-9]+)/$', render_object_preview),

--- a/cms/middleware/toolbar.py
+++ b/cms/middleware/toolbar.py
@@ -26,6 +26,7 @@ cms_endpoints = (
     'cms_placeholder_render_object_edit',
     'cms_placeholder_render_object_preview',
     'cms_placeholder_render_object_structure',
+    'cms_placeholder_edit_field',
 )
 
 

--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -220,7 +220,7 @@ class BaseRenderer:
 class ContentRenderer(BaseRenderer):
     plugin_edit_template = (
         '<template class="cms-plugin '
-        'cms-plugin-start cms-plugin-{pk}" data-cms-placeholder="{placeholder}" data-cms-position="{position}"></template>{content}'
+        'cms-plugin-start cms-plugin-{pk}" data-cms-placeholder="{placeholder}"></template>{content}'
         '<template class="cms-plugin cms-plugin-end cms-plugin-{pk}"></template>'
     )
     placeholder_edit_template = (

--- a/cms/static/cms/js/modules/cms.base.js
+++ b/cms/static/cms/js/modules/cms.base.js
@@ -117,8 +117,8 @@ export const Helpers = {
      * @public
      */
     onPluginSave: function() {
-        const data = this.dataBridge;
-        const action = data && data.plugin_id ? (data.action || 'ADD').toUpperCase() : '';
+        const data = this.dataBridge || { action: '' };
+        const action = (data.action || (data.plugin_id ? 'ADD' : '')).toUpperCase() ;
 
         switch (action) {
             case 'CHANGE':

--- a/cms/static/cms/js/modules/cms.base.js
+++ b/cms/static/cms/js/modules/cms.base.js
@@ -123,14 +123,12 @@ export const Helpers = {
         switch (action) {
             case 'CHANGE':
             case 'EDIT':
-                if (window.CMS._instances.some(plugin =>
-                    Number(plugin.options.plugin_id) === Number(data.plugin_id) &&
-                    plugin.options.type === 'plugin')
-                ) {
+                if (this._pluginExists(data.plugin_id)) {
                     CMS.API.StructureBoard.invalidateState('EDIT', data);
-                    return;
+                } else {
+                    CMS.API.StructureBoard.invalidateState('ADD', data);
                 }
-                break;
+                return;
             case 'ADD':
             case 'DELETE':
             case 'CLEAR_PLACEHOLDER':

--- a/cms/static/cms/js/modules/cms.base.js
+++ b/cms/static/cms/js/modules/cms.base.js
@@ -117,8 +117,12 @@ export const Helpers = {
      * @public
      */
     onPluginSave: function() {
-        const data = this.dataBridge || { action: '' };
-        const action = (data.action || (data.plugin_id ? 'ADD' : '')).toUpperCase() ;
+        const data = this.dataBridge || {};
+        let action = data.action?.toUpperCase();
+
+        if (data.plugin_id && !action) {
+            action = 'ADD';
+        }
 
         switch (action) {
             case 'CHANGE':

--- a/cms/static/cms/js/modules/cms.base.js
+++ b/cms/static/cms/js/modules/cms.base.js
@@ -144,6 +144,20 @@ export const Helpers = {
         }
     },
 
+    /*
+     * Check if a plugin object existst for the given plugin id
+     *
+     * @method _pluginExists
+     * @private
+     * @param {String} pluginId
+     * @returns {Boolean}
+     */
+    _pluginExists: function(pluginId) {
+        return window.CMS._instances.some(function(plugin) {
+            return Number(plugin.options.plugin_id) === Number(pluginId) && plugin.options.type === 'plugin';
+        });
+    },
+
     /**
      * Assigns an event handler to forms located in the toolbar
      * to prevent multiple submissions.

--- a/cms/static/cms/js/modules/cms.base.js
+++ b/cms/static/cms/js/modules/cms.base.js
@@ -118,11 +118,7 @@ export const Helpers = {
      */
     onPluginSave: function() {
         const data = this.dataBridge || {};
-        let action = data.action?.toUpperCase();
-
-        if (data.plugin_id && !action) {
-            action = 'ADD';
-        }
+        const action = data.action ? data.action.toUpperCase() : null;
 
         switch (action) {
             case 'CHANGE':

--- a/cms/static/cms/js/modules/cms.plugins.js
+++ b/cms/static/cms/js/modules/cms.plugins.js
@@ -189,17 +189,16 @@ var Plugin = new Class({
      * @returns {jQuery}
      * @example
      * // Given the following HTML:
-     * <template class="cms-plugin cms-plugin-4711 cms-plugin-start" data-cms-position="1"></template>
+     * <template class="cms-plugin cms-plugin-4711 cms-plugin-start"></template>
      * <p>Some text</p>
-     * <template class="cms-plugin cms-plugin-4711 cms-plugin-end" data-cms-position="1"></template>
+     * <template class="cms-plugin cms-plugin-4711 cms-plugin-end"></template>
      *
      * // The following jQuery collection will be returned:
-     * $('<p class="cms-plugin cms-plugin-4711 cms-plugin-start cms-plugin-end" data-cms-position="1">Some text</p>')
+     * $('<p class="cms-plugin cms-plugin-4711 cms-plugin-start cms-plugin-end">Some text</p>')
      */
     _processTemplateGroup: function (items, container) {
         const templateStart = $(items[0]);
         const className = templateStart.attr('class').replace('cms-plugin-start', '');
-        const position = templateStart.attr('data-cms-position');
         let itemContents = $(nextUntil(templateStart[0], container));
 
         itemContents.each((index, el) => {
@@ -216,8 +215,6 @@ var Plugin = new Class({
         });
 
         itemContents.addClass(`cms-plugin ${className}`);
-        itemContents.first().addClass('cms-plugin-start').attr('data-cms-position', position);
-        itemContents.last().addClass('cms-plugin-end').attr('data-cms-position', position);
 
         return itemContents;
     },

--- a/cms/static/cms/js/modules/cms.plugins.js
+++ b/cms/static/cms/js/modules/cms.plugins.js
@@ -215,6 +215,8 @@ var Plugin = new Class({
         });
 
         itemContents.addClass(`cms-plugin ${className}`);
+        itemContents.first().addClass('cms-plugin-start');
+        itemContents.last().addClass('cms-plugin-end');
 
         return itemContents;
     },

--- a/cms/static/cms/js/modules/cms.structureboard.js
+++ b/cms/static/cms/js/modules/cms.structureboard.js
@@ -1716,7 +1716,7 @@ class StructureBoard {
         setTimeout(() => {
             Helpers._getWindow().document.dispatchEvent(new Event('DOMContentLoaded'));
             Helpers._getWindow().dispatchEvent(new Event('load'));
-            $(Helpers._getWindow()).trigger('cms-content-refresh');
+            Helpers._getWindow().dispatchEvent(new Event('cms-content-refresh'));
         }, 0);
     }
 

--- a/cms/tests/frontend/unit/cms.base.test.js
+++ b/cms/tests/frontend/unit/cms.base.test.js
@@ -52,7 +52,7 @@ describe('cms.base.js', function() {
         it('exists', function() {
             expect(CMS.API.Helpers).toEqual(jasmine.any(Object));
             // this expectation is here so no one ever forgets to add a test
-            expect(Object.keys(CMS.API.Helpers).length).toEqual(26);
+            expect(Object.keys(CMS.API.Helpers).length).toEqual(27);
         });
 
         describe('.reloadBrowser()', function() {
@@ -164,9 +164,11 @@ describe('cms.base.js', function() {
             it('invalidates state if the plugin was added', () => {
                 CMS._instances = [{ options: { plugin_id: 1, type: 'generic' } }];
 
-                CMS.API.Helpers.dataBridge = { plugin_id: '1' };
+                // FrontendEditableMixin issues "change" action, databridge processes it as an
+                // add action
+                CMS.API.Helpers.dataBridge = { plugin_id: '1', action: 'change' };
                 CMS.API.Helpers.onPluginSave();
-                expect(CMS.API.StructureBoard.invalidateState).toHaveBeenCalledWith('ADD', { plugin_id: '1' });
+                expect(CMS.API.StructureBoard.invalidateState).toHaveBeenCalledWith('ADD', { plugin_id: '1', action: 'change' });
             });
 
             it('proxies to reloadBrowser', function() {

--- a/cms/tests/frontend/unit/cms.base.test.js
+++ b/cms/tests/frontend/unit/cms.base.test.js
@@ -168,7 +168,9 @@ describe('cms.base.js', function() {
                 // add action
                 CMS.API.Helpers.dataBridge = { plugin_id: '1', action: 'change' };
                 CMS.API.Helpers.onPluginSave();
-                expect(CMS.API.StructureBoard.invalidateState).toHaveBeenCalledWith('ADD', { plugin_id: '1', action: 'change' });
+                expect(CMS.API.StructureBoard.invalidateState).toHaveBeenCalledWith(
+                    'ADD', { plugin_id: '1', action: 'change' }
+                );
             });
 
             it('proxies to reloadBrowser', function() {

--- a/cms/tests/frontend/unit/cms.plugins.test.js
+++ b/cms/tests/frontend/unit/cms.plugins.test.js
@@ -373,8 +373,8 @@ describe('CMS.Plugin', function() {
                         '<cms-plugin class="cms-plugin-text-node cms-plugin cms-plugin-101 cms-plugin-start">\n' +
                         '        text </cms-plugin>',
                         '<div class="plugin101 cms-plugin cms-plugin-101">element</div>',
-                        '<cms-plugin class="cms-plugin-text-node cms-plugin cms-plugin-101 cms-plugin-end"> another text\n' +
-                        '    </cms-plugin>'
+                        '<cms-plugin class="cms-plugin-text-node cms-plugin cms-plugin-101 cms-plugin-end">' +
+                        ' another text\n    </cms-plugin>'
                     ]
                 },
                 {
@@ -382,8 +382,8 @@ describe('CMS.Plugin', function() {
                     name: 'element + textnode',
                     expected: [
                         '<div class="plugin102 cms-plugin cms-plugin-102 cms-plugin-start">element</div>',
-                        '<cms-plugin class="cms-plugin-text-node cms-plugin cms-plugin-102 cms-plugin-end"> and text\n' +
-                        '    </cms-plugin>'
+                        '<cms-plugin class="cms-plugin-text-node cms-plugin cms-plugin-102 cms-plugin-end">' +
+                        ' and text\n    </cms-plugin>'
                     ]
                 },
                 {

--- a/cms/tests/frontend/unit/cms.plugins.test.js
+++ b/cms/tests/frontend/unit/cms.plugins.test.js
@@ -351,9 +351,9 @@ describe('CMS.Plugin', function() {
                     pluginId: 99,
                     name: 'element + element',
                     expected: [
-                        '<div class="plugin99-1 cms-plugin cms-plugin-99 cms-plugin-start" data-cms-position="42">' +
+                        '<div class="plugin99-1 cms-plugin cms-plugin-99 cms-plugin-start">' +
                         'element</div>',
-                        '<div class="plugin99-2 cms-plugin cms-plugin-99 cms-plugin-end" data-cms-position="42">' +
+                        '<div class="plugin99-2 cms-plugin cms-plugin-99 cms-plugin-end">' +
                         'and another element</div>'
                     ]
                 },
@@ -361,23 +361,19 @@ describe('CMS.Plugin', function() {
                     pluginId: 100,
                     name: 'textnode + element',
                     expected: [
-                        '<cms-plugin class="cms-plugin-text-node cms-plugin cms-plugin-100 cms-plugin-start" ' +
-                        'data-cms-position="42">\n' +
+                        '<cms-plugin class="cms-plugin-text-node cms-plugin cms-plugin-100 cms-plugin-start">\n' +
                         '        text </cms-plugin>',
-                        '<div class="plugin100 cms-plugin cms-plugin-100 cms-plugin-end"' +
-                        ' data-cms-position="42"> and element</div>'
+                        '<div class="plugin100 cms-plugin cms-plugin-100 cms-plugin-end"> and element</div>'
                     ]
                 },
                 {
                     pluginId: 101,
                     name: 'textnode + element + textnode',
                     expected: [
-                        '<cms-plugin class="cms-plugin-text-node cms-plugin cms-plugin-101 cms-plugin-start" ' +
-                        'data-cms-position="42">\n' +
+                        '<cms-plugin class="cms-plugin-text-node cms-plugin cms-plugin-101 cms-plugin-start">\n' +
                         '        text </cms-plugin>',
                         '<div class="plugin101 cms-plugin cms-plugin-101">element</div>',
-                        '<cms-plugin class="cms-plugin-text-node cms-plugin cms-plugin-101 cms-plugin-end" ' +
-                        'data-cms-position="42"> another text\n' +
+                        '<cms-plugin class="cms-plugin-text-node cms-plugin cms-plugin-101 cms-plugin-end"> another text\n' +
                         '    </cms-plugin>'
                     ]
                 },
@@ -385,10 +381,8 @@ describe('CMS.Plugin', function() {
                     pluginId: 102,
                     name: 'element + textnode',
                     expected: [
-                        '<div class="plugin102 cms-plugin cms-plugin-102 cms-plugin-start" ' +
-                        'data-cms-position="42">element</div>',
-                        '<cms-plugin class="cms-plugin-text-node cms-plugin cms-plugin-102 cms-plugin-end" ' +
-                        'data-cms-position="42"> and text\n' +
+                        '<div class="plugin102 cms-plugin cms-plugin-102 cms-plugin-start">element</div>',
+                        '<cms-plugin class="cms-plugin-text-node cms-plugin cms-plugin-102 cms-plugin-end"> and text\n' +
                         '    </cms-plugin>'
                     ]
                 },
@@ -397,7 +391,7 @@ describe('CMS.Plugin', function() {
                     name: 'textnode',
                     expected: [
                         '<cms-plugin class="cms-plugin-text-node cms-plugin cms-plugin-103 ' +
-                        'cms-plugin-start cms-plugin-end" data-cms-position="42">\n' +
+                        'cms-plugin-start cms-plugin-end">\n' +
                          '        only text node\n    </cms-plugin>'
                     ]
                 },
@@ -406,7 +400,7 @@ describe('CMS.Plugin', function() {
                     name: 'textnode + comment',
                     expected: [
                         '<cms-plugin class="cms-plugin-text-node cms-plugin cms-plugin-104 ' +
-                        'cms-plugin-start cms-plugin-end" data-cms-position="42">\n' +
+                        'cms-plugin-start cms-plugin-end">\n' +
                          '        text node </cms-plugin>'
                     ]
                 },
@@ -415,7 +409,7 @@ describe('CMS.Plugin', function() {
                     name: 'comment + textnode',
                     expected: [
                         '<cms-plugin class="cms-plugin-text-node cms-plugin cms-plugin-105 ' +
-                        'cms-plugin-start cms-plugin-end" data-cms-position="42">' +
+                        'cms-plugin-start cms-plugin-end">' +
                          ' and a text node\n' +
                          '    </cms-plugin>'
                     ]
@@ -424,11 +418,9 @@ describe('CMS.Plugin', function() {
                     pluginId: 106,
                     name: 'textnode + comment + textnode',
                     expected: [
-                        '<cms-plugin class="cms-plugin-text-node cms-plugin cms-plugin-106 cms-plugin-start" ' +
-                        'data-cms-position="42">\n' +
+                        '<cms-plugin class="cms-plugin-text-node cms-plugin cms-plugin-106 cms-plugin-start">\n' +
                         '        text node </cms-plugin>',
-                        '<cms-plugin class="cms-plugin-text-node cms-plugin cms-plugin-106 cms-plugin-end" ' +
-                        'data-cms-position="42">' +
+                        '<cms-plugin class="cms-plugin-text-node cms-plugin cms-plugin-106 cms-plugin-end">' +
                         ' and a text node\n' +
                         '    </cms-plugin>'
                     ]
@@ -438,7 +430,7 @@ describe('CMS.Plugin', function() {
                     name: 'whitespace textnode + comment + textnode',
                     expected: [
                         '<cms-plugin class="cms-plugin-text-node cms-plugin cms-plugin-107 ' +
-                            'cms-plugin-start cms-plugin-end" data-cms-position="42">' +
+                            'cms-plugin-start cms-plugin-end">' +
                             ' and a text node\n' +
                             '    </cms-plugin>'
                     ]

--- a/cms/tests/frontend/unit/fixtures/plugins_complex_markup.html
+++ b/cms/tests/frontend/unit/fixtures/plugins_complex_markup.html
@@ -1,46 +1,46 @@
 <div>
-    <template class="cms-plugin cms-plugin-start cms-plugin-99" data-cms-position="42"></template>
+    <template class="cms-plugin cms-plugin-start cms-plugin-99"></template>
         <div class="plugin99-1">element</div>
         <div class="plugin99-2">and another element</div>
     <template class="cms-plugin cms-plugin-end cms-plugin-99"></template>
 
-    <template class="cms-plugin cms-plugin-start cms-plugin-100" data-cms-position="42"></template>
+    <template class="cms-plugin cms-plugin-start cms-plugin-100"></template>
         text <div class="plugin100"> and element</div>
     <template class="cms-plugin cms-plugin-end cms-plugin-100"></template>
 
-    <template class="cms-plugin cms-plugin-start cms-plugin-101" data-cms-position="42"></template>
+    <template class="cms-plugin cms-plugin-start cms-plugin-101"></template>
         text <div class="plugin101">element</div> another text
     <template class="cms-plugin cms-plugin-end cms-plugin-101"></template>
 
-    <template class="cms-plugin cms-plugin-start cms-plugin-102" data-cms-position="42"></template>
+    <template class="cms-plugin cms-plugin-start cms-plugin-102"></template>
         <div class="plugin102">element</div> and text
     <template class="cms-plugin cms-plugin-end cms-plugin-102"></template>
 
-    <template class="cms-plugin cms-plugin-start cms-plugin-103" data-cms-position="42"></template>
+    <template class="cms-plugin cms-plugin-start cms-plugin-103"></template>
         only text node
     <template class="cms-plugin cms-plugin-end cms-plugin-103"></template>
 
-    <template class="cms-plugin cms-plugin-start cms-plugin-104" data-cms-position="42"></template>
+    <template class="cms-plugin cms-plugin-start cms-plugin-104"></template>
         text node <!-- and a comment -->
     <template class="cms-plugin cms-plugin-end cms-plugin-104"></template>
 
-    <template class="cms-plugin cms-plugin-start cms-plugin-105" data-cms-position="42"></template><!-- a comment --> and a text node
+    <template class="cms-plugin cms-plugin-start cms-plugin-105"></template><!-- a comment --> and a text node
     <template class="cms-plugin cms-plugin-end cms-plugin-105"></template>
 
-    <template class="cms-plugin cms-plugin-start cms-plugin-106" data-cms-position="42"></template>
+    <template class="cms-plugin cms-plugin-start cms-plugin-106"></template>
         text node <!-- a comment --> and a text node
     <template class="cms-plugin cms-plugin-end cms-plugin-106"></template>
 
-    <template class="cms-plugin cms-plugin-start cms-plugin-107" data-cms-position="42"></template>
+    <template class="cms-plugin cms-plugin-start cms-plugin-107"></template>
         <!-- a comment --> and a text node
     <template class="cms-plugin cms-plugin-end cms-plugin-107"></template>
 
     <!-- next one is rendered twice -->
-    <template class="cms-plugin cms-plugin-start cms-plugin-108" data-cms-position="42"></template>
+    <template class="cms-plugin cms-plugin-start cms-plugin-108"></template>
         <div class="plugin-108">element</div>
     <template class="cms-plugin cms-plugin-end cms-plugin-108"></template>
 
-    <template class="cms-plugin cms-plugin-start cms-plugin-108" data-cms-position="42"></template>
+    <template class="cms-plugin cms-plugin-start cms-plugin-108"></template>
         <div class="plugin-108">element</div>
-    <template class="cms-plugin cms-plugin-end cms-plugin-108" data-cms-position="42"></template>
+    <template class="cms-plugin cms-plugin-end cms-plugin-108"></template>
 </div>

--- a/cms/tests/test_rendering.py
+++ b/cms/tests/test_rendering.py
@@ -793,8 +793,7 @@ class RenderingTestCase(CMSTestCase):
                 placeholder=placeholder,
                 editable=True,
             )
-            tag_format = ('<template class="cms-plugin cms-plugin-start cms-plugin-{}" data-cms-placeholder="{}" '
-                          'data-cms-position="{}">')
+            tag_format = ('<template class="cms-plugin cms-plugin-start cms-plugin-{}" data-cms-placeholder="{}">')
 
         for plugin in plugins:
             start_tag = tag_format.format(plugin.pk, plugin.placeholder_id, plugin.position)

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -510,8 +510,7 @@ class NoFixtureDatabaseTemplateTagTests(CMSTestCase):
         request.toolbar.show_toolbar = True
         output = self.render_template_obj(template, {'plugin': plugin}, request)
         expected = (
-            '<template class="cms-plugin cms-plugin-start cms-plugin-{0}" data-cms-placeholder="{2}" '
-            'data-cms-position="{1}"></template>'
+            '<template class="cms-plugin cms-plugin-start cms-plugin-{0}" data-cms-placeholder="{2}"></template>'
             '<b>Test</b>'
             '<template class="cms-plugin cms-plugin-end cms-plugin-{0}"></template>'
         )
@@ -552,7 +551,7 @@ class NoFixtureDatabaseTemplateTagTests(CMSTestCase):
         self.assertEqual(
             output,
             f'<template class="cms-plugin cms-plugin-start cms-plugin-{plugin.pk}" '
-            f'data-cms-placeholder="{plugin.placeholder_id}" data-cms-position="{plugin.position}"></template>'
+            f'data-cms-placeholder="{plugin.placeholder_id}"></template>'
             f'Test<template class="cms-plugin cms-plugin-end cms-plugin-{plugin.pk}"></template>'
         )
 

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -1253,7 +1253,7 @@ class EditModelTemplateTagTest(ToolbarTestBase):
         self.assertContains(
             response,
             f'<h1><template class="cms-plugin cms-plugin-start cms-plugin-{plugin.pk}" '
-            f'data-cms-placeholder="{plugin.placeholder_id}" data-cms-position="{plugin.position}"></template>'
+            f'data-cms-placeholder="{plugin.placeholder_id}"></template>'
             f'{render_placeholder_body}'
             f'<template class="cms-plugin cms-plugin-end cms-plugin-{plugin.pk}"></template>'
         )

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -155,6 +155,12 @@ class ToolbarMiddlewareTest(ToolbarTestBase):
         mid(request)
         self.assertTrue(hasattr(request, 'toolbar'))
 
+        # edit-field endpoint
+        request = self.get_request(admin_reverse('cms_placeholder_edit_field', args=(content.pk, 'en')))
+        mid = ToolbarMiddleware(lambda req: HttpResponse(""))
+        mid(request)
+        self.assertTrue(hasattr(request, 'toolbar'))
+
     @override_settings(CMS_TOOLBAR_HIDE=True)
     def test_app_setted_provide_toolbar_obj_to_edit_actions(self):
         from cms.middleware.toolbar import ToolbarMiddleware


### PR DESCRIPTION
## Description

* Fixes another issue of #8158
* Removes the unused "data-cms-position" attribute when rendering the edit mode
* Fixes typos

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Remove `data-cms-position` attribute from plugin templates to prevent browser reloads when clearing placeholders

Bug Fixes:
- Fixed an issue causing browser reloads when clearing placeholders by removing the `data-cms-position` attribute from plugin templates

Tests:
- Updated frontend and backend test cases to reflect the removal of `data-cms-position` attribute

## Summary by Sourcery

Remove unnecessary data attributes and improve plugin handling logic to prevent browser reloads when clearing placeholders

Bug Fixes:
- Fix browser reload issue when clearing placeholders by modifying plugin save and rendering logic

Enhancements:
- Refactor plugin rendering to remove redundant data-cms-position attributes
- Improve plugin existence checking logic

Tests:
- Update frontend unit tests to reflect changes in plugin rendering and handling