### PR TITLE
fix: XSS vulnerability in validator error message (#8576)

### DIFF
--- a/cms/forms/validators.py
+++ b/cms/forms/validators.py
@@ -3,6 +3,7 @@ import re
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator, URLValidator
 from django.utils.encoding import force_str
+from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext
 
@@ -82,7 +83,7 @@ def validate_url_uniqueness(site, path, language, exclude_page=None):
 
     conflict_url = '<a href="%(change_url)s" target="_blank">%(page_title)s</a>' % {
         'change_url': change_url,
-        'page_title': force_str(conflict_page),
+        'page_title': escape(force_str(conflict_page)),
     }
 
     if exclude_page:


### PR DESCRIPTION
## Summary by Sourcery

Escape the page title in the conflict URL to prevent XSS.

Bug Fixes:
- Escape the conflict page title used in the conflict URL within validation errors to avoid potential XSS vulnerabilities.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8576 
* #8580 
* #8579

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.
