### PR TITLE
chore: Replace Django 6.0a1 with 6.0 in test requirements

### DIFF
--- a/test_requirements/django-6.0.txt
+++ b/test_requirements/django-6.0.txt
@@ -1,2 +1,2 @@
 -r requirements_base.txt
-Django>=6.0a1,<6.1
+Django>=6.0,<6.1


### PR DESCRIPTION
Updates the test requirements to use Django 6.0 instead of 6.0a1

## Summary by Sourcery

Bug Fixes:
- Align test dependency on Django 6.0 with the stable release rather than the alpha pre-release.