### PR TITLE
fix: Allow clicks to propagate to plugins

### DIFF
--- a/cms/static/cms/js/modules/cms.plugins.js
+++ b/cms/static/cms/js/modules/cms.plugins.js
@@ -2235,8 +2235,6 @@ Plugin._clickToHighlightHandler = function _clickToHighlightHandler(e) {
     if (CMS.settings.mode !== 'structure') {
         return;
     }
-    e.preventDefault();
-    e.stopPropagation();
     // FIXME refactor into an object
     CMS.API.StructureBoard._showAndHighlightPlugin(200, true); // eslint-disable-line no-magic-numbers
 };

--- a/cms/static/cms/js/modules/cms.plugins.js
+++ b/cms/static/cms/js/modules/cms.plugins.js
@@ -2231,7 +2231,7 @@ Plugin._highlightPluginContent = function _highlightPluginContent(
     }
 };
 
-Plugin._clickToHighlightHandler = function _clickToHighlightHandler(e) {
+Plugin._clickToHighlightHandler = function _clickToHighlightHandler() {
     if (CMS.settings.mode !== 'structure') {
         return;
     }


### PR DESCRIPTION
## Description

When clicking on a plugin in edit mode, the structure board highlights the clicked plugin. The handler, however, prevents the propagation of the click and prevents the browser, e.g., from processing interactions with `<details>`/`<summary>` tags. 

This PR allows the click to propagate:
* Plugins will still be highlighted in the structure board
* Other handler can process the click

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Remove preventDefault and stopPropagation from the plugin click highlight handler to enable event propagation to other handlers