### PR TITLE
fix: Page '__str__' return page title for all pages

### DIFF
--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -146,7 +146,7 @@ class Page(MP_Node):
         #: Might be larger than the page_content_cache
 
     def __str__(self):
-        page_content = self.get_content_obj(get_language(), fallback=True)
+        page_content = self.get_admin_content(get_language(), fallback=True)
         if page_content:
             title = page_content.menu_title or page_content.title
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ djangocms = "cms.management.djangocms:execute_from_command_line"
 
 [tool.setuptools]
 packages = [ "cms", "menus" ]
+include-package-data = true
 
 [tool.setuptools.dynamic]
 version = { attr = "cms.__version__" }


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* # Issue: [link](https://github.com/django-cms/django-cms/issues/8278)

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``main``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Always return a page title in PageModel.__str__ by using admin content and removing the “No available title” fallback.

Enhancements:
- Use get_admin_content instead of get_content_obj in PageModel.__str__ to retrieve the page’s menu title or title.
- Remove the fallback to “No available title” so __str__ consistently shows a page title.