### PR TITLE
fix: Updating plugins could lead to minified toolbar

### DIFF
--- a/cms/static/cms/js/modules/cms.navigation.js
+++ b/cms/static/cms/js/modules/cms.navigation.js
@@ -14,14 +14,25 @@ import throttle from 'lodash-es/throttle.js';
 class Navigation {
     constructor() {
         this._setupUI();
-        this._getWidths();
+
+        /**
+         * Whether item widths have been measured yet.
+         * Widths are measured lazily on the first resize/load event to ensure CSS is applied.
+         *
+         * @property _widthsReady {Boolean}
+         * @private
+         */
+        this._widthsReady = false;
+
+        // Initialise items with empty arrays so properties exist before _getWidths runs
+        this.items = { left: [], leftTotalWidth: 0, right: [], rightTotalWidth: 0, moreButtonWidth: 0 };
 
         /**
          * The zero based index of the right-most visible menu item of the left toolbar part.
          *
          * @property rightMostItemIndex {Number}
          */
-        this.rightMostItemIndex = this.items.left.length - 1;
+        this.rightMostItemIndex = -1;
 
         /**
          * The zero based index of the left-most visible item of the right toolbar part.
@@ -77,12 +88,19 @@ class Navigation {
 
     /**
      * Calculates all the movable menu items widths.
+     * Must be called when all items are in their natural toolbar positions
+     * (not inside the "more" dropdown) so that measured widths reflect the
+     * actual inline size of each item.
      *
      * @method _getWidths
      * @private
      */
     _getWidths() {
         var that = this;
+
+        // Move all items back into the toolbar before measuring so we get
+        // their natural inline widths, not the dropdown's stacked width.
+        this._showAll();
 
         that.items = {
             left: [],
@@ -118,6 +136,10 @@ class Navigation {
         that.items.leftTotalWidth = that.items.left.reduce(sumWidths, 0);
         that.items.rightTotalWidth = that.items.right.reduce(sumWidths, 0);
         that.items.moreButtonWidth = that.ui.trigger.outerWidth();
+
+        that.rightMostItemIndex = that.items.left.length - 1;
+        that.leftMostItemIndex = 0;
+        that._widthsReady = true;
     }
 
     /**
@@ -162,6 +184,18 @@ class Navigation {
      */
     // eslint-disable-next-line complexity
     _handleResize() {
+        // Lazily measure widths once CSS is confirmed to be applied.
+        // The toolbar CSS sets `float: left` on navigation <li> items.
+        // If the computed style is still `none`, stylesheets haven't loaded yet — skip this call.
+        if (!this._widthsReady) {
+            var probe = this.ui.toolbarLeftPart.find('.cms-toolbar-item-navigation > li:first')[0];
+
+            if (!probe || window.getComputedStyle(probe).cssFloat === 'none') {
+                return;
+            }
+            this._getWidths();
+        }
+
         var remainingWidth;
         var availableWidth = this._calculateAvailableWidth();
 

--- a/cms/static/cms/js/modules/cms.structureboard.js
+++ b/cms/static/cms/js/modules/cms.structureboard.js
@@ -545,7 +545,7 @@ class StructureBoard {
                     CMS.API.Messages.open({
                         message: CMS.config.lang.unhandledPageChange
                     });
-                    Helpers.reloadBrowser('REFRESH_PAGE');
+                    window.location.href = CMS.config.settings.edit;
                 }
 
                 that._loadedContent = true;

--- a/cms/tests/frontend/unit/cms.navigation.test.js
+++ b/cms/tests/frontend/unit/cms.navigation.test.js
@@ -70,7 +70,19 @@ describe('CMS.Navigation', function () {
             expect(nav.ui.window).toHandle('orientationchange.cms.navigation');
         });
 
-        it('has initial state', function () {
+        it('defers width measurement until CSS is ready', function () {
+            // Before CSS is applied, items should be empty and indices at initial values
+            expect(nav._widthsReady).toEqual(false);
+            expect(nav.leftMostItemIndex).toEqual(0);
+            expect(nav.rightMostItemIndex).toEqual(-1);
+            expect(nav.items.left.length).toEqual(0);
+            expect(nav.items.right.length).toEqual(0);
+        });
+
+        it('has initial state after _getWidths', function () {
+            // Explicitly measure widths (simulates CSS being ready)
+            nav._getWidths();
+            expect(nav._widthsReady).toEqual(true);
             expect(nav.leftMostItemIndex).toEqual(0);
             expect(nav.rightMostItemIndex).toEqual(2);
             expect(nav.items).toEqual({
@@ -156,6 +168,8 @@ describe('CMS.Navigation', function () {
             fixture.load('toolbar.html');
             $(function () {
                 nav = new CMS.Navigation();
+                // Explicitly measure widths (test env has no real CSS)
+                nav._getWidths();
                 spyOn(nav, '_calculateAvailableWidth');
                 spyOn(nav, '_moveOutOfDropdown').and.callThrough();
                 spyOn(nav, '_moveToDropdown').and.callThrough();

--- a/cms/tests/frontend/unit/cms.navigation.test.js
+++ b/cms/tests/frontend/unit/cms.navigation.test.js
@@ -84,7 +84,7 @@ describe('CMS.Navigation', function () {
             nav._getWidths();
             expect(nav._widthsReady).toEqual(true);
             expect(nav.leftMostItemIndex).toEqual(0);
-            expect(nav.rightMostItemIndex).toEqual(2);
+            expect(nav.rightMostItemIndex).toEqual(nav.items.left.length - 1);
             expect(nav.items).toEqual({
                 left: [
                     { element: jasmine.any(Object), width: jasmine.any(Number) },


### PR DESCRIPTION
## Description
Ensure toolbar item widths are measured only after styles are applied to prevent the navigation toolbar from collapsing after plugin updates.

Bug Fixes:
- Prevent toolbar items from being measured while in the dropdown or before CSS is applied, avoiding a permanently minified toolbar state.

Enhancements:
- Initialize navigation state and item collections more defensively to support lazy width measurement and reliable resize handling.

Tests:
- Extend navigation unit tests to cover deferred width measurement and updated initial state after width calculation.

fixes #8549 
fixex #8522

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8549
* #8522

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Prevent the toolbar navigation from collapsing into a permanently minified state by deferring width measurement until styles are applied and ensuring items are measured in their natural positions.

Bug Fixes:
- Avoid measuring toolbar item widths while items are in the dropdown or before CSS is applied to prevent a stuck minified toolbar state.

Enhancements:
- Initialize navigation item collections and indices defensively and recompute them when widths are first measured for more robust resize handling.

Tests:
- Extend navigation unit tests to cover deferred width measurement, initial state before sizing, and state after widths are calculated.