### PR TITLE
fix: Deleting a non-local plugin did not refresh the screen

### DIFF
--- a/cms/static/cms/js/modules/cms.structureboard.js
+++ b/cms/static/cms/js/modules/cms.structureboard.js
@@ -1515,7 +1515,9 @@ class StructureBoard {
         const lastPluginDeleted = CMS._instances.find(
             plugin => plugin.options.placeholder_id == placeholder_id // eslint-disable-line eqeqeq
         ) === undefined;
-        // Additionally always redraw if the last plugin was deleted. The then empty placeholders can render alternative content
+
+        // Additionally always redraw if the last plugin was deleted.
+        // The then empty placeholders can render alternative content
         return lastPluginDeleted || this._updateContentFromDataBridge(contentData);
     }
 

--- a/cms/static/cms/js/modules/cms.structureboard.js
+++ b/cms/static/cms/js/modules/cms.structureboard.js
@@ -1515,8 +1515,8 @@ class StructureBoard {
         const lastPluginDeleted = CMS._instances.find(
             plugin => plugin.options.placeholder_id == placeholder_id // eslint-disable-line eqeqeq
         ) === undefined;
-
-        return lastPluginDeleted || contentData.content && this._updateContentFromDataBridge(contentData);
+        // Additionally always redraw if the last plugin was deleted. The then empty placeholders can render alternative content
+        return lastPluginDeleted || this._updateContentFromDataBridge(contentData);
     }
 
     handleClearPlaceholder(data) {


### PR DESCRIPTION

## Summary by Sourcery

Ensure the structure board view properly refreshes after plugin deletion events.

Bug Fixes:
- Fix missing UI refresh when deleting certain plugins by always updating content from the data bridge after deletions.
- Ensure placeholders are fully redrawn when the last plugin is removed so that alternative content can be rendered.

fixes #8581 

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8581 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.
