### PR TITLE
chore: Move from script tags containing dom elements to template tags

### DIFF
--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -726,9 +726,9 @@ class ContentRenderer(BaseRenderer):
 class StructureRenderer(BaseRenderer):
     load_structure = True
     placeholder_edit_template = """
-        <script data-cms id="cms-plugin-child-classes-{placeholder_id}" type="text/cms-template">
+        <template data-cms id="cms-plugin-child-classes-{placeholder_id}" type="text/cms-template">
             {plugin_menu_js}
-        </script>
+        </template>
         {plugin_js}{placeholder_js}
         """
 
@@ -794,9 +794,9 @@ class LegacyRenderer(ContentRenderer):
     placeholder_edit_template = """
         {content}
         <div class="cms-placeholder cms-placeholder-{placeholder_id}"></div>
-        <script data-cms id="cms-plugin-child-classes-{placeholder_id}" type="text/cms-template">
+        <template data-cms id="cms-plugin-child-classes-{placeholder_id}" type="text/cms-template">
             {plugin_menu_js}
-        </script>
+        </template>
         {plugin_js}{placeholder_js}
         """
 

--- a/cms/tests/frontend/unit/fixtures/plugin_child_classes.html
+++ b/cms/tests/frontend/unit/fixtures/plugin_child_classes.html
@@ -1,4 +1,4 @@
-<script id="cms-plugin-child-classes-1" type="text/cms-template">
+<template id="cms-plugin-child-classes-1" type="text/cms-template">
     <div class="cms-submenu-item cms-submenu-item-title"><span>Accordion</span></div>
     <div class="cms-submenu-item"><a data-rel="add" href="Bootstrap3AccordionItemCMSPlugin">Accordion item</a></div>
     <div class="cms-submenu-item cms-submenu-item-title"><span>Bootstrap3</span></div>
@@ -81,4 +81,4 @@
     <div class="cms-submenu-item"><a data-rel="add" href="NewsBlogTagsPlugin">Tags</a></div>
     <div class="cms-submenu-item cms-submenu-item-title"><span>People</span></div>
     <div class="cms-submenu-item"><a data-rel="add" href="PeoplePlugin">People list</a></div>
-</script>
+</template>

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -1014,7 +1014,7 @@ class PlaceholderTestCase(TransactionCMSTestCase):
         for placeholder in declared_placeholders:
             self.assertContains(
                 response,
-                '<script data-cms id="cms-plugin-child-classes-%s" type="text/cms-template">'
+                '<template data-cms id="cms-plugin-child-classes-%s" type="text/cms-template">'
                 % placeholders.get(slot=placeholder.slot).pk,
             )
 
@@ -1037,7 +1037,7 @@ class PlaceholderTestCase(TransactionCMSTestCase):
         for placeholder in declared_placeholders:
             self.assertContains(
                 response,
-                '<script data-cms id="cms-plugin-child-classes-%s" type="text/cms-template">'
+                '<template data-cms id="cms-plugin-child-classes-%s" type="text/cms-template">'
                 % placeholders.get(slot=placeholder.slot).pk,
             )
 


### PR DESCRIPTION
## Description

Structure mode uses `<script>` tags to enclose DOM elements to not be rendered on the screen. These should be `<template>` tags.


## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Replace `<script>` tags with `<template>` tags for hidden plugin templates in structure mode.

Enhancements:
- Use `<template>` tags instead of `<script>` tags in StructureRenderer and LegacyRenderer placeholder edit templates.
- Update HTML fixtures to wrap plugin child class markup in `<template>` tags.

Tests:
- Adjust placeholder tests to expect `<template>` tags instead of `<script>` tags.