### PR TITLE
ci: Fix new contributor message

### DIFF
--- a/.github/workflows/new_contributor_pr.yml
+++ b/.github/workflows/new_contributor_pr.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          pr-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_message: |
             Hello! Thank you for your contribution! 🎉
 
             As it's your first contribution, be sure to check out the [contribution docs](https://docs.django-cms.org/en/latest/contributing/index.html).


### PR DESCRIPTION
## Description

This fixes the issue with the new contributor message;

```
Warning: Unexpected input(s) 'repo-token', 'pr-message', valid inputs are ['issue_message', 'pr_message', 'repo_token']
```

## Summary by Sourcery

Fix the new contributor message workflow by correcting the input parameter names in the GitHub Actions configuration.

Bug Fixes:
- Use correct snake_case inputs for actions/first-interaction to resolve unexpected input warnings

CI:
- Update new_contributor_pr workflow to use 'repo_token' and 'pr_message' parameters