### PR TITLE
fix: Show all text-enabled plugins

### DIFF
--- a/cms/plugin_pool.py
+++ b/cms/plugin_pool.py
@@ -177,8 +177,8 @@ class PluginPool:
         return plugins
 
     def get_text_enabled_plugins(self, placeholder, page) -> list[type[CMSPluginBase]]:
-        plugins = set(self.get_all_plugins(placeholder, page))
-        plugins.update(self.get_all_plugins(placeholder, page, "text_only_plugins"))
+        plugins = set(self.get_all_plugins(placeholder, page, root_plugin=False))
+        plugins.update(self.get_all_plugins(placeholder, page, setting_key="text_only_plugins", root_plugin=False))
         return sorted((p for p in plugins if p.text_enabled), key=attrgetter("module", "name"))
 
     def get_plugin(self, name) -> type[CMSPluginBase]:


### PR DESCRIPTION
## Description

In django CMS 5.0 not all text-enabled plugins are sent to djangocms-text/djangocms-text-editor. This PR fixes the issue.

Tests, for historical reason, are part of djangocms-text.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* https://github.com/django-cms/djangocms-text/actions/runs/15013809793/job/42187277923?pr=87 (tests in djangocms-text)
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Fix text-enabled plugin retrieval to include all relevant plugins in the editor

Bug Fixes:
- Ensure non-root text-enabled plugins are included in the plugin list

Enhancements:
- Explicitly pass root_plugin=False and name the setting_key parameter when retrieving plugins