### PR TITLE
fix: Add `page_title` parameter to `cms.api.create_page` function  for branch `releases/5.0.x`

### DIFF
--- a/cms/api.py
+++ b/cms/api.py
@@ -152,6 +152,7 @@ def create_page(
     position="last-child",
     overwrite_url=None,
     xframe_options=constants.X_FRAME_OPTIONS_INHERIT,
+    page_title=None,
 ):
     """
     Creates a :class:`cms.models.Page` instance and returns it. Also
@@ -263,6 +264,7 @@ def create_page(
         language=language,
         title=title,
         menu_title=menu_title,
+        page_title=page_title,
         slug=slug,
         created_by=created_by,
         redirect=redirect,


### PR DESCRIPTION
## Description

The parameter was already documented but was missing from the function signature.

## Related resources

* #8567
* #8570 

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Add the missing page_title parameter to cms.api.create_page and propagate it to the created Page title.