### PR TITLE
docs: Fix instructions on setting editor permissions

### DIFF
--- a/docs/explanation/permissions.rst
+++ b/docs/explanation/permissions.rst
@@ -28,18 +28,47 @@ You can find the permissions you can set for a user or groups in the Django admi
 Page permissions mode.
 
 Filtering by ``cms`` will show the ones that belong to the CMS application. Permissions that a CMS
-editor will need are likely to include:
+editor will need are likely to include the following core package permissions:
 
-* ``cms | cms plugin``
-* ``cms | page``
-* ``cms | placeholder``
-* ``cms | placeholder reference``
-* ``cms | static placeholder``
-* ``cms | placeholder reference``
-* ``cms | title``
+* ``django CMS | cms plugin``
+* ``django CMS | page``
+* ``django CMS | placeholder``
+* ``django CMS | placeholder reference``
+* ``django CMS | static placeholder``
 
 Most of these offer the usual add/change/delete options, though there are some exceptions, such as
-``cms | placeholder | Can use Structure mode``.
+``django CMS | placeholder | Can use Structure mode``.
+
+In addition to the core package permissions, an editor will likely need the following permissions
+from 3rd-party packages:
+
+* `djangocms-alias <https://pypi.org/project/djangocms-alias/>`_
+
+  * ``django CMS Alias | alias``
+  * ``django CMS Alias | alias content``
+  * ``django CMS Alias | category``
+
+* `djangocms-frontend <https://pypi.org/project/djangocms-frontend/>`_
+
+  * ``django CMS Frontend | UI item``
+  * After adding these permissions, save and use the ``python manage.py frontend sync_permissions``
+    command as documented in `djangocms-frontend's documentation
+    <https://djangocms-frontend.readthedocs.io/en/stable/tutorial/builtin_components.html#assigning-permissions>`_
+
+* `djangocms-text <https://pypi.org/project/djangocms-text/>`_
+
+  * ``django CMS Rich Text | text``
+
+* `djangocms-versioning <https://pypi.org/project/djangocms-versioning/>`_
+
+  * ``django CMS Versioning | alias content version``
+  * ``django CMS Versioning | page content version``
+  * ``django CMS Versioning | version``
+
+Typically when adding other 3rd party packages or custom plugins you may need to add additional
+permissions to enable their features. Sometimes documentation for such needed permissions may be
+missing, in that case you can compare the list of available permissions with the package enabled
+and disabled on your site.
 
 See :ref:`use-permissions-on-groups` below on applying permissions to groups rather than users.
 

--- a/docs/explanation/permissions.rst
+++ b/docs/explanation/permissions.rst
@@ -34,7 +34,6 @@ editor will need are likely to include the following core package permissions:
 * ``django CMS | page``
 * ``django CMS | placeholder``
 * ``django CMS | placeholder reference``
-* ``django CMS | static placeholder``
 
 Most of these offer the usual add/change/delete options, though there are some exceptions, such as
 ``django CMS | placeholder | Can use Structure mode``.


### PR DESCRIPTION
## Description

Without the versioning permissions, an editor cannot begin editing a page. Without the frontend permissions, no components other than comment shows up, without alias/alias versioning permissions an editor cannot edit aliases, without rich text permissions an editor cannot add text blocks, `cms | placeholder reference` was mentioned twice and `cms | title` does not seem to exist any longer.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Documentation:
- Correct the list of required permissions for editors, adding missing ones and removing outdated entries.