### PR TITLE
fix: XSS vulnerability in validator error message (#8576)

### DIFF
--- a/cms/forms/validators.py
+++ b/cms/forms/validators.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator, URLValidator
+from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext
 
@@ -73,7 +74,7 @@ def validate_url_uniqueness(
     if user_language:
         change_url += f"?language={user_language}"
 
-    conflict_url = f'<a href="{change_url}" target="_blank">{str(conflict_translation.title)}</a>'
+    conflict_url = f'<a href="{change_url}" target="_blank">{escape(str(conflict_translation.title))}</a>'
 
     if exclude_page:
         message = gettext("Page %(conflict_page)s has the same url '%(url)s' as current page \"%(instance)s\".")
@@ -81,7 +82,7 @@ def validate_url_uniqueness(
         message = gettext("Page %(conflict_page)s has the same url '%(url)s' as current page.")
     message = message % {
         "conflict_page": conflict_url,
-        "url": path,
-        "instance": exclude_page.get_title(language) if exclude_page else "",
+        "url": escape(path),
+        "instance": escape(exclude_page.get_title(language)) if exclude_page else "",
     }
     raise ValidationError(mark_safe(message))

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -265,6 +265,52 @@ class PagesTestCase(TransactionCMSTestCase):
         response = self.client.get(child.get_absolute_url("en"))
         self.assertEqual(response.status_code, 200)
 
+    def test_validate_url_uniqueness_escapes_html_in_error_message(self):
+        """
+        validate_url_uniqueness raises a ValidationError whose message is
+        wrapped in mark_safe so it can render an <a> link to the conflicting
+        page in the admin. Any user-controlled fragments interpolated into
+        that message MUST be HTML-escaped, otherwise a page title containing
+        markup like ``<script>...</script>`` would render unescaped wherever
+        Django renders the validation error (admin form errors, toolbar
+        notifications, ...).
+        """
+        from django.utils.safestring import SafeString
+
+        site = _get_current_site()
+        evil = "<script>alert('xss')</script>"
+
+        # Page A: the existing page that owns the conflicting slug. Its title
+        # ends up inside the <a>...</a> link in the rendered error message.
+        conflict_page = create_page(f"conflict {evil}", "nav_playground.html", "en", slug="foo")
+        # Page B: the page being validated. Its title is interpolated into
+        # the "current page" portion of the message via the `instance` kwarg.
+        current_page = create_page(f"current {evil}", "nav_playground.html", "en", slug="bar")
+
+        with self.assertRaises(ValidationError) as ctx:
+            validate_url_uniqueness(
+                site,
+                path=conflict_page.get_path("en"),
+                language="en",
+                exclude_page=current_page,
+            )
+
+        # ValidationError messages are a list; the validator only raises one.
+        rendered = ctx.exception.messages[0]
+        self.assertIsInstance(rendered, SafeString)
+
+        # The raw <script> tag must NOT survive into the safe message — neither
+        # from the conflict page's title (escaped explicitly via django.utils.html.escape)
+        # nor from the current page's title (interpolated via `instance`).
+        self.assertNotIn("<script>", rendered)
+        self.assertNotIn("</script>", rendered)
+        # Both titles should appear in their HTML-escaped form.
+        self.assertIn("&lt;script&gt;", rendered)
+        self.assertIn("&lt;/script&gt;", rendered)
+        # The legitimate <a> tag the validator builds for the admin link is
+        # still preserved (it's the only HTML the message is allowed to emit).
+        self.assertIn('<a href="', rendered)
+
     def test_details_view(self):
         """
         Test the details view

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -277,7 +277,7 @@ class PagesTestCase(TransactionCMSTestCase):
         """
         from django.utils.safestring import SafeString
 
-        site = _get_current_site()
+        site = get_current_site()
         evil = "<script>alert('xss')</script>"
 
         # Page A: the existing page that owns the conflicting slug. Its title


### PR DESCRIPTION

## Summary by Sourcery

Fix HTML escaping in URL uniqueness validation error messages to prevent XSS when rendering admin/UI errors.

Bug Fixes:
- Escape user-controlled page titles and paths in validate_url_uniqueness error messages to avoid XSS while still allowing the admin link markup.

Tests:
- Add regression test ensuring validate_url_uniqueness error messages HTML-escape user-provided content while preserving the intended admin link HTML.
## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8576
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.
