### PR TITLE
fix: Remove unused import

### DIFF
--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.core.cache import cache
-from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.utils import IntegrityError
 from django.http import HttpResponse, HttpResponseNotFound


### PR DESCRIPTION
## Description

While I was reviewing the tests for the project while working on another PR, I found an unused import statement in `cms/tests/test_page.py`. I took the initiative to remove it and submit this small pull request.

If this change is unnecessary or if I should have consulted the Discord server or opened an issue beforehand, I apologize for any oversight.

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
