### PR TITLE
build: bump minimum Django version to 4.2.26 (CVE-2025-64459)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
 ]
 dynamic = [ "version" ]
 dependencies = [
-  "Django >= 4.2",
+  "Django >= 4.2.26",
   "django-classy-tags >=0.7.2",
   "django-formtools >=2.1",
   "django-treebeard >=4.3",


### PR DESCRIPTION
Django versions below 4.2.26 are affected by CVE-2025-64459 (CVSS 9.1), a SQL injection vulnerability in the ORM. When a developer passes user-controlled dictionary keys directly to `filter(**kwargs)`, attackers can inject `_connector=OR` or `_negated=True` to manipulate the WHERE clause logic.

The fix was released in Django 4.2.26, 5.1.14, and 5.2.8.

This PR bumps the minimum required Django version from `>= 4.2` to `>= 4.2.26` to ensure downstream projects installing django-cms are protected against this vulnerability.

Reference: https://www.djangoproject.com/weblog/2025/may/07/security-releases/