### PR TITLE
fix: Readonly-fields of GrouperAdmin had side effects

### DIFF
--- a/cms/admin/utils.py
+++ b/cms/admin/utils.py
@@ -667,11 +667,11 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
             content_obj = self.get_content_obj(obj)
             if not self.can_change_content(request, content_obj):
                 # Only allow content object fields to be edited if user can change them
-                fields += tuple(
+                fields = [*fields,  *(
                     CONTENT_PREFIX + field
                     for field in self.form._content_fields
                     if field != self.grouper_field_name and field not in self.extra_grouping_fields
-                )
+                )]
         return fields
 
     def save_model(self, request: HttpRequest, obj: models.Model, form: forms.Form, change: bool) -> None:


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent side effects when computing GrouperAdmin readonly fields by changing how additional content fields are combined with existing fields.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.
