### PR TITLE
fix: Multi-site permissions were incomplete for wizards and autocomplete

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -364,10 +364,11 @@ class PageAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
             raise PermissionDenied("No permission for page list view")
 
         if request.headers.get("x-requested-with") == "XMLHttpRequest":
+            site = get_site_from_request(request)
             query_term = request.GET.get("q", "").strip("/")
 
             language_code = request.GET.get("language_code", settings.LANGUAGE_CODE)
-            matching_published_pages = self.model.objects.filter(
+            matching_published_pages = self.model.objects.on_site(site).filter(
                 Q(pagecontent_set__title__icontains=query_term, pagecontent_set__language=language_code)
                 | Q(urls__path__icontains=query_term, pagecontent_set__language=language_code)
                 | Q(pagecontent_set__menu_title__icontains=query_term, pagecontent_set__language=language_code)

--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -102,7 +102,7 @@ class PlaceholderToolbar(CMSToolbar):
 
         user = self.request.user
         page_pk = self.page.pk if self.page else ""
-        disabled = not list(entry_choices(user, self.page))
+        disabled = not list(entry_choices(user, self.page, site=self.current_site))
 
         url = "{url}?page={page}&language={lang}&edit".format(
             url=admin_reverse("cms_wizard_create"),

--- a/cms/cms_wizards.py
+++ b/cms/cms_wizards.py
@@ -1,4 +1,3 @@
-from django.contrib.sites.models import Site
 from django.utils.translation import gettext_lazy as _
 
 from cms.models import Page
@@ -11,14 +10,15 @@ from .wizards.wizard_base import Wizard
 class CMSPageWizard(Wizard):
 
     def user_has_add_permission(self, user, page=None, **kwargs):
+        site = kwargs.get("site")
         parent_page = page.parent if page else None
         if page and parent_page:
             # User is adding a page which will be a right
             # sibling to the current page.
-            return user_can_add_subpage(user, target=parent_page)
+            return user_can_add_subpage(user, target=parent_page, site=site or parent_page.site)
         elif page:
-            return user_can_add_page(user, site=page.site)
-        return user_can_add_page(user, site=Site.objects.first())
+            return user_can_add_page(user, site=site or page.site)
+        return user_can_add_page(user, site=site)
 
     def get_success_url(self, obj, **kwargs):
         page_content = obj.pagecontent_set(manager="admin_manager").first()

--- a/cms/forms/wizards.py
+++ b/cms/forms/wizards.py
@@ -115,9 +115,9 @@ class CreateCMSPageForm(AddPageForm):
             parent_page = None
 
         if parent_page:
-            has_perm = user_can_add_subpage(self._user, target=parent_page)
+            has_perm = user_can_add_subpage(self._user, target=parent_page, site=self._site)
         else:
-            has_perm = user_can_add_page(self._user)
+            has_perm = user_can_add_page(self._user, site=self._site)
 
         if not has_perm:
             message = gettext('You don\'t have the permissions required to add a page.')

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -1856,6 +1856,40 @@ class PageActionsTestCase(PageTestBase):
             self.assertRedirects(response, redirect_url)
             self.assertEqual(Page.objects.all().count(), 2)
 
+    def test_get_list_is_scoped_to_requested_site(self):
+        site2 = Site.objects.create(id=2, name="example-2.com", domain="example-2.com")
+        create_page(
+            "Bravo Site 1",
+            "nav_playground.html",
+            "en",
+            site=self.site,
+            slug="bravo-site-1",
+            created_by=self.admin,
+        )
+        with self.settings(CMS_LANGUAGES={2: [{"code": "en", "name": "English"}]}):
+            create_page(
+                "Bravo Site 2",
+                "nav_playground.html",
+                "en",
+                site=site2,
+                slug="bravo-site-2",
+                created_by=self.admin,
+            )
+
+            endpoint = admin_reverse("cms_page_get_list")
+            with self.login_user_context(self.admin):
+                response = self.client.get(
+                    endpoint,
+                    data={"site": self.site.pk, "q": "Bravo", "language_code": "en"},
+                    HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+                )
+
+        self.assertEqual(response.status_code, 200)
+        results = json.loads(response.content.decode("utf-8"))
+        titles = {result["title"] for result in results}
+        self.assertIn("Bravo Site 1", titles)
+        self.assertNotIn("Bravo Site 2", titles)
+
     def test_actions_menu_superuser(self):
         """Test actions_menu view returns correct context for superuser"""
         with self.login_user_context(self.admin):

--- a/cms/tests/test_wizards.py
+++ b/cms/tests/test_wizards.py
@@ -28,7 +28,7 @@ from cms.toolbar.utils import (
 from cms.utils.conf import get_cms_setting
 from cms.utils.setup import setup_cms_apps
 from cms.utils.urlutils import admin_reverse
-from cms.wizards.forms import WizardStep2BaseForm, step2_form_factory
+from cms.wizards.forms import WizardStep1Form, WizardStep2BaseForm, step2_form_factory
 from cms.wizards.helpers import get_entries, get_entry
 from cms.wizards.wizard_base import Wizard
 from cms.wizards.wizard_pool import (
@@ -589,7 +589,6 @@ class TestPageWizard(WizardTestMixin, CMSTestCase):
         self.assertTrue(form.is_valid())
         self.assertTrue(form.save().get_urls().filter(slug="page-2-3"))
 
-
 class TestPageWizardSubmission(CMSTestCase):
     def test_page_wizard_submission(self):
         from cms.wizards.helpers import get_entries
@@ -684,3 +683,34 @@ class TestEntryChoices(CMSTestCase):
             (cms_subpage_wizard.id, cms_subpage_wizard.title),
         ]
         self.assertListEqual(wizard_choices, expected)
+
+    def test_wizard_step1_uses_selected_site_for_root_page_entries(self):
+        site1 = Site.objects.get_current()
+        site2 = Site.objects.create(domain="second.example.com", name="Second", pk=2)
+        user = self._create_user("wizard-staff", is_staff=True, is_superuser=False)
+        self.add_permission(user, "add_page")
+        self.add_permission(user, "change_page")
+        global_permission = self.add_global_permission(user, can_add=True, can_change=True)
+        global_permission.sites.set([site1])
+
+        with self.login_user_context(user):
+            request = self.get_request()
+
+        form_site1 = WizardStep1Form(
+            wizard_page=None,
+            wizard_site=site1,
+            wizard_language="en",
+            wizard_request=request,
+        )
+        form_site2 = WizardStep1Form(
+            wizard_page=None,
+            wizard_site=site2,
+            wizard_language="en",
+            wizard_request=request,
+        )
+
+        choices_site1 = [choice[0] for choice in form_site1.fields["entry"].choices]
+        choices_site2 = [choice[0] for choice in form_site2.fields["entry"].choices]
+
+        self.assertIn(cms_page_wizard.id, choices_site1)
+        self.assertNotIn(cms_page_wizard.id, choices_site2)

--- a/cms/wizards/forms.py
+++ b/cms/wizards/forms.py
@@ -78,6 +78,7 @@ class WizardStep1Form(BaseFormMixin, forms.Form):
         self.fields['entry'].choices = entry_choices(
             user=self._request.user,
             page=self._page,
+            site=self._site,
         )
 
     def get_wizard_entries(self):

--- a/cms/wizards/wizard_base.py
+++ b/cms/wizards/wizard_base.py
@@ -36,14 +36,14 @@ def get_entry(entry_key):
     return apps.get_app_config('cms').cms_extension.wizards[entry_key]
 
 
-def entry_choices(user, page):
+def entry_choices(user, page, site=None):
     """
     Yields a list of wizard entry tuples of the form (wizard.id, wizard.title) that
     the current user can use based on their permission to add instances of the
     underlying model objects.
     """
     for entry in get_entries():
-        if entry.user_has_add_permission(user, page=page):
+        if entry.user_has_add_permission(user, page=page, site=site):
             yield (entry.id, entry.title)
 
 


### PR DESCRIPTION
Fix multi-site permission scoping in django-cms.

- Use the request/current site when checking root page wizard permissions.
- Scope the page autocomplete endpoint to the requested site.
- Add regression tests for both cases.

Validation:
- Remote manage.py tests passed for the wizard and page-admin regressions.
- Local py_compile and git diff --check passed.

## Summary by Sourcery

Scope page admin autocomplete and wizard root page permissions to the active site in multi-site setups.

Bug Fixes:
- Ensure the page autocomplete (get_list) endpoint only returns results for the requested site.
- Ensure page creation wizards respect the selected/current site when evaluating add-page permissions.

Tests:
- Add regression test verifying the page autocomplete endpoint is scoped to the requested site.
- Add regression test verifying wizard step 1 uses the selected site for root page entries.