### PR TITLE
fix: `delete_orphaned_plugins` could corrupt the plugin tree order

### DIFF
--- a/cms/management/commands/subcommands/delete_orphaned_plugins.py
+++ b/cms/management/commands/subcommands/delete_orphaned_plugins.py
@@ -1,4 +1,5 @@
 from cms.management.commands.subcommands.list import plugin_report
+from cms.models.pluginmodel import CMSPlugin
 
 from .base import SubcommandsCommand
 
@@ -19,23 +20,23 @@ class DeleteOrphanedPluginsCommand(SubcommandsCommand):
         but not saved).
         """
         self.stdout.write('Obtaining plugin report\n')
-        uninstalled_instances = []
-        unsaved_instances = []
+        uninstalled_instance_ids = []
+        unsaved_instance_ids = []
 
         for plugin in plugin_report():
             if not plugin['model']:
                 for instance in plugin['instances']:
-                    uninstalled_instances.append(instance)
+                    uninstalled_instance_ids.append(instance.pk)
 
             for instance in plugin['unsaved_instances']:
-                unsaved_instances.append(instance)
+                unsaved_instance_ids.append(instance.pk)
 
         if options.get('interactive'):
             confirm = input("""
 You have requested to delete any instances of uninstalled plugins and empty plugin instances.
 There are %d uninstalled plugins and %d empty plugins.
 Are you sure you want to do this?
-Type 'yes' to continue, or 'no' to cancel: """ % (len(uninstalled_instances), len(unsaved_instances)))
+Type 'yes' to continue, or 'no' to cancel: """ % (len(uninstalled_instance_ids), len(unsaved_instance_ids)))
         else:
             confirm = 'yes'
 
@@ -43,19 +44,29 @@ Type 'yes' to continue, or 'no' to cancel: """ % (len(uninstalled_instances), le
             # delete items whose plugin is uninstalled and items with unsaved instances
             self.stdout.write('... deleting any instances of uninstalled plugins and empty plugin instances\n')
 
-            for instance in uninstalled_instances:
+            for instance_id in uninstalled_instance_ids:
+                try:
+                    instance = CMSPlugin.objects.get(pk=instance_id)
+                except CMSPlugin.DoesNotExist:
+                    continue
+
                 if instance.placeholder:
                     instance.placeholder.delete_plugin(instance)
                 else:
                     instance.delete()
 
-            for instance in unsaved_instances:
+            for instance_id in unsaved_instance_ids:
+                try:
+                    instance = CMSPlugin.objects.get(pk=instance_id)
+                except CMSPlugin.DoesNotExist:
+                    continue
+
                 if instance.placeholder:
                     instance.placeholder.delete_plugin(instance)
                 else:
                     instance.delete()
 
             self.stdout.write(
-                f'Deleted instances of: \n    {len(uninstalled_instances)} uninstalled plugins  \n    {len(unsaved_instances)} plugins with unsaved instances\n'
+                f'Deleted instances of: \n    {len(uninstalled_instance_ids)} uninstalled plugins  \n    {len(unsaved_instance_ids)} plugins with unsaved instances\n'
             )
             self.stdout.write('all done\n')

--- a/cms/tests/test_management.py
+++ b/cms/tests/test_management.py
@@ -288,6 +288,76 @@ class ManagementTestCase(CMSTestCase):
         max_position = placeholder.cmsplugin_set.aggregate(models.Max('position'))['position__max']
         self.assertEqual(max_position, 3)
 
+    @override_settings(INSTALLED_APPS=TEST_INSTALLED_APPS)
+    def test_delete_orphaned_plugins_keeps_positions_consecutive(self):
+        placeholder = Placeholder.objects.create(slot="test")
+        add_plugin(placeholder, TextPlugin, "en", body="first")
+        CMSPlugin.objects.create(
+            position=placeholder.get_next_plugin_position("en", insert_order="last"),
+            language="en",
+            plugin_type="BogusPlugin",
+            placeholder=placeholder,
+        )
+        add_plugin(placeholder, TextPlugin, "en", body="second")
+        CMSPlugin.objects.create(
+            position=placeholder.get_next_plugin_position("en", insert_order="last"),
+            language="en",
+            plugin_type="BogusPlugin",
+            placeholder=placeholder,
+        )
+        add_plugin(placeholder, TextPlugin, "en", body="third")
+
+        self.assertEqual(
+            list(placeholder.cmsplugin_set.order_by("position").values_list("plugin_type", "position")),
+            [
+                ("TextPlugin", 1),
+                ("BogusPlugin", 2),
+                ("TextPlugin", 3),
+                ("BogusPlugin", 4),
+                ("TextPlugin", 5),
+            ],
+        )
+
+        management.call_command("cms", "delete-orphaned-plugins", interactive=False, stdout=StringIO())
+
+        self.assertEqual(
+            list(placeholder.cmsplugin_set.order_by("position").values_list("plugin_type", "position")),
+            [
+                ("TextPlugin", 1),
+                ("TextPlugin", 2),
+                ("TextPlugin", 3),
+            ],
+        )
+
+    @override_settings(INSTALLED_APPS=TEST_INSTALLED_APPS)
+    def test_delete_plugin_uses_stale_position_from_prefetched_instance(self):
+        placeholder = Placeholder.objects.create(slot="test")
+        add_plugin(placeholder, TextPlugin, "en", body="first")
+        CMSPlugin.objects.create(
+            position=placeholder.get_next_plugin_position("en", insert_order="last"),
+            language="en",
+            plugin_type="BogusPlugin",
+            placeholder=placeholder,
+        )
+        add_plugin(placeholder, TextPlugin, "en", body="second")
+        CMSPlugin.objects.create(
+            position=placeholder.get_next_plugin_position("en", insert_order="last"),
+            language="en",
+            plugin_type="BogusPlugin",
+            placeholder=placeholder,
+        )
+        add_plugin(placeholder, TextPlugin, "en", body="third")
+
+        stale_plugins = list(CMSPlugin.objects.filter(plugin_type="BogusPlugin").order_by("position"))
+        self.assertEqual([plugin.position for plugin in stale_plugins], [2, 4])
+
+        placeholder.delete_plugin(stale_plugins[0])
+
+        self.assertEqual(stale_plugins[1].position, 4)
+        stale_plugins[1].refresh_from_db()
+
+        self.assertEqual(stale_plugins[1].position, 3)
+
     def test_uninstall_plugins_without_plugin(self):
         out = StringIO()
         management.call_command('cms', 'uninstall', 'plugins', PLUGIN, interactive=False, stdout=out)


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->
This PR fixes issue #8525 bug where `cms delete-orphaned-plugins` could accidentally break plugin ordering while cleaning up bad rows. 

- Tracing the deletion path showed that `delete-orphaned-plugins` was collecting plugin model instances up front, then deleting them later, while each delete could renumber positions in the same placeholder. The command was still holding old in-memory plugin objects from before that renumbering so later deletions used stale `position` values.

- Work done:
  - instead of storing full plugin objects to delete later, only database IDs are now stored right before deleting each plugin, so a fresh copy is fetched from the database
  - that fresh object has the current position, even if earlier deletions already renumbered the tree

- Tests added:
  - `test_delete_orphaned_plugins_keeps_positions_consecutive` reproduced the bug at the command level by deleting multiple orphaned plugins from one placeholder and asserting the positions should collapse to 1, 2, 3.
  - `test_delete_plugin_uses_stale_position_from_prefetched_instance` isolates the process by showing that after deleting one plugin, a second plugin object still held its old position in memory until `refresh_from_db()`.

- Based on the failed regression test `test_delete_orphaned_plugins_keeps_positions_consecutive`, the `delete_orphaned_plugins.py` was updated to:
  - stop storing plugin instances in the command
  - store only their primary keys
  - re-fetch each plugin with `CMSPlugin.objects.get(pk=...)` immediately before deleting it

That way, every call into `placeholder.delete_plugin(instance)` uses fresh database state instead of stale in-memory positions.



## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``main``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Add regression coverage and adjust orphaned plugin deletion to avoid corrupting plugin ordering when cleaning up uninstalled or unsaved plugins.

Bug Fixes:
- Ensure the delete-orphaned-plugins management subcommand reloads plugin instances from the database before deletion so placeholder positions remain consistent and consecutive.

Tests:
- Add management command regression test verifying delete-orphaned-plugins keeps remaining plugin positions consecutive after removing bogus plugins.
- Add unit test demonstrating stale in-memory plugin positions after deletions and the need to refresh plugin instances from the database.