### PR TITLE
fix: copying failed if a target placeholders was missing (#8399)

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -1210,8 +1210,11 @@ class PageContentAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
         target_page_content = page.get_content_obj(target_language, fallback=False)
 
         for placeholder in source_page_content.get_placeholders():
-            # TODO: Handle missing placeholder
-            target = target_page_content.get_placeholders().get(slot=placeholder.slot)
+            try:
+                target = target_page_content.get_placeholders().get(slot=placeholder.slot)
+            except Placeholder.DoesNotExist:
+                messages.warning(request, _("Placeholder '%s' does not exist in target language") % placeholder.slot)
+                continue
             plugins = placeholder.get_plugins_list(source_page_content.language)
 
             if not target.has_add_plugins_permission(request.user, plugins):

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -3126,6 +3126,73 @@ class PermissionsOnGlobalTest(PermissionsTestCase):
             new_plugins = placeholder.get_plugins(translation.language)
             self.assertEqual(new_plugins.count(), 0)
 
+    def test_copy_plugins_to_language_skips_missing_placeholders(self):
+        """
+        When copying plugins to another language, placeholders that don't
+        exist in the target template should be skipped without raising
+        DoesNotExist exception.
+
+        Regression test for copying content when template placeholders have
+        changed between languages. This test ensures the fix at pageadmin.py:1213-1217
+        properly handles the DoesNotExist exception.
+        """
+        admin = self.get_superuser()
+
+        # Create page with nav_playground template (has 'body' and 'right-column' placeholders)
+        page = create_page(
+            "test-page",
+            "nav_playground.html",
+            "en",
+            created_by=admin,
+        )
+
+        # Add plugins to both placeholders in English
+        body_placeholder = page.get_placeholders("en").get(slot='body')
+        right_column_placeholder = page.get_placeholders("en").get(slot='right-column')
+
+        add_plugin(
+            body_placeholder,
+            'LinkPlugin',
+            'en',
+            name='Body Link',
+            external_link='https://example.com'
+        )
+        add_plugin(
+            right_column_placeholder,
+            'LinkPlugin',
+            'en',
+            name='Right Column Link',
+            external_link='https://example.com'
+        )
+
+        # Create German translation with col_two template (has 'col_sidebar' and 'col_left' placeholders)
+        # This simulates a template change where old placeholders no longer exist
+        de_content = create_page_content(
+            "de",
+            "test-page-de",
+            page,
+            slug="test-page-de",
+            template="col_two.html",
+        )
+
+        # Try to copy from English to German - should not raise DoesNotExist
+        endpoint = self.get_admin_url(PageContent, 'copy_language', de_content.pk)
+        data = {
+            'source_language': 'en',
+            'target_language': 'de',
+        }
+
+        with self.login_user_context(admin):
+            response = self.client.post(endpoint, data)
+            # Should succeed without raising DoesNotExist exception
+            # This is the key behavior being tested - the operation completes
+            # successfully even when source placeholders don't exist in target
+            self.assertEqual(response.status_code, 200)
+
+        # Verify original English plugins are still intact
+        self.assertEqual(body_placeholder.get_plugins('en').count(), 1)
+        self.assertEqual(right_column_placeholder.get_plugins('en').count(), 1)
+
     # Placeholder related tests
 
     def test_user_can_clear_empty_placeholder(self):


### PR DESCRIPTION
* fix: handle missing target placeholders gracefully

* fix: add regression test for copying plugins to language with missing placeholders

* fix: enhance regression test to verify handling of DoesNotExist exception during placeholder copying

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Handle missing placeholders gracefully when copying plugins between languages by catching DoesNotExist, warning the user, and skipping missing slots, and add a regression test to cover this scenario.

Bug Fixes:
- Gracefully handle missing target placeholders when copying plugins to avoid DoesNotExist errors.

Enhancements:
- Log a user-facing warning when skipping missing placeholders during language copy.

Tests:
- Add regression test for copying plugins to a language with missing placeholders and verifying DoesNotExist handling.