### PR TITLE
chore: Missing empty options in PageSmartLinkWidger

### DIFF
--- a/cms/templates/cms/widgets/pagesmartlinkwidget.html
+++ b/cms/templates/cms/widgets/pagesmartlinkwidget.html
@@ -1,4 +1,5 @@
 <select name="{{ widget.name }}"{% for attr, val in widget.attrs.items %}{% if val is not False %} {{ attr }}{% if val is not True %}="{{ val|stringformat:'s' }}"{% endif %}{% endif %}{% endfor %}>
+    <option></option>
     {% if widget.value %}<option value="{{ widget.value }}" selected data-select2-tag="true">{{ widget.value }}</option>{% endif %}
 </select>
 <div data-cms-widget-pagesmartlinkwidget="true" hidden>


### PR DESCRIPTION
## Summary by Sourcery

Fix:
- Ensure the PageSmartLinkWidget select element includes an initial empty option for users to clear or leave the field unset. 

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

