### PR TITLE
fix: Ensure edit endpoint language selection when admin is not using i18n_patterns (#8367)

### DIFF
--- a/cms/static/cms/js/modules/cms.structureboard.js
+++ b/cms/static/cms/js/modules/cms.structureboard.js
@@ -1211,7 +1211,8 @@ class StructureBoard {
                     placeholderIds +
                     '&' +
                     `obj_id=${CMS.config.request.pk}&` +
-                    `obj_type=${encodeURIComponent(CMS.config.request.model)}`
+                    `obj_type=${encodeURIComponent(CMS.config.request.model)}` +
+                    `&language=${encodeURIComponent(CMS.config.request.language)}`
             )
         });
     }

--- a/cms/templates/cms/toolbar/toolbar_javascript.html
+++ b/cms/templates/cms/toolbar/toolbar_javascript.html
@@ -18,7 +18,7 @@
         "model": "{{ cms_toolbar.get_object_model }}",
         "page_id": "{{ request.current_page.pk|unlocalize }}",
         "pk": "{{ cms_toolbar.get_object_pk|unlocalize }}",
-        "toolbar": "{% language cms_toolbar.request_language %}{% cms_admin_url "cms_usersettings_get_toolbar" %}{% endlanguage %}"
+        "toolbar": "{% url "admin:cms_usersettings_get_toolbar" %}"
     },
     "lang": {
         {% if debug and user.is_authenticated %}

--- a/cms/tests/frontend/unit/cms.structureboard.test.js
+++ b/cms/tests/frontend/unit/cms.structureboard.test.js
@@ -2123,14 +2123,15 @@ describe('CMS.StructureBoard', function() {
             CMS.config.request = {
                 toolbar: 'TOOLBAR_URL',
                 pk: 100,
-                model: 'cms.page'
+                model: 'cms.page',
+                language: 'en'
             };
 
             board._loadToolbar();
 
             expect($.ajax).toHaveBeenCalledWith({
                 url: jasmine.stringMatching(
-                    /TOOLBAR_URL\?obj_id=100&obj_type=cms.page&cms_path=%2Fstructure*/
+                    /TOOLBAR_URL\?obj_id=100&obj_type=cms.page&language=en&cms_path=%2Fstructure*/
                 )
             });
         });

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -1,5 +1,6 @@
 import datetime
 import re
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import iptools
@@ -2244,6 +2245,55 @@ class ToolbarUtilsTestCase(ToolbarTestBase):
 
         self.assertEqual(page_content["en"], get_object_for_language(page_content["en"], "en"))
         self.assertEqual(get_object_for_language(page_content["en"], "de"), page_content["de"])
+
+    @patch('cms.toolbar.utils.get_cms_setting')
+    @patch('cms.toolbar.utils.get_language_from_path')
+    @patch('cms.toolbar.utils.admin_reverse')
+    @patch('cms.toolbar.utils.ContentType')
+    def test_get_object_edit_url_appends_language_if_no_i18n_prefix(
+        self, mock_contenttype, mock_admin_reverse, mock_get_lang_from_path, mock_get_cms_setting
+    ):
+        mock_get_cms_setting.return_value = False
+        mock_get_lang_from_path.return_value = None
+        mock_admin_reverse.return_value = '/admin/cms/placeholder/render/object/edit/1/'
+
+        mock_contenttype.objects.get_for_model.return_value = SimpleNamespace(pk=42)
+
+        obj = SimpleNamespace(pk=1)
+        url = get_object_edit_url(obj, language='de')
+        self.assertIn('?language=de', url)
+
+    @patch('cms.toolbar.utils.get_cms_setting')
+    @patch('cms.toolbar.utils.get_language_from_path')
+    @patch('cms.toolbar.utils.admin_reverse')
+    @patch('cms.toolbar.utils.ContentType')
+    def test_get_object_preview_url_appends_language_if_no_i18n_prefix(
+        self, mock_contenttype, mock_admin_reverse, mock_get_lang_from_path, mock_get_cms_setting
+    ):
+        mock_get_cms_setting.return_value = False
+        mock_get_lang_from_path.return_value = None
+        mock_admin_reverse.return_value = '/admin/cms/placeholder/render/object/preview/1/'
+
+        mock_contenttype.objects.get_for_model.return_value = SimpleNamespace(pk=99)
+
+        obj = SimpleNamespace(pk=2)
+        url = get_object_preview_url(obj, language='fr')
+        self.assertIn('?language=fr', url)
+
+    @patch('cms.toolbar.utils.get_language_from_path')
+    @patch('cms.toolbar.utils.admin_reverse')
+    @patch('cms.toolbar.utils.ContentType')
+    def test_get_object_structure_url_appends_language_if_no_i18n_prefix(
+        self, mock_contenttype, mock_admin_reverse, mock_get_lang_from_path
+    ):
+        mock_get_lang_from_path.return_value = None
+        mock_admin_reverse.return_value = '/admin/cms/placeholder/render/object/structure/1/'
+
+        mock_contenttype.objects.get_for_model.return_value = SimpleNamespace(pk=7)
+
+        obj = SimpleNamespace(pk=3)
+        url = get_object_structure_url(obj, language='es')
+        self.assertIn('?language=es', url)
 
 
 class CharPkFrontendPlaceholderAdminTest(ToolbarTestBase):

--- a/cms/toolbar/utils.py
+++ b/cms/toolbar/utils.py
@@ -12,6 +12,7 @@ from django.urls import NoReverseMatch
 from django.utils.encoding import force_str
 from django.utils.translation import (
     get_language,
+    get_language_from_path,
     gettext,
     override as force_language,
 )
@@ -250,6 +251,8 @@ def get_object_edit_url(obj: models.Model, language: str = None) -> str:
 
     with force_language(language):
         url = admin_reverse('cms_placeholder_render_object_edit', args=[content_type.pk, obj.pk])
+        if not get_language_from_path(url):
+            url += f'?language={language}'
     if get_cms_setting('ENDPOINT_LIVE_URL_QUERYSTRING_PARAM_ENABLED'):
         url = add_live_url_querystring_param(obj, url, language)
     return url
@@ -270,6 +273,8 @@ def get_object_preview_url(obj: models.Model, language: str = None) -> str:
 
     with force_language(language):
         url = admin_reverse('cms_placeholder_render_object_preview', args=[content_type.pk, obj.pk])
+        if not get_language_from_path(url):
+            url += f'?language={language}'
     if get_cms_setting('ENDPOINT_LIVE_URL_QUERYSTRING_PARAM_ENABLED'):
         url = add_live_url_querystring_param(obj, url, language)
     return url
@@ -290,8 +295,10 @@ def get_object_structure_url(obj: models.Model, language: str = None) -> str:
         language = get_language()
 
     with force_language(language):
-        return admin_reverse('cms_placeholder_render_object_structure', args=[content_type.pk, obj.pk])
-
+        url = admin_reverse('cms_placeholder_render_object_structure', args=[content_type.pk, obj.pk])
+        if not get_language_from_path(url):
+            url += f'?language={language}'
+    return url
 
 def get_object_for_language(obj: models.Model, language: str, latest: bool = False) -> models.Model | None:
     """

--- a/cms/utils/__init__.py
+++ b/cms/utils/__init__.py
@@ -35,7 +35,6 @@ def get_language_from_request(request: HttpRequest, current_page=None):
     if not language and request:
         # get the active language
         language = get_current_language()
-        request._cms_language = language
     if language:
         if language not in get_language_list(site_id):
             language = None
@@ -53,4 +52,5 @@ def get_language_from_request(request: HttpRequest, current_page=None):
         # best match
         language = get_default_language(site_id=site_id)
 
+    request._cms_language = language
     return language

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "gulp-sourcemaps": "2.4.1",
         "gulp-util": "^3.0.8",
         "imports-loader": "^0.7.1",
-        "istanbul-instrumenter-loader": "*",
+        "istanbul-instrumenter-loader": "latest",
         "jasmine-core": "^2.3.4",
         "karma": "^6.4.4",
         "karma-chrome-launcher": "^3.2.0",


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Ensure object edit, preview, and structure admin endpoints include a language query parameter when i18n URL prefixes are disabled, and propagate language to frontend toolbar requests.

Bug Fixes:
- Correct the timing of `_cms_language` assignment in `get_language_from_request`

Enhancements:
- Append `?language=…` to edit, preview, and structure object admin endpoints if no i18n prefix is present
- Include `language` parameter in StructureBoard toolbar AJAX requests
- Simplify toolbar URL generation in the toolbar JavaScript template by removing deprecated language wrapper

Tests:
- Add tests verifying that edit, preview, and structure URLs append the language query parameter
- Update StructureBoard unit test to expect the `language` parameter in toolbar request URLs