### PR TITLE
fix: slug and overwrite_url caching failed in read-only change_views (#8507)

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -890,18 +890,18 @@ class PageContentAdmin(admin.ModelAdmin):
         return form
 
     def slug(self, obj):
-        # For read-only views: Get slug from the page
-        if not hasattr(self, "url_obj"):
-            self.url_obj = obj.page.get_url(obj.language)
-        return self.url_obj.slug
+        # For read-only views: Get slug from the page content object
+        if not hasattr(obj, "_url_obj"):
+            obj._url_obj = obj.page.get_url(obj.language)
+        return obj._url_obj.slug
 
     def overwrite_url(self, obj):
-        # For read-only views: Get slug from the page
-        if not hasattr(self, "url_obj"):
-            self.url_obj = obj.page.get_url(obj.language)
-        if self.url_obj.managed:
+        # For read-only views: Get slug from the page content object
+        if not hasattr(obj, "_url_obj"):
+            obj._url_obj = obj.page.get_url(obj.language)
+        if obj._url_obj.managed:
             return None
-        return self.url_obj.path
+        return obj._url_obj.path
 
     def duplicate(self, request, object_id):
         """

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -1324,6 +1324,33 @@ class PageTest(PageTestBase):
             self.assertTrue('form_url' in response.context_data)
             self.assertEqual(response.context_data['form_url'], form_url)
 
+    def test_pagecontent_change_view_uses_cached_url_obj(self):
+        superuser = self.get_superuser()
+        with self.login_user_context(superuser):
+            content_admin = PageContentAdmin(PageContent, admin.site)
+            page1 = self.get_page()
+            content1 = self.get_pagecontent_obj(page1, "en")
+            content1.page = page1
+            page2 = self.get_page()
+            content2 = self.get_pagecontent_obj(page2, "en")
+
+            content_admin.slug(content1)
+            content_admin.overwrite_url(content1)
+
+            with self.assertNumQueries(0):
+                # Slugs and overwrite urls are cached
+                slug = content_admin.slug(content1)
+                content_admin.overwrite_url(content1)
+
+            self.assertNotEqual(slug, content_admin.slug(content2))
+
+            with self.assertNumQueries(0):
+                # Both still cached
+                content_admin.overwrite_url(content1)
+                content_admin.slug(content1)
+                content_admin.slug(content2)
+                content_admin.overwrite_url(content2)
+
     def _parse_page_tree(self, response, parser_class):
         content = response.content
         content = content.decode(response.charset)
@@ -3333,7 +3360,6 @@ class PermissionsOnPageTest(PermissionsTestCase):
                 row for row in rows if (not row.is_global and row.permission.pk == other_permission.pk)
             )
             self.assertFalse(permission_row.can_change)
-
 
     def test_pages_not_in_admin_index(self):
         """


### PR DESCRIPTION
## Description

Backport of #8507.

Fix page content admin read-only views to use per-object cached URL data for slug and overwrite URL display.

Bug Fixes:
- Correct slug and overwrite URL resolution in read-only page content admin views by caching URL data on the content object instead of the admin instance.

Tests:
- Add regression test ensuring page content admin reuses cached URL objects per content item without triggering additional queries and distinguishes between different pages.


## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8507 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

