### PR TITLE
ci: Stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,41 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+
+jobs:
+  stale:
+    name: 🧹 Clean up stale issues and PRs
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: 🚀 Run stale
+        uses: actions/stale@v9.1.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 30
+          days-before-close: 7
+          remove-stale-when-updated: true
+          stale-issue-label: "stale"
+          exempt-issue-labels: "no-stale,help-wanted"
+          stale-issue-message: >
+            There hasn't been any activity on this issue recently, so we
+            clean up some of the older and inactive issues.
+
+            Please make sure to update to the latest version and
+            check if that solves the issue. Let us know if that works for you
+            by leaving a comment 👍
+
+            This issue has now been marked as stale and will be closed if no
+            further activity occurs. Thanks!
+          stale-pr-label: "stale"
+          exempt-pr-labels: "no-stale"
+          stale-pr-message: >
+            There hasn't been any activity on this pull request recently. This
+            pull request has been automatically marked as stale because of that
+            and will be closed if no further activity occurs within 7 days.
+            Thank you for your contributions.


### PR DESCRIPTION
Adds the stale workflow

## Summary by Sourcery

CI:
- Configure stale action to mark and close inactive issues and pull requests after 30 days of inactivity