### PR TITLE
docs: Fix code errors and add an example for using class based views in using placeholders outside the CMS

### DIFF
--- a/docs/how_to/01-placeholders.rst
+++ b/docs/how_to/01-placeholders.rst
@@ -41,6 +41,7 @@ you would like to use:
 .. code-block::
 
     from django.db import models
+    from django.utils.functional import cached_property
     from cms.models.fields import PlaceholderRelationField
     from cms.utils.placeholder import get_placeholder_from_slot
 
@@ -154,6 +155,27 @@ Preview buttons:**
 
 .. note::
 
+    If using class based views, you can set the toolbar object in the ``get_context_data``
+    method of your view and add a stub view usable when you
+    :ref:`register the model for frontend editing <register_model_frontend_editing>`.
+
+    .. code-block:: python
+
+        from django.views.generic.detail import DetailView
+
+        class MyModelDetailView(DetailView):
+            # your detail view attributes
+
+            def get_context_data(self, **kwargs):
+                context = super().get_context_data(**kwargs)
+                self.request.toolbar.set_object(self.object)
+                return context
+
+        def my_model_endpoint_view(request, my_model):
+            return MyModelDetailView.as_view()(request, pk=my_model.pk)
+
+.. note::
+
     If you want to render plugins from a specific language, you can use the tag like
     this:
 
@@ -193,6 +215,8 @@ Let the model know about this template by declaring the ``get_template()`` metho
 
         ...
 
+.. _register_model_frontend_editing:
+
 Registering the model for frontend editing
 ------------------------------------------
 
@@ -202,7 +226,7 @@ The final step is to register the model for frontend editing. Since django CMS 4
 done by adding a :class:`~cms.app_base.CMSAppConfig` class to the app's `cms_config.py`
 file:
 
-.. code-block::
+.. code-block:: python
 
     from cms.app_base import CMSAppConfig
     from . import models, views
@@ -211,6 +235,15 @@ file:
     class MyAppConfig(CMSAppConfig):
         cms_enabled = True
         cms_toolbar_enabled_models = [(models.MyModel, views.render_my_model)]
+
+.. note::
+
+    If using class based views, use the stub view in ``cms_toolbar_enabled_models`` attribute.
+
+    .. code-block:: python
+
+        cms_toolbar_enabled_models = [(models.MyModel, views.my_model_endpoint_view)]
+
 
 Adding content to a placeholder
 -------------------------------

--- a/docs/how_to/12-namespaced_apphooks.rst
+++ b/docs/how_to/12-namespaced_apphooks.rst
@@ -144,7 +144,7 @@ Let us quickly create the new app:
    .. code-block::
 
        class Entry(models.Model):
-           app_config = models.ForeignKey(FaqConfigModel, null=False)  # We need to assign an FAQ entry to its app instance
+           app_config = models.ForeignKey(FaqConfigModel, null=False, on_delete=models.PROTECT)  # We need to assign an FAQ entry to its app instance
            question = models.TextField(blank=True, default='')
            answer = models.TextField()
 
@@ -185,9 +185,9 @@ Let us quickly create the new app:
                except ObjectDoesNotExist:
                    return None
 
-          def  get_config_add_url(self):
+           def  get_config_add_url(self):
                try:
-                  return reverse("admin:{}_{}_add".format(self.app_config._meta.app_label, self.app_config._meta.model_name))
+                   return reverse("admin:{}_{}_add".format(self.app_config._meta.app_label, self.app_config._meta.model_name))
                except AttributeError:
                    return reverse(
                        "admin:{}_{}_add".format(self.app_config._meta.app_label, self.app_config._meta.module_name)


### PR DESCRIPTION
## Description

As stated here #8203 there were some errors in the code examples (minor things, but copy/pasting didn't work because of them).

Also, this is my proposal, entirely taken from this issue #7869 , for updating the documentation adding an example for the "How to use placeholders outside the CMS" section when using class based views.

## Related resources

Fix #8203 

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
