### PR TITLE
fix: Added back jQuery and $ to the window object for plugin change forms

### DIFF
--- a/cms/static/cms/js/admin.base.js
+++ b/cms/static/cms/js/admin.base.js
@@ -18,3 +18,9 @@ const CMS = {
 // in case some data is already attached to the global CMS
 // we must not override it
 window.CMS = CMS.$.extend(window.CMS || {}, CMS);
+
+// make sure that jQuery is available as $ and jQuery
+if (!window.jQuery) {
+    window.jQuery = CMS.$;
+    window.$ = window.jQuery;
+}

--- a/cms/static/cms/js/admin.base.js
+++ b/cms/static/cms/js/admin.base.js
@@ -21,6 +21,5 @@ window.CMS = CMS.$.extend(window.CMS || {}, CMS);
 
 // make sure that jQuery is available as $ and jQuery
 if (!window.jQuery) {
-    window.jQuery = CMS.$;
-    window.$ = window.jQuery;
+    window.$ = window.jQuery = CMS.$;
 }


### PR DESCRIPTION
## Description

#8109 removed inline scripts effectively eliminating `jQuery` and `$` from the plguin change form window namespace.

This PR restores them. Some 3rd party packages rely on `$` instead of `CMS.$`, e.g. when using the select2 library.


## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Reintroduce jQuery and $ global variables that were previously removed, ensuring compatibility with third-party packages like select2