### PR TITLE
fix: Convert value to string in ApplicationConfigSelect. (#8594)

### DIFF
--- a/cms/forms/widgets.py
+++ b/cms/forms/widgets.py
@@ -229,7 +229,7 @@ class ApplicationConfigSelect(Select):
             "apphooks_configuration": configs,
             "apphooks_configuration_url": urls,
             "apphooks_configuration_value": str(value) if value is not None else "",
-            # apphook_configuration_value needs to correspond to correspond to str(config.pk)
+            # apphook_configuration_value needs to correspond to str(config.pk)
         }
 
     def get_context(self, name, value, attrs):

--- a/cms/forms/widgets.py
+++ b/cms/forms/widgets.py
@@ -228,7 +228,8 @@ class ApplicationConfigSelect(Select):
         return {
             "apphooks_configuration": configs,
             "apphooks_configuration_url": urls,
-            "apphooks_configuration_value": value,
+            "apphooks_configuration_value": str(value) if value is not None else "",
+            # apphook_configuration_value needs to correspond to correspond to str(config.pk)
         }
 
     def get_context(self, name, value, attrs):


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Normalize the apphooks configuration value to a string (or empty string) to align with expected primary key string values in the frontend widget.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

