### PR TITLE
fix: copy lang management command - include PageUrl (#7548)

### DIFF
--- a/cms/management/commands/subcommands/copy.py
+++ b/cms/management/commands/subcommands/copy.py
@@ -73,7 +73,7 @@ class CopyLangCommand(SubcommandsCommand):
             raise CommandError('Both languages have to be present in settings.LANGUAGES and settings.CMS_LANGUAGES')
 
         # obey node path (tree order) to make sure parent records are created before children (for slug generation)
-        for page in Page.objects.on_site(site).order_by('path'):
+        for page in Page.objects.on_site(site).order_by('node__path'):
             # copy title
             if from_lang in page.get_languages():
 
@@ -96,7 +96,7 @@ class CopyLangCommand(SubcommandsCommand):
 
                     # copy PageUrls - inspired from pagemodels.Page.copy() - possibly refactorable
                     page_url = page.urls.get(language=from_lang)
-                    parent_page = page.parent
+                    parent_page = page.node.parent.cms_pages.first() if page.node.parent else None
 
                     new_url = model_to_dict(page_url)
                     new_url.pop("id", None)  # No PK

--- a/cms/tests/test_management.py
+++ b/cms/tests/test_management.py
@@ -1,6 +1,6 @@
-import uuid
 import os
 import sys
+import uuid
 from io import StringIO
 
 from django.conf import settings


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #7548
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Enhance the copy subcommand to include URL records and ensure correct ordering when copying page languages

Enhancements:
- Order pages by node path to guarantee parent pages are processed before children during language copying
- Copy PageUrl entries for the new language with unique slug and path generation

Tests:
- Assert that PageUrl objects are correctly duplicated for the target language