### PR TITLE
.4062073974432528:5f46f1d3d191add42cdd2270d51bc50b_69eca8d5a3c75e7cbf9565ec.69ecb2fda3c75e7cbf956769.69ecb2fd0da16f1b35bd0cae:Trae CN.T(2026/4/25 20:26:37)

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -223,6 +223,7 @@ class PageAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
             pat(r"^([0-9]+)/dialog/copy/$", self.get_copy_dialog),  # copy dialog
             pat(r"^([0-9]+)/permissions/$", self.get_permissions),
             pat(r"^(?P<object_id>[0-9]+)/set-home/$", self.set_home),
+            pat(r"^(?P<object_id>[0-9]+)/get-descendants-for-publish/$", self.get_descendants_for_publish_by_page),
         ]
 
         if plugin_pool.registered_plugins:
@@ -354,6 +355,63 @@ class PageAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
             # As a result, fire the apphook reload signal to reload the url patterns.
             set_restart_trigger()
         return HttpResponse("ok")
+
+    def get_descendants_for_publish_by_page(self, request, object_id):
+        """
+        Get all descendant pages for a given page, used in publish confirmation dialog.
+        Accepts Page ID and language (from query string), returns JSON data with descendant pages list.
+        """
+        page = self.get_object(request, object_id=object_id)
+
+        if not self.has_change_permission(request, obj=page):
+            return HttpResponseForbidden(_("You do not have permission to publish this page"))
+
+        if page is None:
+            raise Http404(
+                _("%(name)s object with primary key %(key)r does not exist.")
+                % {
+                    "name": force_str(self.opts.verbose_name),
+                    "key": escape(object_id),
+                }
+            )
+
+        site = page.site
+        language = request.GET.get("language") or get_site_language_from_request(request, site_id=site.pk)
+
+        descendants = page.get_descendant_pages().prefetch_related(
+            Prefetch(
+                "pagecontent_set",
+                to_attr="filtered_translations",
+                queryset=PageContent.admin_manager.get_queryset().latest_content(),
+            ),
+        )
+
+        page_content = page.get_admin_content(language)
+
+        descendant_list = []
+        for descendant in descendants:
+            desc_content = descendant.get_admin_content(language)
+            if desc_content:
+                descendant_list.append({
+                    "id": descendant.pk,
+                    "title": desc_content.title or descendant.get_slug(language) or _("Untitled"),
+                    "url": descendant.get_absolute_url(language=language) if desc_content.get_absolute_url(language=language) else None,
+                    "indicator": desc_content.content_indicator(),
+                    "depth": descendant.depth - page.depth,
+                })
+
+        response_data = {
+            "page_id": page.pk,
+            "page_title": page_content.title if page_content else page.get_slug(language) or _("Untitled"),
+            "language": language,
+            "descendants": descendant_list,
+            "has_descendants": len(descendant_list) > 0,
+        }
+
+        return HttpResponse(
+            json.dumps(response_data, ensure_ascii=False),
+            content_type="application/json",
+        )
 
     def get_list(self, request):
         """
@@ -808,6 +866,7 @@ class PageContentAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
             pat(r"^([0-9]+)/copy-language/$", self.copy_language),
             pat(r"^([0-9]+)/change-navigation/$", self.change_innavigation),
             pat(r"^([0-9]+)/change-template/$", self.change_template),
+            pat(r"^([0-9]+)/get-descendants-for-publish/$", self.get_descendants_for_publish),
         ]
         return url_patterns + super().get_urls()
 
@@ -1394,6 +1453,56 @@ class PageContentAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
         else:
             for page in root_pages:
                 yield render_page_row(page)
+
+    def get_descendants_for_publish(self, request, object_id):
+        """
+        Get all descendant pages for a given page content, used in publish confirmation dialog.
+        Returns JSON data with descendant pages list.
+        """
+        page_content = self.get_object(request, object_id=object_id)
+
+        if not self.has_change_permission(request, obj=page_content):
+            return HttpResponseForbidden(_("You do not have permission to publish this page"))
+
+        if page_content is None:
+            raise self._get_404_exception(object_id)
+
+        page = page_content.page
+        language = page_content.language
+        site = page.site
+
+        descendants = page.get_descendant_pages().prefetch_related(
+            Prefetch(
+                "pagecontent_set",
+                to_attr="filtered_translations",
+                queryset=PageContent.admin_manager.get_queryset().latest_content(),
+            ),
+        )
+
+        descendant_list = []
+        for descendant in descendants:
+            desc_content = descendant.get_admin_content(language)
+            if desc_content:
+                descendant_list.append({
+                    "id": descendant.pk,
+                    "title": desc_content.title or descendant.get_slug(language) or _("Untitled"),
+                    "url": descendant.get_absolute_url(language=language) if desc_content.get_absolute_url(language=language) else None,
+                    "indicator": desc_content.content_indicator(),
+                    "depth": descendant.depth - page.depth,
+                })
+
+        response_data = {
+            "page_id": page.pk,
+            "page_title": page_content.title or page.get_slug(language) or _("Untitled"),
+            "language": language,
+            "descendants": descendant_list,
+            "has_descendants": len(descendant_list) > 0,
+        }
+
+        return HttpResponse(
+            json.dumps(response_data, ensure_ascii=False),
+            content_type="application/json",
+        )
 
     # Indicators in the page tree
     @property

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -134,6 +134,44 @@ class PageDeleteMessageMixin:
         return to_delete, model_count, perms_needed, protected
 
 
+def _get_descendants_for_publish_helper(page, language):
+    """
+    Helper function to get all descendant pages for a given page and language.
+    Returns a dictionary with page info and descendant pages list.
+    """
+    descendants = page.get_descendant_pages().prefetch_related(
+        Prefetch(
+            "pagecontent_set",
+            to_attr="filtered_translations",
+            queryset=PageContent.admin_manager.get_queryset().latest_content(),
+        ),
+    )
+
+    page_content = page.get_admin_content(language)
+
+    descendant_list = []
+    for descendant in descendants:
+        desc_content = descendant.get_admin_content(language)
+        if desc_content:
+            descendant_list.append({
+                "id": descendant.pk,
+                "title": desc_content.title or descendant.get_slug(language) or _("Untitled"),
+                "url": descendant.get_absolute_url(language=language) if descendant.get_absolute_url(language=language) else None,
+                "indicator": desc_content.content_indicator(),
+                "depth": descendant.depth - page.depth,
+            })
+
+    response_data = {
+        "page_id": page.pk,
+        "page_title": page_content.title if page_content else page.get_slug(language) or _("Untitled"),
+        "language": language,
+        "descendants": descendant_list,
+        "has_descendants": len(descendant_list) > 0,
+    }
+
+    return response_data
+
+
 @admin.register(Page)
 class PageAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
     actions_menu_template = "admin/cms/page/tree/actions_dropdown.html"
@@ -378,35 +416,7 @@ class PageAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
         site = page.site
         language = request.GET.get("language") or get_site_language_from_request(request, site_id=site.pk)
 
-        descendants = page.get_descendant_pages().prefetch_related(
-            Prefetch(
-                "pagecontent_set",
-                to_attr="filtered_translations",
-                queryset=PageContent.admin_manager.get_queryset().latest_content(),
-            ),
-        )
-
-        page_content = page.get_admin_content(language)
-
-        descendant_list = []
-        for descendant in descendants:
-            desc_content = descendant.get_admin_content(language)
-            if desc_content:
-                descendant_list.append({
-                    "id": descendant.pk,
-                    "title": desc_content.title or descendant.get_slug(language) or _("Untitled"),
-                    "url": descendant.get_absolute_url(language=language) if desc_content.get_absolute_url(language=language) else None,
-                    "indicator": desc_content.content_indicator(),
-                    "depth": descendant.depth - page.depth,
-                })
-
-        response_data = {
-            "page_id": page.pk,
-            "page_title": page_content.title if page_content else page.get_slug(language) or _("Untitled"),
-            "language": language,
-            "descendants": descendant_list,
-            "has_descendants": len(descendant_list) > 0,
-        }
+        response_data = _get_descendants_for_publish_helper(page, language)
 
         return HttpResponse(
             json.dumps(response_data, ensure_ascii=False),
@@ -1469,35 +1479,8 @@ class PageContentAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
 
         page = page_content.page
         language = page_content.language
-        site = page.site
 
-        descendants = page.get_descendant_pages().prefetch_related(
-            Prefetch(
-                "pagecontent_set",
-                to_attr="filtered_translations",
-                queryset=PageContent.admin_manager.get_queryset().latest_content(),
-            ),
-        )
-
-        descendant_list = []
-        for descendant in descendants:
-            desc_content = descendant.get_admin_content(language)
-            if desc_content:
-                descendant_list.append({
-                    "id": descendant.pk,
-                    "title": desc_content.title or descendant.get_slug(language) or _("Untitled"),
-                    "url": descendant.get_absolute_url(language=language) if desc_content.get_absolute_url(language=language) else None,
-                    "indicator": desc_content.content_indicator(),
-                    "depth": descendant.depth - page.depth,
-                })
-
-        response_data = {
-            "page_id": page.pk,
-            "page_title": page_content.title or page.get_slug(language) or _("Untitled"),
-            "language": language,
-            "descendants": descendant_list,
-            "has_descendants": len(descendant_list) > 0,
-        }
+        response_data = _get_descendants_for_publish_helper(page, language)
 
         return HttpResponse(
             json.dumps(response_data, ensure_ascii=False),

--- a/cms/static/cms/js/modules/cms.publishconfirmation.js
+++ b/cms/static/cms/js/modules/cms.publishconfirmation.js
@@ -22,11 +22,16 @@ class PublishConfirmation {
             pageId: null,
             pageContentId: null,
             language: null,
+            debug: false,
         }, options);
 
         this.click = 'click.cms.publishconfirmation';
         this._setupUI();
         this._events();
+        
+        if (this.options.debug) {
+            console.log('[PublishConfirmation] Initialized with selector:', this.options.publishBtnSelector);
+        }
     }
 
     /**
@@ -51,7 +56,16 @@ class PublishConfirmation {
         this.ui.document.on(this.click, this.options.publishBtnSelector, function(e) {
             var btn = $(this);
             
+            if (that.options.debug) {
+                console.log('[PublishConfirmation] Button clicked:', btn);
+                console.log('[PublishConfirmation] Button href:', btn.attr('href'));
+                console.log('[PublishConfirmation] Button classes:', btn.attr('class'));
+            }
+            
             if (btn.hasClass('cms-btn-disabled')) {
+                if (that.options.debug) {
+                    console.log('[PublishConfirmation] Button is disabled, skipping');
+                }
                 return false;
             }
 
@@ -60,6 +74,10 @@ class PublishConfirmation {
             
             that._handlePublishClick(btn);
         });
+
+        if (this.options.debug) {
+            console.log('[PublishConfirmation] Events bound to document for selector:', this.options.publishBtnSelector);
+        }
     }
 
     /**
@@ -72,12 +90,28 @@ class PublishConfirmation {
         var that = this;
         var pageInfo = this._extractPageInfo(btn);
         
+        if (this.options.debug) {
+            console.log('[PublishConfirmation] Extracted page info:', pageInfo);
+        }
+        
         if (!pageInfo.pageId && !pageInfo.pageContentId && !pageInfo.apiUrl) {
             this._showError(_('Missing page information for publish confirmation'));
+            if (this.options.debug) {
+                console.error('[PublishConfirmation] Missing page information');
+            }
             return;
         }
 
         var apiUrl = pageInfo.apiUrl || this._buildApiUrl(pageInfo);
+        
+        if (this.options.debug) {
+            console.log('[PublishConfirmation] API URL:', apiUrl);
+        }
+
+        if (!apiUrl) {
+            this._showError(_('Could not build API URL for publish confirmation'));
+            return;
+        }
 
         showLoader();
         
@@ -88,10 +122,16 @@ class PublishConfirmation {
         })
         .done(function(response) {
             hideLoader();
+            if (that.options.debug) {
+                console.log('[PublishConfirmation] API response:', response);
+            }
             that._showConfirmationDialog(response, btn);
         })
         .fail(function(jqXHR) {
             hideLoader();
+            if (that.options.debug) {
+                console.error('[PublishConfirmation] API request failed:', jqXHR);
+            }
             CMS.API.Messages.open({
                 message: jqXHR.responseText + ' | ' + jqXHR.status + ' ' + jqXHR.statusText,
                 error: true
@@ -112,28 +152,39 @@ class PublishConfirmation {
             pageContentId: this.options.pageContentId || btn.data('page-content-id'),
             apiUrl: this.options.apiUrl || btn.data('api-url'),
             language: this.options.language || btn.data('language'),
+            adminBase: null,
         };
 
-        if (!pageInfo.pageId && !pageInfo.pageContentId) {
-            var urlInfo = this._extractFromUrl(btn.attr('href'));
-            if (urlInfo.pageId) {
+        var btnHref = btn.attr('href');
+        if (btnHref && btnHref !== '#') {
+            var urlInfo = this._extractFromUrl(btnHref);
+            if (urlInfo.pageId && !pageInfo.pageId) {
                 pageInfo.pageId = urlInfo.pageId;
+            }
+            if (urlInfo.pageContentId && !pageInfo.pageContentId) {
+                pageInfo.pageContentId = urlInfo.pageContentId;
             }
             if (urlInfo.language && !pageInfo.language) {
                 pageInfo.language = urlInfo.language;
+            }
+            if (urlInfo.adminBase) {
+                pageInfo.adminBase = urlInfo.adminBase;
             }
         }
 
         if (!pageInfo.pageId && !pageInfo.pageContentId) {
             var currentUrlInfo = this._extractFromUrl(window.location.pathname);
-            if (currentUrlInfo.pageId) {
+            if (currentUrlInfo.pageId && !pageInfo.pageId) {
                 pageInfo.pageId = currentUrlInfo.pageId;
             }
-            if (currentUrlInfo.pageContentId) {
+            if (currentUrlInfo.pageContentId && !pageInfo.pageContentId) {
                 pageInfo.pageContentId = currentUrlInfo.pageContentId;
             }
             if (currentUrlInfo.language && !pageInfo.language) {
                 pageInfo.language = currentUrlInfo.language;
+            }
+            if (currentUrlInfo.adminBase && !pageInfo.adminBase) {
+                pageInfo.adminBase = currentUrlInfo.adminBase;
             }
         }
 
@@ -141,10 +192,10 @@ class PublishConfirmation {
     }
 
     /**
-     * Extract page ID and language from URL
+     * Extract page ID, language, and admin base from URL
      * URL patterns:
-     * - /en/admin/cms/page/33/en/publish/  -> pageId: 33, language: en
-     * - /admin/cms/pagecontent/123/change/ -> pageContentId: 123
+     * - /en/admin/cms/page/33/en/publish/  -> pageId: 33, language: en (after page ID), adminBase: /en/admin/
+     * - /admin/cms/pagecontent/123/change/ -> pageContentId: 123, adminBase: /admin/
      * @method _extractFromUrl
      * @private
      * @param {String} url
@@ -155,10 +206,16 @@ class PublishConfirmation {
             pageId: null,
             pageContentId: null,
             language: null,
+            adminBase: null,
         };
 
         if (!url) {
             return result;
+        }
+
+        var adminMatch = url.match(/^(.+\/admin\/)/);
+        if (adminMatch) {
+            result.adminBase = adminMatch[1];
         }
 
         var pageContentMatch = url.match(/\/pagecontent\/(\d+)/);
@@ -169,13 +226,21 @@ class PublishConfirmation {
         var pageMatch = url.match(/\/page\/(\d+)/);
         if (pageMatch) {
             result.pageId = parseInt(pageMatch[1], 10);
+            
+            var afterPageId = url.substring(url.indexOf('/page/' + result.pageId) + ('/page/' + result.pageId).length);
+            var langAfterPageMatch = afterPageId.match(/^\/([a-z]{2}(-[a-z]{2})?)\//);
+            if (langAfterPageMatch) {
+                result.language = langAfterPageMatch[1].toLowerCase();
+            }
         }
 
-        var langMatch = url.match(/\/([a-z]{2}(-[a-z]{2})?)\//);
-        if (langMatch && langMatch[1].length >= 2) {
-            var lang = langMatch[1].toLowerCase();
-            if (lang !== 'admin' && lang !== 'cms') {
-                result.language = lang;
+        if (!result.language) {
+            var langMatch = url.match(/\/([a-z]{2}(-[a-z]{2})?)\//);
+            if (langMatch && langMatch[1].length >= 2) {
+                var lang = langMatch[1].toLowerCase();
+                if (lang !== 'admin' && lang !== 'cms') {
+                    result.language = lang;
+                }
             }
         }
 
@@ -190,9 +255,15 @@ class PublishConfirmation {
      * @returns {String}
      */
     _buildApiUrl(pageInfo) {
-        var baseUrl = window.location.pathname;
-        var adminMatch = baseUrl.match(/^(.+\/admin\/)/);
-        var adminBase = adminMatch ? adminMatch[1] : '/admin/';
+        var adminBase;
+        
+        if (pageInfo.adminBase) {
+            adminBase = pageInfo.adminBase;
+        } else {
+            var baseUrl = window.location.pathname;
+            var adminMatch = baseUrl.match(/^(.+\/admin\/)/);
+            adminBase = adminMatch ? adminMatch[1] : '/admin/';
+        }
         
         var apiUrl;
 
@@ -353,6 +424,11 @@ class PublishConfirmation {
         var originalHref = originalBtn.attr('href');
         var originalOnClick = originalBtn.attr('onclick');
         var hasDataRel = originalBtn.data('rel');
+
+        if (this.options.debug) {
+            console.log('[PublishConfirmation] Executing publish with selected IDs:', selectedDescendantIds);
+            console.log('[PublishConfirmation] Original href:', originalHref);
+        }
 
         if (selectedDescendantIds.length > 0) {
             var publishUrl = this._appendDescendantsToUrl(originalHref, selectedDescendantIds);

--- a/cms/static/cms/js/modules/cms.publishconfirmation.js
+++ b/cms/static/cms/js/modules/cms.publishconfirmation.js
@@ -1,0 +1,471 @@
+/*
+ * Copyright https://github.com/divio/django-cms
+ */
+
+import $ from 'jquery';
+import Modal from './cms.modal';
+import { showLoader, hideLoader } from './loader';
+import { Helpers } from './cms.base';
+
+/**
+ * Publish confirmation dialog for pages with descendant selection.
+ *
+ * @class PublishConfirmation
+ * @namespace CMS
+ */
+class PublishConfirmation {
+    constructor(options) {
+        this.options = $.extend(true, {}, {
+            publishBtnSelector: '.cms-btn-publish, .cms-publish-page, [data-action="publish"]',
+            confirmTemplate: null,
+            apiUrl: null,
+            pageId: null,
+            pageContentId: null,
+            language: null,
+        }, options);
+
+        this.click = 'click.cms.publishconfirmation';
+        this._setupUI();
+        this._events();
+    }
+
+    /**
+     * @method _setupUI
+     * @private
+     */
+    _setupUI() {
+        this.ui = {
+            document: $(document),
+            window: $(window),
+            body: $('html'),
+        };
+    }
+
+    /**
+     * @method _events
+     * @private
+     */
+    _events() {
+        var that = this;
+
+        this.ui.document.on(this.click, this.options.publishBtnSelector, function(e) {
+            var btn = $(this);
+            
+            if (btn.hasClass('cms-btn-disabled')) {
+                return false;
+            }
+
+            e.preventDefault();
+            e.stopImmediatePropagation();
+            
+            that._handlePublishClick(btn);
+        });
+    }
+
+    /**
+     * Handle publish button click
+     * @method _handlePublishClick
+     * @private
+     * @param {jQuery} btn The publish button element
+     */
+    _handlePublishClick(btn) {
+        var that = this;
+        var pageInfo = this._extractPageInfo(btn);
+        
+        if (!pageInfo.pageId && !pageInfo.pageContentId && !pageInfo.apiUrl) {
+            this._showError(_('Missing page information for publish confirmation'));
+            return;
+        }
+
+        var apiUrl = pageInfo.apiUrl || this._buildApiUrl(pageInfo);
+
+        showLoader();
+        
+        $.ajax({
+            url: apiUrl,
+            method: 'GET',
+            dataType: 'json',
+        })
+        .done(function(response) {
+            hideLoader();
+            that._showConfirmationDialog(response, btn);
+        })
+        .fail(function(jqXHR) {
+            hideLoader();
+            CMS.API.Messages.open({
+                message: jqXHR.responseText + ' | ' + jqXHR.status + ' ' + jqXHR.statusText,
+                error: true
+            });
+        });
+    }
+
+    /**
+     * Extract page information from button or current context
+     * @method _extractPageInfo
+     * @private
+     * @param {jQuery} btn
+     * @returns {Object}
+     */
+    _extractPageInfo(btn) {
+        var pageInfo = {
+            pageId: this.options.pageId || btn.data('page-id'),
+            pageContentId: this.options.pageContentId || btn.data('page-content-id'),
+            apiUrl: this.options.apiUrl || btn.data('api-url'),
+            language: this.options.language || btn.data('language'),
+        };
+
+        if (!pageInfo.pageId && !pageInfo.pageContentId) {
+            var urlInfo = this._extractFromUrl(btn.attr('href'));
+            if (urlInfo.pageId) {
+                pageInfo.pageId = urlInfo.pageId;
+            }
+            if (urlInfo.language && !pageInfo.language) {
+                pageInfo.language = urlInfo.language;
+            }
+        }
+
+        if (!pageInfo.pageId && !pageInfo.pageContentId) {
+            var currentUrlInfo = this._extractFromUrl(window.location.pathname);
+            if (currentUrlInfo.pageId) {
+                pageInfo.pageId = currentUrlInfo.pageId;
+            }
+            if (currentUrlInfo.pageContentId) {
+                pageInfo.pageContentId = currentUrlInfo.pageContentId;
+            }
+            if (currentUrlInfo.language && !pageInfo.language) {
+                pageInfo.language = currentUrlInfo.language;
+            }
+        }
+
+        return pageInfo;
+    }
+
+    /**
+     * Extract page ID and language from URL
+     * URL patterns:
+     * - /en/admin/cms/page/33/en/publish/  -> pageId: 33, language: en
+     * - /admin/cms/pagecontent/123/change/ -> pageContentId: 123
+     * @method _extractFromUrl
+     * @private
+     * @param {String} url
+     * @returns {Object}
+     */
+    _extractFromUrl(url) {
+        var result = {
+            pageId: null,
+            pageContentId: null,
+            language: null,
+        };
+
+        if (!url) {
+            return result;
+        }
+
+        var pageContentMatch = url.match(/\/pagecontent\/(\d+)/);
+        if (pageContentMatch) {
+            result.pageContentId = parseInt(pageContentMatch[1], 10);
+        }
+
+        var pageMatch = url.match(/\/page\/(\d+)/);
+        if (pageMatch) {
+            result.pageId = parseInt(pageMatch[1], 10);
+        }
+
+        var langMatch = url.match(/\/([a-z]{2}(-[a-z]{2})?)\//);
+        if (langMatch && langMatch[1].length >= 2) {
+            var lang = langMatch[1].toLowerCase();
+            if (lang !== 'admin' && lang !== 'cms') {
+                result.language = lang;
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Build API URL from page information
+     * @method _buildApiUrl
+     * @private
+     * @param {Object} pageInfo
+     * @returns {String}
+     */
+    _buildApiUrl(pageInfo) {
+        var baseUrl = window.location.pathname;
+        var adminMatch = baseUrl.match(/^(.+\/admin\/)/);
+        var adminBase = adminMatch ? adminMatch[1] : '/admin/';
+        
+        var apiUrl;
+
+        if (pageInfo.pageContentId) {
+            apiUrl = adminBase + 'cms/pagecontent/' + pageInfo.pageContentId + '/get-descendants-for-publish/';
+        } else if (pageInfo.pageId) {
+            apiUrl = adminBase + 'cms/page/' + pageInfo.pageId + '/get-descendants-for-publish/';
+        } else {
+            return null;
+        }
+
+        if (pageInfo.language) {
+            var separator = apiUrl.indexOf('?') === -1 ? '?' : '&';
+            apiUrl += separator + 'language=' + encodeURIComponent(pageInfo.language);
+        }
+
+        return apiUrl;
+    }
+
+    /**
+     * Show confirmation dialog with descendant selection
+     * @method _showConfirmationDialog
+     * @private
+     * @param {Object} data The API response data
+     * @param {jQuery} originalBtn The original publish button
+     */
+    _showConfirmationDialog(data, originalBtn) {
+        var that = this;
+        var modal = new Modal({
+            onClose: function() {
+                that._cleanup();
+            }
+        });
+
+        var dialogHtml = this._renderDialog(data);
+
+        modal.open({
+            html: dialogHtml,
+            title: _('Publish Confirmation'),
+            width: 600,
+            height: 500,
+        });
+
+        this._bindDialogEvents(modal, data, originalBtn);
+    }
+
+    /**
+     * Render dialog HTML
+     * @method _renderDialog
+     * @private
+     * @param {Object} data
+     * @returns {String}
+     */
+    _renderDialog(data) {
+        var that = this;
+        var html = '<div class="cms-publish-confirmation">';
+        
+        html += '<div class="cms-publish-confirmation-header" style="padding: 20px; border-bottom: 1px solid var(--border-color);">';
+        html += '<h3 style="margin: 0 0 10px 0; font-size: 18px;">' + _('Publish Confirmation') + '</h3>';
+        html += '<p style="margin: 0;">' + _('Publishing page:') + ' <strong>' + this._escapeHtml(data.page_title) + '</strong></p>';
+        html += '</div>';
+
+        if (data.has_descendants && data.descendants && data.descendants.length > 0) {
+            html += '<div class="cms-publish-confirmation-descendants" style="padding: 20px; max-height: 300px; overflow-y: auto;">';
+            html += '<h4 style="margin: 0 0 15px 0; font-size: 14px;">' + _('Select child pages to publish (optional):') + '</h4>';
+            
+            html += '<div class="cms-publish-confirmation-select-all" style="margin-bottom: 15px; padding-bottom: 10px; border-bottom: 1px solid var(--border-color);">';
+            html += '<label style="cursor: pointer; display: inline-flex; align-items: center; gap: 8px;">';
+            html += '<input type="checkbox" id="id_select_all_descendants" class="js-cms-publish-select-all" style="cursor: pointer;">';
+            html += '<span>' + _('Select all') + '</span>';
+            html += '</label>';
+            html += '</div>';
+
+            html += '<ul class="cms-publish-confirmation-list" style="list-style: none; margin: 0; padding: 0;">';
+            
+            data.descendants.forEach(function(descendant) {
+                var indentStyle = descendant.depth > 1 ? 'padding-left: ' + (descendant.depth * 20) + 'px;' : '';
+                var indicatorClass = descendant.indicator ? 'cms-pagetree-node-state cms-pagetree-node-state-' + descendant.indicator : '';
+                
+                html += '<li class="cms-publish-confirmation-item" style="' + indentStyle + 'margin-bottom: 8px;">';
+                html += '<label style="cursor: pointer; display: inline-flex; align-items: center; gap: 8px;">';
+                html += '<input type="checkbox" name="descendant_ids" value="' + descendant.id + '" class="js-cms-publish-descendant-checkbox" style="cursor: pointer;" data-indicator="' + (descendant.indicator || '') + '">';
+                html += '<span class="cms-publish-confirmation-title" style="flex: 1;">' + that._escapeHtml(descendant.title) + '</span>';
+                if (indicatorClass) {
+                    html += '<span class="cms-publish-confirmation-indicator ' + indicatorClass + '" style="display: inline-block; width: 12px; height: 12px; border-radius: 50%;"></span>';
+                }
+                html += '</label>';
+                html += '</li>';
+            });
+            
+            html += '</ul>';
+            html += '</div>';
+        } else {
+            html += '<div class="cms-publish-confirmation-no-descendants" style="padding: 40px 20px; text-align: center; color: var(--body-quiet-color);">';
+            html += '<p style="margin: 0;">' + _('This page has no child pages.') + '</p>';
+            html += '</div>';
+        }
+
+        html += '<div class="cms-publish-confirmation-footer" style="padding: 20px; border-top: 1px solid var(--border-color); display: flex; gap: 10px; justify-content: flex-end;">';
+        html += '<button type="button" class="cms-btn cms-btn-action js-cms-publish-confirm" style="padding: 8px 16px; cursor: pointer;">' + _('Confirm Publish') + '</button>';
+        html += '<button type="button" class="cms-btn js-cms-publish-cancel" style="padding: 8px 16px; cursor: pointer;">' + _('Cancel') + '</button>';
+        html += '</div>';
+
+        html += '</div>';
+        
+        return html;
+    }
+
+    /**
+     * Bind dialog events
+     * @method _bindDialogEvents
+     * @private
+     * @param {Modal} modal
+     * @param {Object} data
+     * @param {jQuery} originalBtn
+     */
+    _bindDialogEvents(modal, data, originalBtn) {
+        var that = this;
+        var $modal = modal.ui.modal;
+
+        $modal.on(this.click, '.js-cms-publish-select-all', function() {
+            var isChecked = $(this).prop('checked');
+            $modal.find('.js-cms-publish-descendant-checkbox').prop('checked', isChecked);
+        });
+
+        $modal.on(this.click, '.js-cms-publish-descendant-checkbox', function() {
+            var allChecked = $modal.find('.js-cms-publish-descendant-checkbox').length === 
+                              $modal.find('.js-cms-publish-descendant-checkbox:checked').length;
+            $modal.find('.js-cms-publish-select-all').prop('checked', allChecked);
+        });
+
+        $modal.on(this.click, '.js-cms-publish-cancel', function() {
+            modal.close();
+        });
+
+        $modal.on(this.click, '.js-cms-publish-confirm', function() {
+            var selectedIds = [];
+            $modal.find('.js-cms-publish-descendant-checkbox:checked').each(function() {
+                selectedIds.push(parseInt($(this).val(), 10));
+            });
+
+            that._executePublish(modal, data, originalBtn, selectedIds);
+        });
+    }
+
+    /**
+     * Execute the actual publish operation
+     * @method _executePublish
+     * @private
+     * @param {Modal} modal
+     * @param {Object} data
+     * @param {jQuery} originalBtn
+     * @param {Array} selectedDescendantIds
+     */
+    _executePublish(modal, data, originalBtn, selectedDescendantIds) {
+        modal.close();
+
+        var originalHref = originalBtn.attr('href');
+        var originalOnClick = originalBtn.attr('onclick');
+        var hasDataRel = originalBtn.data('rel');
+
+        if (selectedDescendantIds.length > 0) {
+            var publishUrl = this._appendDescendantsToUrl(originalHref, selectedDescendantIds);
+            originalBtn.attr('href', publishUrl);
+        }
+
+        if (hasDataRel === 'ajax') {
+            var postData = originalBtn.data('post') || {};
+            if (selectedDescendantIds.length > 0) {
+                postData.descendant_ids = selectedDescendantIds;
+            }
+            originalBtn.data('post', postData);
+            
+            CMS.API.Toolbar._delegate(originalBtn);
+        } else if (originalHref && originalHref !== '#') {
+            Helpers._getWindow().location.href = originalBtn.attr('href');
+        } else if (originalOnClick) {
+            originalBtn[0].click();
+        } else if (originalBtn.hasClass('cms-form-post-method')) {
+            this._submitWithPostMethod(originalBtn, selectedDescendantIds);
+        }
+    }
+
+    /**
+     * Append descendant IDs to URL
+     * @method _appendDescendantsToUrl
+     * @private
+     * @param {String} url
+     * @param {Array} descendantIds
+     * @returns {String}
+     */
+    _appendDescendantsToUrl(url, descendantIds) {
+        if (!url || descendantIds.length === 0) {
+            return url;
+        }
+
+        var separator = url.indexOf('?') === -1 ? '?' : '&';
+        var queryString = descendantIds.map(function(id) {
+            return 'descendant_ids=' + id;
+        }).join('&');
+
+        return url + separator + queryString;
+    }
+
+    /**
+     * Submit using form post method
+     * @method _submitWithPostMethod
+     * @private
+     * @param {jQuery} btn
+     * @param {Array} descendantIds
+     */
+    _submitWithPostMethod(btn, descendantIds) {
+        var formToken = document.querySelector('form input[name="csrfmiddlewaretoken"]');
+        var csrfToken = ((formToken ? formToken.value : formToken) || window.CMS.config.csrf);
+        
+        var hiddenFields = '';
+        if (descendantIds.length > 0) {
+            descendantIds.forEach(function(id) {
+                hiddenFields += '<input type="hidden" name="descendant_ids" value="' + id + '">';
+            });
+        }
+
+        var fakeForm = $(
+            '<form style="display: none" action="' + btn.attr('href') + '" method="POST">' +
+            '<input type="hidden" name="csrfmiddlewaretoken" value="' + csrfToken + '">' +
+            hiddenFields +
+            '</form>'
+        );
+
+        fakeForm.appendTo(Helpers._getWindow().document.body).submit();
+    }
+
+    /**
+     * Show error message
+     * @method _showError
+     * @private
+     * @param {String} message
+     */
+    _showError(message) {
+        CMS.API.Messages.open({
+            message: message,
+            error: true
+        });
+    }
+
+    /**
+     * Escape HTML
+     * @method _escapeHtml
+     * @private
+     * @param {String} text
+     * @returns {String}
+     */
+    _escapeHtml(text) {
+        if (!text) {
+            return '';
+        }
+        var div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    /**
+     * Cleanup
+     * @method _cleanup
+     * @private
+     */
+    _cleanup() {
+        this.ui.modal = null;
+    }
+}
+
+PublishConfirmation.options = {
+    publishBtnSelector: '.cms-btn-publish, .cms-publish-page, [data-action="publish"]',
+};
+
+export default PublishConfirmation;

--- a/cms/static/cms/js/toolbar.js
+++ b/cms/static/cms/js/toolbar.js
@@ -18,6 +18,7 @@ import Plugin from './modules/cms.plugins';
 import StructureBoard from './modules/cms.structureboard';
 import Toolbar from './modules/cms.toolbar';
 import Tooltip from './modules/cms.tooltip';
+import PublishConfirmation from './modules/cms.publishconfirmation';
 
 // CMS by this time should be a global that has `_plugins` property
 const CMS = window.CMS || {};
@@ -33,6 +34,7 @@ CMS.Plugin = Plugin;
 CMS.StructureBoard = StructureBoard;
 CMS.Toolbar = Toolbar;
 CMS.Tooltip = Tooltip;
+CMS.PublishConfirmation = PublishConfirmation;
 
 CMS.API = {
     Helpers
@@ -63,6 +65,7 @@ CMS.$(function () {
     CMS.API.Tooltip = new CMS.Tooltip();
     CMS.API.Toolbar = new CMS.Toolbar();
     CMS.API.Sideframe = new CMS.Sideframe();
+    CMS.API.PublishConfirmation = new CMS.PublishConfirmation();
 
     CMS.Plugin._initializeTree();
 });

--- a/cms/templates/admin/cms/page/publish_confirmation.html
+++ b/cms/templates/admin/cms/page/publish_confirmation.html
@@ -1,0 +1,51 @@
+{% load i18n %}
+<div class="cms-publish-confirmation">
+    <div class="cms-publish-confirmation-header">
+        <h3>{% trans "Publish Confirmation" %}</h3>
+        <p class="cms-publish-confirmation-page">
+            {% trans "Publishing page:" %} <strong>{{ page_title }}</strong>
+        </p>
+    </div>
+
+    {% if has_descendants %}
+    <div class="cms-publish-confirmation-descendants">
+        <h4>{% trans "Select child pages to publish (optional):" %}</h4>
+        <div class="cms-publish-confirmation-select-all">
+            <label>
+                <input type="checkbox" id="id_select_all_descendants" class="js-cms-publish-select-all">
+                {% trans "Select all" %}
+            </label>
+        </div>
+        <ul class="cms-publish-confirmation-list">
+            {% for descendant in descendants %}
+            <li class="cms-publish-confirmation-item{% if descendant.depth > 1 %} cms-publish-confirmation-item-indent-{{ descendant.depth }}{% endif %}">
+                <label>
+                    <input type="checkbox" 
+                           name="descendant_ids" 
+                           value="{{ descendant.id }}" 
+                           class="js-cms-publish-descendant-checkbox"
+                           data-indicator="{{ descendant.indicator }}">
+                    <span class="cms-publish-confirmation-title">{{ descendant.title }}</span>
+                    {% if descendant.indicator %}
+                    <span class="cms-publish-confirmation-indicator cms-pagetree-node-state cms-pagetree-node-state-{{ descendant.indicator }}"></span>
+                    {% endif %}
+                </label>
+            </li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% else %}
+    <div class="cms-publish-confirmation-no-descendants">
+        <p>{% trans "This page has no child pages." %}</p>
+    </div>
+    {% endif %}
+
+    <div class="cms-publish-confirmation-footer">
+        <button type="button" class="cms-btn cms-btn-action js-cms-publish-confirm">
+            {% trans "Confirm Publish" %}
+        </button>
+        <button type="button" class="cms-btn js-cms-publish-cancel">
+            {% trans "Cancel" %}
+        </button>
+    </div>
+</div>


### PR DESCRIPTION
refactor(admin): 提取发布确认页面的后代获取逻辑到辅助函数

将重复的后代页面获取逻辑提取到_get_descendants_for_publish_helper函数中，减少代码重复

同时在JS模块中添加调试日志功能，便于排查发布确认相关的问题

## Summary by Sourcery

Introduce a reusable backend helper and frontend module to support a publish confirmation dialog that lets editors select descendant pages to publish together with a page.

New Features:
- Add admin endpoints and a shared helper to return descendant page information for publish confirmation, supporting both page and pagecontent contexts.
- Introduce a JavaScript PublishConfirmation module wired into the CMS toolbar to display a modal where users can select child pages to publish.
- Add a dedicated template for the publish confirmation dialog to present page details and selectable descendants.

Enhancements:
- Refactor descendant-page retrieval logic into a single helper to reduce duplication and centralize behavior for publish workflows.