### PR TITLE
fix: Do not lock whole tree when editing a page

### DIFF
--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -682,8 +682,7 @@ class ChangePageForm(BasePageContentForm):
             **data,
         )
         from cms.models.pagemodel import _lock_tree_roots
-        _lock_tree_roots(page)
-
+ 
         page.update_urls(
             self._language,
             path=page_path,

--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -682,7 +682,7 @@ class ChangePageForm(BasePageContentForm):
             **data,
         )
         from cms.models.pagemodel import _lock_tree_roots
- 
+
         page.update_urls(
             self._language,
             path=page_path,


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent editing a single page from locking all tree roots, limiting locking behavior to the edited page only.

Overlocking introduced with #8610 interferes with versioning 

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8610
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

