### PR TITLE
fix: Fallback languages rendered empty (when not redirecting)

### DIFF
--- a/.github/workflows/new_contributor_pr.yml
+++ b/.github/workflows/new_contributor_pr.yml
@@ -23,6 +23,10 @@ jobs:
             We invite you to join us on our [Discord Server](https://discord-main-channel.django-cms.org)!
 
             Welcome aboard ⛵️!
+          issue_message: |
+            Hello! Thank you for opening your first issue! 🎉
+
+            We invite you to join us on our [Discord Server](https://discord-main-channel.django-cms.org)!
   discord:
     name: Discord Notification
     runs-on: ubuntu-latest

--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -15,7 +15,7 @@ from django.template import Context
 from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
 from django.utils.safestring import SafeText, mark_safe
-from django.utils.translation import override
+from django.utils.translation import get_language, override
 from django.views.debug import ExceptionReporter
 
 from cms.cache.placeholder import get_placeholder_cache, set_placeholder_cache
@@ -411,12 +411,13 @@ class ContentRenderer(BaseRenderer):
             return ""
 
         current_page = page or self.current_page
+        language = get_language()
         placeholder_cache = self._placeholders_by_page_cache
 
         if current_page.pk not in placeholder_cache:
             # Instead of loading plugins for this one placeholder
             # try and load them for all placeholders on the page.
-            self._preload_placeholders_for_page(current_page)
+            self._preload_placeholders_for_page(current_page, language=language)
 
         try:
             placeholder = placeholder_cache[current_page.pk][slot]
@@ -427,6 +428,7 @@ class ContentRenderer(BaseRenderer):
             content = self.render_placeholder(
                 placeholder,
                 context=context,
+                language=language,
                 page=placeholder.source,
                 editable=editable,
                 use_cache=True,
@@ -619,7 +621,7 @@ class ContentRenderer(BaseRenderer):
         else:
             return Placeholder.objects.none()
 
-    def _preload_placeholders_for_page(self, page, slots=None, inherit=False):
+    def _preload_placeholders_for_page(self, page, language=None, slots=None, inherit=False):
         """
         Populates the internal plugin cache of each placeholder
         in the given page if the placeholder has not been
@@ -628,6 +630,7 @@ class ContentRenderer(BaseRenderer):
         from cms.utils.plugins import assign_plugins
 
         placeholders = self._get_content_object(page, slots=slots)
+        language = language or self.request_language
 
         if inherit:
             # When the inherit flag is True,
@@ -648,7 +651,7 @@ class ContentRenderer(BaseRenderer):
             placeholders_to_fetch = [
                 placeholder
                 for placeholder in placeholders
-                if _cached_content(placeholder, self.request_language) is None
+                if _cached_content(placeholder, language) is None
             ]
         else:
             # cache is disabled, prefetch plugins for all
@@ -660,7 +663,7 @@ class ContentRenderer(BaseRenderer):
                 request=self.request,
                 placeholders=placeholders_to_fetch,
                 template=page.get_template(),
-                lang=self.request_language,
+                lang=language,
             )
 
         # Inherit only placeholders that have no plugins
@@ -674,6 +677,7 @@ class ContentRenderer(BaseRenderer):
         if page.parent and placeholders_to_inherit:
             self._preload_placeholders_for_page(
                 page=page.parent,
+                language=language,
                 slots=placeholders_to_inherit,
                 inherit=True,
             )

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -905,7 +905,7 @@ class RenderPlaceholder(AsTag):
         content = renderer.render_placeholder(
             placeholder=placeholder,
             context=context,
-            language=language,
+            language=language or get_language(),
             editable=editable,
             use_cache=not nocache,
             width=width,

--- a/cms/tests/test_i18n.py
+++ b/cms/tests/test_i18n.py
@@ -539,6 +539,47 @@ class TestLanguageFallbacks(CMSTestCase):
             self.assertEqual(rendered_placeholder, "Hello, world!")
 
     @override_settings(
+        LANGUAGES=(
+            ('en', 'English'),
+            ('de', 'Deutsch'),
+            ('it', 'Italian'),
+            ('fr', 'French'),
+        ),
+        CMS_LANGUAGES={
+            'default': {
+                'fallbacks': ['en', 'fr'],
+                'public': True,
+                'redirect_on_fallback': False,
+                'hide_untranslated': False,
+            },
+        },
+    )
+    def test_no_redirect_on_fallback_placeholder_rendering(self):
+        """
+        When redirect_on_fallback is False and hide_untranslated is False,
+        requesting a page in a language that has no content should render
+        the placeholder content from the fallback language, not empty placeholders.
+        Regression test for issue #8556.
+        """
+        homepage = self.create_homepage(
+            "home",
+            "nav_playground.html",
+            "en",
+        )
+        homepage_ph = homepage.get_placeholders("en").get(slot="body")
+        api.add_plugin(
+            homepage_ph,
+            plugin_type="TextPlugin",
+            language="en",
+            body="English content",
+        )
+        # Request the page in Italian which has no translation;
+        # the fallback chain is ['en', 'fr'] so English content should appear.
+        response = self.client.get(homepage.get_absolute_url(language="it"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "English content")
+
+    @override_settings(
         CMS_LANGUAGES={
             'default': {
                 'fallbacks': ['en', 'fr'],


### PR DESCRIPTION
## Summary by Sourcery

Ensure placeholders correctly render fallback language content when no redirect occurs for untranslated pages.

Bug Fixes:
- Fix placeholder rendering so fallback language content is displayed instead of empty output when redirect_on_fallback is disabled and hide_untranslated is False.

Tests:
- Add regression test covering placeholder rendering with fallback languages when requesting an untranslated page without redirecting.
## Related resources

Fixes #8556 

* #8556


## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

