### PR TITLE
fix: Copying x-language lead to unique constraint violation (#8366)

### DIFF
--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -769,7 +769,7 @@ class PlaceholderAdmin(admin.ModelAdmin):
             target_parent_id=target_parent_id,
         )
 
-        target_last_plugin = target_placeholder.get_last_plugin(plugin.language)
+        target_last_plugin = target_placeholder.get_last_plugin(target_language)
 
         if target_last_plugin:
             target_offset = target_last_plugin.position + len(plugins)

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -421,7 +421,7 @@ class PlaceholderTestCase(TransactionCMSTestCase):
         plugin = add_plugin(
             user_settings.clipboard,
             "LinkPlugin",
-            language="en",
+            language="de",  # Test x-language
             name="A Link",
             external_link="https://www.django-cms.org",
         )

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -408,7 +408,23 @@ class PluginsTestCase(PluginsTestBaseCase):
         self.assertEqual(text_plugin_de.body, text_plugin_en.body)
 
         # test subplugin copy
-        copy_plugins_to_placeholder([link_plugin_en], ph_de, language='de')
+        copy_plugins_to_placeholder([link_plugin_en], ph_de, language="de")
+        self.assertEqual(ph_de.cmsplugin_set.filter(parent=None).count(), 2)
+
+        # Assert that copied plugins have distinct, sequential positions
+        plugins = list(ph_de.cmsplugin_set.filter(language="de").order_by('position'))
+        positions = [plugin.position for plugin in plugins]
+        self.assertEqual(len(positions), len(set(positions)), "Plugin positions should be unique")
+        self.assertEqual(positions, list(range(positions[0], positions[0] + len(positions))), "Plugin positions should be sequential")
+
+        # Assert that no integrity errors are raised (uniqueness constraints maintained)
+        from django.db import IntegrityError
+        try:
+            for plugin in plugins:
+                # Try to save plugin again to check for uniqueness constraint
+                plugin.save()
+        except IntegrityError:
+            self.fail("IntegrityError raised: uniqueness constraint violated when saving copied plugins")
 
     def test_deep_copy_plugins(self):
         page_en = api.create_page("CopyPluginTestPage (EN)", "nav_playground.html", "en")

--- a/cms/utils/plugins.py
+++ b/cms/utils/plugins.py
@@ -289,7 +289,7 @@ def copy_plugins_to_placeholder(plugins, placeholder, language=None,
         try:
             position = positions_by_language[new_plugin.language]
         except KeyError:
-            offset = placeholder.get_last_plugin_position(language) or 0
+            offset = placeholder.get_last_plugin_position(new_plugin.language) or 0
             # The position is relative to language.
             position = placeholder.get_next_plugin_position(
                 language=new_plugin.language,
@@ -299,7 +299,7 @@ def copy_plugins_to_placeholder(plugins, placeholder, language=None,
             # Because it is the first time this language is processed,
             # shift all plugins to the right of the next position.
             placeholder._shift_plugin_positions(
-                language,
+                new_plugin.language,
                 start=position,
                 offset=offset,
             )


### PR DESCRIPTION
* fix: Copying x-language lead to unique constraint violation

* Update cms/tests/test_plugins.py



* fix: test

* fix: import errors

---------

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8366
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Fix cross-language plugin copying by using the correct language for position calculations to prevent unique constraint violations, and add tests to verify that copied plugins maintain unique, sequential positions without integrity errors.

Bug Fixes:
- Prevent unique constraint violations when copying or pasting plugins across different languages by using the correct language for position calculations.

Enhancements:
- Ensure position offset and shifting logic leverages the plugin's actual language instead of the passed language argument.

Tests:
- Add tests to assert that copied plugins maintain unique, sequential positions and do not raise IntegrityError.
- Update placeholder paste test to cover cross-language paste behavior.