### PR TITLE
fix: Add `default_auto_field` to cms/apps.py

### DIFF
--- a/cms/apps.py
+++ b/cms/apps.py
@@ -5,6 +5,7 @@ from django.utils.translation import gettext_lazy as _
 class CMSConfig(AppConfig):
     name = 'cms'
     verbose_name = _("django CMS")
+    default_auto_field = 'django.db.models.AutoField'
 
     def ready(self):
         from cms.utils.setup import setup, setup_cms_apps

--- a/menus/apps.py
+++ b/menus/apps.py
@@ -5,3 +5,4 @@ from django.utils.translation import gettext_lazy as _
 class MenusConfig(AppConfig):
     name = 'menus'
     verbose_name = _("django CMS menus system")
+    default_auto_field = 'django.db.models.AutoField'


### PR DESCRIPTION
## Description

Adds the `default_auto_field` property to `cms.apps` and menus.apps`.

Fixes #8253 - no more migrations created when project `DEFAULT_AUTO_FIELD` is not set to `AutoField`.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8253 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Enhancements:
- Add default_auto_field attribute to CMSConfig and MenusConfig to prevent Django warnings about missing default auto fields