### PR TITLE
feat: add Django 5.2 tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,8 @@ jobs:
           django-4.1.txt,
           django-4.2.txt,
           django-5.0.txt,
-          django-5.1.txt
+          django-5.1.txt,
+          django-5.2.txt
         ]
         os: [
           ubuntu-24.04,
@@ -33,10 +34,14 @@ jobs:
             python-version: 3.8
           - requirements-file: django-5.1.txt
             python-version: 3.9
+          - requirements-file: django-5.2.txt
+            python-version: 3.8
+          - requirements-file: django-5.2.txt
+            python-version: 3.9
 
     services:
       postgres:
-        image: postgres:13
+        image: postgres:14
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -82,7 +87,8 @@ jobs:
           django-4.1.txt,
           django-4.2.txt,
           django-5.0.txt,
-          django-5.1.txt
+          django-5.1.txt,
+          django-5.2.txt
         ]
         os: [
           ubuntu-24.04,
@@ -95,6 +101,10 @@ jobs:
           - requirements-file: django-5.1.txt
             python-version: 3.8
           - requirements-file: django-5.1.txt
+            python-version: 3.9
+          - requirements-file: django-5.2.txt
+            python-version: 3.8
+          - requirements-file: django-5.2.txt
             python-version: 3.9
 
     services:
@@ -144,7 +154,8 @@ jobs:
           django-4.1.txt,
           django-4.2.txt,
           django-5.0.txt,
-          django-5.1.txt
+          django-5.1.txt,
+          django-5.2.txt
         ]
         os: [
           ubuntu-24.04,
@@ -157,6 +168,10 @@ jobs:
           - requirements-file: django-5.1.txt
             python-version: 3.8
           - requirements-file: django-5.1.txt
+            python-version: 3.9
+          - requirements-file: django-5.2.txt
+            python-version: 3.8
+          - requirements-file: django-5.2.txt
             python-version: 3.9
 
     steps:

--- a/cms/test_utils/testcases.py
+++ b/cms/test_utils/testcases.py
@@ -1,9 +1,9 @@
-import django
 import json
 import sys
 import warnings
 from urllib.parse import unquote, urljoin
 
+import django
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser, Permission

--- a/cms/test_utils/testcases.py
+++ b/cms/test_utils/testcases.py
@@ -1,3 +1,4 @@
+import django
 import json
 import sys
 import warnings
@@ -98,10 +99,20 @@ def _collectWarnings(observeWarning, f, *args, **kwargs):
 class BaseCMSTestCase:
     counter = 1
 
-    def _fixture_setup(self):
-        super()._fixture_setup()
-        self.create_fixtures()
-        translation.activate("en")
+    if django.VERSION >= (5, 2):
+        @classmethod
+        def _fixture_setup(cls):
+            super()._fixture_setup()
+
+        def _callSetUp(self):
+            self.create_fixtures()
+            translation.activate("en")
+            super()._callSetUp()
+    else:
+        def _fixture_setup(self):
+            super()._fixture_setup()
+            self.create_fixtures()
+            translation.activate("en")
 
     def create_fixtures(self):
         pass

--- a/cms/tests/test_admin.py
+++ b/cms/tests/test_admin.py
@@ -1,6 +1,8 @@
 import datetime
 import json
 
+import django
+
 from django.contrib import admin
 from django.contrib.admin.models import LogEntry
 from django.contrib.admin.sites import site
@@ -860,10 +862,16 @@ class AdminFormsTests(AdminTestsBase):
         with self.login_user_context(superuser):
             # Invalid parent
             response = self.client.post(self.get_admin_url(Page, 'add'), new_page_data)
-            expected_error = (
-                '<ul class="errorlist">'
-                '<li>Site doesn&#39;t match the parent&#39;s page site</li></ul>'
-            )
+            if django.VERSION >= (5, 2):
+                expected_error = (
+                    '<ul class="errorlist" id="id_parent_node_error">'
+                    "<li>Site doesn't match the parent's page site</li></ul>"
+                )
+            else:
+                expected_error = (
+                    '<ul class="errorlist">'
+                    '<li>Site doesn&#39;t match the parent&#39;s page site</li></ul>'
+                )
             self.assertEqual(response.status_code, 200)
             self.assertContains(response, expected_error, html=True)
 
@@ -881,10 +889,16 @@ class AdminFormsTests(AdminTestsBase):
         with self.login_user_context(superuser):
             # Invalid parent
             response = self.client.post(self.get_admin_url(Page, 'add'), new_page_data)
-            expected_error = (
-                '<ul class="errorlist">'
-                '<li>Site doesn&#39;t match the parent&#39;s page site</li></ul>'
-            )
+            if django.VERSION >= (5, 2):
+                expected_error = (
+                    '<ul class="errorlist" id="id_parent_node_error">'
+                    "<li>Site doesn't match the parent's page site</li></ul>"
+                )
+            else:
+                expected_error = (
+                    '<ul class="errorlist">'
+                    '<li>Site doesn&#39;t match the parent&#39;s page site</li></ul>'
+                )
             self.assertEqual(response.status_code, 200)
             self.assertContains(response, expected_error, html=True)
 
@@ -896,10 +910,20 @@ class AdminFormsTests(AdminTestsBase):
         with self.login_user_context(superuser):
             # Invalid slug
             response = self.client.post(self.get_admin_url(Page, 'add'), new_page_data)
-            expected_error = '<ul class="errorlist"><li>Enter a valid “slug” consisting of letters, numbers, ' \
-                             'underscores or hyphens.</li></ul>'
-            if DJANGO_2_2:
-                expected_error = expected_error.replace("“", "&#39").replace("”", "&#39")
+            if django.VERSION >= (5, 2):
+                expected_error = (
+                    '<ul class="errorlist" id="id_slug_error">'
+                    '<li>Enter a valid “slug” consisting of letters, numbers, '
+                    'underscores or hyphens.</li></ul>'
+                )
+            else:
+                expected_error = (
+                    '<ul class="errorlist">'
+                    '<li>Enter a valid “slug” consisting of letters, numbers, '
+                    'underscores or hyphens.</li></ul>'
+                )
+                if DJANGO_2_2:
+                    expected_error = expected_error.replace("“", "&#39").replace("”", "&#39")
             self.assertEqual(response.status_code, 200)
             self.assertContains(response, expected_error, html=True)
 
@@ -912,11 +936,18 @@ class AdminFormsTests(AdminTestsBase):
         with self.login_user_context(superuser):
             # Duplicate slug / path
             response = self.client.post(self.get_admin_url(Page, 'add'), new_page_data)
-            expected_error = (
-                '<ul class="errorlist"><li>Page '
-                '<a href="{}" target="_blank">test</a> '
-                'has the same url \'test\' as current page.</li></ul>'
-            ).format(self.get_admin_url(Page, 'change', page2.pk))
+            if django.VERSION >= (5, 2):
+                expected_error = (
+                    '<ul class="errorlist" id="id_slug_error"><li>Page '
+                    '<a href="{}" target="_blank">test</a> '
+                    "has the same url 'test' as current page.</li></ul>"
+                ).format(self.get_admin_url(Page, 'change', page2.pk))
+            else:
+                expected_error = (
+                    '<ul class="errorlist"><li>Page '
+                    '<a href="{}" target="_blank">test</a> '
+                    "has the same url 'test' as current page.</li></ul>"
+                ).format(self.get_admin_url(Page, 'change', page2.pk))
             self.assertEqual(response.status_code, 200)
             self.assertContains(response, expected_error, html=True)
 

--- a/cms/tests/test_admin.py
+++ b/cms/tests/test_admin.py
@@ -2,7 +2,6 @@ import datetime
 import json
 
 import django
-
 from django.contrib import admin
 from django.contrib.admin.models import LogEntry
 from django.contrib.admin.sites import site

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -4,7 +4,6 @@ import sys
 from unittest import skipUnless
 
 import django
-
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.sites.models import Site

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -3,6 +3,8 @@ import json
 import sys
 from unittest import skipUnless
 
+import django
+
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.sites.models import Site
@@ -280,11 +282,18 @@ class PageTest(PageTestBase):
 
             response = self.client.post(URL_CMS_PAGE_ADD, page_data)
             new_page_id = Page.objects.only('id').latest('id').pk
-            expected_error = (
-                '<ul class="errorlist"><li>Page '
-                '<a href="{}" target="_blank">test page 1</a> '
-                'has the same url \'test-page-1\' as current page.</li></ul>'
-            ).format(self.get_admin_url(Page, 'change', new_page_id))
+            if django.VERSION >= (5, 2):
+                expected_error = (
+                    '<ul class="errorlist" id="id_slug_error"><li>Page '
+                    '<a href="{}" target="_blank">test page 1</a> '
+                    "has the same url 'test-page-1' as current page.</li></ul>"
+                ).format(self.get_admin_url(Page, 'change', new_page_id))
+            else:
+                expected_error = (
+                    '<ul class="errorlist"><li>Page '
+                    '<a href="{}" target="_blank">test page 1</a> '
+                    "has the same url 'test-page-1' as current page.</li></ul>"
+                ).format(self.get_admin_url(Page, 'change', new_page_id))
 
             self.assertEqual(response.status_code, 200)
             self.assertTrue(response.request['PATH_INFO'].endswith(URL_CMS_PAGE_ADD))
@@ -305,11 +314,18 @@ class PageTest(PageTestBase):
             page_data = self.get_new_page_data(page.node.pk)
             page_data['slug'] = 'subpage'
             response = self.client.post(URL_CMS_PAGE_ADD, page_data)
-            expected_markup = (
-                '<ul class="errorlist">'
-                '<li>Page <a href="{}" target="_blank">subpage</a> '
-                'has the same url \'page/subpage\' as current page.</li></ul>'
-            ).format(self.get_admin_url(Page, 'change', sub_page.pk))
+            if django.VERSION >= (5, 2):
+                expected_markup = (
+                    '<ul class="errorlist" id="id_slug_error">'
+                    '<li>Page <a href="{}" target="_blank">subpage</a> '
+                    "has the same url 'page/subpage' as current page.</li></ul>"
+                ).format(self.get_admin_url(Page, 'change', sub_page.pk))
+            else:
+                expected_markup = (
+                    '<ul class="errorlist">'
+                    '<li>Page <a href="{}" target="_blank">subpage</a> '
+                    "has the same url 'page/subpage' as current page.</li></ul>"
+                ).format(self.get_admin_url(Page, 'change', sub_page.pk))
 
             self.assertEqual(response.status_code, 200)
             self.assertTrue(response.request['PATH_INFO'].endswith(URL_CMS_PAGE_ADD))
@@ -319,11 +335,18 @@ class PageTest(PageTestBase):
             page_data = self.get_new_page_data()
             page_data['slug'] = 'child-page'
             response = self.client.post(URL_CMS_PAGE_ADD, page_data)
-            expected_markup = (
-                '<ul class="errorlist">'
-                '<li>Page <a href="{}" target="_blank">child-page</a> '
-                'has the same url \'child-page\' as current page.</li></ul>'
-            ).format(self.get_admin_url(Page, 'change', child_page.pk))
+            if django.VERSION >= (5, 2):
+                expected_markup = (
+                    '<ul class="errorlist" id="id_slug_error">'
+                    '<li>Page <a href="{}" target="_blank">child-page</a> '
+                    "has the same url 'child-page' as current page.</li></ul>"
+                ).format(self.get_admin_url(Page, 'change', child_page.pk))
+            else:
+                expected_markup = (
+                    '<ul class="errorlist">'
+                    '<li>Page <a href="{}" target="_blank">child-page</a> '
+                    "has the same url 'child-page' as current page.</li></ul>"
+                ).format(self.get_admin_url(Page, 'change', child_page.pk))
 
             self.assertEqual(response.status_code, 200)
             self.assertTrue(response.request['PATH_INFO'].endswith(URL_CMS_PAGE_ADD))
@@ -333,11 +356,18 @@ class PageTest(PageTestBase):
             page_data = self.get_new_page_data()
             page_data['slug'] = 'page'
             response = self.client.post(URL_CMS_PAGE_ADD, page_data)
-            expected_markup = (
-                '<ul class="errorlist">'
-                '<li>Page <a href="{}" target="_blank">page</a> '
-                'has the same url \'page\' as current page.</li></ul>'
-            ).format(self.get_admin_url(Page, 'change', page.pk))
+            if django.VERSION >= (5, 2):
+                expected_markup = (
+                    '<ul class="errorlist" id="id_slug_error">'
+                    '<li>Page <a href="{}" target="_blank">page</a> '
+                    "has the same url 'page' as current page.</li></ul>"
+                ).format(self.get_admin_url(Page, 'change', page.pk))
+            else:
+                expected_markup = (
+                    '<ul class="errorlist">'
+                    '<li>Page <a href="{}" target="_blank">page</a> '
+                    "has the same url 'page' as current page.</li></ul>"
+                ).format(self.get_admin_url(Page, 'change', page.pk))
 
             self.assertEqual(response.status_code, 200)
             self.assertTrue(response.request['PATH_INFO'].endswith(URL_CMS_PAGE_ADD))
@@ -463,14 +493,26 @@ class PageTest(PageTestBase):
             data['redirect'] = 'javascript:alert(1)'
             # Asserts users can't insert javascript call
             response = self.client.post(endpoint, data)
-            validation_error = '<ul class="errorlist"><li>Enter a valid URL.</li></ul>'
+            if django.VERSION >= (5, 2):
+                validation_error = (
+                    '<ul class="errorlist" id="id_redirect_error">'
+                    '<li>Enter a valid URL.</li></ul>'
+                )
+            else:
+                validation_error = '<ul class="errorlist"><li>Enter a valid URL.</li></ul>'
             self.assertContains(response, validation_error, html=True)
 
         with self.login_user_context(superuser):
             data['redirect'] = '<script>alert("test")</script>'
             # Asserts users can't insert javascript call
             response = self.client.post(endpoint, data)
-            validation_error = '<ul class="errorlist"><li>Enter a valid URL.</li></ul>'
+            if django.VERSION >= (5, 2):
+                validation_error = (
+                    '<ul class="errorlist" id="id_redirect_error">'
+                    '<li>Enter a valid URL.</li></ul>'
+                )
+            else:
+                validation_error = '<ul class="errorlist"><li>Enter a valid URL.</li></ul>'
             self.assertContains(response, validation_error, html=True)
 
     def test_moderator_edit_page_redirect(self):
@@ -1401,11 +1443,18 @@ class PageTest(PageTestBase):
         create_page('home', 'nav_playground.html', 'en', published=True)
         boo = create_page('boo', 'nav_playground.html', 'en', published=True)
         hoo = create_page('hoo', 'nav_playground.html', 'en', published=True)
-        expected_error = (
-            '<ul class="errorlist"><li>Page '
-            '<a href="{}" target="_blank">boo</a> '
-            'has the same url \'boo\' as current page "hoo".</li></ul>'
-        ).format(self.get_admin_url(Page, 'change', boo.pk))
+        if django.VERSION >= (5, 2):
+            expected_error = (
+                '<ul class="errorlist" id="id_overwrite_url_error"><li>Page '
+                '<a href="{}" target="_blank">boo</a> '
+                "has the same url 'boo' as current page \"hoo\".</li></ul>"
+            ).format(self.get_admin_url(Page, 'change', boo.pk))
+        else:
+            expected_error = (
+                '<ul class="errorlist"><li>Page '
+                '<a href="{}" target="_blank">boo</a> '
+                "has the same url 'boo' as current page \"hoo\".</li></ul>"
+            ).format(self.get_admin_url(Page, 'change', boo.pk))
 
         with self.login_user_context(superuser):
             endpoint = self.get_admin_url(Page, 'advanced', hoo.pk)

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,6 @@ skip = package-lock.json,*.js,*.po,./node_modules/*,./.idea/*,./docs/env/*,./doc
 
 [options]
 install_requires =
-    Django>=3.2,<5.2
+    Django>=3.2,<5.3
 python_requires = >=3.7
 

--- a/test_requirements/django-5.2.txt
+++ b/test_requirements/django-5.2.txt
@@ -1,0 +1,2 @@
+-r requirements_base.txt
+Django>=5.2,<5.3


### PR DESCRIPTION
## Description

This adds Django 5.2 compatibility: no changes in the actual code, just in some tests because Django 5.2 adds a `field_id` argument in `ErrorList`.

As discussed in Discord, feel free to do whatever you like with this :)

## Checklist

* [ ] I have opened this pull request against ``main``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Add Django 5.2 compatibility across tests, dependencies, and CI matrix.

Enhancements:
- Adjust BaseCMSTestCase fixture setup to support Django 5.2 lifecycle changes.

Build:
- Expand supported Django version range to <5.3 in setup configuration.

CI:
- Add Django 5.2 environments to the GitHub Actions test matrix for PostgreSQL, MySQL, and SQLite runs.

Tests:
- Update admin and page admin tests to handle Django 5.2 ErrorList HTML changes, including new field-specific error IDs.
- Introduce Django 5.2 test requirements file for running the test suite against the new version.