### PR TITLE
fix: Adjust checks for `GrouperAdmin` to allow for `prepopulated_fields`

### DIFF
--- a/cms/admin/utils.py
+++ b/cms/admin/utils.py
@@ -1,9 +1,11 @@
 import re
 import typing
+from copy import copy
 from urllib.parse import parse_qsl
 
 from django import forms
 from django.contrib.admin import ModelAdmin
+from django.contrib.admin.checks import ModelAdminChecks
 from django.contrib.admin.utils import label_for_field
 from django.contrib.admin.views.main import ChangeList
 from django.core.exceptions import ImproperlyConfigured, ValidationError
@@ -59,20 +61,21 @@ class ChangeListActionsMixin(metaclass=forms.MediaDefiningClass):
                 ...
 
                 def get_actions_list(self):
-                    return super().get_actions_list() + [self.my_first_action, self.my_second_action]
+                    return super().get_actions_list() + [
+                        self.my_first_action,
+                        self.my_second_action,
+                    ]
         """
         return []
 
-    def get_admin_list_actions(
-        self, request: HttpRequest
-    ) -> typing.Callable[[models.Model], str]:
+    def get_admin_list_actions(self, request: HttpRequest) -> typing.Callable[[models.Model], str]:
         """Method to register the admin action menu with the admin's list display
 
         Usage (in your model admin)::
 
             class MyModelAdmin(AdminActionsMixin, admin.ModelAdmin):
                 ...
-                list_display = ('name', ..., 'admin_list_actions')
+                list_display = ("name", ..., "admin_list_actions")
 
         """
 
@@ -81,10 +84,7 @@ class ChangeListActionsMixin(metaclass=forms.MediaDefiningClass):
             return format_html_join(
                 "",
                 "{}",
-                (
-                    (action(obj, request),)
-                    for action in self.get_actions_list()
-                ),
+                ((action(obj, request),) for action in self.get_actions_list()),
             )
 
         list_actions.short_description = _("Actions")
@@ -102,10 +102,7 @@ class ChangeListActionsMixin(metaclass=forms.MediaDefiningClass):
     ) -> tuple[typing.Union[str, typing.Callable[[models.Model], str]], ...]:
         list_display = super().get_list_display(request)
         return tuple(
-            self.get_admin_list_actions(request)
-            if item == "admin_list_actions"
-            else item
-            for item in list_display
+            self.get_admin_list_actions(request) if item == "admin_list_actions" else item for item in list_display
         )
 
     @staticmethod
@@ -135,11 +132,13 @@ class ChangeListActionsMixin(metaclass=forms.MediaDefiningClass):
         To add an action button to the change list use the following pattern in your admin class::
 
                  def my_custom_button(self, obj, request, disabled=False):
-                    # do preparations, e.g., check permissions, get url, ...
-                    url = admin_reverse("...", args=[obj.pk])
-                    if permissions_ok:
-                        return self.admin_action_button(url, "info",  _("View usage"), disabled=disabled)
-                    return ""  # No button
+                     # do preparations, e.g., check permissions, get url, ...
+                     url = admin_reverse("...", args=[obj.pk])
+                     if permissions_ok:
+                         return self.admin_action_button(
+                             url, "info", _("View usage"), disabled=disabled
+                         )
+                     return ""  # No button
 
         """
         return render_to_string(
@@ -172,6 +171,29 @@ class GrouperChangeListBase(ChangeList):
             if field in lookup_params:
                 del lookup_params[field]
         return lookup_params
+
+
+class GrouperModelAdminChecks(ModelAdminChecks):
+    def _check_prepopulated_fields_value_item(self, obj, field_name, label):
+        """For `prepopulated_fields` equal to {"slug": ("content__title",)},
+        `field_name` is "content__title"."""
+
+        if field_name.startswith(CONTENT_PREFIX) and obj.content_model:
+            field_name = field_name[len(CONTENT_PREFIX) :]
+            obj = copy(obj)
+            obj.model = obj.content_model
+        return super()._check_prepopulated_fields_value_item(obj, field_name, label)
+
+    def _check_prepopulated_fields_key(self, obj, field_name, label):
+        """Check a key of `prepopulated_fields` dictionary, i.e. check that it
+        is a name of existing field and the field is one of the allowed types.
+        """
+
+        if field_name.startswith(CONTENT_PREFIX) and obj.content_model:
+            field_name = field_name[len(CONTENT_PREFIX) :]
+            obj = copy(obj)
+            obj.model = obj.content_model
+        return super()._check_prepopulated_fields_key(obj, field_name, label)
 
 
 class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
@@ -229,6 +251,7 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
 
     change_list_template = "admin/cms/grouper/change_list.html"
     change_form_template = "admin/cms/grouper/change_form.html"
+    checks_class = GrouperModelAdminChecks
 
     class Media:
         js = (
@@ -254,9 +277,7 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
             # If not, try identifying using the naming convention {GrouperName}Content
             from django.apps import apps
 
-            self.content_model = apps.get_model(
-                f"{self.opts.app_label}.{self.model.__name__}Content"
-            )
+            self.content_model = apps.get_model(f"{self.opts.app_label}.{self.model.__name__}Content")
 
         # Add an admin manager if the content model does not have one.
         if not hasattr(self.content_model, "admin_manager"):
@@ -269,9 +290,7 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
                     self.content_related_field = related_object.get_accessor_name()
                     break
             else:
-                raise ImproperlyConfigured(
-                    f"Related field for grouper model {model.__name__} not found"
-                )
+                raise ImproperlyConfigured(f"Related field for grouper model {model.__name__} not found")
 
         # Set grouper field name to snake case grouper model name if not given explicitly
         if not self.grouper_field_name:
@@ -303,16 +322,16 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
     def _getter_factory(self, field: str) -> typing.Callable[[models.Model], typing.Any]:
         """Creates a getter function with ``short_description``, ``admin_order_field``, and ``boolean``
         properties suitable for the :attr:`~django.contrib.admin.ModelAdmin.list_display` field."""
+
         def getter(obj):
             return self.get_content_field(obj, field)
+
         getter.short_description = label_for_field(field, self.content_model)
         if field in self._content_subquery_fields:
             getter.admin_order_field = CONTENT_PREFIX + field
             if isinstance(self.content_model._meta.get_field(field), self.LC_SORTED_FIELDS):
                 getter.admin_order_field += "__lc"
-        getter.boolean = isinstance(
-            self.form.base_fields[CONTENT_PREFIX + field], forms.BooleanField
-        )
+        getter.boolean = isinstance(self.form.base_fields[CONTENT_PREFIX + field], forms.BooleanField)
         if not getter.boolean:
             # First non-boolean field will show empty content value by default.
             for display in getattr(self, "list_display", ()):
@@ -349,8 +368,7 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
             if isinstance(field, DateField):
                 # MySql needs an explicit cast, or it will return a string and not a date object
                 annotation[CONTENT_PREFIX + field_name] = Cast(
-                    annotation[CONTENT_PREFIX + field_name],
-                    field.__class__()
+                    annotation[CONTENT_PREFIX + field_name], field.__class__()
                 )
             if isinstance(field, self.LC_SORTED_FIELDS):
                 # Sort CharFields independently of case
@@ -361,7 +379,7 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
 
     def get_queryset(self, request: HttpRequest) -> models.QuerySet:
         """Annotates content fields with the name "content__{field_name}" to the grouper queryset if
-        for all content fields that appear in the """
+        for all content fields that appear in the"""
         return super().get_queryset(request).annotate(**self._get_annotation())
 
     def get_language_from_request(self, request: HttpRequest) -> str:
@@ -387,7 +405,9 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
     @property
     def current_content_filters(self) -> dict[str, typing.Any]:
         """Filters needed to get the correct content model instance"""
-        return {field: getattr(self, field, self.get_extra_grouping_field(field)) for field in self.extra_grouping_fields}
+        return {
+            field: getattr(self, field, self.get_extra_grouping_field(field)) for field in self.extra_grouping_fields
+        }
 
     def get_language(self) -> str:
         """Hook on how to get the current language. By default, if it is set as a
@@ -474,23 +494,17 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
             preserved_filters["_changelist_filters"] = urlencode(grouping_filters)
         return urlencode(preserved_filters)
 
-    def get_extra_context(
-        self, request: HttpRequest, object_id: typing.Optional[str] = None
-    ) -> dict[str, typing.Any]:
+    def get_extra_context(self, request: HttpRequest, object_id: typing.Optional[str] = None) -> dict[str, typing.Any]:
         """Provide the grouping fields to the change view."""
         if object_id:
             # Instance provided? Get corresponding postconent
             obj = get_object_or_404(self.model, pk=object_id)
             content_instance = self.get_content_obj(obj)
-            title = _("%(object_name)s Properties") % dict(
-                object_name=obj._meta.verbose_name.capitalize()
-            )
+            title = _("%(object_name)s Properties") % dict(object_name=obj._meta.verbose_name.capitalize())
         else:
             obj = None
             content_instance = None
-            title = _("Add new %(object_name)s") % dict(
-                object_name=self.model._meta.verbose_name
-            )
+            title = _("Add new %(object_name)s") % dict(object_name=self.model._meta.verbose_name)
 
         if content_instance:
             subtitle = str(content_instance)
@@ -511,11 +525,7 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
         if "language" in self.extra_grouping_fields:
             language = self.language
             if obj:
-                filled_languages = (
-                    self.get_content_objects(obj)
-                    .values_list("language", flat=True)
-                    .distinct()
-                )
+                filled_languages = self.get_content_objects(obj).values_list("language", flat=True).distinct()
             else:
                 filled_languages = []
 
@@ -523,17 +533,13 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
             extra_context["language"] = language
             extra_context["filled_languages"] = filled_languages
             if content_instance is None:
-                subtitle = _("Add %(language)s content") % dict(
-                    language=get_language_dict().get(self.language)
-                )
+                subtitle = _("Add %(language)s content") % dict(language=get_language_dict().get(self.language))
                 extra_context["subtitle"] = subtitle
 
         # TODO: Add context for other grouping fields to be shown as a dropdown
         return extra_context
 
-    def get_form(
-        self, request: HttpRequest, obj: typing.Optional[models.Model] = None, **kwargs
-    ) -> type:
+    def get_form(self, request: HttpRequest, obj: typing.Optional[models.Model] = None, **kwargs) -> type:
         """Adds the language from the request to the form class"""
         form_class = super().get_form(request, obj, **kwargs)
         form_class._admin = self
@@ -569,9 +575,7 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
         return self.EMPTY_ACTION
 
     def _get_settings_action(self, obj: models.Model, request: HttpRequest) -> str:
-        edit_url = admin_reverse(
-            f"{obj._meta.app_label}_{obj._meta.model_name}_change", args=(obj.pk,)
-        )
+        edit_url = admin_reverse(f"{obj._meta.app_label}_{obj._meta.model_name}_change", args=(obj.pk,))
         edit_url += f"?{urlencode(self.current_content_filters)}"
         return self.admin_action_button(
             url=edit_url,
@@ -612,23 +616,17 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
             ).latest_content()
         return self._content_qs_cache[obj]
 
-    def get_content_obj(
-        self, obj: typing.Optional[models.Model]
-    ) -> typing.Optional[models.Model]:
+    def get_content_obj(self, obj: typing.Optional[models.Model]) -> typing.Optional[models.Model]:
         if obj is None or self._is_content_obj(obj):
             return obj
         else:
             if obj not in self._content_obj_cache:
                 self._content_obj_cache[obj] = (
-                    self._get_content_queryset(obj)
-                    .filter(**self.current_content_filters)
-                    .first()
+                    self._get_content_queryset(obj).filter(**self.current_content_filters).first()
                 )
             return self._content_obj_cache[obj]
 
-    def get_content_objects(
-        self, obj: typing.Optional[models.Model]
-    ) -> models.QuerySet:
+    def get_content_objects(self, obj: typing.Optional[models.Model]) -> models.QuerySet:
         if obj is None:
             return None
         if self._is_content_obj(obj):
@@ -658,9 +656,7 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
             return get_object_preview_url(content_obj, language=getattr(content_obj, "language", None))
         return None
 
-    def get_readonly_fields(
-        self, request: HttpRequest, obj: typing.Optional[models.Model] = None
-    ):
+    def get_readonly_fields(self, request: HttpRequest, obj: typing.Optional[models.Model] = None):
         """Allow access to content fields to be controlled by a method "can_change_content":
         This allows versioned content to be protected if needed"""
         # First, get read-only fields for grouper
@@ -672,14 +668,11 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
                 fields += tuple(
                     CONTENT_PREFIX + field
                     for field in self.form._content_fields
-                    if field != self.grouper_field_name
-                    and field not in self.extra_grouping_fields
+                    if field != self.grouper_field_name and field not in self.extra_grouping_fields
                 )
         return fields
 
-    def save_model(
-        self, request: HttpRequest, obj: models.Model, form: forms.Form, change: bool
-    ) -> None:
+    def save_model(self, request: HttpRequest, obj: models.Model, form: forms.Form, change: bool) -> None:
         """Save/create both grouper and content object"""
         super().save_model(request, obj or form.instance, form, change)
         content_dict = {
@@ -691,15 +684,11 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
             content_dict[self.grouper_field_name] = form.instance
             if hasattr(form._content_model.objects, "with_user"):
                 # Create new using with_user syntax if available ...
-                form._content_model.objects.with_user(request.user).create(
-                    **content_dict
-                )
+                form._content_model.objects.with_user(request.user).create(**content_dict)
             else:  # pragma: no cover
                 # ... without otherwise
                 form._content_model.objects.create(**content_dict)
-        elif not hasattr(self, "can_change_content") or self.can_change_content(
-            request, form._content_instance
-        ):
+        elif not hasattr(self, "can_change_content") or self.can_change_content(request, form._content_instance):
             # Update content instance (only if can_change_content allows it)
             for key, value in content_dict.items():
                 setattr(form._content_instance, key, value)
@@ -744,16 +733,12 @@ class _GrouperAdminFormMixin:
         super().__init__(*args, **kwargs)
 
         # Hide grouper foreign key
-        self.fields[
-            CONTENT_PREFIX + self._admin.grouper_field_name
-        ].widget = forms.HiddenInput()
+        self.fields[CONTENT_PREFIX + self._admin.grouper_field_name].widget = forms.HiddenInput()
         # Will be set on admin model save
         self.fields[CONTENT_PREFIX + self._admin.grouper_field_name].required = False
         self.update_labels(self._content_fields)
         if hasattr(self._admin, "can_change_content") and False:
-            if not self._admin.can_change_content(
-                self._request, self._content_instance
-            ):
+            if not self._admin.can_change_content(self._request, self._content_instance):
                 # Only allow content object fields to be edited if user can change them
                 for field in self._additional_content_fields:
                     self.fields[field].disabled = True
@@ -773,30 +758,23 @@ class _GrouperAdminFormMixin:
                         self._meta.labels = {}
                     self._meta.labels.setdefault(
                         CONTENT_PREFIX + field,
-                        label_for_field(field, self._admin.content_model)
-                        + language_postfix,
+                        label_for_field(field, self._admin.content_model) + language_postfix,
                     )
 
     def clean(self) -> dict:
         if (
             f"{CONTENT_PREFIX}language" in self.cleaned_data
-            and self.cleaned_data[f"{CONTENT_PREFIX}language"]
-            not in get_language_list()
+            and self.cleaned_data[f"{CONTENT_PREFIX}language"] not in get_language_list()
         ):
             raise ValidationError(
-                _(
-                    "Invalid language %(value)s. This form cannot be processed. Try changing languages."
-                ),
-                params=dict(
-                    value=self.cleaned_data.get("language", _("<unspecified>"))
-                ),
+                _("Invalid language %(value)s. This form cannot be processed. Try changing languages."),
+                params=dict(value=self.cleaned_data.get("language", _("<unspecified>"))),
                 code="invalid-language",
             )
         return super().clean()
 
 
 class GrouperAdminFormMixin:
-
     """Actually a factory class that creates the GrouperAdminFormMixin. Pass the Model or ModelForm as a
     parameter::
 
@@ -817,9 +795,7 @@ class GrouperAdminFormMixin:
 
     def __new__(cls, content_model: models.base.ModelBase) -> type:
         model_form = modelform_factory(content_model, fields="__all__")
-        base_fields = {
-            CONTENT_PREFIX + key: value for key, value in model_form.base_fields.items()
-        }
+        base_fields = {CONTENT_PREFIX + key: value for key, value in model_form.base_fields.items()}
         return forms.forms.DeclarativeFieldsMetaclass(
             GrouperAdminFormMixin.__name__,
             (_GrouperAdminFormMixin,),

--- a/cms/test_utils/project/sampleapp/models.py
+++ b/cms/test_utils/project/sampleapp/models.py
@@ -9,7 +9,7 @@ from cms.utils.placeholder import get_placeholder_from_slot
 
 
 class Category(MP_Node):
-    parent = models.ForeignKey('self', blank=True, null=True, on_delete=models.CASCADE)
+    parent = models.ForeignKey("self", blank=True, null=True, on_delete=models.CASCADE)
     name = models.CharField(max_length=20)
     placeholders = PlaceholderRelationField()
 
@@ -21,10 +21,10 @@ class Category(MP_Node):
         return self.name
 
     def get_absolute_url(self):
-        return reverse('category_view', args=[self.pk])
+        return reverse("category_view", args=[self.pk])
 
     class Meta:
-        verbose_name_plural = 'categories'
+        verbose_name_plural = "categories"
 
 
 class Picture(models.Model):
@@ -46,6 +46,7 @@ class SomeEditableModel(models.Model):
 
 class GrouperModel(models.Model):
     category_name = models.CharField(max_length=200, default="")
+    some_field = models.CharField(max_length=200, default="")
 
 
 class GrouperModelContent(models.Model):
@@ -61,7 +62,7 @@ class GrouperModelContent(models.Model):
             ("en", "English"),
             ("de", "German"),
             ("it", "Italian"),
-        )
+        ),
     )
 
     region = models.TextField(
@@ -73,8 +74,8 @@ class GrouperModelContent(models.Model):
             ("europe", "Europe"),
             ("africa", "Africa"),
             ("asia", "Asia"),
-            ("australia", "Australia")
-        )
+            ("australia", "Australia"),
+        ),
     )
 
     uptodate = models.BooleanField(
@@ -104,10 +105,8 @@ class SimpleGrouperModelContent(models.Model):
             ("en", "English"),
             ("de", "German"),
             ("it", "Italian"),
-        )
+        ),
     )
-
-
 
     region = models.TextField(
         default="world",
@@ -118,8 +117,8 @@ class SimpleGrouperModelContent(models.Model):
             ("europe", "Europe"),
             ("africa", "Africa"),
             ("asia", "Asia"),
-            ("australia", "Australia")
-        )
+            ("australia", "Australia"),
+        ),
     )
 
     uptodate = models.BooleanField(

--- a/cms/tests/test_grouper_admin.py
+++ b/cms/tests/test_grouper_admin.py
@@ -1,3 +1,5 @@
+import copy
+
 from django.contrib.admin import site
 from django.templatetags.static import static
 from django.utils.crypto import get_random_string
@@ -18,10 +20,9 @@ from cms.utils.urlutils import admin_reverse, static_with_version
 
 class SetupMixin:
     """Create one grouper object and retrieve the admin instance"""
+
     def setUp(self) -> None:
-        self.grouper_instance = GrouperModel.objects.create(
-            category_name="Grouper Category"
-        )
+        self.grouper_instance = GrouperModel.objects.create(category_name="Grouper Category")
         self.add_url = admin_reverse("sampleapp_groupermodel_add")
         self.change_url = admin_reverse("sampleapp_groupermodel_change", args=(self.grouper_instance.pk,))
         self.changelist_url = admin_reverse("sampleapp_groupermodel_changelist")
@@ -48,10 +49,9 @@ class SetupMixin:
 
 class SimpleSetupMixin:
     """Create one grouper object and retrieve the admin instance"""
+
     def setUp(self) -> None:
-        self.grouper_instance = SimpleGrouperModel.objects.create(
-            category_name="Grouper Category"
-        )
+        self.grouper_instance = SimpleGrouperModel.objects.create(category_name="Grouper Category")
         self.add_url = admin_reverse("sampleapp_simplegroupermodel_add")
         self.change_url = admin_reverse("sampleapp_simplegroupermodel_change", args=(self.grouper_instance.pk,))
         self.changelist_url = admin_reverse("sampleapp_simplegroupermodel_changelist")
@@ -97,8 +97,9 @@ class SimpleChangeListActionsTestCase(SimpleSetupMixin, CMSTestCase):
             response = self.client.get(f"{self.changelist_url}?language=en", follow=True)
             # Assert
             self.assertContains(response, 'class="cms-icon cms-icon-plus"')
-            self.assertContains(response, f'href="/en/admin/sampleapp/{self.groupermodel}/{self.grouper_instance.pk}'
-                                          f'/change/?')
+            self.assertContains(
+                response, f'href="/en/admin/sampleapp/{self.groupermodel}/{self.grouper_instance.pk}/change/?'
+            )
             self.assertNotContains(response, 'class="cms-icon cms-icon-view"')
 
     def test_change_action(self):
@@ -110,8 +111,9 @@ class SimpleChangeListActionsTestCase(SimpleSetupMixin, CMSTestCase):
             response = self.client.get(f"{self.changelist_url}?language=en", follow=True)
             # Assert
             self.assertContains(response, 'class="cms-icon cms-icon-view"')
-            self.assertContains(response, f'href="/en/admin/sampleapp/{self.groupermodel}/{self.grouper_instance.pk}'
-                                          f'/change/?')
+            self.assertContains(
+                response, f'href="/en/admin/sampleapp/{self.groupermodel}/{self.grouper_instance.pk}/change/?'
+            )
             self.assertContains(response, 'class="cms-icon cms-icon-view"')
 
     def test_get_action(self):
@@ -176,7 +178,7 @@ class GrouperModelAdminTestCase(SetupMixin, CMSTestCase):
             current_content_filters = self.admin.current_content_filters
 
             self.assertEqual(admin_language, expected_language)
-            self.assertEqual(current_content_filters["language"],  expected_language)
+            self.assertEqual(current_content_filters["language"], expected_language)
 
     def test_extra_grouping_field_current(self):
         """Extra grouping fields (language) when not set return current default correctly"""
@@ -188,6 +190,39 @@ class GrouperModelAdminTestCase(SetupMixin, CMSTestCase):
 
         self.assertEqual(admin_language, expected_language)
         self.assertEqual(current_content_filters["language"], expected_language)
+
+    def test_prepopulated_fields_pass_checks(self):
+        """Prepopulated fields work for content field"""
+        # Arrange
+        admin = copy.copy(self.admin)
+        admin.prepopulated_fields = dict(
+            category_name=["category_name"],  # Both key and value from GrouperModel
+            some_field=["content__secret_greeting"],  # Value from ContentModel
+            content__secret_greeting=["category_name"],  # Key from GrouperModel
+            content__region=["content__secret_greeting"],  # Both key and value from ContentModel
+        )
+
+        # Act
+        check_results = admin.check()
+
+        # Assert
+        self.assertEqual(check_results, [])  # No errors
+
+    def test_invalid_prepopulated_content_fields_fail_checks(self):
+        """Prepopulated fields with invalid content field names fail checks"""
+        # Arrange
+        admin = copy.copy(self.admin)
+        admin.prepopulated_fields = dict(
+            some_field=["content__public_greeting"],  # Value from ContentModel: 1 error
+            content__public_greeting=["category_name"],  # Key from GrouperModel: 1 error
+            content__country=["content__public_greeting"],  # Both key and value from ContentModel: 2 errors
+        )
+
+        # Act
+        check_results = admin.check()
+
+        # Assert
+        self.assertEqual(len(check_results), 4)  # No errors
 
 
 class GrouperChangeListTestCase(SetupMixin, CMSTestCase):
@@ -371,6 +406,7 @@ class GrouperChangeTestCase(SetupMixin, CMSTestCase):
         data = {
             "content__language": "en",
             "category_name": "Changed content",
+            "some_field": "some content",
             "content__region": "world",
             "content__secret_greeting": random_content.secret_greeting,
         }
@@ -388,6 +424,7 @@ class GrouperChangeTestCase(SetupMixin, CMSTestCase):
         data = {
             "content__language": "en",
             "category_name": self.grouper_instance.category_name,
+            "some_field": "some content",
             "content__region": "world",
             "content__secret_greeting": "New greeting",
         }
@@ -405,6 +442,7 @@ class GrouperChangeTestCase(SetupMixin, CMSTestCase):
         data = {
             "content__language": "de",
             "category_name": "My new category",
+            "some_field": "some content",
             "content__region": "world",
             "content__secret_greeting": "Some new content",
         }
@@ -429,6 +467,7 @@ class GrouperChangeTestCase(SetupMixin, CMSTestCase):
         data = {
             "content__language": "de",
             "category_name": self.grouper_instance.category_name,
+            "some_field": "some content",
             "content__region": "world",
             "content__secret_greeting": "New German content",
         }

--- a/cms/tests/test_grouper_admin.py
+++ b/cms/tests/test_grouper_admin.py
@@ -222,7 +222,7 @@ class GrouperModelAdminTestCase(SetupMixin, CMSTestCase):
         check_results = admin.check()
 
         # Assert
-        self.assertEqual(len(check_results), 4)  # No errors
+        self.assertEqual(len(check_results), 4)  # 4 errors expected (see above)
 
 
 class GrouperChangeListTestCase(SetupMixin, CMSTestCase):


### PR DESCRIPTION
## Description

This PR fixes #8231 . `GrouperAdmin` supports prepopulated fields, the checks framework, however, needs to recognize fields that belong to the content model. This PR adjusts the checks for the `GrouperAdmin` class.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8231 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Adjust GrouperAdmin to properly validate prepopulated_fields entries referencing content model fields by recognizing and stripping the “content__” prefix and hooking a custom checks class into GrouperModelAdmin, and add tests covering valid and invalid prepopulated_fields scenarios.

Bug Fixes:
- Allow prepopulated_fields keys and values prefixed with “content__” to pass checks by mapping them to the content model before validation.

Enhancements:
- Introduce GrouperModelAdminChecks and configure it as the checks_class for GrouperModelAdmin to handle content model field validation.
- Improve code formatting and line wrapping consistency across admin utility methods.

Tests:
- Add tests verifying that valid content model fields in prepopulated_fields produce no check errors.
- Add tests verifying that invalid content model field names in prepopulated_fields produce appropriate check errors.