### PR TITLE
docs: Remove reference to page_moved signal which is never called

### DIFF
--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -388,7 +388,7 @@ class Page(MP_Node):
         """
         Called from admin interface when page is moved. Should be used on
         all the places which are changing page position. Used like an interface
-        to django-treebeard, but after move is done page_moved signal is fired.
+        to django-treebeard.
         """
         assert isinstance(target_page, Page), f"{target_page} is not an instance of Page."
         inherited_template = self.template == constants.TEMPLATE_INHERITANCE_MAGIC

--- a/cms/signals/__init__.py
+++ b/cms/signals/__init__.py
@@ -49,10 +49,6 @@ def check_v4_confirmation(**kwargs):
 
 # ################### Our own signals ###################
 
-
-# fired after page location is changed - is moved from one node to other
-page_moved = Signal()
-
 # fired if a public page with an apphook is added or changed
 urls_need_reloading = Signal()
 

--- a/cms/signals/__init__.py
+++ b/cms/signals/__init__.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django.conf import settings
 from django.contrib.auth.models import Group, User
 from django.db.models import signals
@@ -33,6 +35,7 @@ from cms.signals.permissions import (
     user_m2m_changed,
 )
 from cms.utils.conf import get_cms_setting
+from cms.utils.compat.warnings import RemovedInDjangoCMS60Warning
 
 
 @receiver(pre_migrate)
@@ -49,8 +52,30 @@ def check_v4_confirmation(**kwargs):
 
 # ################### Our own signals ###################
 
+
+class DeprecatedSignal(Signal):
+    def __init__(self, name, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._deprecation_name = name
+
+    def connect(self, receiver, sender=None, weak=True, dispatch_uid=None):
+        warnings.warn(
+            f"The '{self._deprecation_name}' signal is deprecated and will be removed in django CMS 6.0.",
+            RemovedInDjangoCMS60Warning,
+            stacklevel=2,
+        )
+        return super().connect(
+            receiver,
+            sender=sender,
+            weak=weak,
+            dispatch_uid=dispatch_uid,
+        )
+
 # fired if a public page with an apphook is added or changed
 urls_need_reloading = Signal()
+
+# Deprecated: use operations hooks or other signals instead.
+move_page = DeprecatedSignal("move_page")
 
 # *disclaimer*
 # The generic object operation signals are very likely to change

--- a/cms/signals/__init__.py
+++ b/cms/signals/__init__.py
@@ -34,8 +34,8 @@ from cms.signals.permissions import (
     pre_save_user,
     user_m2m_changed,
 )
-from cms.utils.conf import get_cms_setting
 from cms.utils.compat.warnings import RemovedInDjangoCMS60Warning
+from cms.utils.conf import get_cms_setting
 
 
 @receiver(pre_migrate)
@@ -45,10 +45,11 @@ def check_v4_confirmation(**kwargs):
 
     This is a temporary step to ensure people only migrate their databases intentionally.
     """
-    if not get_cms_setting('CONFIRM_VERSION4'):
+    if not get_cms_setting("CONFIRM_VERSION4"):
         raise ConfirmationOfVersion4Required(
             "You must confirm your intention to use django-cms version 4 with the setting CMS_CONFIRM_VERSION4"
         )
+
 
 # ################### Our own signals ###################
 
@@ -70,6 +71,7 @@ class DeprecatedSignal(Signal):
             weak=weak,
             dispatch_uid=dispatch_uid,
         )
+
 
 # fired if a public page with an apphook is added or changed
 urls_need_reloading = Signal()
@@ -96,10 +98,7 @@ if settings.DEBUG:
     urls_need_reloading.connect(debug_server_restart)
 
 
-urls_need_reloading.connect(
-    trigger_server_restart,
-    dispatch_uid='aldryn-apphook-reload-handle-urls-need-reloading'
-)
+urls_need_reloading.connect(trigger_server_restart, dispatch_uid="aldryn-apphook-reload-handle-urls-need-reloading")
 
 
 # ##################### log entries #######################
@@ -109,34 +108,35 @@ post_placeholder_operation.connect(log_placeholder_operations)
 
 # ##################### permissions #######################
 
-if get_cms_setting('PERMISSION'):
+if get_cms_setting("PERMISSION"):
     # only if permissions are in use
-    signals.pre_save.connect(pre_save_user, sender=User, dispatch_uid='cms_pre_save_user')
-    signals.post_save.connect(post_save_user, sender=User, dispatch_uid='cms_post_save_user')
-    signals.pre_delete.connect(pre_delete_user, sender=User, dispatch_uid='cms_pre_delete_user')
-    signals.m2m_changed.connect(user_m2m_changed, sender=User.groups.through, dispatch_uid='cms_user_m2m_changed')
+    signals.pre_save.connect(pre_save_user, sender=User, dispatch_uid="cms_pre_save_user")
+    signals.post_save.connect(post_save_user, sender=User, dispatch_uid="cms_post_save_user")
+    signals.pre_delete.connect(pre_delete_user, sender=User, dispatch_uid="cms_pre_delete_user")
+    signals.m2m_changed.connect(user_m2m_changed, sender=User.groups.through, dispatch_uid="cms_user_m2m_changed")
 
-    signals.pre_save.connect(pre_save_user, sender=PageUser, dispatch_uid='cms_pre_save_pageuser')
-    signals.pre_delete.connect(pre_delete_user, sender=PageUser, dispatch_uid='cms_pre_delete_pageuser')
+    signals.pre_save.connect(pre_save_user, sender=PageUser, dispatch_uid="cms_pre_save_pageuser")
+    signals.pre_delete.connect(pre_delete_user, sender=PageUser, dispatch_uid="cms_pre_delete_pageuser")
 
-    signals.pre_save.connect(pre_save_group, sender=Group, dispatch_uid='cms_pre_save_group')
-    signals.post_save.connect(post_save_user_group, sender=Group, dispatch_uid='cms_post_save_group')
-    signals.pre_delete.connect(pre_delete_group, sender=Group, dispatch_uid='cms_post_save_group')
+    signals.pre_save.connect(pre_save_group, sender=Group, dispatch_uid="cms_pre_save_group")
+    signals.post_save.connect(post_save_user_group, sender=Group, dispatch_uid="cms_post_save_group")
+    signals.pre_delete.connect(pre_delete_group, sender=Group, dispatch_uid="cms_post_save_group")
 
-    signals.pre_save.connect(pre_save_group, sender=PageUserGroup, dispatch_uid='cms_pre_save_pageusergroup')
-    signals.pre_delete.connect(pre_delete_group, sender=PageUserGroup, dispatch_uid='cms_pre_delete_pageusergroup')
-
-    signals.pre_save.connect(
-        pre_save_pagepermission, sender=PagePermission, dispatch_uid='cms_pre_save_pagepermission'
-    )
-    signals.pre_delete.connect(
-        pre_delete_pagepermission, sender=PagePermission, dispatch_uid='cms_pre_delete_pagepermission'
-    )
+    signals.pre_save.connect(pre_save_group, sender=PageUserGroup, dispatch_uid="cms_pre_save_pageusergroup")
+    signals.pre_delete.connect(pre_delete_group, sender=PageUserGroup, dispatch_uid="cms_pre_delete_pageusergroup")
 
     signals.pre_save.connect(
-        pre_save_globalpagepermission, sender=GlobalPagePermission, dispatch_uid='cms_pre_save_globalpagepermission'
+        pre_save_pagepermission, sender=PagePermission, dispatch_uid="cms_pre_save_pagepermission"
     )
     signals.pre_delete.connect(
-        pre_delete_globalpagepermission, sender=GlobalPagePermission,
-        dispatch_uid='cms_pre_delete_globalpagepermission'
+        pre_delete_pagepermission, sender=PagePermission, dispatch_uid="cms_pre_delete_pagepermission"
+    )
+
+    signals.pre_save.connect(
+        pre_save_globalpagepermission, sender=GlobalPagePermission, dispatch_uid="cms_pre_save_globalpagepermission"
+    )
+    signals.pre_delete.connect(
+        pre_delete_globalpagepermission,
+        sender=GlobalPagePermission,
+        dispatch_uid="cms_pre_delete_globalpagepermission",
     )

--- a/cms/tests/test_signals.py
+++ b/cms/tests/test_signals.py
@@ -1,12 +1,15 @@
+import warnings
+
 from django.conf import settings
 from django.test.utils import override_settings
 
 from cms.api import create_page
 from cms.models import Page, UrlconfRevision
-from cms.signals import urls_need_reloading
+from cms.signals import move_page, urls_need_reloading
 from cms.test_utils.project.sampleapp.cms_apps import SampleApp
 from cms.test_utils.testcases import CMSTestCase
 from cms.test_utils.util.context_managers import apphooks, signal_tester
+from cms.utils.compat.warnings import RemovedInDjangoCMS60Warning
 
 overrides = {
     'MIDDLEWARE': ['cms.middleware.utils.ApphookReloadMiddleware'] + settings.MIDDLEWARE,
@@ -16,6 +19,19 @@ overrides = {
 
 @override_settings(**overrides)
 class SignalTests(CMSTestCase):
+    def test_move_page_signal_warns_on_connect(self):
+        def receiver(**kwargs):
+            return None
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", RemovedInDjangoCMS60Warning)
+            move_page.connect(receiver)
+
+        self.assertTrue(
+            any(issubclass(warning.category, RemovedInDjangoCMS60Warning) for warning in caught),
+            "Expected deprecation warning when connecting to move_page signal.",
+        )
+
     def test_urls_need_reloading_signal_set_apphook(self):
         superuser = self.get_superuser()
 


### PR DESCRIPTION
## Description

Deprecate the unused page move signal in favor of newer mechanisms and update related tests and signal wiring. The page move signal has not been called since PR #6112. It is time to remove it using the deprecation process.

New Features:
- Introduce a DeprecatedSignal wrapper to emit deprecation warnings when connecting to legacy signals.

Enhancements:
- Add a move_page deprecated signal that warns on use and is slated for removal in django CMS 6.0.
- Clarify Page.move_page docstring to remove reference to the obsolete page_moved signal.
- Normalize signal connection style and string quoting for consistency in the signals module.

Tests:
- Add a test ensuring the move_page signal emits a deprecation warning on connection.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #6112 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.