### PR TITLE
fix: clarify page permission labels and error messages

### DIFF
--- a/cms/models/permissionmodels.py
+++ b/cms/models/permissionmodels.py
@@ -91,9 +91,9 @@ class AbstractPagePermission(models.Model):
     )
     can_move_page = models.BooleanField(_("can move"), default=True)
     can_view = models.BooleanField(
-    _("Can view restricted pages"), 
-    default=False, 
-    help_text=_("Grant access to pages that are otherwise hidden from the public.")
+        _("Can view restricted pages"),
+        default=False,
+        help_text=_("Grant access to pages that are otherwise hidden from the public.")
     )
 
     class Meta:

--- a/cms/models/permissionmodels.py
+++ b/cms/models/permissionmodels.py
@@ -120,7 +120,7 @@ class AbstractPagePermission(models.Model):
             raise ValidationError(message)
 
         if self.can_publish:
-            message = _("To grant 'Can publish' permissions, the 'Can edit' permission must also be checked.")
+            message = _("To grant 'can publish' permissions, the 'can edit' permission must also be checked.")
             raise ValidationError(message)
 
         if self.can_change_advanced_settings:

--- a/cms/models/permissionmodels.py
+++ b/cms/models/permissionmodels.py
@@ -90,7 +90,11 @@ class AbstractPagePermission(models.Model):
         _("can change permissions"), default=False, help_text=_("on page level")
     )
     can_move_page = models.BooleanField(_("can move"), default=True)
-    can_view = models.BooleanField(_("view restricted"), default=False, help_text=_("frontend view restriction"))
+    can_view = models.BooleanField(
+    _("Can view restricted pages"), 
+    default=False, 
+    help_text=_("Grant access to pages that are otherwise hidden from the public.")
+    )
 
     class Meta:
         abstract = True
@@ -116,8 +120,7 @@ class AbstractPagePermission(models.Model):
             raise ValidationError(message)
 
         if self.can_publish:
-            message = _("Users can't publish a page without permissions "
-                        "to change the page. Edit permissions required.")
+            message = _("To grant 'Can publish' permissions, the 'Can edit' permission must also be checked.")
             raise ValidationError(message)
 
         if self.can_change_advanced_settings:
@@ -193,9 +196,9 @@ class GlobalPagePermission(AbstractPagePermission):
     """Permissions for all pages (global).
     """
     can_recover_page = models.BooleanField(
-        verbose_name=_("can recover pages"),
-        default=True,
-        help_text=_("can recover any deleted page"),
+    verbose_name=_("can recover pages"),
+    default=True,
+    help_text=_("Allows the user to restore pages from the trash/delete history."),
     )
     sites = models.ManyToManyField(
         to=Site,

--- a/cms/models/permissionmodels.py
+++ b/cms/models/permissionmodels.py
@@ -196,9 +196,9 @@ class GlobalPagePermission(AbstractPagePermission):
     """Permissions for all pages (global).
     """
     can_recover_page = models.BooleanField(
-    verbose_name=_("can recover pages"),
-    default=True,
-    help_text=_("Allows the user to restore pages from the trash/delete history."),
+        verbose_name=_("can recover pages"),
+        default=True,
+        help_text=_("Allows the user to restore pages from the trash/delete history."),
     )
     sites = models.ManyToManyField(
         to=Site,


### PR DESCRIPTION
## Description
This PR improves the clarity of page permission labels and error messages in `cms/models/permissionmodels.py`. 

Specifically, it renames the ambiguous "View restricted" label to **"Can view restricted pages"** and updates the help text to clearly explain that these settings control frontend visibility for the public. It also refines the `ValidationError` to provide actionable instructions when a user attempts to grant "Can publish" permissions without the required "Can edit" permissions.
<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* Fixes #7633
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Clarify page permission labels and supporting text to better describe visibility and publishing requirements.

Enhancements:
- Rename the page view permission label to clearly indicate access to otherwise hidden restricted pages and update its help text for frontend visibility.
- Improve the validation error message when assigning publish permissions without edit permissions to provide explicit guidance.
- Refine the global page recovery permission help text to clearly describe restoring pages from trash or delete history.