### PR TITLE
fix: Deleting a non-local plugin did not refresh the screen (#8582)

### DIFF
--- a/cms/static/cms/js/modules/cms.structureboard.js
+++ b/cms/static/cms/js/modules/cms.structureboard.js
@@ -1502,7 +1502,9 @@ class StructureBoard {
             plugin => plugin.options.placeholder_id == placeholder_id  // eslint-disable-line eqeqeq
         ) === undefined;
 
-        return lastPluginDeleted || contentData.content && this._updateContentFromDataBridge(contentData);
+        // Additionally always redraw if the last plugin was deleted.
+        // The then empty placeholders can render alternative content
+        return lastPluginDeleted || this._updateContentFromDataBridge(contentData);
     }
 
     handleClearPlaceholder(data) {


### PR DESCRIPTION

## Summary by Sourcery

Ensure the structure board UI is refreshed when deleting plugins, including non-local and last plugins in a placeholder.

Bug Fixes:
- Fix missing UI refresh after deleting a non-local plugin so the structure board reflects the updated state.
- Ensure the structure board redraws when the last plugin in a placeholder is deleted so empty placeholders can render alternative content.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8582
* #8581

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.
