### PR TITLE
fix: Add `page_title` parameter to `cms.api.create_page` function  for branch `releases/4.1.x`

### DIFF
--- a/cms/api.py
+++ b/cms/api.py
@@ -133,7 +133,7 @@ def create_page(title, template, language, menu_title=None, slug=None,
                 navigation_extenders=None, published=None, site=None,
                 login_required=False, limit_visibility_in_menu=constants.VISIBILITY_ALL,
                 position="last-child", overwrite_url=None,
-                xframe_options=constants.X_FRAME_OPTIONS_INHERIT):
+                xframe_options=constants.X_FRAME_OPTIONS_INHERIT, page_title=None):
     """
     Creates a :class:`cms.models.Page` instance and returns it. Also
     creates a :class:`cms.models.PageContent` instance for the specified
@@ -239,6 +239,7 @@ def create_page(title, template, language, menu_title=None, slug=None,
         language=language,
         title=title,
         menu_title=menu_title,
+        page_title=page_title,
         slug=slug,
         created_by=created_by,
         redirect=redirect,


### PR DESCRIPTION
## Description

The parameter was already documented but was missing from the function signature.

## Related resources

* #8567
* #8569 

## Checklist

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Include the documented page_title parameter in the cms.api.create_page function signature and propagate it to PageContent creation.