### PR TITLE
fix: Structure board update sometimes failed to add all interactive elements

### DIFF
--- a/cms/static/cms/js/modules/cms.structureboard.js
+++ b/cms/static/cms/js/modules/cms.structureboard.js
@@ -395,7 +395,8 @@ class StructureBoard {
                 CMS.settings.states = Helpers.getSettings().states;
 
                 const bodyRegex = /<body[\S\s]*?>([\S\s]*)<\/body>/gi;
-                const body = document.createElement("div");  // Switch to plain JS due to problem with $(body)
+                const body = document.createElement('div');  // Switch to plain JS due to problem with $(body)
+
                 body.innerHTML = bodyRegex.exec(contentMarkup)[1];
 
                 const structure = $(body.querySelector('.cms-structure-content'));

--- a/cms/static/cms/js/modules/cms.structureboard.js
+++ b/cms/static/cms/js/modules/cms.structureboard.js
@@ -395,22 +395,19 @@ class StructureBoard {
                 CMS.settings.states = Helpers.getSettings().states;
 
                 const bodyRegex = /<body[\S\s]*?>([\S\s]*)<\/body>/gi;
-                const body = $(bodyRegex.exec(contentMarkup)[1]);
+                const body = document.createElement("div");  // Switch to plain JS due to problem with $(body)
+                body.innerHTML = bodyRegex.exec(contentMarkup)[1];
 
-                const structure = body.find('.cms-structure-content');
-                const toolbar = body.find('.cms-toolbar');
-                const scripts = body.filter(function() {
-                    return $(this).is('[type="text/cms-template"]'); // cms scripts
-                });
-                const pluginIds = this.getIds(body.find('.cms-draggable'));
-                const pluginDataSource = body.filter('script[data-cms]').toArray()
-                    .map(script => script.textContent || '').join();
+                const structure = $(body.querySelector('.cms-structure-content'));
+                const toolbar = $(body.querySelector('.cms-toolbar'));
+                const scripts = $(body.querySelector('[type="text/cms-template"]')); // cms scripts
+                const pluginIds = this.getIds($(body.querySelectorAll('.cms-draggable')));
                 const pluginData = StructureBoard._getPluginDataFromMarkup(
-                    pluginDataSource,
+                    body,
                     pluginIds
                 );
 
-                Plugin._updateRegistry(pluginData.map(([, data]) => data));
+                Plugin._updateRegistry(pluginData);
 
                 CMS.API.Toolbar._refreshMarkup(toolbar);
 
@@ -1744,21 +1741,19 @@ class StructureBoard {
      *
      * @method _getPluginDataFromMarkup
      * @private
-     * @param {String} markup
+     * @param {Node} body
      * @param {Array<Number | String>} pluginIds
      * @returns {Array<[String, Object]>}
      */
-    static _getPluginDataFromMarkup(markup, pluginIds) {
+    static _getPluginDataFromMarkup(body, pluginIds) {
         return compact(
             pluginIds.map(pluginId => {
-                // oh boy
-                const regex = new RegExp(`CMS._plugins.push\\((\\["cms\-plugin\-${pluginId}",[\\s\\S]*?\\])\\)`, 'g');
-                const matches = regex.exec(markup);
+                const pluginData = body.querySelector(`#cms-plugin-${pluginId}`);
                 let settings;
 
-                if (matches) {
+                if (pluginData) {
                     try {
-                        settings = JSON.parse(matches[1]);
+                        settings = JSON.parse(pluginData.textContent);
                     } catch (e) {
                         settings = false;
                     }

--- a/cms/tests/frontend/unit/cms.structureboard.test.js
+++ b/cms/tests/frontend/unit/cms.structureboard.test.js
@@ -2424,42 +2424,41 @@ describe('CMS.StructureBoard', function() {
     });
 
     describe('_getPluginDataFromMarkup()', () => {
+        const wrap = markup => $(`<div>${markup}</div>`)[0];
         [
             {
-                args: ['', [1, 2, 3]],
+                args: [wrap(''), [1, 2, 3]],
                 expected: []
             },
             {
-                args: ['whatever', []],
+                args: [wrap('whatever'), []],
                 expected: []
             },
             {
-                args: ['CMS._plugins.push(["cms-plugin-4",{"plugin_id":"4"}]);', [1, 2, 3]],
+                args: [wrap('<script id="cms-plugin-4">{"plugin_id":"4"}</script>'), [1, 2, 3]],
                 expected: []
             },
             {
-                args: ['CMS._plugins.push(["cms-plugin-4",{"plugin_id":"4"}]);', [1, 2, 4]],
-                expected: [['cms-plugin-4', { plugin_id: '4' }]]
+                args: [wrap('<script id="cms-plugin-4">{"plugin_id":"4"}</script>'), [1, 2, 4]],
+                expected: [{ plugin_id: '4' }]
             },
             {
                 args: [
-                    `CMS._plugins.push(["cms-plugin-4",{"plugin_id":"4"}]);
-                    CMS._plugins.push(["cms-plugin-10", { "plugin_id": "meh"}]);`, [1, 2, 10]],
-                expected: [['cms-plugin-10', { plugin_id: 'meh' }]]
+                    wrap('<script id="cms-plugin-4">{"plugin_id":"4"}</script><script id="cms-plugin-10">{"plugin_id":"meh"}</script>'),
+                    [1, 2, 10]],
+                expected: [{ plugin_id: 'meh' }]
             },
             {
-                args: ['CMS._plugins.push(["cms-plugin-4",{plugin_id:"4"}])', [4]],
+                args: [wrap('<script id="cms-plugin-4">{plugin_id:"4"}</script>'), [4]],
                 expected: []
             },
             {
-                args: ['CMS._plugins.push(["cms-plugin-4",not a json :(]);', [4]],
+                args: [wrap('<script id="cms-plugin-4">not a json :(]</script>'), [4]],
                 expected: []
             },
             {
-                args: [`CMS._plugins.push(["cms-plugin-4", {
-                    "something": 1
-                }])`, [4]],
-                expected: [['cms-plugin-4', { something: 1 }]]
+                args: [wrap('<script id="cms-plugin-4">{"something":1}</script>'), [4]],
+                expected: [{ something: 1 }]
             }
         ].forEach((test, i) => {
             it(`extracts plugin data from markup ${i}`, () => {

--- a/cms/tests/frontend/unit/cms.structureboard.test.js
+++ b/cms/tests/frontend/unit/cms.structureboard.test.js
@@ -2444,7 +2444,8 @@ describe('CMS.StructureBoard', function() {
             },
             {
                 args: [
-                    wrap('<script id="cms-plugin-4">{"plugin_id":"4"}</script><script id="cms-plugin-10">{"plugin_id":"meh"}</script>'),
+                    wrap('<script id="cms-plugin-4">{"plugin_id":"4"}</script>' +
+                        '<script id="cms-plugin-10">{"plugin_id":"meh"}</script>'),
                     [1, 2, 10]],
                 expected: [{ plugin_id: 'meh' }]
             },


### PR DESCRIPTION
## Description

When opening the edit endpoint under (not entirely clear) circumstances not all plugin data inside the structure markup is recognized. This leads to some items in the structure board to be missing interaction handlers. 

Reason is an outdated regex for inline javascript (which has been removed in django CMS 5.0).

## Related resources

https://github.com/user-attachments/assets/4b6a5e7e-0eed-45fe-9644-0529bf3e5a8d



* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Fix structure board update to reliably add all interactive elements by replacing outdated regex-based parsing with native DOM querying and update associated tests.

Bug Fixes:
- Replace outdated inline-JS regex to ensure all plugins in the structure board load their interaction handlers correctly

Enhancements:
- Refactor structure board content parsing to use plain JS (`document.createElement`, `querySelector`) instead of jQuery and regex
- Simplify plugin registry update to accept parsed plugin data directly
- Revise `_getPluginDataFromMarkup` to extract plugin settings from `<script>` elements

Tests:
- Update unit tests to pass a DOM node to `_getPluginDataFromMarkup` and validate the new plugin data extraction output