### PR TITLE
fix: XSS vulnerability in validator error message (#8576)

### DIFF
--- a/cms/forms/validators.py
+++ b/cms/forms/validators.py
@@ -1,6 +1,7 @@
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator, URLValidator
 from django.utils.encoding import force_str
+from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext
 
@@ -50,7 +51,7 @@ def validate_url_uniqueness(site, path, language, user_language=None, exclude_pa
 
     conflict_url = '<a href="%(change_url)s" target="_blank">%(page_title)s</a>' % {
         'change_url': change_url,
-        'page_title': force_str(conflict_page),
+        'page_title': escape(force_str(conflict_page)),
     }
 
     if exclude_page:
@@ -58,8 +59,8 @@ def validate_url_uniqueness(site, path, language, user_language=None, exclude_pa
     else:
         message = gettext('Page %(conflict_page)s has the same url \'%(url)s\' as current page.')
     message = message % {
-        'conflict_page': conflict_url,
-        'url': path,
-        'instance': exclude_page.get_title(language) if exclude_page else ''
+        "conflict_page": conflict_url,
+        "url": escape(path),
+        "instance": escape(exclude_page.get_title(language)) if exclude_page else "",
     }
     raise ValidationError(mark_safe(message))

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -311,7 +311,7 @@ class PagesTestCase(TransactionCMSTestCase):
         """
         from django.utils.safestring import SafeString
 
-        site = _get_current_site()
+        site = get_current_site()
         evil = "<script>alert('xss')</script>"
 
         # Page A: the existing page that owns the conflicting slug. Its title

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -299,6 +299,52 @@ class PagesTestCase(TransactionCMSTestCase):
             exclude_page=page1_1_2,
         )
 
+    def test_validate_url_uniqueness_escapes_html_in_error_message(self):
+        """
+        validate_url_uniqueness raises a ValidationError whose message is
+        wrapped in mark_safe so it can render an <a> link to the conflicting
+        page in the admin. Any user-controlled fragments interpolated into
+        that message MUST be HTML-escaped, otherwise a page title containing
+        markup like ``<script>...</script>`` would render unescaped wherever
+        Django renders the validation error (admin form errors, toolbar
+        notifications, ...).
+        """
+        from django.utils.safestring import SafeString
+
+        site = _get_current_site()
+        evil = "<script>alert('xss')</script>"
+
+        # Page A: the existing page that owns the conflicting slug. Its title
+        # ends up inside the <a>...</a> link in the rendered error message.
+        conflict_page = create_page(f"conflict {evil}", "nav_playground.html", "en", slug="foo")
+        # Page B: the page being validated. Its title is interpolated into
+        # the "current page" portion of the message via the `instance` kwarg.
+        current_page = create_page(f"current {evil}", "nav_playground.html", "en", slug="bar")
+
+        with self.assertRaises(ValidationError) as ctx:
+            validate_url_uniqueness(
+                site,
+                path=conflict_page.get_path("en"),
+                language="en",
+                exclude_page=current_page,
+            )
+
+        # ValidationError messages are a list; the validator only raises one.
+        rendered = ctx.exception.messages[0]
+        self.assertIsInstance(rendered, SafeString)
+
+        # The raw <script> tag must NOT survive into the safe message — neither
+        # from the conflict page's title (escaped explicitly via django.utils.html.escape)
+        # nor from the current page's title (interpolated via `instance`).
+        self.assertNotIn("<script>", rendered)
+        self.assertNotIn("</script>", rendered)
+        # Both titles should appear in their HTML-escaped form.
+        self.assertIn("&lt;script&gt;", rendered)
+        self.assertIn("&lt;/script&gt;", rendered)
+        # The legitimate <a> tag the validator builds for the admin link is
+        # still preserved (it's the only HTML the message is allowed to emit).
+        self.assertIn('<a href="', rendered)
+
     def test_details_view(self):
         """
         Test the details view


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8576 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Escape user-controlled content in URL uniqueness validation error messages to prevent XSS in rendered admin and toolbar output.

Bug Fixes:
- HTML-escape conflicting page titles, current page titles, and URL paths interpolated into the URL uniqueness validator error message to mitigate XSS risk.

Tests:
- Add regression test ensuring the URL uniqueness validator’s error message is marked safe while properly escaping any injected HTML from page titles and paths.