### PR TITLE
chore: Move from script tags containing dom elements to template tags

### DIFF
--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -764,9 +764,9 @@ class ContentRenderer(BaseRenderer):
 class StructureRenderer(BaseRenderer):
     load_structure = True
     placeholder_edit_template = """
-        <script data-cms id="cms-plugin-child-classes-{placeholder_id}" type="text/cms-template">
+        <template data-cms id="cms-plugin-child-classes-{placeholder_id}" type="text/cms-template">
             {plugin_menu_js}
-        </script>
+        </template>
         {plugin_js}{placeholder_js}
         """
 
@@ -853,9 +853,9 @@ class LegacyRenderer(ContentRenderer):
     placeholder_edit_template = """
         {content}
         <div class="cms-placeholder cms-placeholder-{placeholder_id}"></div>
-        <script data-cms id="cms-plugin-child-classes-{placeholder_id}" type="text/cms-template">
+        <template data-cms id="cms-plugin-child-classes-{placeholder_id}" type="text/cms-template">
             {plugin_menu_js}
-        </script>
+        </template>
         {plugin_js}{placeholder_js}
         """
 

--- a/cms/tests/frontend/unit/fixtures/plugin_child_classes.html
+++ b/cms/tests/frontend/unit/fixtures/plugin_child_classes.html
@@ -1,4 +1,4 @@
-<script id="cms-plugin-child-classes-1" type="text/cms-template">
+<template id="cms-plugin-child-classes-1" type="text/cms-template">
     <div class="cms-submenu-item cms-submenu-item-title"><span>Accordion</span></div>
     <div class="cms-submenu-item"><a data-rel="add" href="Bootstrap3AccordionItemCMSPlugin">Accordion item</a></div>
     <div class="cms-submenu-item cms-submenu-item-title"><span>Bootstrap3</span></div>
@@ -81,4 +81,4 @@
     <div class="cms-submenu-item"><a data-rel="add" href="NewsBlogTagsPlugin">Tags</a></div>
     <div class="cms-submenu-item cms-submenu-item-title"><span>People</span></div>
     <div class="cms-submenu-item"><a data-rel="add" href="PeoplePlugin">People list</a></div>
-</script>
+</template>

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -1023,7 +1023,7 @@ class PlaceholderTestCase(TransactionCMSTestCase):
         for placeholder in declared_placeholders:
             self.assertContains(
                 response,
-                '<script data-cms id="cms-plugin-child-classes-%s" type="text/cms-template">'
+                '<template data-cms id="cms-plugin-child-classes-%s" type="text/cms-template">'
                 % placeholders.get(slot=placeholder.slot).pk,
             )
 
@@ -1046,7 +1046,7 @@ class PlaceholderTestCase(TransactionCMSTestCase):
         for placeholder in declared_placeholders:
             self.assertContains(
                 response,
-                '<script data-cms id="cms-plugin-child-classes-%s" type="text/cms-template">'
+                '<template data-cms id="cms-plugin-child-classes-%s" type="text/cms-template">'
                 % placeholders.get(slot=placeholder.slot).pk,
             )
 


### PR DESCRIPTION
## Description

Ports back #8233 to `release/5.0.x`
<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8233 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Backport the change to use HTML <template> elements in place of <script> tags for plugin placeholder content in the 5.0.x release

Enhancements:
- Replace <script> tags wrapping cms-plugin-child-classes content with <template> tags in rendering logic

Tests:
- Update test fixtures and assertions to expect <template> tags instead of <script> for plugin-child-classes templates