### PR TITLE
chore: Include package data in distr

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ djangocms = "cms.management.djangocms:execute_from_command_line"
 
 [tool.setuptools]
 packages = [ "cms", "menus" ]
+include-package-data = true
 
 [tool.setuptools.dynamic]
 version = { attr = "cms.__version__" }


### PR DESCRIPTION
## Description

With current pyproject.toml the build process does not include code of submodules such as `cms.models` .
This PR fixes that.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.
