### PR TITLE
fix: 404 no raised in CMS view when no URLs match

### DIFF
--- a/cms/page_rendering.py
+++ b/cms/page_rendering.py
@@ -63,7 +63,7 @@ def _handle_no_page(request):
     try:
         match = resolve(request.path)
     except Resolver404 as e:
-        raise Http404(dict(path=request.path, tried=e.args[0]['tried']))
+        raise Http404(dict(path=request.path, tried=e.args[0]['tried'])) from e
 
     # redirect to PageContent's changelist if the root page is detected
     if match.url_name == 'pages-root':

--- a/cms/page_rendering.py
+++ b/cms/page_rendering.py
@@ -61,17 +61,15 @@ def render_page(request, page, current_language, slug=None):
 
 def _handle_no_page(request):
     try:
-        # redirect to PageContent's changelist if the root page is detected
-        resolved_path = resolve(request.path)
-        if resolved_path.url_name == 'pages-root':
-            redirect_url = admin_reverse('cms_pagecontent_changelist')
-            return HttpResponseRedirect(redirect_url)
-
-        # add a $ to the end of the url (does not match on the cms anymore)
-        return resolve('%s$' % request.path).func(request)
+        match = resolve(request.path)
     except Resolver404 as e:
-        # raise a django http 404 page
         raise Http404(dict(path=request.path, tried=e.args[0]['tried']))
+
+    # redirect to PageContent's changelist if the root page is detected
+    if match.url_name == 'pages-root':
+        redirect_url = admin_reverse('cms_pagecontent_changelist')
+        return HttpResponseRedirect(redirect_url)
+    raise Http404(dict(path=request.path, tried=match.tried))
 
 
 def _handle_no_apphook(request):


### PR DESCRIPTION
Fixes #8239

I split up the intentions:
- Resolve path and raise 404 if it fails
- Detect `"pages-root"` on the match and redirect
- Otherwise raise 404 with the tries from the match.

## Summary by Sourcery

Refactor the page-rendering fallback to resolve the request path once, redirect root pages correctly, and consistently raise Http404 with accurate resolution attempts

Bug Fixes:
- Raise Http404 with the correct `tried` information when URL resolution fails

Enhancements:
- Consolidate URL resolution in `_handle_no_page` by removing the redundant `$`-suffix resolve
- Maintain the admin redirect for `pages-root` based on the initial path resolution instead of inside the exception handler