### PR TITLE
chore: Introduce dynamic badges

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,14 +2,13 @@
 source =
     cms
     menus
+parallel = True
 branch = False
 omit =
     cms/migrations/*
-    cms/south_migrations/*
     cms/tests/*
     cms/test_utils/*
     menus/migrations/*
-    menus/south_migrations/*
     docs/*
     env/*
     env*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,12 +59,18 @@ jobs:
         uv pip install --system -r test_requirements/databases.txt
         uv pip install --system -e .
 
-    - name: Test with django test runner
+    - name: Test with django test runner (coverage enabled)
       run: |
-        python manage.py test
+        coverage run manage.py test
       env:
         DATABASE_URL: postgres://postgres:postgres@127.0.0.1/postgres
 
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-data-${{ github.job }}-${{ matrix.python-version }}-${{ matrix.requirements-file }}
+        include-hidden-files: true
+        path: '.coverage*'
 
   mysql:
     runs-on: ${{ matrix.os }}
@@ -117,11 +123,18 @@ jobs:
         uv pip install --system -r test_requirements/databases.txt
         uv pip install --system -e .
 
-    - name: Test with django test runner
+    - name: Test with django test runner (coverage enabled)
       run: |
-        python manage.py test
+        coverage run manage.py test
       env:
         DATABASE_URL: mysql://root@127.0.0.1/djangocms_test
+
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-data-${{ github.job }}-${{ matrix.python-version }}-${{ matrix.requirements-file }}
+        include-hidden-files: true
+        path: '.coverage*'
 
   sqlite:
     runs-on: ${{ matrix.os }}
@@ -163,10 +176,17 @@ jobs:
         uv pip install --system -r test_requirements/databases.txt
         uv pip install --system -e .
 
-    - name: Test with django test runner
-      run: python manage.py test
+    - name: Test with django test runner (coverage enabled)
+      run: coverage run manage.py test
       env:
         DATABASE_URL: sqlite://localhost/testdb.sqlite
+
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-data-${{ github.job }}-${{ matrix.python-version }}-${{ matrix.requirements-file }}
+        include-hidden-files: true
+        path: '.coverage*'
 
   django-main-sqlite:
     runs-on: ${{ matrix.os }}
@@ -194,11 +214,18 @@ jobs:
         uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
         uv pip install --system -e .
 
-    - name: Test with django test runner
-      run: python manage.py test
+    - name: Test with django test runner (coverage enabled)
+      run: coverage run manage.py test
       continue-on-error: true
       env:
         DATABASE_URL: sqlite://localhost/testdb.sqlite
+
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-data-${{ github.job }}-${{ matrix.python-version }}-${{ matrix.requirements-file }}
+        include-hidden-files: true
+        path: '.coverage*'
 
   django-main-postgres:
     runs-on: ${{ matrix.os }}
@@ -240,13 +267,20 @@ jobs:
         uv pip install --system -r test_requirements/databases.txt
         uv pip install --system -e .
 
-    - name: Test with django test runner
+    - name: Test with django test runner (coverage enabled)
       run: |
         python -c "from django import __version__ ; print(f'Django version {__version__}')"
-        python manage.py test
+        coverage run manage.py test
       continue-on-error: true
       env:
         DATABASE_URL: postgres://postgres:postgres@127.0.0.1/postgres
+
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-data-${{ github.job }}-${{ matrix.python-version }}-${{ matrix.requirements-file }}
+        include-hidden-files: true
+        path: '.coverage*'
 
   django-main-mysql:
     runs-on: ${{ matrix.os }}
@@ -287,9 +321,62 @@ jobs:
         uv pip install --system -r test_requirements/databases.txt
         uv pip install --system -e .
 
-    - name: Test with django test runner
+    - name: Test with django test runner (coverage enabled)
       run: |
-        python manage.py test
+        coverage run manage.py test
       continue-on-error: true
       env:
         DATABASE_URL: mysql://root@127.0.0.1/djangocms_test
+
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-data-${{ github.job }}-${{ matrix.python-version }}-${{ matrix.requirements-file }}
+        include-hidden-files: true
+        path: '.coverage*'
+
+  coverage:
+    name: Coverage
+    runs-on: ${{ matrix.os }}
+    needs: [
+      postgres, mysql, sqlite,
+      django-main-sqlite,
+      django-main-postgres,
+      django-main-mysql,
+    ]
+    strategy:
+      matrix:
+        python-version: ['3.12']
+        os: [ ubuntu-latest, ]
+    steps:
+      - uses: actions/checkout@v4
+        name: Set up Python ${{ matrix.python-version }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: python -m pip install --upgrade coverage[toml]
+
+      - name: Download data
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-data-*
+          merge-multiple: true
+
+      - name: Combine coverage
+        run: |
+          python -m coverage combine
+          python -m coverage html
+          python -m coverage report
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+
+      - name: Upload HTML report (for debugging)
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: html-report
+          path: htmlcov

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 django CMS
 ##########
 
-|PyPiVersion| |PyVersion| |DjVersion| |License|
+|PyPiVersion| |PyVersion| |DjVersion| |License| |Coverage|
 
 Open source enterprise content management system based on the Django framework and backed by the non-profit django CMS Association (`Sponsor us! <https://www.django-cms.org/en/memberships/>`_).
 
@@ -134,3 +134,5 @@ Credits
 .. |License| image:: https://img.shields.io/github/license/django-cms/django-cms.svg
     :target: https://pypi.python.org/pypi/django-cms/
     :alt: License
+.. |Coverage| image:: https://codecov.io/gh/django-cms/django-cms/graph/badge.svg?token=Jyx7Ilpibf 
+ :target: https://codecov.io/gh/django-cms/django-cms

--- a/README.rst
+++ b/README.rst
@@ -1,15 +1,8 @@
 ##########
 django CMS
 ##########
-.. image:: https://img.shields.io/pypi/v/django-cms.svg
-    :target: https://pypi.python.org/pypi/django-cms/
-.. image:: https://img.shields.io/badge/wheel-yes-green.svg
-    :target: https://pypi.python.org/pypi/django-cms/
-.. image:: https://img.shields.io/pypi/l/django-cms.svg
-    :target: https://pypi.python.org/pypi/django-cms/
-.. image:: https://codeclimate.com/github/divio/django-cms/badges/gpa.svg
-   :target: https://codeclimate.com/github/divio/django-cms
-   :alt: Code Climate
+
+|PyPiVersion| |PyVersion| |DjVersion| |License|
 
 Open source enterprise content management system based on the Django framework and backed by the non-profit django CMS Association (`Sponsor us! <https://www.django-cms.org/en/memberships/>`_).
 
@@ -130,3 +123,14 @@ Credits
 * Many thanks to
   `all the contributors <https://github.com/django-cms/django-cms/graphs/contributors>`_
   to django CMS!
+
+.. |PyPiVersion| image:: https://img.shields.io/pypi/v/django-cms.svg
+    :target: https://pypi.python.org/pypi/django-cms/
+.. |PyVersion| image:: https://img.shields.io/pypi/pyversions/django-cms
+    :target: https://pypi.python.org/pypi/django-cms/
+    :alt: PyPI - Python Version
+.. |DjVersion| image:: https://img.shields.io/pypi/frameworkversions/django/django-cms
+    :alt: PyPI - Versions from Framework Classifiers
+.. |License| image:: https://img.shields.io/github/license/django-cms/django-cms.svg
+    :target: https://pypi.python.org/pypi/django-cms/
+    :alt: License

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -1,6 +1,6 @@
 -e .
 argparse
-coverage<5
+coverage
 dj-database-url
 django-app-helper  # required to run the server for integration tests
 django-classy-tags>=0.7.2


### PR DESCRIPTION
## Description

Use badges from shields.io to consistently show Python and Django version.

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->



* [x] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Add dynamic Python and Django version badges in the README sourced from PyPI trove classifiers via shields.io

Documentation:
- Add badge displaying supported Python versions from PyPI classifiers
- Add badge displaying supported Django versions from PyPI classifiers