### PR TITLE
fix: show_placeholder did not respect edit/preview mode and failed loudly

### DIFF
--- a/cms/admin/utils.py
+++ b/cms/admin/utils.py
@@ -737,11 +737,6 @@ class _GrouperAdminFormMixin:
         # Will be set on admin model save
         self.fields[CONTENT_PREFIX + self._admin.grouper_field_name].required = False
         self.update_labels(self._content_fields)
-        if hasattr(self._admin, "can_change_content") and False:
-            if not self._admin.can_change_content(self._request, self._content_instance):
-                # Only allow content object fields to be edited if user can change them
-                for field in self._additional_content_fields:
-                    self.fields[field].disabled = True
 
     def update_labels(self, fields: list[str]) -> None:
         """Adds a language indicator to field labels"""

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -872,10 +872,13 @@ class Page(MP_Node):
             return self.get_title(language, True, force_reload)
         return menu_title
 
-    def get_placeholders(self, language):
+    def get_placeholders(self, language: str, admin_manager: bool = False) -> models.QuerySet:
         from cms.models import PageContent, Placeholder
 
-        page_content = PageContent.objects.get(language=language, page=self)
+        if admin_manager:
+            page_content = PageContent.admin_manager.latest_content().get(language=language, page=self)
+        else:
+            page_content = PageContent.objects.get(language=language, page=self)
         return Placeholder.objects.get_for_obj(page_content)
 
     def get_changed_date(self, language=None, fallback=True, force_reload=False):

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -38,6 +38,7 @@ from cms.exceptions import PlaceholderNotFound
 from cms.models import (
     CMSPlugin,
     Page,
+    PageContent,
     Placeholder as PlaceholderModel,
 )
 from cms.plugin_pool import plugin_pool
@@ -121,8 +122,10 @@ def _show_placeholder_by_id(context, placeholder_name, reverse_id, lang=None, si
         lang = renderer.request_language
 
     try:
-        placeholder = page.get_placeholders(lang).get(slot=placeholder_name)
-    except PlaceholderModel.DoesNotExist:
+        toolbar = get_toolbar_from_request(request)
+        admin_manager = toolbar.edit_mode_active or toolbar.preview_mode_active
+        placeholder = page.get_placeholders(lang, admin_manager=admin_manager).get(slot=placeholder_name)
+    except (PlaceholderModel.DoesNotExist, PageContent.DoesNotExist):
         if settings.DEBUG:
             raise
         return ""

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -295,6 +295,22 @@ class TemplatetagDatabaseTests(TwoPagesFixture, CMSTestCase):
             context = self.get_context("/")
 
             self.assertRaises(
+                PageContent.DoesNotExist, _show_placeholder_by_id, context, "does_not_exist", "myreverseid", lang="go-lang"
+            )
+        with self.settings(DEBUG=False):
+            content = _show_placeholder_by_id(context, "does_not_exist", "myreverseid", lang="go-lang")
+            self.assertEqual(content, "")
+
+    def test_show_placeholder_for_page_content_does_not_exist(self):
+        """
+        Verify ``show_placeholder`` correctly handles being given an
+        invalid identifier.
+        """
+
+        with self.settings(DEBUG=True):
+            context = self.get_context("/")
+
+            self.assertRaises(
                 Placeholder.DoesNotExist, _show_placeholder_by_id, context, "does_not_exist", "myreverseid"
             )
         with self.settings(DEBUG=False):


### PR DESCRIPTION
## Description

This PR fixes #8271, by 
* letting the `{% show_placeholder %}` tag fail silently if the targeted page does not have a content object in the required language
* respecting page content objects only visible in the admin in edit and preview mode

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8271 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``main``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
