### PR TITLE
fix: Compatibility shim for Page.objects.order_by used non-existing fields

### DIFF
--- a/cms/models/query.py
+++ b/cms/models/query.py
@@ -90,4 +90,4 @@ class PageQuerySet(MP_NodeQuerySet):
                 modified.append(f[6:])
             else:
                 modified.append(f)
-        return super().order_by(*fieldnames)
+        return super().order_by(*modified)


### PR DESCRIPTION

## Summary by Sourcery

Bug Fixes:
- Correct the Page.objects.order_by compatibility shim to use the modified field names when delegating to the base queryset, preventing ordering by non-existent fields.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.
