### PR TITLE
fix: avoid stringifying None-values in page attribute template tag

### DIFF
--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -440,7 +440,7 @@ class PageAttribute(AsTag):
         if page and name in self.valid_attributes:
             func = getattr(page, "get_%s" % name)
             ret_val = func(language=lang, fallback=True)
-            if not isinstance(ret_val, datetime):
+            if not isinstance(ret_val, datetime) and ret_val is not None:
                 ret_val = escape(ret_val)
             return ret_val
         return ""

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -197,6 +197,14 @@ class TemplatetagTests(CMSTestCase):
         output_script = self.render_template_obj(template, {}, request_script)
         output_ampersand = self.render_template_obj(template, {}, request_ampersand)
         output_partial = self.render_template_obj(template, {}, FakeRequest(FakePage(partial)))
+        output_none = self.render_template_obj(
+            (
+                "{% load cms_tags %}{% page_attribute page_title as somevar %}"
+                "{% if somevar %}WRONG VALUE!{% else %}YAY{% endif %}"
+            ),
+            {},
+            FakeRequest(FakePage(None)),
+        )
 
         self.assertNotEqual(script, output_script)
         self.assertNotEqual(ampersand, output_ampersand)
@@ -204,6 +212,7 @@ class TemplatetagTests(CMSTestCase):
         self.assertEqual(escape(script), output_script)
         self.assertEqual(escape(ampersand), output_ampersand)
         self.assertEqual(escape(partial), output_partial)
+        self.assertEqual("YAY", output_none)
 
     def test_json_encoder(self):
         self.assertEqual(json_filter(True), "true")


### PR DESCRIPTION
## Description

See linked issue for more information.

In short: the TemplateTag returned `"None"` instead of `None` if the attribute has `NULL` in the database.

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

- fix #8374 

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``main``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Prevent None-valued page attributes from being escaped to the string "None" and ensure they render as actual None in templates.

Bug Fixes:
- Stop escaping None values in the PageAttribute TemplateTag so it returns actual None instead of the string "None".

Tests:
- Add a test to verify that a None page attribute is treated as false in templates.