### PR TITLE
fix: Allow clicks to propagate to plugins (#8288)

### DIFF
--- a/cms/static/cms/js/modules/cms.plugins.js
+++ b/cms/static/cms/js/modules/cms.plugins.js
@@ -2231,12 +2231,10 @@ Plugin._highlightPluginContent = function _highlightPluginContent(
     }
 };
 
-Plugin._clickToHighlightHandler = function _clickToHighlightHandler(e) {
+Plugin._clickToHighlightHandler = function _clickToHighlightHandler() {
     if (CMS.settings.mode !== 'structure') {
         return;
     }
-    e.preventDefault();
-    e.stopPropagation();
     // FIXME refactor into an object
     CMS.API.StructureBoard._showAndHighlightPlugin(200, true); // eslint-disable-line no-magic-numbers
 };


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined the channel #pr-reviews on our [Discord Server](https://discord-pr-review-channel.django-cms.org) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Allow clicks to propagate to plugins by removing preventDefault and stopPropagation calls and updating the handler signature