### PR TITLE
fix: Language changer for edit and preview mode if no get_absolute_url is available

### DIFF
--- a/menus/utils.py
+++ b/menus/utils.py
@@ -270,25 +270,25 @@ class DefaultLanguageChanger:
             self.request.toolbar.obj
         ):
             # Toolbar object
+            obj = self.request.toolbar.obj
             if self.request.toolbar.edit_mode_active:
-                lang_obj = get_object_for_language(self.request.toolbar.obj, lang, latest=True)
+                lang_obj = get_object_for_language(obj, lang, latest=True)
                 return '' if lang_obj is None else get_object_edit_url(lang_obj, language=lang)
             if self.request.toolbar.preview_mode_active:
-                lang_obj = get_object_for_language(self.request.toolbar.obj, lang, latest=True)
+                lang_obj = get_object_for_language(obj, lang, latest=True)
                 return '' if lang_obj is None else get_object_preview_url(lang_obj, language=lang)
-            if hasattr(self.request.toolbar.obj, 'get_absolute_url'):
+            if hasattr(obj, 'get_absolute_url'):
                 try:
                     # First see, if object can get language-specific absolute urls (like PageContent)
-                    return self.request.toolbar.obj.get_absolute_url(language=lang)
+                    return obj.get_absolute_url(language=lang)
                 except (TypeError, NoReverseMatch):
                     # Object's get_absolute_url does not accept language parameter, set the language
                     with force_language(lang):
                         try:
-                            url = self.request.toolbar.obj.get_absolute_url()
+                            return obj.get_absolute_url()
                         except NoReverseMatch:
-                            url = None
-                    if url:
-                        return url
+                            # Fall back to view
+                            pass
         if view and view.url_name not in ('pages-details-by-slug', 'pages-root'):
             view_name = view.url_name
             if view.namespace:

--- a/menus/utils.py
+++ b/menus/utils.py
@@ -267,8 +267,7 @@ class DefaultLanguageChanger:
                 view = None
         if (
             hasattr(self.request, 'toolbar') and
-            self.request.toolbar.obj and
-            hasattr(self.request.toolbar.obj, "get_absolute_url")
+            self.request.toolbar.obj
         ):
             # Toolbar object
             if self.request.toolbar.edit_mode_active:
@@ -277,19 +276,20 @@ class DefaultLanguageChanger:
             if self.request.toolbar.preview_mode_active:
                 lang_obj = get_object_for_language(self.request.toolbar.obj, lang, latest=True)
                 return '' if lang_obj is None else get_object_preview_url(lang_obj, language=lang)
-            try:
-                # First see, if object can get language-specific absolute urls (like PageContent)
-                return self.request.toolbar.obj.get_absolute_url(language=lang)
-            except (TypeError, NoReverseMatch):
-                # Object's get_absolute_url does not accept language parameter, set the language
-                with force_language(lang):
-                    try:
-                        url = self.request.toolbar.obj.get_absolute_url()
-                    except NoReverseMatch:
-                        url = None
-                if url:
-                    return url
-        elif view and view.url_name not in ('pages-details-by-slug', 'pages-root'):
+            if hasattr(self.request.toolbar.obj, 'get_absolute_url'):
+                try:
+                    # First see, if object can get language-specific absolute urls (like PageContent)
+                    return self.request.toolbar.obj.get_absolute_url(language=lang)
+                except (TypeError, NoReverseMatch):
+                    # Object's get_absolute_url does not accept language parameter, set the language
+                    with force_language(lang):
+                        try:
+                            url = self.request.toolbar.obj.get_absolute_url()
+                        except NoReverseMatch:
+                            url = None
+                    if url:
+                        return url
+        if view and view.url_name not in ('pages-details-by-slug', 'pages-root'):
             view_name = view.url_name
             if view.namespace:
                 view_name = f"{view.namespace}:{view_name}"


### PR DESCRIPTION
## Description

Adjust language switcher URL resolution for toolbar objects without language-aware absolute URLs.

Bug Fixes:
- Handle language change URLs correctly in edit and preview mode when the toolbar object does not implement get_absolute_url.

Enhancements:
- Simplify and relax toolbar object checks so non-page views still resolve language-specific URLs when no object URL is available.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.