### PR TITLE
fix: Convert value to string in ApplicationConfigSelect.

### DIFF
--- a/cms/forms/widgets.py
+++ b/cms/forms/widgets.py
@@ -239,7 +239,8 @@ class ApplicationConfigSelect(Select):
         return {
             "apphooks_configuration": configs,
             "apphooks_configuration_url": urls,
-            "apphooks_configuration_value": value,
+            "apphooks_configuration_value": str(value) if value is not None else "",
+            # If str(config.pk) than str(value). Otherwise attribute selected was not set in element option.
         }
 
     def get_context(self, name, value, attrs):

--- a/cms/forms/widgets.py
+++ b/cms/forms/widgets.py
@@ -240,7 +240,7 @@ class ApplicationConfigSelect(Select):
             "apphooks_configuration": configs,
             "apphooks_configuration_url": urls,
             "apphooks_configuration_value": str(value) if value is not None else "",
-            # If str(config.pk) than str(value). Otherwise attribute selected was not set in element option.
+            # apphook_configuration_value needs to correspond to correspond to str(config.pk)
         }
 
     def get_context(self, name, value, attrs):


### PR DESCRIPTION
## Description

Fixed `value` conversion to string type when value is left as int type. This prevents setting select attribute on option element. Otherwise selected would not be set.

I'm sorry, but I'm currently unable to complete the tests.

## Summary by Sourcery

Bug Fixes:
- Convert the apphook configuration value to a string before passing it to the widget script to restore proper setting of the selected option.