### PR TITLE
fix: Wrong placholders rendered when using apphooks with own placeholder

### DIFF
--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -383,8 +383,10 @@ class ContentRenderer(BaseRenderer):
         nodelist=None,
         editable: bool = True,
     ):
+        # Get current object from toolbar
+        current_obj = self.toolbar.get_object()
         # Check if page, if so delegate to render_page_placeholder
-        if self.current_page:
+        if self.current_page and (isinstance(current_obj, (PageContent, type(None)))):
             return self.render_page_placeholder(
                 slot,
                 context,
@@ -392,10 +394,8 @@ class ContentRenderer(BaseRenderer):
                 nodelist=nodelist,
                 editable=editable,
             )
-
         # Not page, therefore we will use toolbar object as
         # the current object and render the placeholder
-        current_obj = self.toolbar.get_object()
         if current_obj is None:
             raise PlaceholderNotFound(f"No object found for placeholder '{slot}'")
         placeholder = rescan_placeholders_for_obj(current_obj).get(slot)


### PR DESCRIPTION
## Description

When viewing a public page of an apphook, the wrong placeholder rendering method was called rendering the page's and not the apphook's placeholder.

Fixes https://github.com/django-cms/djangocms-stories/issues/24

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* https://github.com/django-cms/djangocms-stories/issues/24
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``main``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Fix wrong placeholder rendering on public pages when using apphooks with custom placeholders by correctly fetching the current toolbar object and refining the page placeholder condition.

Bug Fixes:
- Fetch the toolbar object before checking page context to ensure correct object is used for placeholder rendering.
- Restrict page placeholder rendering to instances of PageContent or NoneType to prevent apphook placeholders from defaulting to the page's placeholders.