### PR TITLE
fix: Adding plugins without models failed with Django

### DIFF
--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -161,6 +161,25 @@ class PluginsTestCase(PluginsTestBaseCase):
         plugin = self.__edit_link_plugin(created_plugin, "Hello World")
         self.assertEqual("Hello World", plugin.name)
 
+    def test_add_empty_plugin(self):
+        """
+        Adding a plugin without form works.
+        """
+        # add a new text plugin
+        page_data = self.get_new_page_data()
+        self.client.post(self.get_page_add_uri("en"), page_data)
+        page = Page.objects.first()
+        endpoint = self.get_add_plugin_uri(
+            page.get_placeholders("en").first(),
+            "SolarSystemPlugin"
+        )
+        with self.login_user_context(self.super_user):
+            response = self.client.get(endpoint)
+            self.assertContains(
+                response,
+                '<div class="description">There are no further settings for this plugin. Please press save.</div>'
+            )
+
     def test_plugin_add_form_integrity(self):
         admin.autodiscover()
         admin_instance = admin.site._registry[ArticlePluginModel]


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Tests:
- Add test_add_empty_plugin to ensure adding a plugin without form fields works and displays a save instruction message.