### PR TITLE
replace outdated usage of `page__node__path` with `page__path`

### DIFF
--- a/cms/models/contentmodels.py
+++ b/cms/models/contentmodels.py
@@ -226,7 +226,7 @@ class PageContent(models.Model):
                     self
                     .get_ancestor_titles()
                     .exclude(template=constants.TEMPLATE_INHERITANCE_MAGIC)
-                    .order_by('-page__node__path')
+                    .order_by('-page__path')
                     .values_list('template', flat=True)
                 )
                 if templates:


### PR DESCRIPTION
## Description

I noticed that there was still a usage of the removed `node` in a order_by of a query.

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
