### PR TITLE
fix: XSS vulnerability in validator error message

### DIFF
--- a/cms/forms/validators.py
+++ b/cms/forms/validators.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Optional
 
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator, URLValidator
+from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext
 
@@ -71,7 +72,7 @@ def validate_url_uniqueness(
     if user_language:
         change_url += f"?language={user_language}"
 
-    conflict_url = f'<a href="{change_url}" target="_blank">{str(conflict_translation.title)}</a>'
+    conflict_url = f'<a href="{change_url}" target="_blank">{escape(str(conflict_translation.title))}</a>'
 
     if exclude_page:
         message = gettext("Page %(conflict_page)s has the same url '%(url)s' as current page \"%(instance)s\".")
@@ -79,7 +80,7 @@ def validate_url_uniqueness(
         message = gettext("Page %(conflict_page)s has the same url '%(url)s' as current page.")
     message = message % {
         "conflict_page": conflict_url,
-        "url": path,
-        "instance": exclude_page.get_title(language) if exclude_page else "",
+        "url": escape(path),
+        "instance": escape(exclude_page.get_title(language)) if exclude_page else "",
     }
     raise ValidationError(mark_safe(message))

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.core.cache import cache
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.utils import IntegrityError
 from django.http import HttpResponse, HttpResponseNotFound
@@ -266,6 +267,52 @@ class PagesTestCase(TransactionCMSTestCase):
         self.assertEqual(response.status_code, 200)
         response = self.client.get(child.get_absolute_url("en"))
         self.assertEqual(response.status_code, 200)
+
+    def test_validate_url_uniqueness_escapes_html_in_error_message(self):
+        """
+        validate_url_uniqueness raises a ValidationError whose message is
+        wrapped in mark_safe so it can render an <a> link to the conflicting
+        page in the admin. Any user-controlled fragments interpolated into
+        that message MUST be HTML-escaped, otherwise a page title containing
+        markup like ``<script>...</script>`` would render unescaped wherever
+        Django renders the validation error (admin form errors, toolbar
+        notifications, ...).
+        """
+        from django.utils.safestring import SafeString
+
+        site = _get_current_site()
+        evil = "<script>alert('xss')</script>"
+
+        # Page A: the existing page that owns the conflicting slug. Its title
+        # ends up inside the <a>...</a> link in the rendered error message.
+        conflict_page = create_page(f"conflict {evil}", "nav_playground.html", "en", slug="foo")
+        # Page B: the page being validated. Its title is interpolated into
+        # the "current page" portion of the message via the `instance` kwarg.
+        current_page = create_page(f"current {evil}", "nav_playground.html", "en", slug="bar")
+
+        with self.assertRaises(ValidationError) as ctx:
+            validate_url_uniqueness(
+                site,
+                path=conflict_page.get_path("en"),
+                language="en",
+                exclude_page=current_page,
+            )
+
+        # ValidationError messages are a list; the validator only raises one.
+        rendered = ctx.exception.messages[0]
+        self.assertIsInstance(rendered, SafeString)
+
+        # The raw <script> tag must NOT survive into the safe message — neither
+        # from the conflict page's title (escaped explicitly via django.utils.html.escape)
+        # nor from the current page's title (interpolated via `instance`).
+        self.assertNotIn("<script>", rendered)
+        self.assertNotIn("</script>", rendered)
+        # Both titles should appear in their HTML-escaped form.
+        self.assertIn("&lt;script&gt;", rendered)
+        self.assertIn("&lt;/script&gt;", rendered)
+        # The legitimate <a> tag the validator builds for the admin link is
+        # still preserved (it's the only HTML the message is allowed to emit).
+        self.assertIn('<a href="', rendered)
 
     def test_details_view(self):
         """


### PR DESCRIPTION
## Description

This PR addresses a stored Cross-Site Scripting (XSS) vulnerability in the admin URL uniqueness validation logic.

### Summary

The issue originates from the construction of HTML error messages in `validate_url_uniqueness`, where user-controlled values (such as page titles) were interpolated into HTML without escaping and then marked safe using `mark_safe()`. This allowed malicious input by Django admin users to be rendered directly in the Django admin.

As demonstrated in the report, a crafted page title could inject arbitrary JavaScript into the admin interface when a URL conflict occurs, leading to execution in another staff user’s session .

### Impact

This vulnerability could allow an attacker with low-privileged CMS access to:

* Execute arbitrary JavaScript in another admin user’s browser
* Hijack sessions via document.cookie
* Perform actions on behalf of other users (including superusers)
* Potentially escalate privileges or persist access within the CMS

### Fix

All user-controlled values included in the validation error message are now properly escaped before being inserted into HTML. The `mark_safe()` call is retained only for the structural HTML (e.g., links), ensuring that dynamic content is no longer treated as safe.

This follows Django’s standard security practices: escape everything, then explicitly mark only trusted HTML as safe.

## 🙏 Acknowledgements

We would like to sincerely thank the security researchers who reported this issue:

* Sanjok Karki (TheSanjok) 
* Javi Escribano (javiescrisalga@gmail.com)
* galbadrakhtergel0820@gmail.com

This issue was independently reported multiple times.

Security contributions like these are incredibly valuable to a community-driven project like django CMS. Responsible disclosure helps ensure the safety of all users and strengthens the ecosystem as a whole.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Fix XSS exposure in URL uniqueness validation error messages by escaping user-controlled content while preserving trusted HTML structure.

Bug Fixes:
- Escape page titles and URL paths interpolated into the URL uniqueness validation error message to prevent stored XSS in the Django admin.

Tests:
- Add a regression test ensuring the URL uniqueness validator’s error message escapes injected HTML/JavaScript while still returning a safe string containing only trusted markup.