### PR TITLE
fix: Migrations failed for django-treebeard >= 5.0.3

### DIFF
--- a/cms/migrations/0005_auto_20140924_1039.py
+++ b/cms/migrations/0005_auto_20140924_1039.py
@@ -16,7 +16,10 @@ class MP_AddHandler():
         self.stmts = []
 
 
-NUM = NumConv(len(ALPHABET), ALPHABET)
+try:
+    NUM = NumConv(len(ALPHABET), ALPHABET)
+except TypeError:
+    NUM = NumConv(ALPHABET)
 
 
 def _int2str(num):


### PR DESCRIPTION
## Description


Bug Fixes:
- Handle NumConv initialization for both old and new django-treebeard constructor signatures to prevent migration failures.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8483 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

