### PR TITLE
fix: badge url show main branch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,5 +134,5 @@ Credits
 .. |License| image:: https://img.shields.io/github/license/django-cms/django-cms.svg
     :target: https://pypi.python.org/pypi/django-cms/
     :alt: License
-.. image:: https://codecov.io/gh/django-cms/django-cms/branch/main/graph/badge.svg?token=Jyx7Ilpibf
-:target: https://codecov.io/gh/django-cms/django-cms
+.. |Coverage| image:: https://codecov.io/gh/django-cms/django-cms/branch/main/graph/badge.svg?token=Jyx7Ilpibf
+    :target: https://codecov.io/gh/django-cms/django-cms


### PR DESCRIPTION
Fix issues with image url that was not tied to main branch

## Summary by Sourcery

Bug Fixes:
- Update build status badge URL to use the main branch