### PR TITLE
fix: Remove circular import in `cms.forms.validators`

### DIFF
--- a/cms/api.py
+++ b/cms/api.py
@@ -22,6 +22,7 @@ Also, the functions defined in this module do sanity checks on arguments.
 
               def my_function():
                   from cms.api import api_function
+
                   api_function(...)
 
           instead of:
@@ -30,10 +31,12 @@ Also, the functions defined in this module do sanity checks on arguments.
 
               from cms.api import api_function
 
+
               def my_function():
                   api_function(...)
 
 """
+
 import warnings
 
 from django.contrib.auth import get_user_model
@@ -47,8 +50,7 @@ from cms import constants
 from cms.app_base import CMSApp
 from cms.apphook_pool import apphook_pool
 from cms.constants import TEMPLATE_INHERITANCE_MAGIC
-from cms.forms.validators import validate_url_uniqueness
-from cms.models import PageContent, PageUrl
+from cms.models import PageContent
 from cms.models.pagemodel import Page
 from cms.models.permissionmodels import (
     ACCESS_PAGE_AND_DESCENDANTS,
@@ -347,6 +349,8 @@ def create_page_content(
         created_by = get_clean_username(created_by)
 
     try:
+        from cms.forms.validators import validate_url_uniqueness
+
         validate_url_uniqueness(page.site, path, language, exclude_page=page.parent)
     except ValidationError as e:
         raise IntegrityError(e)

--- a/cms/forms/validators.py
+++ b/cms/forms/validators.py
@@ -8,6 +8,7 @@ from django.utils.translation import gettext
 from cms.utils.urlutils import admin_reverse, relative_url_regex
 
 if TYPE_CHECKING:
+    # Only needed for type hinting - avoid circular import
     from cms.models.pagemodel import Page
 
 

--- a/cms/forms/validators.py
+++ b/cms/forms/validators.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator, URLValidator
@@ -6,8 +6,6 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import gettext
 
 from cms.utils.urlutils import admin_reverse, relative_url_regex
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from cms.models.pagemodel import Page

--- a/cms/forms/validators.py
+++ b/cms/forms/validators.py
@@ -5,8 +5,12 @@ from django.core.validators import RegexValidator, URLValidator
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext
 
-from cms.models.pagemodel import Page
 from cms.utils.urlutils import admin_reverse, relative_url_regex
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from cms.models.pagemodel import Page
 
 
 def validate_relative_url(value):
@@ -22,7 +26,9 @@ def validate_url(value):
         URLValidator()(value)
 
 
-def validate_url_uniqueness(site, path: str, language: str, user_language: Optional[str] = None, exclude_page: Optional[Page] = None):
+def validate_url_uniqueness(
+    site, path: str, language: str, user_language: Optional[str] = None, exclude_page: Optional["Page"] = None
+):
     """Checks for conflicting urls"""
     from cms.models.pagemodel import Page, PageUrl
 

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -838,7 +838,7 @@ class Page(MP_Node):
         if fallback:
             languages.extend(self.get_fallbacks(language))
 
-        if language not in self.urls_cache:
+        if self.urls_cache is None or language not in self.urls_cache:
             # `get_page_from_request` will fill the cache only for the current language
             # Here, we fully fill it and try again
             self.urls_cache = {url.language: url for url in self.urls.all() if url.language in languages}


### PR DESCRIPTION
## Description

Removes an import on `cms.forms.validators` that can lead to a circular import.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
