### PR TITLE
fix: Cut children from inactive menu nodes when level is less or equal to 0

### DIFF
--- a/cms/tests/test_menu.py
+++ b/cms/tests/test_menu.py
@@ -227,6 +227,16 @@ class ExtendedFixturesMenuTests(ExtendedMenusFixture, BaseMenuTest):
             tpl = Template("{% load menu_tags %}{% show_menu 0 0 0 0 'menu/menu.html' child %}")
             self.assertRaises(TemplateSyntaxError, tpl.render, context)
 
+    def test_show_menu_cut_inactive(self):
+        root = self.get_page(2)
+        context = self.get_context(page=root)
+        tpl = Template("{% load menu_tags %}{% show_menu 1 100 0 1 %}")
+        tpl.render(context)
+        nodes = context["children"]
+        self.assertEqual(len(nodes), 2)
+        self.assertEqual(len(nodes[0].children), 1)
+        self.assertEqual(len(nodes[1].children), 0)
+
     def test_show_submenu_nephews(self):
         page_2 = self.get_page(2)
         context = self.get_context(path=page_2.get_absolute_url(), page=page_2)

--- a/menus/templatetags/menu_tags.py
+++ b/menus/templatetags/menu_tags.py
@@ -32,7 +32,7 @@ def cut_after(node, levels, removed=None):
     if removed is not None:
         raise TypeError("menus.template_tags.cut_after() does not accept 'removed' list argument")
 
-    if levels == 0:
+    if levels <= 0:
         node.children = []
     else:
         for child in node.children:


### PR DESCRIPTION
## Description

Fixes #8321 and adds a test.

## Related resources

- #8321 

## Checklist

* [x] I have opened this pull request against ``main``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Fix the cut_after logic to remove children when levels is non-positive and add a test to verify inactive nodes have no children at non-positive levels

Bug Fixes:
- Ensure cut_after clears node.children when levels is less or equal to zero instead of only zero

Tests:
- Add test_show_menu_cut_inactive to verify children are cut from inactive nodes at non-positive levels