### PR TITLE
fix: Keep GET params when toggling structure mode (#8497)

### DIFF
--- a/cms/static/cms/js/modules/cms.structureboard.js
+++ b/cms/static/cms/js/modules/cms.structureboard.js
@@ -665,7 +665,7 @@ class StructureBoard {
         this.ui.container.addClass('cms-structure-condensed');
 
         if (CMS.settings.mode === 'structure') {
-            history.replaceState({}, '', CMS.config.settings.edit + window.location.search);
+            history.replaceState({}, '', CMS.config.settings.edit);
         }
 
         const width = this.ui.toolbar.width();
@@ -688,7 +688,7 @@ class StructureBoard {
         this.ui.container.removeClass('cms-structure-condensed');
 
         if (CMS.settings.mode === 'structure') {
-            history.replaceState({}, '', CMS.config.settings.structure + window.location.search);
+            history.replaceState({}, '', CMS.config.settings.structure);
             $('html.cms-structure-mode-structure').addClass('cms-overflow');
         }
 

--- a/cms/templates/cms/toolbar/toolbar_javascript.html
+++ b/cms/templates/cms/toolbar/toolbar_javascript.html
@@ -113,9 +113,9 @@
         "sideframe": { "url": "" },
         "sideframe_enabled": {{ cms_toolbar.sideframe_enabled|yesno:"true,false" }},
         "states": [],
-        "edit": "{{ cms_edit_url }}",
-        "edit_off": "{{ cms_preview_url }}",
-        "structure": "{{ cms_structure_url }}",
+        "edit": "{{ cms_edit_url | escapejs }}",
+        "edit_off": "{{ cms_preview_url | escapejs }}",
+        "structure": "{{ cms_structure_url | escapejs }}",
         "legacy_mode": {{ cms_toolbar.uses_legacy_structure_mode|yesno:"true,false" }}
     },
     "clipboard": {

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.contrib import admin
 from django.contrib.auth.models import AnonymousUser, Permission
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.sites.models import Site
 from django.http import HttpResponse, QueryDict
 from django.template.defaultfilters import truncatewords
 from django.test import TestCase

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -8,8 +8,7 @@ from django.conf import settings
 from django.contrib import admin
 from django.contrib.auth.models import AnonymousUser, Permission
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.sites.models import Site
-from django.http import HttpResponse
+from django.http import HttpResponse, QueryDict
 from django.template.defaultfilters import truncatewords
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -2330,6 +2329,184 @@ class ToolbarUtilsTestCase(ToolbarTestBase):
         obj = SimpleNamespace(pk=3)
         url = get_object_structure_url(obj, language="es")
         self.assertIn("?language=es", url)
+
+
+    # --- Tests for GET parameter forwarding (params argument) ---
+
+    @patch("cms.toolbar.utils.get_cms_setting")
+    @patch("cms.toolbar.utils.get_language_from_path")
+    @patch("cms.toolbar.utils.admin_reverse")
+    @patch("cms.toolbar.utils.ContentType")
+    def test_get_object_edit_url_appends_extra_params(
+        self, mock_contenttype, mock_admin_reverse, mock_get_lang_from_path, mock_get_cms_setting
+    ):
+        """Extra GET parameters passed via a QueryDict are appended to the edit URL."""
+        mock_get_cms_setting.return_value = False
+        mock_get_lang_from_path.return_value = None
+        mock_admin_reverse.return_value = "/admin/cms/placeholder/render/object/edit/1/"
+        mock_contenttype.objects.get_for_model.return_value = SimpleNamespace(pk=42)
+
+        params = QueryDict("foo=bar&baz=qux")
+        obj = SimpleNamespace(pk=1)
+        url = get_object_edit_url(obj, language="de", params=params)
+        self.assertIn("foo=bar", url)
+        self.assertIn("baz=qux", url)
+        self.assertIn("language=de", url)
+
+    @patch("cms.toolbar.utils.get_cms_setting")
+    @patch("cms.toolbar.utils.get_language_from_path")
+    @patch("cms.toolbar.utils.admin_reverse")
+    @patch("cms.toolbar.utils.ContentType")
+    def test_get_object_preview_url_appends_extra_params(
+        self, mock_contenttype, mock_admin_reverse, mock_get_lang_from_path, mock_get_cms_setting
+    ):
+        """Extra GET parameters passed via a QueryDict are appended to the preview URL."""
+        mock_get_cms_setting.return_value = False
+        mock_get_lang_from_path.return_value = None
+        mock_admin_reverse.return_value = "/admin/cms/placeholder/render/object/preview/1/"
+        mock_contenttype.objects.get_for_model.return_value = SimpleNamespace(pk=99)
+
+        params = QueryDict("alpha=1&beta=2")
+        obj = SimpleNamespace(pk=2)
+        url = get_object_preview_url(obj, language="fr", params=params)
+        self.assertIn("alpha=1", url)
+        self.assertIn("beta=2", url)
+        self.assertIn("language=fr", url)
+
+    @patch("cms.toolbar.utils.get_language_from_path")
+    @patch("cms.toolbar.utils.admin_reverse")
+    @patch("cms.toolbar.utils.ContentType")
+    def test_get_object_structure_url_appends_extra_params(
+        self, mock_contenttype, mock_admin_reverse, mock_get_lang_from_path
+    ):
+        """Extra GET parameters passed via a QueryDict are appended to the structure URL."""
+        mock_get_lang_from_path.return_value = None
+        mock_admin_reverse.return_value = "/admin/cms/placeholder/render/object/structure/1/"
+        mock_contenttype.objects.get_for_model.return_value = SimpleNamespace(pk=7)
+
+        params = QueryDict("x=10&y=20")
+        obj = SimpleNamespace(pk=3)
+        url = get_object_structure_url(obj, language="es", params=params)
+        self.assertIn("x=10", url)
+        self.assertIn("y=20", url)
+        self.assertIn("language=es", url)
+
+    @patch("cms.toolbar.utils.get_cms_setting")
+    @patch("cms.toolbar.utils.get_language_from_path")
+    @patch("cms.toolbar.utils.admin_reverse")
+    @patch("cms.toolbar.utils.ContentType")
+    def test_get_object_url_without_params_has_no_extra_querystring(
+        self, mock_contenttype, mock_admin_reverse, mock_get_lang_from_path, mock_get_cms_setting
+    ):
+        """When params is None, only the language parameter (if needed) is appended."""
+        mock_get_cms_setting.return_value = False
+        mock_get_lang_from_path.return_value = None
+        mock_admin_reverse.return_value = "/admin/cms/placeholder/render/object/edit/1/"
+        mock_contenttype.objects.get_for_model.return_value = SimpleNamespace(pk=42)
+
+        obj = SimpleNamespace(pk=1)
+        url = get_object_edit_url(obj, language="de", params=None)
+        self.assertEqual(url, "/admin/cms/placeholder/render/object/edit/1/?language=de")
+
+    @patch("cms.toolbar.utils.get_cms_setting")
+    @patch("cms.toolbar.utils.get_language_from_path")
+    @patch("cms.toolbar.utils.admin_reverse")
+    @patch("cms.toolbar.utils.ContentType")
+    def test_get_object_url_does_not_mutate_original_params(
+        self, mock_contenttype, mock_admin_reverse, mock_get_lang_from_path, mock_get_cms_setting
+    ):
+        """Calling get_object_*_url must not mutate the original QueryDict."""
+        mock_get_cms_setting.return_value = False
+        mock_get_lang_from_path.return_value = None
+        mock_admin_reverse.return_value = "/admin/cms/placeholder/render/object/edit/1/"
+        mock_contenttype.objects.get_for_model.return_value = SimpleNamespace(pk=42)
+
+        params = QueryDict("keep=me")
+        obj = SimpleNamespace(pk=1)
+        get_object_edit_url(obj, language="de", params=params)
+        # The original immutable QueryDict must not have been altered
+        self.assertNotIn("language", params)
+        self.assertEqual(params["keep"], "me")
+
+    # --- Integration tests: toolbar methods forward request.GET ---
+
+    def test_toolbar_get_object_edit_url_passes_request_get(self):
+        """CMSToolbar.get_object_edit_url forwards request.GET to the utility function."""
+        page = create_page("home", "nav_playground.html", "en")
+        page_content = page.get_content_obj()
+
+        superuser = self.get_superuser()
+        edit_url = get_object_edit_url(page_content)
+        request = self.get_page_request(page, superuser, edit_url + "?custom=value")
+        toolbar = CMSToolbar(request)
+        toolbar.set_object(page_content)
+
+        url = toolbar.get_object_edit_url()
+        self.assertIn("custom=value", url)
+
+    def test_toolbar_get_object_preview_url_passes_request_get(self):
+        """CMSToolbar.get_object_preview_url forwards request.GET to the utility function."""
+        page = create_page("home", "nav_playground.html", "en")
+        page_content = page.get_content_obj()
+
+        superuser = self.get_superuser()
+        edit_url = get_object_edit_url(page_content)
+        request = self.get_page_request(page, superuser, edit_url + "?custom=value")
+        toolbar = CMSToolbar(request)
+        toolbar.set_object(page_content)
+
+        url = toolbar.get_object_preview_url()
+        self.assertIn("custom=value", url)
+
+    def test_toolbar_get_object_structure_url_passes_request_get(self):
+        """CMSToolbar.get_object_structure_url forwards request.GET to the utility function."""
+        page = create_page("home", "nav_playground.html", "en")
+        page_content = page.get_content_obj()
+
+        superuser = self.get_superuser()
+        edit_url = get_object_edit_url(page_content)
+        request = self.get_page_request(page, superuser, edit_url + "?custom=value")
+        toolbar = CMSToolbar(request)
+        toolbar.set_object(page_content)
+
+        url = toolbar.get_object_structure_url()
+        self.assertIn("custom=value", url)
+
+    # --- Template integration test: URLs with params are correctly escaped in JS config ---
+
+    def test_toolbar_javascript_template_contains_escaped_urls_with_params(self):
+        """
+        The toolbar_javascript.html template renders cms_edit_url, cms_preview_url,
+        and cms_structure_url through the escapejs filter so that query-string
+        ampersands appear as \\u0026 inside the JSON string literals.
+        """
+        page = create_page("home", "nav_playground.html", "en")
+        page_content = page.get_content_obj()
+        superuser = self.get_superuser()
+        edit_url = get_object_edit_url(page_content)
+
+        with self.login_user_context(superuser):
+            response = self.client.get(edit_url + "?myparam=myval")
+        self.assertEqual(response.status_code, 200)
+
+        content = response.content.decode()
+        # The rendered JSON should contain the custom parameter in all three URLs.
+        # The template uses {{ ... | escapejs }} so '&' becomes '\\u0026'.
+        self.assertIn("myparam=myval", content)
+
+        # Verify the edit, edit_off (preview), and structure keys exist with the param
+        import json
+        # Extract the JSON config block from the <script> tag
+        match = re.search(
+            r'<script[^>]*id="cms-config-json"[^>]*>\s*(\{.*?\})\s*</script>',
+            content,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(match, "Could not find cms-config-json script block")
+        config = json.loads(match.group(1))
+        self.assertIn("myparam=myval", config["settings"]["edit"])
+        self.assertIn("myparam=myval", config["settings"]["edit_off"])
+        self.assertIn("myparam=myval", config["settings"]["structure"])
 
 
 class GetObjectLiveUrlTests(CMSTestCase):

--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -425,17 +425,17 @@ class CMSToolbarBase(BaseToolbar):
 
     def get_object_preview_url(self):
         if self.obj:
-            return get_object_preview_url(self.obj, language=self.request_language)
+            return get_object_preview_url(self.obj, language=self.request_language, params=self.request.GET)
         return ''
 
     def get_object_edit_url(self):
         if self.obj:
-            return get_object_edit_url(self.obj, language=self.request_language)
+            return get_object_edit_url(self.obj, language=self.request_language, params=self.request.GET)
         return ''
 
     def get_object_structure_url(self):
         if self.obj:
-            return get_object_structure_url(self.obj, language=self.request_language)
+            return get_object_structure_url(self.obj, language=self.request_language, params=self.request.GET)
         return ''
 
     def object_is_editable(self, obj=None):


### PR DESCRIPTION
## Description

Port forward of #8497

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8497 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Preserve and correctly escape query parameters when generating and using CMS toolbar edit, preview, and structure URLs, ensuring they survive mode toggling and are safely embedded in the client-side config.

Bug Fixes:
- Ensure CMS toolbar object edit, preview, and structure URLs forward existing request GET parameters instead of dropping them when switching modes.

Enhancements:
- Escape CMS toolbar edit, preview, and structure URLs in the toolbar JavaScript template to produce JSON-safe query strings without double-appending window.location.search.

Tests:
- Add unit, integration, and template-level tests verifying that object URLs accept extra params, do not mutate input QueryDicts, that the toolbar forwards request.GET, and that rendered JS config contains the expected escaped URLs with preserved query parameters.