### PR TITLE
docs: Fix broken link in 01-install.rst

### DIFF
--- a/docs/introduction/01-install.rst
+++ b/docs/introduction/01-install.rst
@@ -268,7 +268,7 @@ appropriate files for your project.
 ``requirements.in`` contains dependencies for the project. Add your dependencies here.
 We suggest to use pip-compile to freeze your requirements as, for example, discussed in
 `this blog post
-<https://blog.typodrive.com/2020/02/04/always-freeze-requirements-with-pip-compile-to-avoid-unpleasant-surprises/>`_.
+<https://www.linkedin.com/pulse/freeze-requirements-pip-compile-best-practise-mario-colombo-7rgse/>`_.
 
 Spin up your Django development server (Step 3)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Documentation:
- Correct the URL in docs/introduction/01-install.rst to point to the valid resource