### PR TITLE
fix: Allow lazy wizard initialization (#8266)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-4.1.7 (2025-06-30)
+4.1.7 (2025-07-08)
 ==================
 
 Bug Fixes:
@@ -10,14 +10,14 @@ Bug Fixes:
 * Added default_auto_field to cms/apps.py (#8254) (14425d) -- Fabian Braun
 * Adjusted checks for GrouperAdmin to allow for `prepopulated_fields` (#8255) (7f08375) -- Fabian Braun
 * Remove text decorations in page tree introduced by django 5.2 (#8214) (56b75e1) -- Fabian Braun
-
+* Allow lazy wizard initialization (#8283) (e1e8f32) -- Fabian Braun
 
 Statistics:
 -----------
 
-This release includes 10 pull requests, and was created with the help of the following contributors (in alphabetical order):
+This release includes 11 pull requests, and was created with the help of the following contributors (in alphabetical order):
 
-* Fabian Braun (7 pull request)
+* Fabian Braun (8 pull request)
 * Github Release Action (3 pull requests)
 
 With the review help of the following contributors:

--- a/cms/wizards/helpers.py
+++ b/cms/wizards/helpers.py
@@ -1,12 +1,12 @@
 import warnings
 
-from cms.utils.compat.warnings import RemovedInDjangoCMS50Warning
+from cms.utils.compat.warnings import RemovedInDjangoCMS60Warning
 
 from .wizard_base import get_entries, get_entry  # noqa: F401
 
 warnings.warn(
     "The cms.wizards.helpers module is deprecated and will be removed in django CMS 5.1. "
     "Use cms.wizards.wizard_base.get_entries and cms.wizards.wizard_pool.get_entry instead.",
-    RemovedInDjangoCMS50Warning,
+    RemovedInDjangoCMS60Warning,
     stacklevel=2,
 )

--- a/cms/wizards/helpers.py
+++ b/cms/wizards/helpers.py
@@ -5,7 +5,7 @@ from cms.utils.compat.warnings import RemovedInDjangoCMS60Warning
 from .wizard_base import get_entries, get_entry  # noqa: F401
 
 warnings.warn(
-    "The cms.wizards.helpers module is deprecated and will be removed in django CMS 5.1. "
+    "The cms.wizards.helpers module is deprecated and will be removed in django CMS 6. "
     "Use cms.wizards.wizard_base.get_entries and cms.wizards.wizard_pool.get_entry instead.",
     RemovedInDjangoCMS60Warning,
     stacklevel=2,

--- a/cms/wizards/wizard_base.py
+++ b/cms/wizards/wizard_base.py
@@ -55,48 +55,6 @@ def clear_wizard_cache():
     del apps.get_app_config('cms').cms_extension.wizards
 
 
-def get_entries():
-    """
-    Returns a list of Wizard objects (for all registered wizards) ordered by weight
-
-    ``get_entries()`` is useful if it is required to have a list of all registered
-    wizards. Typically, this is used to iterate over them all. Note that they will
-    be returned in the order of their ``weight``: smallest numbers for weight are
-    returned first.::
-
-        for wizard in get_entries():
-            # do something with a wizard...
-    """
-    wizards = apps.get_app_config('cms').cms_extension.wizards
-    return sorted(wizards.values(), key=lambda e: e.weight)
-
-
-def get_entry(entry_key):
-    """
-    Returns a wizard object based on its :attr:`~.cms.wizards.wizard_base.Wizard.id`.
-    """
-    return apps.get_app_config('cms').cms_extension.wizards[entry_key]
-
-
-def entry_choices(user, page):
-    """
-    Yields a list of wizard entry tuples of the form (wizard.id, wizard.title) that
-    the current user can use based on their permission to add instances of the
-    underlying model objects.
-    """
-    for entry in get_entries():
-        if entry.user_has_add_permission(user, page=page):
-            yield (entry.id, entry.title)
-
-
-def clear_wizard_cache():
-    """
-    Clears the wizard cache. This is useful if you have added or removed wizards
-    and want to ensure that the changes are reflected immediately.
-    """
-    del apps.get_app_config('cms').cms_extension.wizards
-
-
 class WizardBase:
     """
 

--- a/cms/wizards/wizard_base.py
+++ b/cms/wizards/wizard_base.py
@@ -15,15 +15,14 @@ from cms.toolbar.utils import (
 
 def get_entries():
     """
-    Returns a list of (wizard.id, wizard) tuples (for all registered
-    wizards) ordered by weight
+    Returns a list of Wizard objects (for all registered wizards) ordered by weight
 
     ``get_entries()`` is useful if it is required to have a list of all registered
     wizards. Typically, this is used to iterate over them all. Note that they will
     be returned in the order of their ``weight``: smallest numbers for weight are
     returned first.::
 
-        for wizard_id, wizard in get_entries():
+        for wizard in get_entries():
             # do something with a wizard...
     """
     wizards = apps.get_app_config('cms').cms_extension.wizards
@@ -39,12 +38,63 @@ def get_entry(entry_key):
 
 def entry_choices(user, page):
     """
-    Yields a list of wizard entries that the current user can use based on their
-    permission to add instances of the underlying model objects.
+    Yields a list of wizard entry tuples of the form (wizard.id, wizard.title) that
+    the current user can use based on their permission to add instances of the
+    underlying model objects.
     """
     for entry in get_entries():
         if entry.user_has_add_permission(user, page=page):
             yield (entry.id, entry.title)
+
+
+def clear_wizard_cache():
+    """
+    Clears the wizard cache. This is useful if you have added or removed wizards
+    and want to ensure that the changes are reflected immediately.
+    """
+    del apps.get_app_config('cms').cms_extension.wizards
+
+
+def get_entries():
+    """
+    Returns a list of Wizard objects (for all registered wizards) ordered by weight
+
+    ``get_entries()`` is useful if it is required to have a list of all registered
+    wizards. Typically, this is used to iterate over them all. Note that they will
+    be returned in the order of their ``weight``: smallest numbers for weight are
+    returned first.::
+
+        for wizard in get_entries():
+            # do something with a wizard...
+    """
+    wizards = apps.get_app_config('cms').cms_extension.wizards
+    return sorted(wizards.values(), key=lambda e: e.weight)
+
+
+def get_entry(entry_key):
+    """
+    Returns a wizard object based on its :attr:`~.cms.wizards.wizard_base.Wizard.id`.
+    """
+    return apps.get_app_config('cms').cms_extension.wizards[entry_key]
+
+
+def entry_choices(user, page):
+    """
+    Yields a list of wizard entry tuples of the form (wizard.id, wizard.title) that
+    the current user can use based on their permission to add instances of the
+    underlying model objects.
+    """
+    for entry in get_entries():
+        if entry.user_has_add_permission(user, page=page):
+            yield (entry.id, entry.title)
+
+
+def clear_wizard_cache():
+    """
+    Clears the wizard cache. This is useful if you have added or removed wizards
+    and want to ensure that the changes are reflected immediately.
+    """
+    del apps.get_app_config('cms').cms_extension.wizards
 
 
 class WizardBase:

--- a/cms/wizards/wizard_pool.py
+++ b/cms/wizards/wizard_pool.py
@@ -2,7 +2,8 @@ from django.apps import apps
 from django.utils.translation import gettext as _
 
 from cms.utils.compat.warnings import RemovedInDjangoCMS60Warning
-from cms.wizards.wizard_base import Wizard, entry_choices, get_entries, get_entry  # noqa: F401
+from cms.wizards.helpers import get_entries, get_entry  # noqa: F401
+from cms.wizards.wizard_base import Wizard, entry_choices  # noqa: F401
 
 
 class AlreadyRegisteredException(Exception):

--- a/docs/upgrade/4.1.7.rst
+++ b/docs/upgrade/4.1.7.rst
@@ -36,14 +36,15 @@ Bug Fixes:
 * Added default_auto_field to cms/apps.py (#8254) (14425d) -- Fabian Braun
 * Adjusted checks for GrouperAdmin to allow for `prepopulated_fields` (#8255) (7f08375) -- Fabian Braun
 * Remove text decorations in page tree introduced by django 5.2 (#8214) (56b75e1) -- Fabian Braun
+* Allow lazy wizard initialization (#8283) (e1e8f32) -- Fabian Braun
 
 
 Statistics:
 -----------
 
-This release includes 10 pull requests, and was created with the help of the following contributors (in alphabetical order):
+This release includes 11 pull requests, and was created with the help of the following contributors (in alphabetical order):
 
-* Fabian Braun (7 pull request)
+* Fabian Braun (8 pull request)
 * Github Release Action (3 pull requests)
 
 With the review help of the following contributors:


### PR DESCRIPTION
## Description
Backport of #8266 
<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8266 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Extract wizard utility functions into a dedicated helpers module, update get_entries and entry_choices to support lazy loading of Wizard objects, and add a clear_wizard_cache function to allow dynamic refreshing of the wizard registry.

Enhancements:
- Extract get_entries, get_entry, entry_choices, and clear_wizard_cache into a new cms.wizards.helpers module
- Change get_entries to return a sorted list of Wizard objects and update entry_choices to yield (id, title) tuples
- Add clear_wizard_cache to enable runtime clearing and reloading of registered wizards