### PR TITLE
fix: Migrations with a custom user model caused a Programming error (#8606)

### DIFF
--- a/cms/admin/permissionadmin.py
+++ b/cms/admin/permissionadmin.py
@@ -5,7 +5,7 @@ from django.contrib.admin import site
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.sites.models import Site
-from django.db import OperationalError
+from django.db import OperationalError, ProgrammingError
 from django.utils.translation import gettext_lazy as _
 
 from cms.admin.forms import (
@@ -58,12 +58,12 @@ class PagePermissionInlineAdmin(TabularInline):
 
         # Given a fresh django-cms install and a django settings with the
         # CMS_RAW_ID_USERS = CMS_PERMISSION = True
-        # django throws an OperationalError when running
-        # ./manage migrate
-        # because auth_user doesn't exists yet
+        # django throws an OperationalError (sqlite) or ProgrammingError
+        # (postgres) when running ./manage migrate because the user table
+        # doesn't exist yet.
         try:
             threshold = threshold and get_user_model().objects.count() > threshold
-        except OperationalError:
+        except (OperationalError, ProgrammingError):
             threshold = False
 
         return ['user'] if threshold else []
@@ -138,7 +138,7 @@ class GlobalPagePermissionAdmin(admin.ModelAdmin):
         threshold = get_cms_setting('RAW_ID_USERS')
         try:
             threshold = threshold and get_user_model().objects.count() > threshold
-        except OperationalError:
+        except (OperationalError, ProgrammingError):
             threshold = False
         filter_copy = deepcopy(self.list_filter)
         if threshold:
@@ -164,12 +164,12 @@ class GlobalPagePermissionAdmin(admin.ModelAdmin):
 
         # Given a fresh django-cms install and a django settings with the
         # CMS_RAW_ID_USERS = CMS_PERMISSION = True
-        # django throws an OperationalError when running
-        # ./manage migrate
-        # because auth_user doesn't exists yet
+        # django throws an OperationalError (sqlite) or ProgrammingError
+        # (postgres) when running ./manage migrate because the user table
+        # doesn't exist yet.
         try:
             threshold = threshold and get_user_model().objects.count() > threshold
-        except OperationalError:
+        except (OperationalError, ProgrammingError):
             threshold = False
 
         return ['user'] if threshold else []

--- a/cms/tests/test_permissions.py
+++ b/cms/tests/test_permissions.py
@@ -1,6 +1,10 @@
+from unittest.mock import patch
+
 from django.contrib.sites.models import Site
+from django.db import OperationalError, ProgrammingError
 from django.test.utils import override_settings
 
+from cms.admin.permissionadmin import GlobalPagePermissionAdmin, PagePermissionInlineAdmin
 from cms.api import assign_user_to_page, create_page
 from cms.cache.permissions import (
     clear_user_permission_cache,
@@ -104,3 +108,44 @@ class PermissionCacheTests(CMSTestCase):
         # Backwards compatibility: check if the old permission names work
         self.assertTrue(has_page_permission(self.user_normal, page_b, "change"))
         self.assertFalse(has_page_permission(self.user_normal, page_b, "publish"))
+
+@override_settings(CMS_PERMISSION=True, CMS_RAW_ID_USERS=1)
+class PermissionAdminMigrationSafetyTests(CMSTestCase):
+    """
+    Regression tests for the case where the user table does not yet exist
+    (e.g. during ``migrate`` on a fresh install with a custom user model).
+
+    Counting users then raises ``OperationalError`` on sqlite or
+    ``ProgrammingError`` on postgres. Both must be swallowed so that the
+    admin classes can still be imported and registered during migrations.
+    """
+
+    def _patched_user_model(self, exc):
+        class _BrokenManager:
+            def count(self):
+                raise exc
+
+        class _BrokenUserModel:
+            objects = _BrokenManager()
+
+        return patch(
+            'cms.admin.permissionadmin.get_user_model',
+            return_value=_BrokenUserModel,
+        )
+
+    def test_inline_raw_id_fields_swallows_db_errors(self):
+        for exc in (OperationalError("no such table"), ProgrammingError("relation does not exist")):
+            with self.subTest(exc=type(exc).__name__), self._patched_user_model(exc):
+                self.assertEqual(PagePermissionInlineAdmin.raw_id_fields, [])
+
+    def test_global_admin_raw_id_fields_swallows_db_errors(self):
+        for exc in (OperationalError("no such table"), ProgrammingError("relation does not exist")):
+            with self.subTest(exc=type(exc).__name__), self._patched_user_model(exc):
+                self.assertEqual(GlobalPagePermissionAdmin.raw_id_fields, [])
+
+    def test_global_admin_get_list_filter_swallows_db_errors(self):
+        admin_instance = GlobalPagePermissionAdmin(GlobalPagePermission, admin_site=None)
+        for exc in (OperationalError("no such table"), ProgrammingError("relation does not exist")):
+            with self.subTest(exc=type(exc).__name__), self._patched_user_model(exc):
+                # Falls back to the unfiltered list_filter (still includes 'user')
+                self.assertIn('user', admin_instance.get_list_filter(request=None))


### PR DESCRIPTION

## Summary by Sourcery

Handle database errors when checking user counts for permission admin configuration to avoid failures during migrations with a missing user table.

Bug Fixes:
- Prevent migration-time crashes by treating both OperationalError and ProgrammingError as a signal that the user table is not yet available when configuring permission-related admin classes.

Tests:
- Add regression tests ensuring permission admin raw_id_fields and list filters gracefully handle database errors when the user model table does not yet exist.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.
