### PR TITLE
fix: Refactor content object caching in GrouperAdmin

### DIFF
--- a/cms/admin/utils.py
+++ b/cms/admin/utils.py
@@ -8,6 +8,7 @@ from django.contrib.admin import ModelAdmin
 from django.contrib.admin.checks import ModelAdminChecks
 from django.contrib.admin.utils import label_for_field
 from django.contrib.admin.views.main import ChangeList
+from django.contrib.auth import get_permission_codename
 from django.contrib.sites.models import Site
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db import models
@@ -385,6 +386,13 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
                 )
         return annotation
 
+    def can_change_content(self, request, content_obj):
+        opts = self.content_model._meta
+        perm = f"{opts.app_label}.{get_permission_codename('change' if content_obj else 'add', opts)}"
+        has_permissions = request.user.has_perm(perm, content_obj)
+        is_editable = getattr(content_obj, "is_editable", lambda req: True)(request)
+        return has_permissions and is_editable
+
     def get_queryset(self, request: HttpRequest) -> models.QuerySet:
         """Annotates content fields with the name "content__{field_name}" to the grouper queryset if
         for all content fields that appear in the"""
@@ -542,6 +550,7 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
             extra_context["language_tabs"] = self.get_language_tuple(site=site)
             extra_context["language"] = language
             extra_context["filled_languages"] = filled_languages
+            extra_context["can_change_content_obj"] = self.can_change_content(request, content_instance)
             if content_instance is None:
                 subtitle = _("Add %(language)s content") % dict(language=get_language_dict(site_id=site.pk).get(self.language))
                 extra_context["subtitle"] = subtitle

--- a/cms/admin/utils.py
+++ b/cms/admin/utils.py
@@ -387,9 +387,9 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
     def can_change_content(self, request, content_obj):
         opts = self.content_model._meta
         perm = f"{opts.app_label}.{get_permission_codename('change' if content_obj else 'add', opts)}"
-        has_permissions = request.user.has_perm(perm, content_obj)
-        is_editable = getattr(content_obj, "is_editable", lambda *_: True)(request)
-        return has_permissions and is_editable
+        if not request.user.has_perm(perm, content_obj):
+            return False
+        return getattr(content_obj, "is_editable", lambda *_: True)(request)
 
     def get_queryset(self, request: HttpRequest) -> models.QuerySet:
         """Annotates content fields with the name "content__{field_name}" to the grouper queryset if

--- a/cms/admin/utils.py
+++ b/cms/admin/utils.py
@@ -100,9 +100,7 @@ class ChangeListActionsMixin(metaclass=forms.widgets.MediaDefiningClass):
             "sure it calls super().get_list_display."
         )  # pragma: no cover
 
-    def get_list_display(
-        self, request: HttpRequest
-    ) -> tuple[str | typing.Callable[[models.Model], str], ...]:
+    def get_list_display(self, request: HttpRequest) -> tuple[str | typing.Callable[[models.Model], str], ...]:
         list_display = super().get_list_display(request)
         return tuple(
             self.get_admin_list_actions(request) if item == "admin_list_actions" else item for item in list_display
@@ -184,7 +182,7 @@ class GrouperModelAdminChecks(ModelAdminChecks):
         `field_name` is "content__title"."""
 
         if field_name.startswith(CONTENT_PREFIX) and obj.content_model:
-            field_name = field_name[len(CONTENT_PREFIX):]
+            field_name = field_name[len(CONTENT_PREFIX) :]
             obj = copy(obj)
             obj.model = obj.content_model
         return super()._check_prepopulated_fields_value_item(obj, field_name, label)
@@ -195,7 +193,7 @@ class GrouperModelAdminChecks(ModelAdminChecks):
         """
 
         if field_name.startswith(CONTENT_PREFIX) and obj.content_model:
-            field_name = field_name[len(CONTENT_PREFIX):]
+            field_name = field_name[len(CONTENT_PREFIX) :]
             obj = copy(obj)
             obj.model = obj.content_model
         return super()._check_prepopulated_fields_key(obj, field_name, label)
@@ -552,7 +550,9 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
             extra_context["filled_languages"] = filled_languages
             extra_context["can_change_content_obj"] = self.can_change_content(request, content_instance)
             if content_instance is None:
-                subtitle = _("Add %(language)s content") % dict(language=get_language_dict(site_id=site.pk).get(self.language))
+                subtitle = _("Add %(language)s content") % dict(
+                    language=get_language_dict(site_id=site.pk).get(self.language)
+                )
                 extra_context["subtitle"] = subtitle
 
         # TODO: Add context for other grouping fields to be shown as a dropdown
@@ -650,7 +650,9 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
             return obj
         else:
             if not hasattr(obj, "_grouper_admin_content_obj_cache"):
-                obj._grouper_admin_content_obj_cache = self._get_content_queryset(obj).filter(**self.current_content_filters).first()
+                obj._grouper_admin_content_obj_cache = (
+                    self._get_content_queryset(obj).filter(**self.current_content_filters).first()
+                )
             return obj._grouper_admin_content_obj_cache
 
     def get_content_objects(self, obj: models.Model | None) -> models.QuerySet:
@@ -687,17 +689,21 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
         This allows versioned content to be protected if needed"""
         # First, get read-only fields for grouper
         fields = super().get_readonly_fields(request, obj)
-        if hasattr(self, "can_change_content"):
-            content_obj = self.get_content_obj(obj)
-            if not self.can_change_content(request, content_obj):
-                # Only allow content object fields to be edited if user can change them
-                fields += tuple(
+        content_obj = self.get_content_obj(obj)
+        if not self.can_change_content(request, content_obj):
+            # Only allow content object fields to be edited if user can change them
+            fields = [
+                *fields,
+                *(
                     CONTENT_PREFIX + field
                     for field in self.form._content_fields
                     if field != self.grouper_field_name and field not in self.extra_grouping_fields
-                )
+                ),
+            ]
         # Ensure no read-only fields are in prepopulated_fields
-        self.prepopulated_fields = {key: value for key, value in self._prepopulated_fields.items() if key not in fields}
+        self.prepopulated_fields = {
+            key: value for key, value in self._prepopulated_fields.items() if key not in fields
+        }
         return fields
 
     def save_model(self, request: HttpRequest, obj: models.Model, form: forms.Form, change: bool) -> None:
@@ -716,7 +722,7 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
             else:  # pragma: no cover
                 # ... without otherwise
                 form._content_model.objects.create(**content_dict)
-        elif not hasattr(self, "can_change_content") or self.can_change_content(request, form._content_instance):
+        elif self.can_change_content(request, form._content_instance):
             # Update content instance (only if can_change_content allows it)
             for key, value in content_dict.items():
                 setattr(form._content_instance, key, value)
@@ -730,7 +736,7 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
         grouper_search_fields = []
         for field_name in self.search_fields:
             if field_name.startswith(CONTENT_PREFIX):
-                content_search_fields.append(field_name[len(CONTENT_PREFIX):])
+                content_search_fields.append(field_name[len(CONTENT_PREFIX) :])
             else:
                 grouper_search_fields.append(field_name)
 
@@ -831,10 +837,9 @@ class _GrouperAdminFormMixin:
 
     def clean(self) -> dict:
         site = get_current_site(self._request)
-        if (
-            f"{CONTENT_PREFIX}language" in self.cleaned_data
-            and self.cleaned_data[f"{CONTENT_PREFIX}language"] not in get_language_list(site_id=site.pk)
-        ):
+        if f"{CONTENT_PREFIX}language" in self.cleaned_data and self.cleaned_data[
+            f"{CONTENT_PREFIX}language"
+        ] not in get_language_list(site_id=site.pk):
             raise ValidationError(
                 _("Invalid language %(value)s. This form cannot be processed. Try changing languages."),
                 params=dict(value=self.cleaned_data.get("language", _("<unspecified>"))),

--- a/cms/admin/utils.py
+++ b/cms/admin/utils.py
@@ -265,14 +265,12 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
 
     EMPTY_CONTENT_VALUE = _("Empty content")
     LC_SORTED_FIELDS = (models.CharField,)
+    CONTENT_OBJ_PK_ANNOTATION = "_content_obj_pk"
 
-    _content_cache_request_hash = None
     _content_content_type = None
 
     def __init__(self, model, admin_site):
         self._content_subquery_fields = []
-        self._content_obj_cache = {}
-        self._content_qs_cache = {}
 
         super().__init__(model, admin_site)
 
@@ -369,7 +367,9 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
         contents = self.content_model.admin_manager.latest_content(
             **{self.grouper_field_name: OuterRef("pk"), **self.current_content_filters}
         )
-        annotation = {}
+        annotation = {
+            self.CONTENT_OBJ_PK_ANNOTATION: Subquery(contents.values("pk")[:1]),
+        }
         for field_name in self._content_subquery_fields:
             annotation[CONTENT_PREFIX + field_name] = Subquery(contents.values(field_name)[:1])
             field = self.content_model._meta.get_field(field_name)
@@ -396,9 +396,6 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
 
     def get_grouping_from_request(self, request: HttpRequest) -> None:
         """Retrieves the current grouping selectors from the request"""
-        if hash(request) != self._content_cache_request_hash:
-            self._content_cache_request_hash = hash(request)
-            self.clear_content_cache()
         for field in self.extra_grouping_fields:
             if hasattr(self, f"get_{field}_from_request"):
                 value = getattr(self, f"get_{field}_from_request")(request)
@@ -578,6 +575,9 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
     # * Settings button that lets the user change the grouper AND the content model
     #   using one form
     def _get_view_action(self, obj: models.Model, request: HttpRequest) -> str:
+        if not is_editable_model(self.content_model):
+            return ""
+
         view_url = self.view_on_site(obj)
         if view_url:
             return self.admin_action_button(
@@ -590,13 +590,21 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
             )
         return ""
 
+    def _has_content(self, obj: models.Model) -> bool:
+        if self._is_content_obj(obj):
+            return True
+        if hasattr(obj, self.CONTENT_OBJ_PK_ANNOTATION):
+            return getattr(obj, self.CONTENT_OBJ_PK_ANNOTATION) is not None
+        return self.get_content_obj(obj) is not None
+
     def _get_settings_action(self, obj: models.Model, request: HttpRequest) -> str:
         edit_url = admin_reverse(f"{obj._meta.app_label}_{obj._meta.model_name}_change", args=(obj.pk,))
         edit_url += f"?{urlencode(self.current_content_filters)}"
+        has_content = self._has_content(obj)
         return self.admin_action_button(
             url=edit_url,
-            icon="settings" if self.get_content_obj(obj) else "plus",
-            title=_("Settings") if self.get_content_obj(obj) else _("Add content"),
+            icon="settings" if has_content else "plus",
+            title=_("Settings") if has_content else _("Add content"),
             disabled=not edit_url,
             name="settings",
         )
@@ -636,11 +644,11 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
         if obj is None or self._is_content_obj(obj):
             return obj
         else:
-            if obj not in self._content_obj_cache:
-                self._content_obj_cache[obj] = (
-                    self._get_content_queryset(obj).filter(**self.current_content_filters).first()
-                )
-            return self._content_obj_cache[obj]
+            if not hasattr(obj, "_grouper_admin_content_obj_cache"):
+                obj._grouper_admin_content_obj_cache = getattr(obj, self.content_related_field)(
+                    manager="admin_manager"
+                ).latest_content().filter(**self.current_content_filters).first()
+            return obj._grouper_admin_content_obj_cache
 
     def get_content_objects(self, obj: models.Model | None) -> models.QuerySet:
         if obj is None:

--- a/cms/admin/utils.py
+++ b/cms/admin/utils.py
@@ -394,7 +394,13 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
     def get_queryset(self, request: HttpRequest) -> models.QuerySet:
         """Annotates content fields with the name "content__{field_name}" to the grouper queryset if
         for all content fields that appear in the"""
-        return super().get_queryset(request).annotate(**self._get_annotation())
+        qs = super().get_queryset(request).annotate(**self._get_annotation())
+        prefetch = models.Prefetch(
+            self.content_related_field,
+            queryset=self.content_model.admin_manager.latest_content(),
+            to_attr="_admin_prefetch_cache",
+        )
+        return qs.prefetch_related(prefetch)
 
     def get_language_from_request(self, request: HttpRequest) -> str:
         """Hook for get_language_from_request which by default uses the cms utility"""
@@ -648,12 +654,22 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
     def get_content_obj(self, obj: models.Model | None) -> models.Model | None:
         if obj is None or self._is_content_obj(obj):
             return obj
-        else:
-            if not hasattr(obj, "_grouper_admin_content_obj_cache"):
-                obj._grouper_admin_content_obj_cache = (
-                    self._get_content_queryset(obj).filter(**self.current_content_filters).first()
-                )
-            return obj._grouper_admin_content_obj_cache
+
+        if not hasattr(obj, "_grouper_admin_content_obj_cache"):
+            # Check prefetch cache
+            if hasattr(obj, "_admin_prefetch_cache"):
+                for content_obj in obj._admin_prefetch_cache:
+                    if all(
+                        getattr(content_obj, key, None) == value for key, value in self.current_content_filters.items()
+                    ):
+                        obj._grouper_admin_content_obj_cache = content_obj
+                        return content_obj
+                obj._grouper_admin_content_obj_cache = None  # no hit
+                return None
+            obj._grouper_admin_content_obj_cache = (
+                self._get_content_queryset(obj).filter(**self.current_content_filters).first()
+            )
+        return obj._grouper_admin_content_obj_cache
 
     def get_content_objects(self, obj: models.Model | None) -> models.QuerySet:
         if obj is None:

--- a/cms/admin/utils.py
+++ b/cms/admin/utils.py
@@ -592,10 +592,10 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
 
     def _has_content(self, obj: models.Model) -> bool:
         if self._is_content_obj(obj):
-            return True
+            return True  # pragma: no cover
         if hasattr(obj, self.CONTENT_OBJ_PK_ANNOTATION):
             return getattr(obj, self.CONTENT_OBJ_PK_ANNOTATION) is not None
-        return self.get_content_obj(obj) is not None
+        return self.get_content_obj(obj) is not None  # pragma: no cover
 
     def _get_settings_action(self, obj: models.Model, request: HttpRequest) -> str:
         edit_url = admin_reverse(f"{obj._meta.app_label}_{obj._meta.model_name}_change", args=(obj.pk,))

--- a/cms/admin/utils.py
+++ b/cms/admin/utils.py
@@ -634,20 +634,14 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
         return isinstance(obj, self.content_model)
 
     def _get_content_queryset(self, obj: models.Model) -> models.QuerySet:
-        if obj not in self._content_qs_cache:
-            self._content_qs_cache[obj] = getattr(obj, self.content_related_field)(
-                manager="admin_manager"
-            ).latest_content()
-        return self._content_qs_cache[obj]
+        return getattr(obj, self.content_related_field)(manager="admin_manager").latest_content()
 
     def get_content_obj(self, obj: models.Model | None) -> models.Model | None:
         if obj is None or self._is_content_obj(obj):
             return obj
         else:
             if not hasattr(obj, "_grouper_admin_content_obj_cache"):
-                obj._grouper_admin_content_obj_cache = getattr(obj, self.content_related_field)(
-                    manager="admin_manager"
-                ).latest_content().filter(**self.current_content_filters).first()
+                obj._grouper_admin_content_obj_cache = self._get_content_queryset(obj).filter(**self.current_content_filters).first()
             return obj._grouper_admin_content_obj_cache
 
     def get_content_objects(self, obj: models.Model | None) -> models.QuerySet:
@@ -659,9 +653,8 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
         return self._get_content_queryset(obj)
 
     def clear_content_cache(self) -> None:
-        """Clear cache, e.g., for a new request"""
-        self._content_obj_cache = {}
-        self._content_qs_cache = {}
+        # Content objects are now stored in the object, no cache clear for admin class necessary
+        pass
 
     def get_grouper_obj(self, obj: models.Model) -> models.Model:
         """Get the admin object. If obj is a content object assume that the admin object

--- a/cms/admin/utils.py
+++ b/cms/admin/utils.py
@@ -390,7 +390,7 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
         opts = self.content_model._meta
         perm = f"{opts.app_label}.{get_permission_codename('change' if content_obj else 'add', opts)}"
         has_permissions = request.user.has_perm(perm, content_obj)
-        is_editable = getattr(content_obj, "is_editable", lambda req: True)(request)
+        is_editable = getattr(content_obj, "is_editable", lambda *_: True)(request)
         return has_permissions and is_editable
 
     def get_queryset(self, request: HttpRequest) -> models.QuerySet:

--- a/cms/templates/admin/cms/grouper/change_form.html
+++ b/cms/templates/admin/cms/grouper/change_form.html
@@ -12,7 +12,7 @@
       </div>
     {% endif %}
   {% endblock %}
-  {% if content_instance.versions and content_instance.versions.first.state != "draft" %}
+  {% if not can_change_content_obj %}
     <div class="errornote">
       <p><i>{% trans "Some fields cannot be changed since they are read-only content." %}</i></p>
     </div>

--- a/cms/templates/admin/cms/grouper/change_form.html
+++ b/cms/templates/admin/cms/grouper/change_form.html
@@ -12,7 +12,7 @@
       </div>
     {% endif %}
   {% endblock %}
-  {% if not can_change_content_obj %}
+  {% if not can_change_content_obj and not add %}
     <div class="errornote">
       <p><i>{% trans "Some fields cannot be changed since they are read-only content." %}</i></p>
     </div>

--- a/cms/tests/test_grouper_admin.py
+++ b/cms/tests/test_grouper_admin.py
@@ -1,14 +1,15 @@
 import copy
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.conf import settings
 from django.contrib.admin import site
+from django.contrib.auth import get_permission_codename
 from django.contrib.sites.models import Site
 from django.templatetags.static import static
 from django.utils.crypto import get_random_string
 from django.utils.translation import get_language, override as force_language
 
-from cms.admin.utils import CONTENT_PREFIX
+from cms.admin.utils import CONTENT_PREFIX, GrouperModelAdmin
 from cms.test_utils.project.sampleapp.models import (
     GrouperModel,
     GrouperModelContent,
@@ -555,6 +556,78 @@ class GrouperChangeTestCase(SetupMixin, CMSTestCase):
         self.assertEqual(content_instance_en.secret_greeting, random_content.secret_greeting)  # unchanged
         self.assertIsNotNone(content_instance_de)  # Exists?
         self.assertEqual(content_instance_de.secret_greeting, data["content__secret_greeting"])  # Has new content
+
+
+class GrouperCanChangeContentTestCase(SetupMixin, CMSTestCase):
+    """Tests for ``GrouperModelAdmin.can_change_content`` in both the add and change case.
+
+    The sampleapp's ``GrouperAdmin`` overrides ``can_change_content``, so we call the base
+    implementation directly. ``request.user`` is a ``MagicMock`` because Django's default
+    auth backend returns no object-level permissions for non-superusers, which would make
+    the change case impossible to exercise otherwise."""
+
+    def _can_change_content(self, request, content_obj):
+        return GrouperModelAdmin.can_change_content(self.admin, request, content_obj)
+
+    def _request(self, has_perm_return=True):
+        request = self.get_request()
+        request.user = MagicMock()
+        request.user.has_perm.return_value = has_perm_return
+        return request
+
+    def test_add_case_checks_add_permission(self):
+        """Without a content object, the content model's add permission is checked."""
+        request = self._request(has_perm_return=True)
+
+        self.assertTrue(self._can_change_content(request, None))
+
+        opts = GrouperModelContent._meta
+        expected_perm = f"{opts.app_label}.{get_permission_codename('add', opts)}"
+        request.user.has_perm.assert_called_once_with(expected_perm, None)
+
+    def test_add_case_denied_without_permission(self):
+        """Without the add permission, the add case returns False."""
+        request = self._request(has_perm_return=False)
+
+        self.assertFalse(self._can_change_content(request, None))
+
+    def test_change_case_checks_change_permission(self):
+        """With a content object, the change permission is checked, passing the object for
+        object-level backends."""
+        content_obj = self.createContentInstance("en")
+        request = self._request(has_perm_return=True)
+
+        self.assertTrue(self._can_change_content(request, content_obj))
+
+        opts = GrouperModelContent._meta
+        expected_perm = f"{opts.app_label}.{get_permission_codename('change', opts)}"
+        request.user.has_perm.assert_called_once_with(expected_perm, content_obj)
+
+    def test_change_case_denied_without_permission(self):
+        """Without the change permission, the change case returns False."""
+        content_obj = self.createContentInstance("en")
+        request = self._request(has_perm_return=False)
+
+        self.assertFalse(self._can_change_content(request, content_obj))
+
+    def test_change_case_respects_is_editable(self):
+        """When the content object exposes ``is_editable`` returning False, the user cannot
+        change it even with the permission."""
+        content_obj = self.createContentInstance("en")
+        content_obj.is_editable = lambda *_: False
+        request = self._request(has_perm_return=True)
+
+        self.assertFalse(self._can_change_content(request, content_obj))
+
+    def test_superuser_can_change_content_in_both_cases(self):
+        """Superusers pass the permission check for both add and change cases."""
+        request = self.get_request()
+        request.user = self.admin_user
+
+        self.assertTrue(self._can_change_content(request, None))
+
+        content_obj = self.createContentInstance("en")
+        self.assertTrue(self._can_change_content(request, content_obj))
 
 
 class SimpleGrouperChangeTestCase(SimpleSetupMixin, CMSTestCase):

--- a/cms/tests/test_grouper_admin.py
+++ b/cms/tests/test_grouper_admin.py
@@ -5,7 +5,9 @@ from django.conf import settings
 from django.contrib.admin import site
 from django.contrib.auth import get_permission_codename
 from django.contrib.sites.models import Site
+from django.db import connection
 from django.templatetags.static import static
+from django.test.utils import CaptureQueriesContext
 from django.utils.crypto import get_random_string
 from django.utils.translation import get_language, override as force_language
 
@@ -337,6 +339,72 @@ class GrouperChangeListTestCase(SetupMixin, CMSTestCase):
                 # Assert
                 self.assertContains(response, "Grouper Category")
                 self.assertContains(response, random_content[language])
+
+    def test_get_content_obj_uses_prefetch_cache(self) -> None:
+        """Iterating the admin queryset and calling ``get_content_obj`` on each grouper must
+        not issue per-row queries — the prefetch registered in ``get_queryset`` is expected
+        to populate ``_admin_prefetch_cache``, so the total query count stays constant."""
+        # Arrange: baseline + many grouper/content pairs.
+        self.createContentInstance("en")
+        for i in range(10):
+            extra = GrouperModel.objects.create(category_name=f"Grouper {i}")
+            GrouperModelContent.objects.create(
+                grouper_model=extra, language="en", secret_greeting=f"Greeting {i}"
+            )
+
+        request = self.get_request()
+        request.user = self.admin_user
+        self.admin.language = "en"
+
+        # Act: mimic what the changelist does — materialize the queryset, then look up
+        # each grouper's content object.
+        with CaptureQueriesContext(connection) as ctx:
+            groupers = list(self.admin.get_queryset(request))
+            for grouper in groupers:
+                self.assertIsNotNone(self.admin.get_content_obj(grouper))
+
+        # Assert: one query for groupers + one for the prefetch = 2.
+        # Without the prefetch we'd see 1 + N queries (12 here).
+        self.assertLessEqual(
+            len(ctx),
+            3,
+            f"Expected ≤ 3 queries for 11 groupers thanks to prefetch_related, got {len(ctx)}. "
+            f"Looks like ``get_content_obj`` is not using the prefetch cache.",
+        )
+
+    def test_changelist_view_has_no_n_plus_1(self) -> None:
+        """End-to-end regression guard: the query count of the changelist HTTP view must
+        not grow with the number of grouper instances. Protects against future n+1s
+        introduced by list_display getters, action buttons, or related hooks."""
+        # Arrange: baseline with a single grouper (from setUp) + one content object.
+        self.createContentInstance("en")
+
+        with self.login_user_context(self.admin_user):
+            # Warm up the client/session so login-related queries don't pollute counts.
+            self.client.get(self.changelist_url + "?language=en")
+
+            with CaptureQueriesContext(connection) as baseline:
+                response = self.client.get(self.changelist_url + "?language=en")
+            self.assertEqual(response.status_code, 200)
+
+            # Act: add many more grouper/content pairs.
+            for i in range(10):
+                extra = GrouperModel.objects.create(category_name=f"Grouper {i}")
+                GrouperModelContent.objects.create(
+                    grouper_model=extra, language="en", secret_greeting=f"Greeting {i}"
+                )
+
+            with CaptureQueriesContext(connection) as scaled:
+                response = self.client.get(self.changelist_url + "?language=en")
+            self.assertEqual(response.status_code, 200)
+
+        # Assert: query count is invariant to number of rows.
+        self.assertEqual(
+            len(baseline),
+            len(scaled),
+            f"Changelist issued {len(baseline)} queries for 1 grouper but {len(scaled)} for 11. "
+            f"This suggests an n+1 has been introduced.",
+        )
 
 
 class SimpleGrouperChangeListTestCase(SimpleSetupMixin, CMSTestCase):

--- a/cms/tests/test_grouper_admin.py
+++ b/cms/tests/test_grouper_admin.py
@@ -1,4 +1,5 @@
 import copy
+from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.admin import site
@@ -245,6 +246,45 @@ class GrouperModelAdminTestCase(SetupMixin, CMSTestCase):
         self.assertIn("content__secret_greeting", readonly_fields)
         self.assertNotIn("content__secret_greeting", admin.prepopulated_fields)
         self.assertIn("category_name", admin.prepopulated_fields)
+
+    def test_changelist_view_does_not_call_get_content_obj(self):
+        self.createContentInstance("en")
+
+        with self.login_user_context(self.admin_user):
+            with patch.object(self.admin, "get_content_obj", wraps=self.admin.get_content_obj) as mocked_get_content_obj:
+                response = self.client.get(f"{self.changelist_url}?language=en", follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(mocked_get_content_obj.call_count, 0)
+
+    def test_change_view_calls_get_content_obj(self):
+        self.createContentInstance("en")
+
+        with self.login_user_context(self.admin_user):
+            with patch.object(self.admin, "get_content_obj", wraps=self.admin.get_content_obj) as mocked_get_content_obj:
+                response = self.client.get(f"{self.change_url}?language=en", follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertGreater(mocked_get_content_obj.call_count, 0)
+        self.assertTrue(any(call.args and call.args[0] == self.grouper_instance for call in mocked_get_content_obj.call_args_list))
+
+    def test_get_content_obj_caches_on_grouper_object(self):
+        content_instance = self.createContentInstance("en")
+        self.admin.language = "en"
+        self.admin.clear_content_cache()
+
+        self.assertFalse(hasattr(self.grouper_instance, "_grouper_admin_content_obj_cache"))
+
+        with self.assertNumQueries(1):
+            cached_content = self.admin.get_content_obj(self.grouper_instance)
+
+        self.assertEqual(cached_content, content_instance)
+        self.assertTrue(hasattr(self.grouper_instance, "_grouper_admin_content_obj_cache"))
+
+        with self.assertNumQueries(0):
+            cached_again = self.admin.get_content_obj(self.grouper_instance)
+
+        self.assertIs(cached_again, cached_content)
 
 
 class GrouperChangeListTestCase(SetupMixin, CMSTestCase):


### PR DESCRIPTION
## Summary by Sourcery

Refine GrouperAdmin content object handling to improve caching and avoid unnecessary lookups in list and settings views.

Bug Fixes:
- Ensure settings actions and icons correctly reflect whether a grouper has associated content without triggering extra content lookups.
- Prevent repeated database queries for content objects by caching them directly on the grouper instance and using an annotated primary key where available.
- Avoid calling content object resolution during the changelist view to reduce redundant work and potential side effects.

Enhancements:
- Use an annotated content object primary key and a dedicated helper to determine whether a grouper has content, improving efficiency of admin actions.
- Hide the view-on-site action for non-editable content models in the GrouperAdmin interface.

Tests:
- Add tests verifying that the changelist view no longer calls content resolution, that the change view still does, and that content objects are cached on the grouper instance.

fixes #8587 

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8587 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Refine GrouperAdmin content handling to rely on per-object caching and explicit permission checks, improving efficiency and access control in the admin UI.

Bug Fixes:
- Ensure the changelist view no longer triggers content object resolution while the change view still does.
- Cache resolved content objects on the grouper instance to avoid repeated database queries.
- Make readonly handling for content fields depend consistently on a central content-permission check rather than ad‑hoc logic.

Enhancements:
- Annotate groupers with a content object primary key and use it to determine whether a grouper has content without extra lookups.
- Introduce a reusable can_change_content helper that enforces add/change permissions and respects a content model's is_editable flag.
- Hide the view-on-site action for non-editable content models in the GrouperAdmin interface.

Tests:
- Add tests verifying changelist vs change view calls to get_content_obj and the per-grouper content cache behavior.
- Add tests covering can_change_content in add and change scenarios, including permission checks, is_editable handling, and superuser behavior.