### PR TITLE
fix: Inline editing could circumvent permissions (#8542)

### DIFF
--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -94,7 +94,7 @@ class BaseEditableAdminMixin:
         saved_successfully = False
         cancel_clicked = request.POST.get("_cancel", False)
         raw_fields = request.GET.get("edit_fields", "")
-        admin_obj = self._get_model_admin(obj)
+        admin_obj, change_permission = self._get_model_admin_and_permission(request, obj)
         allowed_fields = getattr(admin_obj, "frontend_editable_fields", [])
         fields = [field for field in raw_fields.split(",") if field in allowed_fields]
         if not fields:
@@ -103,13 +103,13 @@ class BaseEditableAdminMixin:
                 'message': _("Field %s not found") % raw_fields
             }
             return TemplateResponse(request, 'admin/cms/page/plugin/error_form.html', context)
-        if not request.user.has_perm(f"{admin_obj.model._meta.app_label}.change_{admin_obj.model._meta.model_name}"):
+        if not change_permission:
             context = {
                 'opts': opts,
                 'message': _("You do not have permission to edit this item")
             }
             return TemplateResponse(request, 'admin/cms/page/plugin/error_form.html', context)
-            # Dynamically creates the form class with only `field_name` field
+        # Dynamically creates the form class with only `field_name` field
         # enabled
         form_class = admin_obj.get_form(request, obj, fields=fields)
         if not cancel_clicked and request.method == 'POST':
@@ -167,10 +167,11 @@ class FrontendEditableAdminMixin(BaseEditableAdminMixin):
         ]
         return url_patterns + super().get_urls()
 
-    def _get_model_admin(self, obj: models.Model) -> admin.ModelAdmin:
+    def _get_model_admin_and_permission(self, request, obj: models.Model) -> tuple[admin.ModelAdmin, bool]:
         # FrontendEditableAdminMixin needs to be added to the model's model admin class.
         # Hence, the relevant admin is the model admin itself.
-        return self
+        change_permission =  request.user.has_perm(f"{obj._meta.app_label}.change_{obj._meta.model_name}")
+        return self, change_permission
 
     def _get_object_for_single_field(self, object_id: int, language: str) -> models.Model:
         # Quick and dirty way to retrieve objects for django-hvad
@@ -269,10 +270,15 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
         plugin = get_object_or_404(CMSPlugin, pk=object_id)  # Returns a CMSPlugin instance
         return plugin.get_bound_plugin()  # Returns the plugin model instance of the appropriate type
 
-    def _get_model_admin(self, obj: CMSPlugin) -> admin.ModelAdmin:
+    def _get_model_admin_and_permission(self, request, obj: CMSPlugin) -> tuple[admin.ModelAdmin, bool]:
         # For BaseEditableAdminMixin: This (private) method retrieves the model admin for the plugin model
-        # which is the plugin instance itself.
-        return obj.get_plugin_class_instance(admin=self.admin_site)
+        # which is the plugin instance itself, and checks change permissions including check_source
+        placeholder = obj.placeholder
+        has_permission = (
+            placeholder.has_change_plugin_permission(request.user, obj)
+            and placeholder.check_source(request.user)
+        )
+        return obj.get_plugin_class_instance(admin=self.admin_site), has_permission
 
     def _get_operation_language(self, request):
         # Unfortunately the ?language GET query

--- a/cms/tests/test_placeholder_app_admin.py
+++ b/cms/tests/test_placeholder_app_admin.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.forms.models import model_to_dict
 from django.test.utils import override_settings
 
@@ -6,6 +8,7 @@ from cms.models import CMSPlugin, Placeholder, UserSettings
 from cms.test_utils.project.placeholderapp.models import Example1
 from cms.test_utils.testcases import CMSTestCase
 from cms.test_utils.util.context_managers import override_placeholder_conf
+from cms.utils.urlutils import admin_reverse
 
 
 class AppAdminTestCase(CMSTestCase):
@@ -794,3 +797,91 @@ class AppAdminPermissionsTest(AppAdminTestCase):
             response = self.client.post(endpoint, data)
             self.assertEqual(response.status_code, 403)
             self.assertEqual(target_placeholder.get_plugins('fr').count(), 0)
+
+
+class AppAdminInlineEditPermissionsTest(AppAdminTestCase):
+    """Tests that the PlaceholderAdmin's edit_field endpoint (inline editing)
+    checks plugin change permissions and runs the placeholder's check_source method."""
+
+    def setUp(self):
+        from cms.test_utils.project.pluginapp.plugins.link.cms_plugins import LinkPlugin
+
+        self._obj = self._get_example_obj()
+        self._staff_user = self.get_staff_user_with_no_permissions()
+        # LinkPlugin does not define frontend_editable_fields by default,
+        # so we patch it for these tests to enable inline editing of the "name" field.
+        self._fe_patcher = patch.object(LinkPlugin, "frontend_editable_fields", ("name",), create=True)
+        self._fe_patcher.start()
+
+    def tearDown(self):
+        self._fe_patcher.stop()
+
+    def _get_edit_field_endpoint(self, plugin):
+        return (
+            admin_reverse("cms_placeholder_edit_field", args=(plugin.pk, "en"))
+            + "?edit_fields=name"
+        )
+
+    def test_inline_edit_checks_change_plugin_permission(self):
+        """
+        Inline editing a plugin via PlaceholderAdmin's edit_field endpoint
+        requires change permission on the model attached to the placeholder
+        and change permission on the plugin model.
+        """
+        staff_user = self._staff_user
+        placeholder = self._obj.placeholder
+        plugin = self._add_plugin_to_placeholder(placeholder)
+        endpoint = self._get_edit_field_endpoint(plugin)
+
+        # Give change permission on the plugin model but NOT on the source model
+        self.add_permission(staff_user, 'change_link')
+
+        with self.login_user_context(staff_user):
+            response = self.client.get(endpoint)
+            # Should be denied because user lacks change_example1 permission
+            self.assertContains(response, "You do not have permission to edit this item")
+
+    def test_inline_edit_allowed_with_correct_permissions(self):
+        """
+        Inline editing a plugin via PlaceholderAdmin's edit_field endpoint
+        succeeds when user has both change permission on the source model
+        and change permission on the plugin model.
+        """
+        staff_user = self._staff_user
+        placeholder = self._obj.placeholder
+        plugin = self._add_plugin_to_placeholder(placeholder)
+        endpoint = self._get_edit_field_endpoint(plugin)
+
+        # Give all required permissions
+        self.add_permission(staff_user, 'change_example1')
+        self.add_permission(staff_user, 'change_link')
+
+        with self.login_user_context(staff_user):
+            response = self.client.get(endpoint)
+            # Should show the edit form
+            self.assertEqual(response.status_code, 200)
+            self.assertNotContains(response, "You do not have permission to edit this item")
+
+    def test_inline_edit_calls_check_source(self):
+        """
+        Inline editing a plugin via PlaceholderAdmin's edit_field endpoint
+        runs the placeholder's check_source method to verify source-level
+        permissions.
+        """
+        staff_user = self._staff_user
+        placeholder = self._obj.placeholder
+        plugin = self._add_plugin_to_placeholder(placeholder)
+        endpoint = self._get_edit_field_endpoint(plugin)
+
+        self.add_permission(staff_user, 'change_example1')
+        self.add_permission(staff_user, 'change_link')
+
+        with self.login_user_context(staff_user):
+            with patch.object(
+                Placeholder, "check_source", return_value=False
+            ) as mock_check_source:
+                response = self.client.get(endpoint)
+                # check_source should have been called
+                mock_check_source.assert_called_once_with(staff_user)
+                # Should be denied because check_source returned False
+                self.assertContains(response, "You do not have permission to edit this item")


### PR DESCRIPTION
* fix: Inline editing could circumvent permissions

* fix tests

* fix: Return types

* fix linting

* fix: Remove typing.Tuple

---------

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Enforce proper permission checks for inline editing of placeholder plugins and extend tests to cover the new behavior.

Bug Fixes:
- Ensure inline editing of plugins verifies both model and plugin change permissions and denies access without them.
- Prevent inline editing when the placeholder source check fails, aligning inline editing with existing permission rules.

Tests:
- Add test coverage for inline editing permission checks, including plugin and source model permissions and placeholder source validation.