### PR TITLE
fix: Migration 0033 failed when empty placeholder objects were not present in the db

### DIFF
--- a/cms/migrations/0033_placeholder_source_data_migration.py
+++ b/cms/migrations/0033_placeholder_source_data_migration.py
@@ -39,7 +39,7 @@ def forwards(apps, schema_editor):
                             content_type_id=cur_ct_obj.pk,
                             object_id=obj.pk,
                         )
-                    else:
+                    elif obj_placeholder_field:
                         obj_placeholder_field.content_type_id = cur_ct_obj.pk
                         obj_placeholder_field.object_id = obj.pk
                         obj_placeholder_field.save()


### PR DESCRIPTION
…esent in the db

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Add explicit check for obj_placeholder_field in migration forward to prevent failures when placeholder objects are not present