### PR TITLE
fix: broken links in CONTRIBUTING file

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -4,7 +4,7 @@ CONTRIBUTING
 
 First, thank you very much, that you would like to contribute to django CMS.
 We always welcome contributions, like many other open-source projects. We are
-very thankful to the many `present, past and future contributors <https://github.com/django-cms/django-cms/graphs/contributors>`_, to our `community heroes <https://github.com/django-cms/django-cms-mgmt/blob/master/community%20heros/list%20of%20community%20heros.md>`_ and to the `members of the django CMS Association <https://github.com/django-cms/django-cms-mgmt/blob/master/association/members.md>`_.
+very thankful to the many `present, past and future contributors <https://github.com/django-cms/django-cms/graphs/contributors>`_, to our `community champions <https://www.django-cms.org/en/community/django-cms-supporters/#champions>`_ and to the `members of the django CMS Association <https://www.django-cms.org/en/about-us/#django-cms-team>`_.
 
 
 Code of Conduct
@@ -79,17 +79,11 @@ You can join us online:
 
 You can join a work group and work collaboratively on django CMS
 
-* `work groups <https://www.django-cms.org/en/join-work-group/>`_
+* `work groups <https://www.django-cms.org/en/roadmap/>`_
 
 You can become a member of the django CMS Association and receive benefits
 
 * `Membership <https://www.django-cms.org/en/memberships/>`_
-
-
-Receive rewards for submitting pull requests
---------------------------------------------
-
-Sign up for our `Bounty program <https://www.django-cms.org/en/bounty-program/>`_.
 
 
 Join a work group

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -77,10 +77,6 @@ You can join us online:
 
 * at our `django CMS Discord Server <https://discord-main-channel.django-cms.org>`_
 
-You can join a work group and work collaboratively on django CMS
-
-* `work groups <https://www.django-cms.org/en/roadmap/>`_
-
 You can become a member of the django CMS Association and receive benefits
 
 * `Membership <https://www.django-cms.org/en/memberships/>`_


### PR DESCRIPTION
## Description

- Fix broken links.
- Update the term "community heroes" to "community champions" for consistency with official documentation.
- Remove duplicated mention of work groups.
- Remove the section about the bounty program.

## Related resources

- #8242 

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Fix broken links and streamline the CONTRIBUTING guide by updating terminology and removing duplicate and outdated sections.

Bug Fixes:
- Fix broken links in CONTRIBUTING file

Documentation:
- Update 'community heroes' to 'community champions' terminology
- Remove duplicate work groups mention and obsolete bounty program section in CONTRIBUTING