### PR TITLE
fix: removed deprecated JavaScript in cms.modal.js

### DIFF
--- a/cms/static/cms/js/modules/cms.modal.js
+++ b/cms/static/cms/js/modules/cms.modal.js
@@ -791,7 +791,8 @@ class Modal {
                     } else {
                         // have to dispatch native submit event so all the submit handlers
                         // can be fired, see #5590
-                        var evt = new CustomEvent('submit', {bubbles: false, cancelable: true});
+                        var evt = new CustomEvent('submit', { bubbles: false, cancelable: true });
+
                         if (frm.dispatchEvent(evt)) {
                             // triggering submit event in webkit based browsers won't
                             // actually submit the form, while in Gecko-based ones it

--- a/cms/static/cms/js/modules/cms.modal.js
+++ b/cms/static/cms/js/modules/cms.modal.js
@@ -777,29 +777,27 @@ class Modal {
 
                 if (item.is('input') || item.is('button')) {
                     that.ui.modalBody.addClass('cms-loader');
-                    var frm = item.closest('form');
+                    var frm = item[0].form;
 
                     // In Firefox with 1Password extension installed (FF 45 1password 4.5.6 at least)
                     // the item[0].click() doesn't work, which notably breaks
                     // deletion of the plugin. Workaround is that if the clicked button
                     // is the only button in the form - submit a form, otherwise
                     // click on the button
-                    if (frm.find('button, input[type="button"], input[type="submit"]').length > 1) {
+                    if (frm.querySelectorAll('button, input[type="button"], input[type="submit"]').length > 1) {
                         // we need to use native `.click()` event specifically
                         // as we are inside an iframe and magic is happening
                         item[0].click();
                     } else {
                         // have to dispatch native submit event so all the submit handlers
                         // can be fired, see #5590
-                        var evt = document.createEvent('HTMLEvents');
-
-                        evt.initEvent('submit', false, true);
-                        if (frm[0].dispatchEvent(evt)) {
+                        var evt = new CustomEvent('submit', {bubbles: false, cancelable: true});
+                        if (frm.dispatchEvent(evt)) {
                             // triggering submit event in webkit based browsers won't
                             // actually submit the form, while in Gecko-based ones it
                             // will and calling frm.submit() would throw NS_ERROR_UNEXPECTED
                             try {
-                                frm[0].submit();
+                                frm.submit();
                             } catch (err) {}
                         }
                     }


### PR DESCRIPTION
## Description

This small PR removes a few deprecated JavaScript usages.

It furthermore fixes another issue:
Form field do not necessarily  need to be descendants of a form, they can also be referred using the `form` attribute. It hence is an antipattern to use DOM traversals for this purpose.

* [x] I have opened this pull request against ``develop-4``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Remove deprecated JavaScript and improve form handling in cms.modal.js

Bug Fixes:
- Fix form submission handling by using the native `form` attribute instead of DOM traversal

Enhancements:
- Refactor form submission logic to use modern JavaScript methods and improve form element referencing

Chores:
- Update deprecated JavaScript methods to use more modern approaches