### PR TITLE
chore: Refactor make-changelog for POSIX compatibility

### DIFF
--- a/scripts/make-changelog
+++ b/scripts/make-changelog
@@ -8,17 +8,39 @@ SCRIPTS=$(dirname "$(realpath "$0")")
 #shellcheck disable=SC1090
 source "${SCRIPTS}/functions"
 
-# Scope used in this script
-declare -A SCOPES_HEADINGS
-declare -a SCOPES
+# Detect if we're on macOS or Linux
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    IS_MAC=true
+else
+    IS_MAC=false
+fi
 
+# Helper function for cross-platform sed -i
+sed_inplace_file() {
+    local file="$1"
+    shift
+    if [[ "$IS_MAC" == "true" ]]; then
+        sed -i '' "$@" "$file"
+    else
+        sed -i "$@" "$file"
+    fi
+}
+
+# Scope used in this script
 SCOPES=("feat" "security" "fix" "style" "refactor" "tools")
-SCOPES_HEADINGS["feat"]="Features:"
-SCOPES_HEADINGS["fix"]="Bug Fixes:"
-SCOPES_HEADINGS["security"]="Security Updates:"
-SCOPES_HEADINGS["style"]="Styles:"
-SCOPES_HEADINGS["refactor"]="Refactoring and Cleanups:"
-SCOPES_HEADINGS["tools"]="Internal Tools:"
+
+# Function to get heading text for a scope (replaces associative array for POSIX compatibility)
+get_scope_heading() {
+    case "$1" in
+        feat) echo "Features:" ;;
+        fix) echo "Bug Fixes:" ;;
+        security) echo "Security Updates:" ;;
+        style) echo "Styles:" ;;
+        refactor) echo "Refactoring and Cleanups:" ;;
+        tools) echo "Internal Tools:" ;;
+        *) echo "" ;;
+    esac
+}
 
 
 # argument checks
@@ -82,10 +104,10 @@ line=$(echo "${title}" | sed 's/./=/g')
 legacy="$(mktemp)"
 current="$(mktemp)"
 
-awk -e "BEGIN {show=0} /^${OLD_FULL_VERSION} \([0-9]{4}-[0-9]{2}-[0-9]{2}\)\$/ {show=1} {if (show==1) print; }" < CHANGELOG.rst > "${legacy}"
-awk -e "/^${OLD_FULL_VERSION} \([0-9]{4}-[0-9]{2}-[0-9]{2}\)\$/ {nextfile} {print; }" < CHANGELOG.rst | awk -e '/^Statistics:$/ {nextfile} {print}' > "${current}"
+awk "BEGIN {show=0} /^${OLD_FULL_VERSION} \([0-9]{4}-[0-9]{2}-[0-9]{2}\)\$/ {show=1} {if (show==1) print; }" < CHANGELOG.rst > "${legacy}"
+awk "/^${OLD_FULL_VERSION} \([0-9]{4}-[0-9]{2}-[0-9]{2}\)\$/ {nextfile} {print; }" < CHANGELOG.rst | awk '/^Statistics:$/ {nextfile} {print}' > "${current}"
 
-LAST_FULL_VERSION=$(awk -e '/^[0-9]+\.[0-9]+\.[0-9].* \(.+\)$/ { print $1; nextfile }' < CHANGELOG.rst )
+LAST_FULL_VERSION=$(awk '/^[0-9]+\.[0-9]+\.[0-9].* \(.+\)$/ { print $1; nextfile }' < CHANGELOG.rst )
 LAST_VERSION=$(get_main_version "${LAST_FULL_VERSION}")
 
 # Sanity checks
@@ -98,34 +120,44 @@ fi
 
 if [ "${VERSION}" = "${LAST_VERSION}" ]; then
     # releasing a golden release from RC, so we just change the version RC to the new one
-    sed -i "${current}" \
-        -e "/^${LAST_FULL_VERSION} (unpublished)$/a${title}" \
-        -e "/^${LAST_FULL_VERSION} (unpublished)$/a${line}" \
-        -e "/^${LAST_FULL_VERSION} (unpublished)$/,+1d" \
-        -e "s/(unpublished)/(${DATE})/"
+    sed_script=$(mktemp)
+    cat > "$sed_script" << EOF
+/^${LAST_FULL_VERSION} (unpublished)$/a\\
+${title}\\
+${line}
+/^${LAST_FULL_VERSION} (unpublished)$/,+1d
+s/(unpublished)/(${DATE})/
+EOF
+    sed_inplace_file "${current}" -f "$sed_script"
+    rm "$sed_script"
 else
 
     # This is a first release (RC or equivalent),
     # let's add some headings to be sure we got all of them right for next steps
-    sed -i "${current}" \
-        -e "/^unreleased$/a${title}" \
-        -e "/^unreleased$/a${line}" \
-        -e "/^unreleased$/a
-" \
-        -e "/^unreleased$/aHighlights:" \
-        -e "/^unreleased$/a-----------" \
-        -e "/^unreleased$/,+1d" \
-        -e "s/(unpublished)/(${DATE})/"
+    sed_script=$(mktemp)
+    cat > "$sed_script" << EOF
+/^unreleased$/a\\
+${title}\\
+${line}\\
+\\
+Highlights:\\
+-----------
+/^unreleased$/,+1d
+s/(unpublished)/(${DATE})/
+EOF
+    sed_inplace_file "${current}" -f "$sed_script"
+    rm "$sed_script"
 fi
 
 # computing / updating each section
 
 for scope in "${SCOPES[@]}"; do
     content=$(mktemp)
-    heading="${SCOPES_HEADINGS[$scope]}"
+    heading=$(get_scope_heading "$scope")
 
     # only checking on the last version *in the changelog" (ex:rc1 to rc2, the changelog already includes old to rc1)
-    git log "${LAST_FULL_VERSION}.." --pretty="format:%s (%h) -- %aN" | grep -i "^${scope}:" | sed -e "s/^${scope}:/*/i" > "${content}"
+    # Deduplicate backports by extracting PR number and keeping only first occurrence
+    git log "${LAST_FULL_VERSION}.." --pretty="format:%s (%h) -- %aN" | grep -i "^${scope}:" | sed -e "s/^${scope}:/*/i" | sort -u > "${content}"
     if [ -z "$(cat "${content}")" ]; then
         continue
     fi
@@ -139,14 +171,32 @@ for scope in "${SCOPES[@]}"; do
         echo "" >> "${current}"
     fi
 
-    sed -i "${current}" -e "/^${heading}\$/{N
-r${content}
-}"
+    # Insert changelog entries after the heading underline (dashes)
+    # Find the line number of the heading, then insert after the underline
+    heading_line=$(grep -n "^${heading}\$" "${current}" | cut -d: -f1)
+    if [ -n "${heading_line}" ]; then
+        insert_line=$((heading_line + 2))
+        {
+            head -n $((insert_line - 1)) "${current}"
+            cat "${content}"
+            tail -n +${insert_line} "${current}"
+        } > "${current}.tmp"
+        mv "${current}.tmp" "${current}"
+    fi
 
    rm "${content}"
 done
 
 # generating statistics
+
+# List of bot accounts to exclude from contributors
+EXCLUDE_BOTS=(
+    "Copilot"
+    "Django CMS Release"
+    "Github Release Action"
+    "dependabot\[bot\]"
+    "Claude"
+)
 
 PR_NUMBER=$(git log --pretty=oneline "${OLD_FULL_VERSION}.." | wc -l)
 
@@ -159,6 +209,19 @@ This release includes ${PR_NUMBER} pull requests, and was created with the help 
 EOF
 
 while read -r name; do
+    # Skip bot accounts
+    skip=false
+    for bot in "${EXCLUDE_BOTS[@]}"; do
+        if [[ "$name" =~ $bot ]]; then
+            skip=true
+            break
+        fi
+    done
+
+    if [ "$skip" = "true" ]; then
+        continue
+    fi
+
     count=$( git log "${OLD_FULL_VERSION}.." --pretty=format:"%aN" | grep -c "${name}" )
     if [ "${count}" -gt 1 ]; then
         pl="s"


### PR DESCRIPTION

Refactor the make-changelog helper script to improve POSIX compatibility and changelog entry handling.

Enhancements:
- Improve the make-changelog script to be compatible with POSIX shells across environments.
- Adjust changelog entry processing in the script for more robust and predictable behavior.

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.
