### PR TITLE
fix: copy lang management command - include PageUrl (#7548)

### DIFF
--- a/cms/management/commands/subcommands/copy.py
+++ b/cms/management/commands/subcommands/copy.py
@@ -6,8 +6,9 @@ from django.db import transaction
 
 from cms.api import copy_plugins_to_language
 from cms.management.commands.subcommands.base import SubcommandsCommand
-from cms.models import EmptyPageContent, Page, PageContent, StaticPlaceholder
+from cms.models import EmptyPageContent, Page, PageContent, PageUrl, StaticPlaceholder
 from cms.utils import get_language_list
+from cms.utils.page import get_available_slug
 from cms.utils.plugins import copy_plugins_to_placeholder
 
 User = get_user_model()
@@ -71,7 +72,8 @@ class CopyLangCommand(SubcommandsCommand):
         except AssertionError:
             raise CommandError('Both languages have to be present in settings.LANGUAGES and settings.CMS_LANGUAGES')
 
-        for page in Page.objects.on_site(site):
+        # obey node path (tree order) to make sure parent records are created before children (for slug generation)
+        for page in Page.objects.on_site(site).order_by('path'):
             # copy title
             if from_lang in page.get_languages():
 
@@ -88,6 +90,29 @@ class CopyLangCommand(SubcommandsCommand):
                     new_title["language"] = to_lang
                     new_title["page"] = page
                     PageContent.objects.with_user(user).create(**new_title)
+
+                    if to_lang not in page.get_languages():
+                        page.update_languages(page.get_languages() + [to_lang])
+
+                    # copy PageUrls - inspired from pagemodels.Page.copy() - possibly refactorable
+                    page_url = page.urls.get(language=from_lang)
+                    parent_page = page.parent
+
+                    new_url = model_to_dict(page_url)
+                    new_url.pop("id", None)  # No PK
+                    new_url["page"] = page
+                    new_url["language"] = to_lang
+
+                    if parent_page:
+                        base = parent_page.get_path(to_lang)
+                        path = '%s/%s' % (base, page_url.slug) if base else page_url.slug
+                    else:
+                        base = ''
+                        path = page_url.slug
+
+                    new_url["slug"] = get_available_slug(site, path, to_lang)
+                    new_url["path"] = '%s/%s' % (base, new_url["slug"]) if base else new_url["slug"]
+                    PageUrl.objects.with_user(user).create(**new_url)
 
                 if copy_content:
                     # copy plugins using API

--- a/cms/tests/test_management.py
+++ b/cms/tests/test_management.py
@@ -1,3 +1,5 @@
+import os
+import sys
 import uuid
 from io import StringIO
 
@@ -11,7 +13,7 @@ from djangocms_text_ckeditor.cms_plugins import TextPlugin
 
 from cms.api import add_plugin, create_page, create_page_content
 from cms.management.commands.subcommands.list import plugin_report
-from cms.models import Page, StaticPlaceholder
+from cms.models import Page, PageUrl, StaticPlaceholder
 from cms.models.placeholdermodel import Placeholder
 from cms.models.pluginmodel import CMSPlugin
 from cms.test_utils.fixtures.navextenders import NavextendersFixture
@@ -341,6 +343,7 @@ class PageFixtureManagementTestCase(NavextendersFixture, CMSTestCase):
         """
         site = 1
         number_start_plugins = CMSPlugin.objects.all().count()
+        number_urls = PageUrl.objects.filter(language='en').count()
 
         out = StringIO()
         management.call_command(
@@ -376,6 +379,8 @@ class PageFixtureManagementTestCase(NavextendersFixture, CMSTestCase):
 
         self.assertEqual(stack_text_en.plugin_type, stack_text_de.plugin_type)
         self.assertEqual(stack_text_en.body, stack_text_de.body)
+
+        self.assertEqual(PageUrl.objects.filter(language='de').count(), number_urls)
 
     def test_copy_langs_no_content(self):
         """


### PR DESCRIPTION
* fix: copy lang management command

Include copy of related PageUrl models

* Update cms/management/commands/subcommands/copy.py

* Apply suggestions from code review

* Update cms/management/commands/subcommands/copy.py

* Add test to check page urls are created

* Add import for sys module in test_management.py

---------

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7548 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Extend the copy language management command to duplicate related PageUrl models, including slug and path generation, and ensure proper parent-child ordering.

Enhancements:
- Include copying of PageUrl instances when duplicating page languages and generate unique slugs and paths.
- Order pages by tree path so parent pages are created before children during copy.
- Update page.language list to include the target language before copying URLs.

Tests:
- Add test to verify that PageUrl records are created for the new language with the correct count.