### PR TITLE
fix: CMS_PLACEHOLDER_CONF needs to also configure allowed child plugins

### DIFF
--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -739,7 +739,7 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
         # Useful in cases like djangocms-text
         # where only text-only plugins are allowed.
         from cms.plugin_pool import plugin_pool
-        return sorted(plugin_pool.get_all_plugins(page=page), key=attrgetter("module", "name"))
+        return sorted(plugin_pool.get_all_plugins(slot, page), key=attrgetter("module", "name"))
 
     @classmethod
     @template_slot_caching
@@ -750,12 +750,12 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
         """
         # Placeholder overrides are highest in priority
         child_classes = cls.get_child_class_overrides(slot, page=page, instance=instance)
-
-        if child_classes:
-            return child_classes
-
         # Get all child plugin candidates
         installed_plugins = cls.get_child_plugin_candidates(slot, page)
+
+        if child_classes:
+            return [plugin.__name__ for plugin in installed_plugins if plugin.__name__ in child_classes]
+
 
         child_classes = []
         plugin_type = cls.__name__

--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -1,6 +1,7 @@
 import json
 import re
 from functools import lru_cache, wraps
+from operator import attrgetter
 from typing import Callable, Optional, TypeVar, cast
 
 from django import forms
@@ -363,7 +364,7 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
 
     @classmethod
     @lru_cache
-    def _get_template_for_conf(cls, page: Optional[Page], instance: Optional[CMSPlugin]):
+    def _get_template_for_conf(cls, page: Optional[Page], instance: Optional[CMSPlugin] = None):
         """Cache page template because page.get_template() might have to fetch the page content object from the db
          since django CMS 4"""
         if page:
@@ -738,7 +739,7 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
         # Useful in cases like djangocms-text
         # where only text-only plugins are allowed.
         from cms.plugin_pool import plugin_pool
-        return plugin_pool.registered_plugins
+        return sorted(plugin_pool.get_all_plugins(page=page), key=attrgetter("module", "name"))
 
     @classmethod
     @template_slot_caching

--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -28,6 +28,7 @@ class CMSPluginBaseMetaclass(forms.MediaDefiningClass):
     Ensure the CMSPlugin subclasses have sane values and set some defaults if
     they're not given.
     """
+
     def __new__(cls, name, bases, attrs):
         super_new = super().__new__
         parents = [base for base in bases if isinstance(base, CMSPluginBaseMetaclass)]
@@ -39,50 +40,35 @@ class CMSPluginBaseMetaclass(forms.MediaDefiningClass):
         if not issubclass(new_plugin.model, CMSPlugin):
             raise SubClassNeededError(
                 "The 'model' attribute on CMSPluginBase subclasses must be "
-                "either CMSPlugin or a subclass of CMSPlugin. %r on %r is not."
-                % (new_plugin.model, new_plugin)
+                "either CMSPlugin or a subclass of CMSPlugin. %r on %r is not." % (new_plugin.model, new_plugin)
             )
         # validate the template:
-        if (not hasattr(new_plugin, 'render_template') and not hasattr(new_plugin, 'get_render_template')):
+        if not hasattr(new_plugin, "render_template") and not hasattr(new_plugin, "get_render_template"):
             raise ImproperlyConfigured(
-                "CMSPluginBase subclasses must have a render_template attribute"
-                " or get_render_template method"
+                "CMSPluginBase subclasses must have a render_template attribute or get_render_template method"
             )
         # Set the default form
         if not new_plugin.form:
             form_meta_attrs = {
-                'model': new_plugin.model,
-                'exclude': ('position', 'placeholder', 'language', 'plugin_type', 'path', 'depth')
+                "model": new_plugin.model,
+                "exclude": ("position", "placeholder", "language", "plugin_type", "path", "depth"),
             }
-            form_attrs = {
-                'Meta': type('Meta', (object,), form_meta_attrs)
-            }
-            new_plugin.form = type('%sForm' % name, (forms.ModelForm,), form_attrs)
+            form_attrs = {"Meta": type("Meta", (object,), form_meta_attrs)}
+            new_plugin.form = type("%sForm" % name, (forms.ModelForm,), form_attrs)
         # Set the default fieldsets
         if not new_plugin.fieldsets:
             basic_fields = []
             advanced_fields = []
             for f in new_plugin.model._meta.fields:
                 if not f.auto_created and f.editable:
-                    if hasattr(f, 'advanced'):
+                    if hasattr(f, "advanced"):
                         advanced_fields.append(f.name)
                     else:
                         basic_fields.append(f.name)
             if advanced_fields:
                 new_plugin.fieldsets = [
-                    (
-                        None,
-                        {
-                            'fields': basic_fields
-                        }
-                    ),
-                    (
-                        _('Advanced options'),
-                        {
-                            'fields': advanced_fields,
-                            'classes': ('collapse',)
-                        }
-                    )
+                    (None, {"fields": basic_fields}),
+                    (_("Advanced options"), {"fields": advanced_fields, "classes": ("collapse",)}),
                 ]
         # Set default name
         if not new_plugin.name:
@@ -91,15 +77,15 @@ class CMSPluginBaseMetaclass(forms.MediaDefiningClass):
         # By flagging the plugin class, we avoid having to call these class
         # methods for every plugin all the time.
         # Instead, we only call them if they are actually overridden.
-        if 'get_extra_placeholder_menu_items' in attrs:
+        if "get_extra_placeholder_menu_items" in attrs:
             new_plugin._has_extra_placeholder_menu_items = True
 
-        if 'get_extra_plugin_menu_items' in attrs:
+        if "get_extra_plugin_menu_items" in attrs:
             new_plugin._has_extra_plugin_menu_items = True
         return new_plugin
 
 
-T = TypeVar('T', bound=Callable)
+T = TypeVar("T", bound=Callable)
 
 
 def template_slot_caching(method: T) -> T:
@@ -122,6 +108,7 @@ def template_slot_caching(method: T) -> T:
             # Method implementation...
             pass
     """
+
     @wraps(method)
     def wrapper(*args, **kwargs):
         return method(*args, **kwargs)
@@ -262,7 +249,7 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
     _has_extra_placeholder_menu_items = False
     _has_extra_plugin_menu_items = False
 
-    cache = get_cms_setting('PLUGIN_CACHE')
+    cache = get_cms_setting("PLUGIN_CACHE")
     """Is this plugin cacheable? If your plugin displays content based on the user or
     request or other dynamic properties set this to ``False``.
 
@@ -299,10 +286,10 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
         self._operation_token = None
 
     def _get_render_template(self, context, instance, placeholder):
-        if hasattr(self, 'get_render_template'):
+        if hasattr(self, "get_render_template"):
             template = self.get_render_template(context, instance, placeholder)
-        elif getattr(self, 'render_template', False):
-            template = getattr(self, 'render_template', False)
+        elif getattr(self, "render_template", False):
+            template = getattr(self, "render_template", False)
         else:
             template = None
 
@@ -350,8 +337,8 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
                 return context
 
         """
-        context['instance'] = instance
-        context['placeholder'] = placeholder
+        context["instance"] = instance
+        context["placeholder"] = placeholder
         return context
 
     @classmethod
@@ -366,11 +353,15 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
     @lru_cache
     def _get_template_for_conf(cls, page: Optional[Page], instance: Optional[CMSPlugin] = None):
         """Cache page template because page.get_template() might have to fetch the page content object from the db
-         since django CMS 4"""
+        since django CMS 4"""
         if page:
             # Make the database access lazy, so that it only happens if needed.
             return lazy(page.get_template, str)()
-        if instance is not None and instance.placeholder.source and hasattr(instance.placeholder.source, 'get_template'):
+        if (
+            instance is not None
+            and instance.placeholder.source
+            and hasattr(instance.placeholder.source, "get_template")
+        ):
             # If source object has get_template method, use it (lazily)
             return lazy(instance.placeholder.source.get_template, str)()
         return None
@@ -383,7 +374,7 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
         template = cls._get_template_for_conf(page, instance)
 
         # config overrides..
-        require_parent = get_placeholder_conf('require_parent', slot, template, default=cls.require_parent)
+        require_parent = get_placeholder_conf("require_parent", slot, template, default=cls.require_parent)
         return require_parent
 
     def get_cache_expiration(self, request, instance, placeholder):
@@ -461,16 +452,18 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
         """
         return None
 
-    def render_change_form(self, request, context, add=False, change=False, form_url='', obj=None):
+    def render_change_form(self, request, context, add=False, change=False, form_url="", obj=None):
         """
         We just need the popup interface here
         """
-        context.update({
-            'preview': "no_preview" not in request.GET,
-            'is_popup': True,
-            'plugin': obj,
-            'CMS_MEDIA_URL': get_cms_setting('MEDIA_URL'),
-        })
+        context.update(
+            {
+                "preview": "no_preview" not in request.GET,
+                "is_popup": True,
+                "plugin": obj,
+                "CMS_MEDIA_URL": get_cms_setting("MEDIA_URL"),
+            }
+        )
 
         return super().render_change_form(request, context, add, change, form_url, obj)
 
@@ -513,11 +506,14 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
             - Includes messages from the request in the context.
         """
 
-        dj_messages = [{
-                    'level': message.level,
-                    'message': message.message,
-                    'tags': message.tags,
-                    } for message in messages.get_messages(request)]
+        dj_messages = [
+            {
+                "level": message.level,
+                "message": message.message,
+                "tags": message.tags,
+            }
+            for message in messages.get_messages(request)
+        ]
 
         if not obj:
             # No object specified - just close the modal frame
@@ -530,9 +526,7 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
                 },
                 **(extra_context or {}),
             }
-            return TemplateResponse(
-                request, 'admin/cms/page/plugin/confirm_form.html', context
-            )
+            return TemplateResponse(request, "admin/cms/page/plugin/confirm_form.html", context)
 
         try:
             root = obj.parent.get_bound_plugin() if obj.parent else obj
@@ -546,16 +540,20 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
 
         plugins = [root] + list(root.get_descendants())
 
-        target_plugin = plugins[0] if action in ("add", "delete") else next(
-            (plugin for plugin in plugins if plugin.pk == obj.pk), None
+        target_plugin = (
+            plugins[0]
+            if action in ("add", "delete")
+            else next((plugin for plugin in plugins if plugin.pk == obj.pk), None)
         )
         structure = get_plugin_tree(request, plugins, target_plugin=target_plugin)
-        plugin_data = next((plugin_data for plugin_data in structure['plugins'] if plugin_data["plugin_id"] == obj.pk), {})
+        plugin_data = next(
+            (plugin_data for plugin_data in structure["plugins"] if plugin_data["plugin_id"] == obj.pk), {}
+        )
 
         context = {
-            'plugin': obj,
-            'is_popup': True,
-            'data_bridge': {
+            "plugin": obj,
+            "is_popup": True,
+            "data_bridge": {
                 **plugin_data,
                 "action": action,
                 "plugin_desc": escapejs(force_str(obj.get_short_description())),
@@ -566,9 +564,7 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
             **(extra_context or {}),
         }
 
-        return TemplateResponse(
-            request, 'admin/cms/page/plugin/confirm_form.html', context
-        )
+        return TemplateResponse(request, "admin/cms/page/plugin/confirm_form.html", context)
 
     def save_model(self, request, obj, form, change):
         """
@@ -581,19 +577,19 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
         pl = obj.placeholder
         pl_admin = site._registry[obj.placeholder.__class__]
         operation_kwargs = {
-            'request': request,
-            'placeholder': pl,
+            "request": request,
+            "placeholder": pl,
         }
         if change:
-            operation_kwargs['old_plugin'] = self.model.objects.get(pk=obj.pk)
-            operation_kwargs['new_plugin'] = obj
-            operation_kwargs['operation'] = operations.CHANGE_PLUGIN
+            operation_kwargs["old_plugin"] = self.model.objects.get(pk=obj.pk)
+            operation_kwargs["new_plugin"] = obj
+            operation_kwargs["operation"] = operations.CHANGE_PLUGIN
         else:
             parent_id = obj.parent.pk if obj.parent else None
             tree_order = obj.placeholder.get_plugin_tree_order(parent_id)
-            operation_kwargs['plugin'] = obj
-            operation_kwargs['operation'] = operations.ADD_PLUGIN
-            operation_kwargs['tree_order'] = tree_order
+            operation_kwargs["plugin"] = obj
+            operation_kwargs["operation"] = operations.ADD_PLUGIN
+            operation_kwargs["tree_order"] = tree_order
         # Remember the operation token
         self._operation_token = pl_admin._send_pre_placeholder_operation(**operation_kwargs)
         # Saves the plugin
@@ -620,7 +616,7 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
     def response_change(self, request, obj):
         self.object_successfully_changed = True
         opts = self.model._meta
-        msg_dict = {'name': force_str(opts.verbose_name), 'obj': force_str(obj)}
+        msg_dict = {"name": force_str(opts.verbose_name), "obj": force_str(obj)}
         msg = _('The %(name)s "%(obj)s" was changed successfully.') % msg_dict
         self.message_user(request, msg, messages.SUCCESS)
         return self.render_close_frame(request, obj, action="change")
@@ -691,14 +687,14 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
         fieldsets = super().get_fieldsets(request, obj)
 
         for name, data in fieldsets:
-            if data.get('fields'):  # if fieldset with non-empty fields is found, return fieldsets
+            if data.get("fields"):  # if fieldset with non-empty fields is found, return fieldsets
                 return fieldsets
 
         if self.inlines:
             return []  # if plugin has inlines but no own fields return empty fieldsets to remove empty white fieldset
 
         try:  # if all fieldsets are empty (assuming there is only one fieldset then) add description
-            fieldsets[0][1]['description'] = self.get_empty_change_form_text(obj=obj)
+            fieldsets[0][1]["description"] = self.get_empty_change_form_text(obj=obj)
         except KeyError:
             pass
         return fieldsets
@@ -709,7 +705,7 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
         Returns the text displayed to the user when editing a plugin
         that requires no configuration.
         """
-        return gettext('There are no further settings for this plugin. Please press save.')
+        return gettext("There are no further settings for this plugin. Please press save.")
 
     @classmethod
     @template_slot_caching
@@ -723,7 +719,7 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
         template = cls._get_template_for_conf(page, instance)
 
         # config overrides..
-        ph_conf = get_placeholder_conf('child_classes', slot, template, default={})
+        ph_conf = get_placeholder_conf("child_classes", slot, template, default={})
         return ph_conf.get(cls.__name__, cls.child_classes)
 
     @classmethod
@@ -739,11 +735,14 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
         # Useful in cases like djangocms-text
         # where only text-only plugins are allowed.
         from cms.plugin_pool import plugin_pool
-        return sorted(plugin_pool.get_all_plugins(slot, page), key=attrgetter("module", "name"))
+
+        return sorted(plugin_pool.get_all_plugins(slot, page, root_plugin=False), key=attrgetter("module", "name"))
 
     @classmethod
     @template_slot_caching
-    def get_child_classes(cls, slot, page: Optional[Page] = None, instance: Optional[CMSPlugin] = None, only_uncached: bool = False) -> list:
+    def get_child_classes(
+        cls, slot, page: Optional[Page] = None, instance: Optional[CMSPlugin] = None, only_uncached: bool = False
+    ) -> list:
         """
         Returns a list of plugin types that can be added
         as children to this plugin.
@@ -755,7 +754,6 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
 
         if child_classes:
             return [plugin.__name__ for plugin in installed_plugins if plugin.__name__ in child_classes]
-
 
         child_classes = []
         plugin_type = cls.__name__
@@ -786,7 +784,7 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
         template = cls._get_template_for_conf(page, instance)
 
         # config overrides..
-        ph_conf = get_placeholder_conf('parent_classes', slot, template, default={})
+        ph_conf = get_placeholder_conf("parent_classes", slot, template, default={})
         parent_classes = ph_conf.get(cls.__name__, cls.parent_classes)
         return parent_classes
 
@@ -803,6 +801,7 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
 
     def plugin_urls(self):
         return self.get_plugin_urls()
+
     plugin_urls = property(plugin_urls)
 
     @classmethod
@@ -844,7 +843,8 @@ class PluginMenuItem:
     :param attributes: Dictionary whose content will be added as data-attributes to the menu item
 
     """
-    def __init__(self, name, url, data=None, question=None, action='ajax', attributes=None):
+
+    def __init__(self, name, url, data=None, question=None, action="ajax", attributes=None):
         if not attributes:
             attributes = {}
 

--- a/cms/plugin_pool.py
+++ b/cms/plugin_pool.py
@@ -134,7 +134,9 @@ class PluginPool:
             raise PluginNotRegistered("The plugin %r is not registered" % plugin)
         del self.plugins[plugin_name]
 
-    def get_all_plugins(self, placeholder=None, page=None, setting_key="plugins", include_page_only=True):
+    def get_all_plugins(
+        self, placeholder=None, page=None, setting_key="plugins", include_page_only=True, root_plugin=True
+    ):
         from cms.utils.placeholder import get_placeholder_conf
 
         self.discover_plugins()
@@ -173,7 +175,7 @@ class PluginPool:
             # Check that plugins are not in the list of the excluded ones
             plugins = (plugin for plugin in plugins if plugin.__name__ not in excluded_plugins)
 
-        if placeholder:
+        if root_plugin:
             # Filters out any plugin that requires a parent or has set parent classes
             plugins = (plugin for plugin in plugins if not plugin.requires_parent_plugin(placeholder, page))
         return plugins

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -835,12 +835,13 @@ class PluginsTestCase(PluginsTestBaseCase):
             CMS_PLACEHOLDER_CONF = {
                 "body": {
                     "child_classes": {
+                        # Config includes existing LinkPlugin and non-existing PicturePlugin
                         "ChildClassesPlugin": ["LinkPlugin", "PicturePlugin"],
                     }
                 }
             }
             with self.settings(CMS_PLACEHOLDER_CONF=CMS_PLACEHOLDER_CONF):
-                self.assertEqual(["LinkPlugin", "PicturePlugin"], plugin.get_child_classes(placeholder.slot, page))
+                self.assertEqual(["LinkPlugin"], plugin.get_child_classes(placeholder.slot, page))
 
     def test_plugin_parent_classes_from_settings(self):
         page = api.create_page("page", "nav_playground.html", "en")
@@ -885,11 +886,15 @@ class PluginsTestCase(PluginsTestBaseCase):
         page = api.create_page("page", "nav_playground.html", "en")
         placeholder = page.get_placeholders("en").get(slot="body")
         ParentPlugin = type("ParentPlugin", (CMSPluginBase,), dict(render_plugin=False, allow_children=True))
-        ChildPlugin = type("ChildPlugin", (CMSPluginBase,), dict(
-            cache_parent_classes=False,
-            parent_classes=["ParentPlugin"],
-            render_plugin=False,
-            ))
+        ChildPlugin = type(
+            "ChildPlugin",
+            (CMSPluginBase,),
+            dict(
+                cache_parent_classes=False,
+                parent_classes=["ParentPlugin"],
+                render_plugin=False,
+            ),
+        )
         restriction_cache = {}  # cache is empty
 
         with register_plugins(ParentPlugin, ChildPlugin):
@@ -916,11 +921,15 @@ class PluginsTestCase(PluginsTestBaseCase):
         page = api.create_page("page", "nav_playground.html", "en")
         placeholder = page.get_placeholders("en").get(slot="body")
         ParentPlugin = type("ParentPlugin", (CMSPluginBase,), dict(render_plugin=False, allow_children=True))
-        ChildPlugin = type("ChildPlugin", (CMSPluginBase,), dict(
-            cache_parent_classes=False,
-            parent_classes=[""],
-            render_plugin=False,
-            ))
+        ChildPlugin = type(
+            "ChildPlugin",
+            (CMSPluginBase,),
+            dict(
+                cache_parent_classes=False,
+                parent_classes=[""],
+                render_plugin=False,
+            ),
+        )
         restriction_cache = {}  # cache is empty
 
         with register_plugins(ParentPlugin, ChildPlugin):


### PR DESCRIPTION
## Description

This fixes #6619, and #6246. `CMS_PLACEHOLDER_CONF` should not only affect root plugins but all plugins within a placeholder.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #6619 
* #6246

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
