### PR TITLE
fix: Create the duplicate page as a sibling

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
       - run: python -m pip install -r docs/requirements.txt
-      - run: python setup.py install
+      - run: python -m pip install -e .
       - run: codespell -w *.rst
       - run: codespell -w docs
       - name: Build docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,9 +12,9 @@ jobs:
     name: docs
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
           cache: 'pip'

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   frontend:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: ['18']

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           django-5.1.txt
         ]
         os: [
-          ubuntu-20.04,
+          ubuntu-latest,
         ]
         exclude:
           - requirements-file: django-5.0.txt
@@ -85,7 +85,7 @@ jobs:
           django-5.1.txt
         ]
         os: [
-          ubuntu-20.04,
+          ubuntu-latest,
         ]
         exclude:
           - requirements-file: django-5.0.txt
@@ -148,7 +148,7 @@ jobs:
           django-5.1.txt
         ]
         os: [
-          ubuntu-20.04,
+          ubuntu-latest,
         ]
         exclude:
           - requirements-file: django-5.0.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,10 +47,10 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
 
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -109,11 +109,11 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
 
 
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -161,10 +161,10 @@ jobs:
             python-version: 3.9
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
 
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           django-5.1.txt
         ]
         os: [
-          ubuntu-latest,
+          ubuntu-24.04,
         ]
         exclude:
           - requirements-file: django-5.0.txt
@@ -85,7 +85,7 @@ jobs:
           django-5.1.txt
         ]
         os: [
-          ubuntu-latest,
+          ubuntu-24.04,
         ]
         exclude:
           - requirements-file: django-5.0.txt
@@ -148,7 +148,7 @@ jobs:
           django-5.1.txt
         ]
         os: [
-          ubuntu-latest,
+          ubuntu-24.04,
         ]
         exclude:
           - requirements-file: django-5.0.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
         pip install pytest
         pip install -r test_requirements/${{ matrix.requirements-file }}
         pip install -r test_requirements/databases.txt
-        python setup.py install
+        pip install -e .
 
     - name: Test with django test runner
       run: |
@@ -124,8 +124,7 @@ jobs:
         pip install pytest
         pip install -r test_requirements/${{ matrix.requirements-file }}
         pip install -r test_requirements/databases.txt
-        python setup.py install
-
+        pip install -e .
 
     - name: Test with django test runner
       run: |
@@ -174,7 +173,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest
         pip install -r test_requirements/${{ matrix.requirements-file }}
-        python setup.py install
+        pip install -e .
 
     - name: Test with django test runner
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
 
 

--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -668,7 +668,11 @@ class PageToolbar(CMSToolbar):
 
             add_page_menu.add_modal_item(
                 _('Duplicate this Page'),
-                url=add_url_parameters(duplicate_page_url, {'language': self.toolbar.request_language}),
+                url=add_url_parameters(
+                    duplicate_page_url,
+                    {'parent_node': self.page.parent_page.node_id} if self.page.parent_page else {},
+                    language=self.toolbar.request_language,
+                ),
                 disabled=not can_add_sibling_page,
             )
 


### PR DESCRIPTION
## Description

Page menu's "Duplicate page" did create a copy of the page at the root level. This PR makes the menu entry create the page as a sibling. The corresponding menu entry in `cms_toolbars.py` did not reference the parent page as a destination for the duplication.

fixes #7563 and #6571

Changes to files other than `cms_toolbar.py` are to update the CI process.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7563
* #6571

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Fix bug where duplicating a page incorrectly created it at the root level instead of alongside the original page.