### PR TITLE
fix: Django 5.2 tried to adding object tools to the page tree throwing an error 

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   frontend:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: ['18']

--- a/.github/workflows/test_startcmsproject.yml
+++ b/.github/workflows/test_startcmsproject.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ['3.11']
         requirements-file: ['requirements_base.txt']
         os: [
-          ubuntu-20.04,
+          ubuntu-latest,
         ]
 
     steps:

--- a/cms/templates/admin/cms/page/tree/base.html
+++ b/cms/templates/admin/cms/page/tree/base.html
@@ -30,8 +30,8 @@
         </div>
     {% endblock %}
 {% endif %}
-
 {% block content_title %}{% endblock %}
+{% block object-tools-items %}{% endblock %}
 
 {% block content %}
     {% spaceless %}


### PR DESCRIPTION
## Description

* Backport of #8133 

* fix: Django 6 tried to add an Add page through the object tools and throws an error

This might actually be an unintentional regression (https://code.djangoproject.com/ticket/36331)

---------

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``main``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Resolve an error when adding pages through object tools in Django 6 admin interface