### PR TITLE
fix: Respect individual placeholder checks if they can be changed (#8317)

### DIFF
--- a/cms/static/cms/js/modules/cms.structureboard.js
+++ b/cms/static/cms/js/modules/cms.structureboard.js
@@ -726,7 +726,7 @@ class StructureBoard {
 
         elem
             .nestedSortable({
-                items: '> .cms-draggable:not(.cms-draggable-disabled .cms-draggable)',
+                items: '> .cms-draggable:not(.cms-drag-disabled):not(.cms-draggable-disabled .cms-draggable)',
                 placeholder: 'cms-droppable',
                 connectWith: '.cms-draggables:not(.cms-hidden)',
                 tolerance: 'intersect',
@@ -862,6 +862,11 @@ class StructureBoard {
                     let immediateParentType;
 
                     if (placeholder && placeholder.closest('.cms-clipboard-containers').length) {
+                        return false;
+                    }
+
+                    // if parent has class disabled, dissalow drop
+                    if (placeholder && placeholder.parent().hasClass('cms-drag-disabled')) {
                         return false;
                     }
 

--- a/cms/static/cms/sass/components/_structureboard.scss
+++ b/cms/static/cms/sass/components/_structureboard.scss
@@ -438,7 +438,6 @@
 
         .cms-draggable {
             margin-inline-start: $structure-draggable-inner-padding !important;
-            margin-inline-start: 15px;
             .cms-dragitem {
                 background-image: none;
                 &:hover {
@@ -446,12 +445,16 @@
                 }
             }
         }
-
         .cms-draggables,
         .cms-droppable {
             display: none !important;
         }
     }
+    .cms-drag-disabled.cms-draggable > .cms-dragitem {
+        // Remove drag handle from read-only dragables
+        background-image: none;
+    }
+
     .cms-plugin-disabled {
         position: absolute;
         top: 50%;
@@ -484,12 +487,12 @@
             padding-inline: 15px;
             overflow-x: hidden;
         }
-        .cms-draggables .cms-draggables {
-            padding-inline-start: 15px;
+        .cms-collapsable-container {
+            padding-inline-start: math.div($structure-draggable-inner-padding, 2);
         }
         .cms-draggable-disabled {
             .cms-draggable {
-                margin-inline-start: 15px !important;
+                margin-inline-start: math.div($structure-draggable-inner-padding, 2) !important;
             }
         }
 

--- a/cms/static/cms/sass/components/_subnav.scss
+++ b/cms/static/cms/sass/components/_subnav.scss
@@ -121,6 +121,9 @@
                     line-height: $dropdown-item-height
                 }
             }
+            &[data-cms-icon=edit] {
+                @include icon(edit);
+            }
             &[data-cms-icon=copy] {
                 @include icon(copy);
             }

--- a/cms/templates/cms/toolbar/dragbar.html
+++ b/cms/templates/cms/toolbar/dragbar.html
@@ -1,4 +1,4 @@
-{% load i18n l10n cms_tags %}
+{% load i18n l10n cms_tags cms_admin %}
 <div class="cms-dragbar cms-dragbar-{{ placeholder.pk|unlocalize }}">
     {% if object_is_immutable %}
         <div class="cms-submenu-btn cms-submenu-add cms-btn cms-btn-disabled">
@@ -12,6 +12,11 @@
     <div class="cms-submenu-settings cms-submenu-btn cms-btn"></div>
     <div class="cms-submenu-dropdown cms-submenu-dropdown-settings" data-touch-action="pan-y">
         <div class="cms-dropdown-inner">
+            {% if placeholder.is_static %}
+                <div class="cms-submenu-item">
+                    <a data-cms-icon="edit" href="{% get_edit_url placeholder.source %}">{% translate "Edit" %}</a>
+                </div>
+            {% endif %}
             <div class="cms-submenu-item"><a data-cms-icon="copy" data-rel="copy" href="#">{% trans "Copy all" %}</a></div>
             {% for language in placeholder.get_filled_languages %}{% if language.code != LANGUAGE_CODE %}
                 <div class="cms-submenu-item"><a data-cms-icon="copy" data-rel="copy-lang" data-language="{{ language.code }}" href="#">{% trans "Copy from" %} {% trans language.name %}</a></div>
@@ -33,7 +38,7 @@
 
     <div class="cms-dragbar-title" title="{{ placeholder.get_label }}">
         {{ placeholder.get_label }}
-        {% if placeholder.is_static %}<span class="cms-hover-tooltip cms-hover-tooltip-right" tabindex="-1" data-cms-tooltip="{% trans 'This is a static placeholder' %}"><span class="cms-icon cms-icon-pin cms-dragarea-static-icon"></span></span>{% endif %}
+        {% if placeholder.is_static %}<span class="cms-hover-tooltip cms-hover-tooltip-right" data-cms-tooltip="{% trans 'This is a static placeholder' %}"><span class="cms-icon cms-icon-pin cms-dragarea-static-icon"></span></span>{% endif %}
         <span class="cms-dragbar-toggler">
             <a href="#" class="cms-dragbar-expand-all" tabindex="-1">{% trans "Expand all" %}</a>
             <a href="#" class="cms-dragbar-collapse-all" tabindex="-1">{% trans "Collapse all" %}</a>

--- a/cms/templates/cms/toolbar/dragitem.html
+++ b/cms/templates/cms/toolbar/dragitem.html
@@ -20,7 +20,9 @@
             {% endif %}
             <div class="cms-submenu-btn cms-submenu-add cms-btn
                 {% if not allow_children or object_is_immutable %} cms-btn-disabled{% endif %}">
-                {% if not allow_children or object_is_immutable %}
+                {% if object_is_immutable %}
+                <span class="cms-hover-tooltip" data-cms-tooltip="{% trans "You do not have permission to edit this item" %}"></span>
+                {% elif not allow_children %}
                 <span class="cms-hover-tooltip" data-cms-tooltip="{% trans "You cannot add plugins to this plugin." %}"></span>
                 {% else %}
                 <span class="cms-hover-tooltip cms-hover-tooltip-left cms-hover-tooltip-delay" data-cms-tooltip="{% trans "Add plugin" %}"></span>
@@ -42,7 +44,7 @@
                         <a data-cms-icon="paste" href="#">{% trans "Paste" %}</a>
                     </div>
                     <div class="cms-submenu-item cms-submenu-item-disabled"><a data-cms-icon="bin" href="#">{% trans "Delete" %}</a></div>
-            {% else %}
+                {% else %}
                     <div class="cms-submenu-item">
                         <a data-cms-icon="paste" data-rel="paste" href="#">{% trans "Paste" %}</a>
                         <span class="cms-submenu-item-paste-tooltip cms-submenu-item-paste-tooltip-empty cms-hover-tooltip cms-hover-tooltip-left cms-hover-tooltip-delay" data-cms-tooltip="{% trans "Clipboard is empty." %}"></span>

--- a/cms/templates/cms/toolbar/toolbar_with_structure.html
+++ b/cms/templates/cms/toolbar/toolbar_with_structure.html
@@ -1,5 +1,5 @@
 {% extends "cms/toolbar/toolbar.html" %}
-{% load i18n l10n %}
+{% load i18n l10n cms_admin %}
 
 {% block toolbar_top %}
     <div class="cms-tooltip">{% trans "Double-click to edit" %}<span></span></div>
@@ -63,16 +63,21 @@
         <div class="cms-structure-content" data-touch-action="pan-y">
         {% if cms_renderer.load_structure %}
             {% for placeholder in cms_renderer.get_rendered_editable_placeholders %}
-            <div class="cms-dragarea cms-dragarea-{{ placeholder.pk|unlocalize }}{% if placeholder.is_static %} cms-dragarea-static{% endif %}">
-                {% include cms_toolbar.templates.dragbar_template with placeholder=placeholder %}
-
-                <div class="cms-draggables cms-draggables-root">
-                    <div class="cms-draggables-empty">{% trans "Drop a plugin here" %}</div>
-                    {% for plugin in placeholder.get_cached_plugins %}
-                        {% include cms_toolbar.templates.drag_item_template with plugin=plugin %}
-                    {% endfor %}
-                </div>
-            </div>
+               {% with object_is_immutable=placeholder|placeholder_is_immutable:request.user %}
+                    <div class="cms-dragarea cms-dragarea-{{ placeholder.pk|unlocalize }}{% if placeholder.is_static %} cms-dragarea-static{% endif %}">
+                        {% include cms_toolbar.templates.dragbar_template with placeholder=placeholder object_is_immutable=object_is_immutable %}
+                        {% if object_is_immutable %}
+                        <div class="cms-draggables cms-draggables-root cms-drag-disabled">
+                        {% else %}
+                        <div class="cms-draggables cms-draggables-root">
+                        {% endif %}
+                            <div class="cms-draggables-empty">{% trans "Drop a plugin here" %}</div>
+                            {% for plugin in placeholder.get_cached_plugins %}
+                                {% include cms_toolbar.templates.drag_item_template with plugin=plugin object_is_immutable=object_is_immutable %}
+                            {% endfor %}
+                        </div>
+                    </div>
+                {% endwith %}
             {% endfor %}
         {% endif %}
         </div>

--- a/cms/tests/frontend/unit/cms.structureboard.test.js
+++ b/cms/tests/frontend/unit/cms.structureboard.test.js
@@ -872,7 +872,7 @@ describe('CMS.StructureBoard', function() {
             options = board.ui.sortables.nestedSortable('option');
             expect(options).toEqual(
                 jasmine.objectContaining({
-                    items: '> .cms-draggable:not(.cms-draggable-disabled .cms-draggable)',
+                    items: '> .cms-draggable:not(.cms-drag-disabled):not(.cms-draggable-disabled .cms-draggable)',
                     placeholder: 'cms-droppable',
                     connectWith: '.cms-draggables:not(.cms-hidden)',
                     appendTo: '.cms-structure-content',

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -28,7 +28,7 @@ from cms.models import (
     PageContent,
     Placeholder,
 )
-from cms.templatetags.cms_admin import GetPreviewUrl, get_page_display_name
+from cms.templatetags.cms_admin import get_page_display_name
 from cms.templatetags.cms_js_tags import json_filter
 from cms.templatetags.cms_tags import (
     _get_page_by_untyped_arg,
@@ -38,7 +38,7 @@ from cms.templatetags.cms_tags import (
 from cms.test_utils.fixtures.templatetags import TwoPagesFixture
 from cms.test_utils.testcases import CMSTestCase
 from cms.toolbar.toolbar import CMSToolbar
-from cms.toolbar.utils import get_object_edit_url
+from cms.toolbar.utils import get_object_edit_url, get_object_preview_url
 from cms.utils.conf import get_cms_setting, get_site_id
 from cms.utils.placeholder import get_placeholders
 
@@ -74,11 +74,58 @@ class TemplatetagTests(CMSTestCase):
         page = create_page("page_a", "nav_playground.html", "en")
         german_content = create_page_content("de", "Seite_a", page)
 
-        page_preview_url = GetPreviewUrl.get_value(None, context={"request": self.get_request()}, page_content=page)
-        german_content_preview_url = GetPreviewUrl.get_value(None, context={}, page_content=german_content)
+        expected_for_page = f'en={get_object_preview_url(page.get_admin_content("en"), language="en")}'
+        expected_for_german_content = f'de={get_object_preview_url(german_content, language="de")}'
 
-        self.assertIn("/en", page_preview_url)
-        self.assertIn("/de/", german_content_preview_url)
+        template = """
+            {% load cms_admin %}
+            en={% get_preview_url page_obj %}
+            de={% get_preview_url german_content %}
+        """
+        output = self.render_template_obj(template, {"page_obj": page, "german_content": german_content}, self.get_request())
+
+        self.assertIn(expected_for_page, output)
+        self.assertIn(expected_for_german_content, output)
+
+    def test_get_edit_url(self):
+        """The get_edit_url template tag returns the content edit url for its language:
+        If a page is given, take the current language (en), if a page_content is given,
+        take its language (de for this test)"""
+        page = create_page("page_a", "nav_playground.html", "en")
+        german_content = create_page_content("de", "Seite_a", page)
+
+        expected_for_page = f'en={get_object_edit_url(page.get_admin_content("en"), language="en")}'
+        expected_for_german_content = f'de={get_object_edit_url(german_content, language="de")}'
+
+        template = """
+            {% load cms_admin %}
+            en={% get_edit_url page_obj %}
+            de={% get_edit_url german_content %}
+        """
+        output = self.render_template_obj(template, {"page_obj": page, "german_content": german_content}, self.get_request())
+
+        self.assertIn(expected_for_page, output)
+        self.assertIn(expected_for_german_content, output)
+
+    def test_placeholder_is_immutable_filter(self):
+        template = """
+            {% load cms_admin %}
+            non-placeholder={{ True|placeholder_is_immutable:request.user }}
+            placeholder={{ placeholder|placeholder_is_immutable:request.user }}
+        """
+        from unittest.mock import patch
+
+        from cms.models import Placeholder
+
+        page = create_page("page_a", "nav_playground.html", "en")
+        placeholder = page.get_placeholders("en").first()
+        request = self.get_request()
+
+        with patch.object(Placeholder, "check_source", wraps=placeholder.check_source) as mock_check_source:
+            output = self.render_template_obj(template, {"placeholder": placeholder}, request=request)
+            self.assertIn("non-placeholder=True", output)
+            self.assertIn("placeholder=False", output)
+            self.assertEqual(mock_check_source.call_count, 1)
 
     def test_get_admin_tree_title(self):
         page = create_page("page_a", "nav_playground.html", "en", slug="slug-test2")

--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -546,7 +546,6 @@ class CMSToolbarBase(BaseToolbar):
 
         context = {
             'cms_toolbar': self,
-            'object_is_immutable': not self.object_is_editable(),
             'cms_renderer': renderer,
             'cms_edit_url': self.get_object_edit_url(),
             'cms_preview_url': self.get_object_preview_url(),


### PR DESCRIPTION
…317)

* fix: Respect placeholder checks of different PlaceholderRelationFields

* fix: tests

* fix: More specific css rule

* fix: Performance optimization

* Update cms/templates/cms/toolbar/dragbar.html

* feat: Add preview option

* feat: Add edit button icon

* tests: Add test for get_edit_url template tag

* fix: Avoid static pin to be selectable

* tests: add test for plcaeholder_is_immutable filter

* fix: ruff issues

* Fix: formatting (missing tab)

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Enforce per-placeholder immutability in the admin UI by introducing a placeholder_is_immutable filter and get_edit_url tag, disabling drag-and-drop and menu actions for read-only placeholders, and updating CSS/JS and tests accordingly

New Features:
- Introduce get_edit_url template tag to retrieve the admin edit URL for page content
- Add placeholder_is_immutable filter to check if a placeholder is editable by a user
- Add edit button icon for static placeholders in the toolbar menu

Bug Fixes:
- Respect individual placeholder immutability checks to prevent unauthorized edits
- Prevent the static placeholder pin icon from being selectable

Enhancements:
- Disable drag-and-drop interactions and menu options for immutable placeholders in the structure board and dragbar
- Refine CSS selectors and JS logic to enforce placeholder immutability in nested sortable items

Tests:
- Add tests for get_preview_url, get_edit_url template tags and placeholder_is_immutable filter