### PR TITLE
fix: Show all text-enabled plugins

### DIFF
--- a/cms/plugin_pool.py
+++ b/cms/plugin_pool.py
@@ -177,8 +177,8 @@ class PluginPool:
         return plugins
 
     def get_text_enabled_plugins(self, placeholder, page) -> list[type[CMSPluginBase]]:
-        plugins = set(self.get_all_plugins(placeholder, page))
-        plugins.update(self.get_all_plugins(placeholder, page, "text_only_plugins"))
+        plugins = set(self.get_all_plugins(placeholder, page, root_plugin=False))
+        plugins.update(self.get_all_plugins(placeholder, page, setting_key="text_only_plugins", root_plugin=False))
         return sorted((p for p in plugins if p.text_enabled), key=attrgetter("module", "name"))
 
     def get_plugin(self, name) -> type[CMSPluginBase]:


### PR DESCRIPTION
## Description

In django CMS 5.0, not all text-enabled plugins are shown. This fixes it.
Tests, for historical reasons, are part of djangocms-text.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Pass root_plugin=False in both get_all_plugins calls within get_text_enabled_plugins to correctly include all text-enabled plugins.