### PR TITLE
fix: Removed inline CSS from headless template (#8291)

### DIFF
--- a/cms/static/cms/sass/cms.headless.scss
+++ b/cms/static/cms/sass/cms.headless.scss
@@ -1,0 +1,29 @@
+@import "settings/all";
+
+html.cms-structure-mode-structure section {
+    margin-inline-end: 436px;
+}
+
+.cms-placeholder-view section {
+    font: normal 18px/24px Helvetica,Arial,sans-serif;
+    padding: 20px;
+}
+
+.cms-placeholder-view h1 {
+    margin: 0 0 20px;
+    padding: 0;
+    padding-bottom: 10px;
+    font-size: 1.5em;
+    border-bottom: 1px solid $gray-light;
+    small {
+        font-size: 0.5em;
+        color: $gray;
+    }
+}
+
+.cms-placeholder-view section img {
+    max-width: 100%;
+    padding: 3px;
+    margin: -5px;
+    border: 1px solid $gray-light;
+}

--- a/cms/templates/cms/headless/placeholder.html
+++ b/cms/templates/cms/headless/placeholder.html
@@ -1,38 +1,11 @@
-<!DOCTYPE html>{% load cms_tags menu_tags sekizai_tags static i18n %}{% spaceless %}
+<!DOCTYPE html>{% load cms_tags cms_static menu_tags sekizai_tags static i18n %}{% spaceless %}
     {% get_current_language as LANGUAGE_CODE %}{% get_current_language_bidi as LANGUAGE_BIDI %}
     <html class="cms-placeholder-view" lang="{{ LANGUAGE_CODE|default:"en-us" }}" dir="{{ LANGUAGE_BIDI|yesno:'rtl,ltr,auto' }}">
         <head>
             <meta charset="utf-8"/>
             <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
             <title>{% block title %}{{ request.current_page.get_page_title|striptags }}{% endblock %}</title>
-            <style>
-                html.cms-structure-mode-structure section {
-                    margin-inline-end: 436px;
-                }
-                .cms-placeholder-view section {
-                    font: normal 18px/24px Helvetica,Arial,sans-serif;
-                    margin: 20px;
-                    padding: 20px;
-                    border: 1px solid #ccc;
-                }
-                .cms-placeholder-view h1 {
-                    margin: 0 0 20px;
-                    padding: 0;
-                    padding-bottom: 10px;
-                    font-size: 1.5em;
-                    border-bottom: 1px solid #ccc;
-                    small {
-                        font-size: 0.5em;
-                        color: #999;
-                    }
-                }
-                .cms-placeholder-view section img {
-                    max-width: 100%;
-                    padding: 3px;
-                    margin: -5px;
-                    border: 1px solid #ccc;
-                }
-            </style>
+            <link rel="stylesheet" href="{% static_with_version 'cms/css/cms.headless.css' %}"/>
 {% endspaceless %}{% render_block 'css' %}{% spaceless %}
     {% block page_head %}{% endblock %}
         </head>


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Externalize inline CSS from the headless placeholder template into a dedicated stylesheet and update the template to load it via the static tag.

Enhancements:
- Move inline CSS from placeholder.html into a new cms.headless.scss file under static assets
- Update headless placeholder template to load the external cms.headless.css via static_with_version
- Add cms_static tag to template to support loading the new stylesheet