### PR TITLE
feat: Add button for django CMS chat

### DIFF
--- a/docs/_static/kapa-ai.css
+++ b/docs/_static/kapa-ai.css
@@ -1,14 +1,3 @@
-#kapa-widget-container {
-  z-index: 10000 !important;
-  position: absolute !important;
-  inset-inline-start: 20px;
-  border-radius: 0;
-  background: #344C4C;
-  color: white;
-  content: "Ask AI";
-  padding: 20px 10px;
-}
-
 #kapa-ai-button {
   position: fixed;
   inset-inline-start: 20px;

--- a/docs/_static/kapa-ai.css
+++ b/docs/_static/kapa-ai.css
@@ -1,9 +1,39 @@
 #kapa-widget-container {
   z-index: 10000 !important;
   position: absolute !important;
+  inset-inline-start: 20px;
+  border-radius: 0;
+  background: #344C4C;
+  color: white;
+  content: "Ask AI";
+  padding: 20px 10px;
 }
 
-.mantine-Modal-root {
-  z-index: 10000;
-  position: absolute;
+#kapa-ai-button {
+  position: fixed;
+  inset-inline-start: 20px;
+  inset-block-end: 20px;
+  z-index: 10001;
+  background: #344c4c;
+  color: #ffffff;
+  border: 0;
+  border-radius: 6px;
+  padding: 10px 16px;
+  font: 600 14px/1.2 "Source Sans 3", "Source Sans Pro", sans-serif;
+  cursor: pointer;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.2);
+}
+
+#kapa-ai-button:hover,
+#kapa-ai-button:focus-visible {
+  background: #2b3d3d;
+  animation: kapa-ai-wiggle 320ms ease-in-out;
+}
+
+@keyframes kapa-ai-wiggle {
+  0% { transform: rotate(0deg); }
+  25% { transform: rotate(-3deg); }
+  50% { transform: rotate(3deg); }
+  75% { transform: rotate(-2deg); }
+  100% { transform: rotate(0deg); }
 }

--- a/docs/_static/kapa-ai.js
+++ b/docs/_static/kapa-ai.js
@@ -1,27 +1,13 @@
 document.addEventListener("DOMContentLoaded", function () {
-  var script = document.createElement("script");
-  script.src = "https://widget.kapa.ai/kapa-widget.bundle.js";
-  script.setAttribute("data-website-id", "08e64dae-cea6-4fbc-8207-1c8bd260a14c");
-  script.setAttribute("data-project-name", "django CMS");
-  script.setAttribute("data-project-color", "#A1C42C");
-  script.setAttribute("data-modal-title", "django CMS AI Bot - ask me anything!");
+	var button = document.createElement("button");
+	button.id = "kapa-ai-button";
+	button.type = "button";
+	button.textContent = "Ask AI";
+	button.setAttribute("aria-label", "Open Django CMS chat");
 
-  script.setAttribute("data-modal-size", "80%");
-  script.setAttribute("data-modal-image-hide", "true");
-  script.setAttribute("data-modal-disclaimer", "This is a custom LLM for django CMS trained on publicly available data such as django CMS' technical documentation. Sponsored by kapa.ai");
+	button.addEventListener("click", function () {
+		window.location.href = "https://chat.django-cms.org/";
+	});
 
-  script.setAttribute("data-button-height", "3em");
-  script.setAttribute("data-button-width", "4em");
-
-  // top right placement conflicts with text on some pages as well,
-  // so I chose the bottom right position as this is a dominant design pattern
-  // script.setAttribute("data-button-position-top", "10px");
-  // script.setAttribute("data-button-position-right", "10px");
-  script.setAttribute("data-button-image", "https://www.django-cms.org/static/img/django-logo.svg");
-  script.setAttribute("data-button-image-height", "11");
-  script.setAttribute("data-button-image-width", "60");
-  script.setAttribute("data-button-text-shadow", "none");
-
-  script.async = true;
-  document.head.appendChild(script);
+	document.body.appendChild(button);
 });


### PR DESCRIPTION
## Description

This PR adds a button to the docs that redirects to the new django CMS chat at https://chat.django-cms.org

Fixes #8477

## Related resources

<img width="1500" height="1060" alt="image" src="https://github.com/user-attachments/assets/9742c35b-ac42-4069-a759-25e82ba83e46" />

* #8477 

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Replace the embedded Kapa AI widget with a dedicated "Ask AI" button that links to the external django CMS chat.

New Features:
- Add a fixed-position "Ask AI" button in the docs that redirects users to https://chat.django-cms.org/.

Enhancements:
- Simplify and restyle the AI assistance UI in the docs, including hover animation and updated positioning.