### PR TITLE
fix: Grouper models w/o must not assume language grouper (#8194)

### DIFF
--- a/cms/admin/utils.py
+++ b/cms/admin/utils.py
@@ -23,7 +23,7 @@ from django.utils.translation import get_language, gettext_lazy as _
 from cms.models.managers import ContentAdminManager
 from cms.toolbar.utils import get_object_preview_url
 from cms.utils import get_language_from_request
-from cms.utils.i18n import get_language_dict, get_language_tuple
+from cms.utils.i18n import get_language_dict, get_language_list, get_language_tuple
 from cms.utils.urlutils import admin_reverse, static_with_version
 
 
@@ -771,8 +771,9 @@ class _GrouperAdminFormMixin:
 
     def clean(self) -> dict:
         if (
-            self.cleaned_data.get(CONTENT_PREFIX + "language", None)
-            not in get_language_dict()
+            f"{CONTENT_PREFIX}language" in self.cleaned_data
+            and self.cleaned_data[f"{CONTENT_PREFIX}language"]
+            not in get_language_list()
         ):
             raise ValidationError(
                 _(

--- a/cms/test_utils/project/sampleapp/admin.py
+++ b/cms/test_utils/project/sampleapp/admin.py
@@ -7,6 +7,7 @@ from cms.test_utils.project.sampleapp.models import (
     GrouperModel,
     Picture,
     SampleAppConfig,
+    SimpleGrouperModel,
     SomeEditableModel,
 )
 
@@ -31,7 +32,15 @@ class GrouperAdmin(GrouperModelAdmin):
         return getattr(self, "change_content", True)
 
 
+class SimpleGrouperAdmin(GrouperModelAdmin):
+    list_display = ("category_name", "content__secret_greeting", "admin_list_actions")
+
+    def can_change_content(self, request, content_obj):
+        return getattr(self, "change_content", True)
+
+
 admin.site.register(Category, CategoryAdmin)
 admin.site.register(SampleAppConfig)
 admin.site.register(SomeEditableModel, SomeEditableAdmin)
 admin.site.register(GrouperModel, GrouperAdmin)
+admin.site.register(SimpleGrouperModel, SimpleGrouperAdmin)

--- a/cms/test_utils/project/sampleapp/models.py
+++ b/cms/test_utils/project/sampleapp/models.py
@@ -78,3 +78,48 @@ class GrouperModelContent(models.Model):
     secret_greeting = models.TextField(
         max_length=100,
     )
+
+
+class SimpleGrouperModel(models.Model):
+    category_name = models.CharField(max_length=200, default="")
+
+
+class SimpleGrouperModelContent(models.Model):
+    # grouper field name: snake case of GrouperModel
+    simple_grouper_model = models.ForeignKey(
+        SimpleGrouperModel,
+        on_delete=models.CASCADE,
+    )
+
+    language = models.TextField(
+        default="en",
+        choices=(
+            ("en", "English"),
+            ("de", "German"),
+            ("it", "Italian"),
+        )
+    )
+
+
+
+    region = models.TextField(
+        default="world",
+        max_length=10,
+        choices=(
+            ("world", "World"),
+            ("americas", "Americas"),
+            ("europe", "Europe"),
+            ("africa", "Africa"),
+            ("asia", "Asia"),
+            ("australia", "Australia")
+        )
+    )
+
+    uptodate = models.BooleanField(
+        verbose_name="Yes/No",
+        default=False,
+    )
+
+    secret_greeting = models.TextField(
+        max_length=100,
+    )

--- a/cms/tests/test_grouper_admin.py
+++ b/cms/tests/test_grouper_admin.py
@@ -7,6 +7,8 @@ from cms.admin.utils import CONTENT_PREFIX
 from cms.test_utils.project.sampleapp.models import (
     GrouperModel,
     GrouperModelContent,
+    SimpleGrouperModel,
+    SimpleGrouperModelContent,
 )
 from cms.test_utils.testcases import CMSTestCase
 from cms.test_utils.util.grouper import wo_content_permission
@@ -25,6 +27,8 @@ class SetupMixin:
         self.changelist_url = admin_reverse("sampleapp_groupermodel_changelist")
         self.admin_user = self.get_superuser()
         self.admin = site._registry[GrouperModel]
+        self.groupermodel = "groupermodel"
+        self.grouper_model = "grouper_model"
 
     def tearDown(self) -> None:
         self.grouper_instance.delete()
@@ -42,13 +46,44 @@ class SetupMixin:
         return instance
 
 
-class ChangeListActionsTestCase(SetupMixin, CMSTestCase):
+class SimpleSetupMixin:
+    """Create one grouper object and retrieve the admin instance"""
+    def setUp(self) -> None:
+        self.grouper_instance = SimpleGrouperModel.objects.create(
+            category_name="Grouper Category"
+        )
+        self.add_url = admin_reverse("sampleapp_simplegroupermodel_add")
+        self.change_url = admin_reverse("sampleapp_simplegroupermodel_change", args=(self.grouper_instance.pk,))
+        self.changelist_url = admin_reverse("sampleapp_simplegroupermodel_changelist")
+        self.admin_user = self.get_superuser()
+        self.admin = site._registry[SimpleGrouperModel]
+        self.groupermodel = "simplegroupermodel"
+        self.grouper_model = "simple_grouper_model"
+
+    def tearDown(self) -> None:
+        self.grouper_instance.delete()
+        self.admin.clear_content_cache()  # The admin does this automatically for each new request.
+
+    def createContentInstance(self, language="en"):
+        """Creates a content instance with a random content for a language. The random content is returned
+        to be able to check if it appears in forms etc."""
+
+        assert language == "en", "Only English is supported for SimpleGrouperModelContent"
+        instance = SimpleGrouperModelContent.objects.create(
+            simple_grouper_model=self.grouper_instance,
+            secret_greeting=get_random_string(16),
+        )
+        self.admin.clear_content_cache()  # The admin does this automatically for each new request.
+        return instance
+
+
+class SimpleChangeListActionsTestCase(SimpleSetupMixin, CMSTestCase):
     def test_action_js_css(self):
         """Are js and css files loaded?
         The js and css files are supposed to be arranged by the GrouperAdminMixin."""
         with self.login_user_context(self.admin_user):
             # Act
-            response = self.client.get(self.changelist_url + "?language=en")
+            response = self.client.get(f"{self.changelist_url}?", follow=True)
             # Assert
             self.assertContains(response, static("admin/js/jquery.init.js"))
             self.assertContains(response, static("cms/js/admin/actions.js"))
@@ -59,11 +94,11 @@ class ChangeListActionsTestCase(SetupMixin, CMSTestCase):
         The button is supposed to be arranged by the GrouperAdminMixin."""
         with self.login_user_context(self.admin_user):
             # Act
-            response = self.client.get(self.changelist_url + "?language=en")
+            response = self.client.get(f"{self.changelist_url}?language=en", follow=True)
             # Assert
             self.assertContains(response, 'class="cms-icon cms-icon-plus"')
-            self.assertContains(response, f'href="/en/admin/sampleapp/groupermodel/{self.grouper_instance.pk}'
-                                          f'/change/?language=en"')
+            self.assertContains(response, f'href="/en/admin/sampleapp/{self.groupermodel}/{self.grouper_instance.pk}'
+                                          f'/change/?')
             self.assertNotContains(response, 'class="cms-icon cms-icon-view"')
 
     def test_change_action(self):
@@ -72,11 +107,11 @@ class ChangeListActionsTestCase(SetupMixin, CMSTestCase):
         self.createContentInstance("en")
         with self.login_user_context(self.admin_user):
             # Act
-            response = self.client.get(self.changelist_url + "?language=en")
+            response = self.client.get(f"{self.changelist_url}?language=en", follow=True)
             # Assert
             self.assertContains(response, 'class="cms-icon cms-icon-view"')
-            self.assertContains(response, f'href="/en/admin/sampleapp/groupermodel/{self.grouper_instance.pk}'
-                                          f'/change/?language=en"')
+            self.assertContains(response, f'href="/en/admin/sampleapp/{self.groupermodel}/{self.grouper_instance.pk}'
+                                          f'/change/?')
             self.assertContains(response, 'class="cms-icon cms-icon-view"')
 
     def test_get_action(self):
@@ -102,6 +137,10 @@ class ChangeListActionsTestCase(SetupMixin, CMSTestCase):
         )
         self.assertNotIn("cms-form-get-method", get_action)
         self.assertIn("cms-form-post-method", get_action)
+
+
+class ChangeListActionsTestCase(SetupMixin, SimpleChangeListActionsTestCase):
+    pass
 
 
 class GrouperModelAdminTestCase(SetupMixin, CMSTestCase):
@@ -177,6 +216,49 @@ class GrouperChangeListTestCase(SetupMixin, CMSTestCase):
                 self.assertContains(response, random_content[language])
 
 
+class SimpleGrouperChangeListTestCase(SimpleSetupMixin, CMSTestCase):
+    def test_mixed_change_form(self):
+        """Change form contains input for both grouper and content objects"""
+        # Arrange
+        random_content = self.createContentInstance("en")
+        with self.login_user_context(self.admin_user):
+            # Act
+            response = self.client.get(f"{self.change_url}?language=en", follow=True)
+            # Assert
+            # Contains relation to grouper as hidden input
+            self.assertContains(
+                response,
+                '<input type="hidden" name="content__simple_grouper_model"',
+            )
+            # Contains grouper field with category (and its value)
+            self.assertContains(
+                response,
+                '<input type="text" name="category_name" value="Grouper Category"',
+            )
+            # Contains content secret message as textarea
+            self.assertContains(response, '<textarea name="content__secret_greeting"')
+            self.assertContains(response, random_content.secret_greeting)
+
+    def test_empty_content(self) -> None:
+        """Without any content being created the changelist shows an empty content text"""
+        with self.login_user_context(self.admin_user):
+            # Act
+            response = self.client.get(self.changelist_url)
+            # Assert
+            self.assertContains(response, "Empty content")
+
+    def test_with_content(self) -> None:
+        """Create one content object and see if it appears in the admin"""
+        # Arrange
+        random_content = self.createContentInstance()
+        with self.login_user_context(self.admin_user):
+            # Act
+            response = self.client.get(self.changelist_url)
+            # Assert
+            self.assertContains(response, "Grouper Category")
+            self.assertContains(response, random_content.secret_greeting)
+
+
 class GrouperChangeTestCase(SetupMixin, CMSTestCase):
     def test_mixed_change_form(self):
         """Change form contains input for both grouper and content objects"""
@@ -184,7 +266,7 @@ class GrouperChangeTestCase(SetupMixin, CMSTestCase):
         random_content = self.createContentInstance("en")
         with self.login_user_context(self.admin_user):
             # Act
-            response = self.client.get(self.change_url + "?language=en")
+            response = self.client.get(f"{self.change_url}?language=en", follow=True)
             # Assert
             # Contains relation to grouper as hidden input
             self.assertContains(
@@ -208,7 +290,7 @@ class GrouperChangeTestCase(SetupMixin, CMSTestCase):
     def test_change_form_contains_defaults_for_groupers(self) -> None:
         with self.login_user_context(self.admin_user):
             # Act
-            response = self.client.get(self.change_url + "?language=en")
+            response = self.client.get(self.change_url + "?language=en", follow=True)
             # Assert
             self.assertContains(response, 'name="content__language" value="en"')
             self.assertNotContains(response, 'name="content__language" value="de"')
@@ -232,6 +314,11 @@ class GrouperChangeTestCase(SetupMixin, CMSTestCase):
             self.assertContains(
                 response,
                 '<input type="hidden" name="content__grouper_model"',
+            )
+            # Contains extra grouping field as hidden input
+            self.assertContains(
+                response,
+                '<input type="hidden" name="content__language" value="en" id="id_content__language">',
             )
             # Contains extra grouping field as hidden input
             self.assertContains(
@@ -333,3 +420,79 @@ class GrouperChangeTestCase(SetupMixin, CMSTestCase):
         self.assertEqual(content_instance_en.secret_greeting, random_content.secret_greeting)  # unchanged
         self.assertIsNotNone(content_instance_de)  # Exists?
         self.assertEqual(content_instance_de.secret_greeting, data["content__secret_greeting"])  # Has new content
+
+
+class SimpleGrouperChangeTestCase(SimpleSetupMixin, CMSTestCase):
+    def test_save_grouper_model(self) -> None:
+        # Arrange
+        random_content = self.createContentInstance()
+        data = {
+            "category_name": "Changed content",
+            "content__region": "world",
+            "content__language": "de",
+            "content__secret_greeting": random_content.secret_greeting,
+        }
+        with self.login_user_context(self.admin_user):
+            # Act
+            response = self.client.post(self.change_url, data=data)
+            # Assert
+            self.grouper_instance.refresh_from_db()
+            self.assertEqual(response.status_code, 302)  # Expecting redirect
+            self.assertEqual(self.grouper_instance.category_name, data["category_name"])
+
+    def test_save_content_model(self) -> None:
+        # Arrange
+        self.createContentInstance()
+        data = {
+            "category_name": self.grouper_instance.category_name,
+            "content__region": "world",
+            "content__language": "de",
+            "content__secret_greeting": "New greeting",
+        }
+        # Act
+        with self.login_user_context(self.admin_user):
+            response = self.client.post(self.change_url, data=data)
+            content_instance = SimpleGrouperModelContent.objects.first()
+        # Assert
+        self.assertEqual(response.status_code, 302)  # Expecting redirect
+        self.assertIsNotNone(content_instance)
+        self.assertEqual(content_instance.secret_greeting, data["content__secret_greeting"])
+
+    def test_create_grouper_model(self) -> None:
+        # Arrange
+        data = {
+            "category_name": "My new category",
+            "content__region": "world",
+            "content__language": "de",
+            "content__secret_greeting": "Some new content",
+        }
+        # Act
+        with self.login_user_context(self.admin_user):
+            response = self.client.post(self.add_url, data=data)
+            grouper_instance = SimpleGrouperModel.objects.filter(category_name=data["category_name"]).first()
+            content_instance = grouper_instance.simplegroupermodelcontent_set.first()  # Get content
+
+        # Assert
+        self.assertEqual(response.status_code, 302)  # Expecting redirect
+        self.assertEqual(SimpleGrouperModel.objects.all().count(), 2)
+        self.assertIsNotNone(grouper_instance)
+        self.assertIsNotNone(content_instance)  # Should exist
+        self.assertEqual(content_instance.secret_greeting, data["content__secret_greeting"])  # Has new content
+
+    def test_create_content_model(self) -> None:
+        # Arrange
+        self.createContentInstance()
+        data = {
+            "category_name": self.grouper_instance.category_name,
+            "content__region": "world",
+            "content__language": "de",
+            "content__secret_greeting": "New content",
+        }
+        # Act
+        with self.login_user_context(self.admin_user):
+            response = self.client.post(self.change_url, data=data)
+            content_instance = SimpleGrouperModelContent.objects.first()  # Get content
+        # Assert
+        self.assertEqual(response.status_code, 302)  # Expecting redirect
+        self.assertIsNotNone(content_instance)
+        self.assertEqual(content_instance.secret_greeting, data["content__secret_greeting"])  # Has new content

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -298,7 +298,7 @@ class PlaceholderTestCase(TransactionCMSTestCase):
         n = 4  # This will be the position of the last plugin
 
         plugins = {lang: [] for lang in language_fun}
-        parent = {lang: None for lang in language_fun}
+        parent = dict.fromkeys(language_fun)
         for i in range(n):
             for lang in language_fun:
                 parent[lang] = add_plugin(ph, 'TextPlugin', lang, target=parent[lang]).cmsplugin_ptr


### PR DESCRIPTION
## Description

Backport of #8194 
<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8194 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Enhance the grouper models admin functionality to support more flexible language and content handling in the test utilities

Bug Fixes:
- Fix language validation in content forms to use a more robust language checking method

Enhancements:
- Extend the grouper model admin to support more flexible content and language management
- Add a new SimpleGrouperModel and related admin class to improve testing capabilities

Tests:
- Add comprehensive test cases for the new SimpleGrouperModel and its admin functionality
- Expand test coverage for grouper model content creation and editing