### PR TITLE
fix: Apphook widget detection (#8263)

### DIFF
--- a/cms/static/cms/js/widgets/forms.apphookselect.js
+++ b/cms/static/cms/js/widgets/forms.apphookselect.js
@@ -10,39 +10,40 @@ __webpack_public_path__ = require('../modules/get-dist-path')('bundle.forms.apph
 // #############################################################################
 // APP HOOK SELECT
 require.ensure([], function (require) {
-    var $ = require('jquery');
-    var apphookData = {
+    const $ = require('jquery');
+    let apphookData = {
         apphooks_configuration: {},
         apphooks_configuration_value: undefined,
         apphooks_configuration_url: {}
     };
-    var dataElement = document.querySelector('script[data-cms-widget-applicationconfigselect]');
-
-    if (dataElement) {
-        apphookData = JSON.parse(dataElement.querySelector('script').textContent);
-    }
-
-    var apphooks_configuration = apphookData.apphooks_configuration || {};
 
     // shorthand for jQuery(document).ready();
     $(function () {
-        var appHooks = $('#application_urls, #id_application_urls');
-        var selected = appHooks.find('option:selected');
-        var appNsRow = $('.form-row.application_namespace, .form-row.field-application_namespace');
-        var appNs = appNsRow.find('#application_namespace, #id_application_namespace');
-        var appCfgsRow = $('.form-row.application_configs, .form-row.field-application_configs');
-        var appCfgs = appCfgsRow.find('#application_configs, #id_application_configs');
-        var appCfgsAdd = appCfgsRow.find('#add_application_configs');
-        var original_ns = appNs.val();
+        const dataElement = document.querySelector('div[data-cms-widget-applicationconfigselect]');
+
+        if (dataElement) {
+            apphookData = JSON.parse(dataElement.querySelector('script').textContent);
+        }
+
+        const apphooks_configuration = apphookData.apphooks_configuration || {};
+
+        const appHooks = $('#application_urls, #id_application_urls');
+        const selected = appHooks.find('option:selected');
+        const appNsRow = $('.form-row.application_namespace, .form-row.field-application_namespace');
+        const appNs = appNsRow.find('#application_namespace, #id_application_namespace');
+        const appCfgsRow = $('.form-row.application_configs, .form-row.field-application_configs');
+        const appCfgs = appCfgsRow.find('#application_configs, #id_application_configs');
+        const appCfgsAdd = appCfgsRow.find('#add_application_configs');
+        const original_ns = appNs.val();
 
         // Shows / hides namespace / config selection widgets depending on the user input
         appHooks.setupNamespaces = function () {
-            var opt = $(this).find('option:selected');
+            const opt = $(this).find('option:selected');
 
             if ($(appCfgs).length > 0 && apphooks_configuration[opt.val()]) {
                 appCfgs.html('');
-                for (var i = 0; i < apphooks_configuration[opt.val()].length; i++) {
-                    var selectedCfgs = '';
+                for (let i = 0; i < apphooks_configuration[opt.val()].length; i++) {
+                    let selectedCfgs = '';
 
                     if (apphooks_configuration[opt.val()][i][0] === apphookData.apphooks_configuration_value) {
                         selectedCfgs = 'selected="selected"';
@@ -58,7 +59,8 @@ require.ensure([], function (require) {
                     // exists, and if it does - we add `_popup` ourselves, because otherwise the popup with
                     // apphook creation form will not be dismissed correctly
                     (window.showRelatedObjectPopup ? '?_popup=1' : ''));
-                appCfgsAdd.on('click', function () {
+                appCfgsAdd.on('click', function (ev) {
+                    ev.preventDefault();
                     window.showAddAnotherPopup(this);
                 });
                 appCfgsRow.removeClass('hidden');


### PR DESCRIPTION
Port forward of #8263 

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8263 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Update the apphook widget JavaScript to correctly detect configuration data by querying the wrapper div, add event prevention for the config-add button, and modernize variable declarations

Bug Fixes:
- Select the outer div rather than the script tag to parse widget configuration JSON
- Prevent default action on the “add configuration” button to avoid unintended navigation

Enhancements:
- Replace var with const/let throughout the widget code