### PR TITLE
fix: Proxy models of `CMSPlugin` were not downcasted correctly (#8539)

### DIFF
--- a/cms/models/pluginmodel.py
+++ b/cms/models/pluginmodel.py
@@ -256,7 +256,7 @@ class CMSPlugin(models.Model, metaclass=PluginModelBase):
 
         plugin = self.get_plugin_class()
 
-        if plugin.model != self.__class__:
+        if plugin.model._meta.concrete_model != self.__class__._meta.concrete_model:
             self._inst = plugin.model.objects.get(cmsplugin_ptr=self)
             # Preserve prefetched placeholder
             self._inst._state.fields_cache["placeholder"] = self.placeholder

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -73,6 +73,18 @@ class DumbFixturePlugin(CMSPluginBase):
         return context
 
 
+class DirectProxyCMSPluginModel(CMSPlugin):
+    class Meta:
+        proxy = True
+        app_label = "test_app"
+
+
+class DirectProxyCMSPlugin(CMSPluginBase):
+    model = DirectProxyCMSPluginModel
+    name = "Direct proxy CMSPlugin"
+    render_plugin = False
+
+
 class DumbFixturePluginWithUrls(DumbFixturePlugin):
     name = DumbFixturePlugin.name + " With custom URLs."
     render_plugin = False
@@ -1071,6 +1083,34 @@ class PluginsTestCase(PluginsTestBaseCase):
                     with mock.patch.object(qs, "iterator", side_effect=patched_iterator):
                         list(get_bound_plugins(plugins))
 
+    def test_downcast_plugins_with_direct_cmsplugin_proxy(self):
+        from cms.utils.plugins import downcast_plugins
+
+        placeholder = self.get_placeholder()
+        with register_plugins(DirectProxyCMSPlugin):
+            plugin = api.add_plugin(placeholder, DirectProxyCMSPlugin, "en")
+            cms_plugin = CMSPlugin.objects.get(pk=plugin.pk)
+
+            downcasted = list(downcast_plugins([cms_plugin]))
+
+        self.assertEqual(len(downcasted), 1)
+        self.assertIsInstance(downcasted[0], DirectProxyCMSPluginModel)
+        self.assertEqual(downcasted[0].pk, plugin.pk)
+
+    def test_get_bound_plugins_with_direct_cmsplugin_proxy(self):
+        from cms.utils.plugins import get_bound_plugins
+
+        placeholder = self.get_placeholder()
+        with register_plugins(DirectProxyCMSPlugin):
+            plugin = api.add_plugin(placeholder, DirectProxyCMSPlugin, "en")
+            cms_plugin = CMSPlugin.objects.get(pk=plugin.pk)
+
+            bound_plugins = list(get_bound_plugins([cms_plugin]))
+
+        self.assertEqual(len(bound_plugins), 1)
+        self.assertIsInstance(bound_plugins[0], DirectProxyCMSPluginModel)
+        self.assertEqual(bound_plugins[0].pk, plugin.pk)
+
 
 class PluginManyToManyTestCase(PluginsTestBaseCase):
     def setUp(self):
@@ -1401,7 +1441,6 @@ class MTIPluginsTestCase(PluginsTestBaseCase):
         )
         # Non plugins are skipped
         self.assertFalse(hasattr(NonPluginModel, "cmsplugin_ptr"))
-
 
 class UserInputValidationPluginTest(PluginsTestBaseCase):
     def test_error_response_escapes(self):

--- a/cms/utils/plugins.py
+++ b/cms/utils/plugins.py
@@ -379,9 +379,11 @@ def get_bound_plugins(plugins):
     # make a map of plugin types, needed later for downcasting
     for plugin in plugins:
         plugin_ids.append(plugin.pk)
-        base_model = get_plugin_model(plugin.plugin_type)._meta.concrete_model  # Collect all base models
+        plugin_model = get_plugin_model(plugin.plugin_type)
+        base_model = plugin_model._meta.concrete_model  # Collect all base models
         if base_model is CMSPlugin:
-            plugin_lookup[plugin.pk] = plugin  # No downcast needed
+            plugin.__class__ = plugin_model  # In case it's a proxy model
+            plugin_lookup[plugin.pk] = plugin  # Otherwise, no downcast needed
         else:
             plugin_types_map[base_model].append(plugin.pk)
 
@@ -433,14 +435,16 @@ def downcast_plugins(
     for plugin in plugins:
         # Keep track of the plugin ids we've received
         try:
-            base_model = get_plugin_model(plugin.plugin_type)._meta.concrete_model  # Collect all base models
+            plugin_model = get_plugin_model(plugin.plugin_type)
+            base_model = plugin_model._meta.concrete_model  # Collect all base models
         except KeyError:
             # Plugin not available
             logger.error(f"Plugin not installed: {plugin.plugin_type} (pk={plugin.pk})", exc_info=sys.exc_info())
             continue
         plugin_ids.append(plugin.pk)
         if base_model is CMSPlugin:
-            plugin_lookup[plugin.pk] = plugin  # No downcast needed
+            plugin.__class__ = plugin_model  # In case it is a proxy model
+            plugin_lookup[plugin.pk] = plugin  # otherwise, no downcast needed
         else:
             plugin_types_map[base_model].append(plugin.pk)
 


### PR DESCRIPTION
* fix: Proxy models of `CMSPlugin` were not downcasted correctly

* fix: Add app_label to test CMSPlugin model

---------

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Ensure CMS plugins backed by proxy models of CMSPlugin are correctly downcasted and bound.

Bug Fixes:
- Fix downcasting of CMSPlugin instances so that proxy models of CMSPlugin are correctly instantiated in both downcast_plugins and get_bound_plugins.
- Correct get_bound_plugin to resolve plugin instances based on their concrete model, allowing proxy CMSPlugin models to be returned properly.

Tests:
- Add proxy CMSPlugin test model and plugin to verify correct downcasting and binding behavior for direct CMSPlugin proxies.