### PR TITLE
fix: Chunk size was missing for plugin queryset.iterator()

### DIFF
--- a/cms/constants.py
+++ b/cms/constants.py
@@ -84,3 +84,7 @@ SCRIPT_USERNAME = 'script'
 CMS_CONFIG_NAME = 'cms_config'
 
 MODAL_HTML_REDIRECT = '<body><a class="cms-view-new-object" target="_top" href="{url}">Redirecting...</a></body>'
+
+#: Default chunk_size for QuerySet.iterator() calls on plugin querysets.
+#: Required since Django 5.0 when prefetch_related is applied.
+PLUGIN_ITERATOR_CHUNK_SIZE = 2000

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -1063,6 +1063,37 @@ class PluginsTestCase(PluginsTestBaseCase):
 
         self.assertEqual([ancestor.pk for ancestor in ancestors], [plugin.pk for plugin in plugins[:-1]])
 
+    def test_iterator_chunk_size_in_get_bound_plugins(self):
+        """iterator() must pass PLUGIN_ITERATOR_CHUNK_SIZE so that
+        querysets with prefetch_related (from custom managers) don't
+        crash on Django 5.0+."""
+        from cms.constants import PLUGIN_ITERATOR_CHUNK_SIZE
+        from cms.utils.plugins import get_bound_plugins
+
+        placeholder = self.get_placeholder()
+        with register_plugins(DumbFixturePlugin):
+            plugin = api.add_plugin(placeholder, DumbFixturePlugin, "en")
+            plugins = CMSPlugin.objects.filter(pk=plugin.pk)
+
+            with mock.patch(
+                "cms.utils.plugins.PLUGIN_ITERATOR_CHUNK_SIZE", 999
+            ):
+                # Patch the queryset's iterator to inspect the chunk_size kwarg
+                original_iterator = None
+
+                def patched_iterator(chunk_size=None):
+                    self.assertEqual(chunk_size, 999)
+                    return original_iterator(chunk_size=chunk_size)
+
+                qs = DumbFixturePlugin.model.objects.filter(pk__in=[plugin.pk])
+                original_iterator = qs.iterator
+
+                with mock.patch.object(
+                    DumbFixturePlugin.model.objects, "filter", return_value=qs
+                ):
+                    with mock.patch.object(qs, "iterator", side_effect=patched_iterator):
+                        list(get_bound_plugins(plugins))
+
 
 class PluginManyToManyTestCase(PluginsTestBaseCase):
     def setUp(self):

--- a/cms/utils/plugins.py
+++ b/cms/utils/plugins.py
@@ -10,6 +10,7 @@ from django.db import models
 from django.http import HttpRequest
 from django.utils.translation import gettext as _
 
+from cms.constants import PLUGIN_ITERATOR_CHUNK_SIZE
 from cms.exceptions import PluginLimitReached
 from cms.models.pluginmodel import CMSPlugin
 from cms.plugin_base import CMSPluginBase
@@ -379,7 +380,7 @@ def get_bound_plugins(plugins):
         plugin_queryset = base_model.objects.filter(pk__in=pks)
         # put them in a map, so we can replace the base CMSPlugins with their
         # downcasted versions
-        for instance in plugin_queryset.iterator():
+        for instance in plugin_queryset.iterator(chunk_size=PLUGIN_ITERATOR_CHUNK_SIZE):
             model = get_plugin_model(instance.plugin_type)  # Get original class
             instance.__class__ = model  # Cast to correct model (including proxies)
             plugin_lookup[instance.pk] = instance
@@ -446,7 +447,7 @@ def downcast_plugins(
 
         # put them in a map, so we can replace the base CMSPlugins with their
         # downcasted versions
-        for instance in plugin_qs.iterator():
+        for instance in plugin_qs.iterator(chunk_size=PLUGIN_ITERATOR_CHUNK_SIZE):
             cls = get_plugin_class(instance.plugin_type)  # Plugin class
             instance.__class__ = cls.model  # Cast to original model (including proxies)
             plugin_lookup[instance.pk] = instance


### PR DESCRIPTION
## Description

Ensure plugin querysets use a configured chunk size when iterating to maintain compatibility with Django 5.0+ and avoid crashes when using prefetch_related.

Bug Fixes:
- Pass a defined chunk size to QuerySet.iterator() in plugin-related utilities to prevent crashes on Django 5.0+ when custom managers apply prefetch_related.

Enhancements:
- Introduce a PLUGIN_ITERATOR_CHUNK_SIZE constant to centralize the default iterator chunk size for plugin querysets.
- Value of 2,000 corresponds to Django's value

Tests:
- Add a regression test verifying that get_bound_plugins passes the configured chunk size to QuerySet.iterator().

Fixes #8531 

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8531 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``main``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.
