### PR TITLE
feat: Extend CMSApp class to provide root template for apphook

### DIFF
--- a/cms/app_base.py
+++ b/cms/app_base.py
@@ -12,6 +12,8 @@ class CMSApp:
     _urls = []
     #: list of menu classes: example: ``_menus = [MyAppMenu]``
     _menus = []
+    #: Root template cache for structure board
+    _root_template = None
     #: Human-readable name of the apphook (required). This name will be displayed
     #: on the admin site.
     name = None
@@ -104,7 +106,7 @@ class CMSApp:
         By default, it returns the urls assigned to :py:attr:`CMSApp._urls`
 
         The method accepts page, language and generic keyword arguments:
-        you can customize this function to return different list of menu classes
+        you can customize this function to return different urlconfs
         according to the given arguments.
 
         This method **must** return a non-empty list of urlconfs,
@@ -115,6 +117,59 @@ class CMSApp:
         :return: list of urlconfs strings
         """
         return self._urls
+
+    def get_root_template(self, page=None, language=None, **kwargs):
+        """
+        .. versionadded:: 5.1
+
+        Returns the template name used by the apphook's root view.
+
+        Best-effort: walks the urlconfs from :meth:`get_urls` to locate the
+        pattern matching the empty path and returns ``template_name`` from its
+        view class (CBVs) or callback (FBVs that expose it). Returns ``None``
+        for views that compute the template dynamically — set
+        :attr:`_root_template` explicitly to override.
+
+        :return: template name or None
+        """
+        if self._root_template is not None:
+            return self._root_template
+
+        from django.urls import URLPattern, URLResolver, get_resolver
+
+        def find_root(patterns):
+            for p in patterns:
+                if p.pattern.match('') is None:
+                    continue
+                if isinstance(p, URLResolver):
+                    inner = find_root(p.url_patterns)
+                    if inner is not None:
+                        return inner
+                elif isinstance(p, URLPattern):
+                    return p
+            return None
+
+        for urlconf in self.get_urls(page=page, language=language, **kwargs):
+            try:
+                resolver = get_resolver(urlconf)
+                pattern = find_root(resolver.url_patterns)
+            except Exception:
+                continue
+            if pattern is None:
+                continue
+            callback = pattern.callback
+            view_class = getattr(callback, 'view_class', None)
+            view_initkwargs = getattr(callback, 'view_initkwargs', None) or {}
+            template = (
+                view_initkwargs.get('template_name')
+                or getattr(view_class, 'template_name', None)
+                or getattr(callback, 'template_name', None)
+            )
+            if template:
+                self._root_template = template
+            return template
+
+        return None
 
 
 class CMSAppConfig:

--- a/cms/app_base.py
+++ b/cms/app_base.py
@@ -12,8 +12,6 @@ class CMSApp:
     _urls = []
     #: list of menu classes: example: ``_menus = [MyAppMenu]``
     _menus = []
-    #: Root template cache for structure board
-    _root_template = None
     #: Human-readable name of the apphook (required). This name will be displayed
     #: on the admin site.
     name = None
@@ -127,14 +125,11 @@ class CMSApp:
         Best-effort: walks the urlconfs from :meth:`get_urls` to locate the
         pattern matching the empty path and returns ``template_name`` from its
         view class (CBVs) or callback (FBVs that expose it). Returns ``None``
-        for views that compute the template dynamically — set
-        :attr:`_root_template` explicitly to override.
+        for views that compute the template dynamically — override this method
+        to return the template name in that case.
 
         :return: template name or None
         """
-        if self._root_template is not None:
-            return self._root_template
-
         from django.urls import URLPattern, URLResolver, get_resolver
 
         def find_root(patterns):
@@ -160,14 +155,11 @@ class CMSApp:
             callback = pattern.callback
             view_class = getattr(callback, 'view_class', None)
             view_initkwargs = getattr(callback, 'view_initkwargs', None) or {}
-            template = (
+            return (
                 view_initkwargs.get('template_name')
                 or getattr(view_class, 'template_name', None)
                 or getattr(callback, 'template_name', None)
             )
-            if template:
-                self._root_template = template
-            return template
 
         return None
 

--- a/cms/models/contentmodels.py
+++ b/cms/models/contentmodels.py
@@ -243,13 +243,28 @@ class PageContent(models.Model):
     def get_template(self):
         """
         get the template of this page if defined or if closer parent if
-        defined or DEFAULT_PAGE_TEMPLATE otherwise
+        defined or DEFAULT_PAGE_TEMPLATE otherwise.
+
+        If the page has an apphook assigned and its root view exposes a
+        template, that template wins — it's what the apphook actually renders
+        at the page URL, so the structure board's placeholder layout must
+        match it.
         """
         if hasattr(self, "_template_cache"):
             return self._template_cache
 
         if not get_cms_setting("TEMPLATES"):
             return ""
+
+        if self.page.application_urls:
+            from cms.apphook_pool import apphook_pool
+
+            apphook = apphook_pool.get_apphook(self.page.application_urls)
+            if apphook is not None:
+                apphook_template = apphook.get_root_template(page=self.page, language=self.language)
+                if apphook_template:
+                    self._template_cache = apphook_template
+                    return self._template_cache
 
         if self.template != constants.TEMPLATE_INHERITANCE_MAGIC:
             self._template_cache = self.template or self.template_choices[0][0]

--- a/cms/models/contentmodels.py
+++ b/cms/models/contentmodels.py
@@ -240,7 +240,7 @@ class PageContent(models.Model):
             self._placeholder_slot_cache = (self._placeholder_slot_cache,)
         return self._placeholder_slot_cache
 
-    def get_template(self):
+    def get_template(self, app_hooks=True):
         """
         get the template of this page if defined or if closer parent if
         defined or DEFAULT_PAGE_TEMPLATE otherwise.
@@ -256,7 +256,7 @@ class PageContent(models.Model):
         if not get_cms_setting("TEMPLATES"):
             return ""
 
-        if self.page.application_urls:
+        if app_hooks and self.page.application_urls:
             from cms.apphook_pool import apphook_pool
 
             apphook = apphook_pool.get_apphook(self.page.application_urls)

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -983,7 +983,7 @@ class Page(MP_Node):
     def get_template(self, language=None, fallback=True, force_reload=False):
         content = self.get_content_obj(language, fallback, force_reload)
         if content:
-            return content.get_template()
+            return content.get_template(app_hooks=False)
         return get_cms_setting("TEMPLATES")[0][0] if get_cms_setting("TEMPLATES") else ""
 
     def get_template_name(self):

--- a/cms/templates/cms/widgets/applicationconfigselect.html
+++ b/cms/templates/cms/widgets/applicationconfigselect.html
@@ -5,6 +5,6 @@
         {{ widget.script_data|json_script }}
     </div>
     <a href="" class="related-widget-wrapper-link add-related" id="add_{{ widget.name }}" title="{% trans 'Add Another' %}">
-        <img src="{% static "/admin/img/icon-addlink.svg" %}" alt="" width="24" height="24">
+        <img src="{% static "admin/img/icon-addlink.svg" %}" alt="" width="24" height="24">
     </a>
 </div>

--- a/cms/tests/test_apphooks.py
+++ b/cms/tests/test_apphooks.py
@@ -1,4 +1,6 @@
 import sys
+import types
+import uuid
 
 from django.apps import apps
 from django.contrib.auth import get_user_model
@@ -9,12 +11,15 @@ from django.core import checks
 from django.core.cache import cache
 from django.core.checks.urls import check_url_config
 from django.http import Http404, HttpResponse
+from django.shortcuts import render
 from django.template import Context, Template
-from django.test import RequestFactory
+from django.template.response import TemplateResponse
+from django.test import RequestFactory, SimpleTestCase
 from django.test.utils import override_settings
-from django.urls import NoReverseMatch, clear_url_caches, resolve, reverse
+from django.urls import NoReverseMatch, clear_url_caches, include, path, resolve, reverse
 from django.utils.timezone import now
 from django.utils.translation import activate, override as force_language
+from django.views.generic import TemplateView
 
 from cms.admin.forms import AdvancedSettingsForm
 from cms.api import create_page, create_page_content
@@ -165,6 +170,36 @@ class ApphooksTestCase(BaseApphooksTestCase):
         self.assertContains(response, '<--noplaceholder-->')
         response = self.client.get('/en/blankapp/')
         self.assertTemplateUsed(response, 'nav_playground.html')
+
+        self.apphook_clear()
+
+    def test_pagecontent_get_template_uses_apphook_root_template(self):
+        """When the apphook exposes a root template, PageContent.get_template
+        returns it instead of the page's own template — so the structure board
+        can show placeholders matching what the apphook actually renders."""
+        self.apphook_clear()
+        superuser = get_user_model().objects.create_superuser('admin', 'admin@admin.com', 'admin')
+        page = create_page(
+            'apphooked-page', 'nav_playground.html', 'en',
+            created_by=superuser, apphook=APP_NAME,
+        )
+        page_content = page.pagecontent_set.get(language='en')
+
+        # SampleApp's root view is a function-based view, so without an
+        # explicit override get_root_template returns None and PageContent
+        # falls back to the page's configured template.
+        self.assertEqual(page_content.get_template(), 'nav_playground.html')
+
+        sample_app = apphook_pool.get_apphook(APP_NAME)
+        sample_app._root_template = 'apphook/from_root_view.html'
+        try:
+            del page_content._template_cache
+            self.assertEqual(
+                page_content.get_template(),
+                'apphook/from_root_view.html',
+            )
+        finally:
+            sample_app._root_template = None
 
         self.apphook_clear()
 
@@ -1303,3 +1338,145 @@ class ApphookFrontendEditingTests(BaseApphooksTestCase):
                 cms_extension.toolbar_enabled_models[Category] = original_renderer
             elif Category in cms_extension.toolbar_enabled_models:
                 del cms_extension.toolbar_enabled_models[Category]
+
+
+def _register_root_template_urlconf(patterns):
+    """Build a unique, throwaway urlconf module so it can be referenced by
+    string path (which is what ``django.urls.get_resolver`` expects)."""
+    name = f'cms.tests._root_template_test_urlconf_{uuid.uuid4().hex}'
+    module = types.ModuleType(name)
+    module.urlpatterns = patterns
+    sys.modules[name] = module
+    return name
+
+
+class GetRootTemplateTests(SimpleTestCase):
+    """Unit tests for :meth:`cms.app_base.CMSApp.get_root_template`."""
+
+    def setUp(self):
+        clear_url_caches()
+
+    def tearDown(self):
+        clear_url_caches()
+
+    def _make_app(self, urlconf):
+        class _App(CMSApp):
+            _urls = [urlconf]
+        return _App()
+
+    def test_class_based_view_with_class_level_template_name(self):
+        class HomeView(TemplateView):
+            template_name = 'apphook/cbv_home.html'
+
+        urlconf = _register_root_template_urlconf([path('', HomeView.as_view())])
+
+        self.assertEqual(
+            self._make_app(urlconf).get_root_template(),
+            'apphook/cbv_home.html',
+        )
+
+    def test_class_based_view_with_template_name_via_as_view_kwargs(self):
+        # ``TemplateView.as_view(template_name=...)`` stashes the template on
+        # ``view_initkwargs``; the lookup must pick it up from there.
+        urlconf = _register_root_template_urlconf([
+            path('', TemplateView.as_view(template_name='apphook/inline.html')),
+        ])
+
+        self.assertEqual(
+            self._make_app(urlconf).get_root_template(),
+            'apphook/inline.html',
+        )
+
+    def test_fbv_returning_template_response_returns_none(self):
+        # The template name lives inside the response, not on the callable.
+        # Without rendering the view, get_root_template can't see it.
+        def home(request):
+            return TemplateResponse(request, 'apphook/fbv_tr.html', {})
+
+        urlconf = _register_root_template_urlconf([path('', home)])
+
+        self.assertIsNone(self._make_app(urlconf).get_root_template())
+
+    def test_fbv_using_render_shortcut_returns_none(self):
+        # ``render()`` returns a plain HttpResponse with the body already
+        # rendered — by the time we'd inspect a response, the template name
+        # is gone.
+        def home(request):
+            return render(request, 'apphook/fbv_render.html')
+
+        urlconf = _register_root_template_urlconf([path('', home)])
+
+        self.assertIsNone(self._make_app(urlconf).get_root_template())
+
+    def test_explicit_root_template_short_circuits_lookup(self):
+        class HomeView(TemplateView):
+            template_name = 'apphook/auto.html'
+
+        urlconf = _register_root_template_urlconf([path('', HomeView.as_view())])
+
+        class _App(CMSApp):
+            _urls = [urlconf]
+            _root_template = 'apphook/manual.html'
+
+        self.assertEqual(_App().get_root_template(), 'apphook/manual.html')
+
+    def test_returns_none_when_no_root_pattern(self):
+        class DetailView(TemplateView):
+            template_name = 'apphook/detail.html'
+
+        urlconf = _register_root_template_urlconf([
+            path('detail/', DetailView.as_view()),
+        ])
+
+        self.assertIsNone(self._make_app(urlconf).get_root_template())
+
+    def test_root_pattern_via_include(self):
+        # ``path('', include(...))`` — the root pattern lives inside the
+        # included urlconf and must still be discovered.
+        class HomeView(TemplateView):
+            template_name = 'apphook/inner_home.html'
+
+        inner = _register_root_template_urlconf([path('', HomeView.as_view())])
+        outer = _register_root_template_urlconf([path('', include(inner))])
+
+        self.assertEqual(
+            self._make_app(outer).get_root_template(),
+            'apphook/inner_home.html',
+        )
+
+    def test_non_root_pattern_template_is_ignored(self):
+        # When the root view doesn't expose a template, we must NOT fall back
+        # to a sibling pattern's template — that would be misleading.
+        def root_fbv(request):
+            return TemplateResponse(request, 'apphook/root.html', {})
+
+        class AboutView(TemplateView):
+            template_name = 'apphook/about.html'
+
+        urlconf = _register_root_template_urlconf([
+            path('', root_fbv),
+            path('about/', AboutView.as_view()),
+        ])
+
+        self.assertIsNone(self._make_app(urlconf).get_root_template())
+
+    def test_inferred_template_is_cached_on_instance(self):
+        class HomeView(TemplateView):
+            template_name = 'apphook/cached.html'
+
+        urlconf = _register_root_template_urlconf([path('', HomeView.as_view())])
+        app = self._make_app(urlconf)
+
+        self.assertEqual(app.get_root_template(), 'apphook/cached.html')
+
+        # If the lookup ran a second time, it would now find no urlconfs and
+        # return None; the cached value should be returned instead.
+        app.get_urls = lambda *args, **kwargs: []
+        self.assertEqual(app.get_root_template(), 'apphook/cached.html')
+
+    def test_invalid_urlconf_string_returns_none(self):
+        # A urlconf that fails to import shouldn't crash the lookup.
+        class _App(CMSApp):
+            _urls = ['cms.tests._does_not_exist_xyz']
+
+        self.assertIsNone(_App().get_root_template())

--- a/cms/tests/test_apphooks.py
+++ b/cms/tests/test_apphooks.py
@@ -185,13 +185,14 @@ class ApphooksTestCase(BaseApphooksTestCase):
         )
         page_content = page.pagecontent_set.get(language='en')
 
-        # SampleApp's root view is a function-based view, so without an
-        # explicit override get_root_template returns None and PageContent
+        # SampleApp's root view is a function-based view, so without a custom
+        # get_root_template override the lookup returns None and PageContent
         # falls back to the page's configured template.
         self.assertEqual(page_content.get_template(), 'nav_playground.html')
 
         sample_app = apphook_pool.get_apphook(APP_NAME)
-        sample_app._root_template = 'apphook/from_root_view.html'
+        original = sample_app.get_root_template
+        sample_app.get_root_template = lambda **kwargs: 'apphook/from_root_view.html'
         try:
             del page_content._template_cache
             self.assertEqual(
@@ -199,7 +200,7 @@ class ApphooksTestCase(BaseApphooksTestCase):
                 'apphook/from_root_view.html',
             )
         finally:
-            sample_app._root_template = None
+            sample_app.get_root_template = original
 
         self.apphook_clear()
 
@@ -1408,15 +1409,14 @@ class GetRootTemplateTests(SimpleTestCase):
 
         self.assertIsNone(self._make_app(urlconf).get_root_template())
 
-    def test_explicit_root_template_short_circuits_lookup(self):
-        class HomeView(TemplateView):
-            template_name = 'apphook/auto.html'
-
-        urlconf = _register_root_template_urlconf([path('', HomeView.as_view())])
-
+    def test_subclass_can_override_get_root_template(self):
+        # The advertised escape hatch when inference doesn't fit: override
+        # the method on the apphook subclass.
         class _App(CMSApp):
-            _urls = [urlconf]
-            _root_template = 'apphook/manual.html'
+            _urls = []
+
+            def get_root_template(self, page=None, language=None, **kwargs):
+                return 'apphook/manual.html'
 
         self.assertEqual(_App().get_root_template(), 'apphook/manual.html')
 
@@ -1460,19 +1460,30 @@ class GetRootTemplateTests(SimpleTestCase):
 
         self.assertIsNone(self._make_app(urlconf).get_root_template())
 
-    def test_inferred_template_is_cached_on_instance(self):
-        class HomeView(TemplateView):
-            template_name = 'apphook/cached.html'
+    def test_inferred_template_is_not_cached(self):
+        # Inferred templates must NOT be cached on the apphook instance:
+        # apphook instances are shared singletons, and apphooks like
+        # VariableUrlsApp return different urlconfs depending on page/language.
+        # Caching the first inferred template would lock it in for every
+        # subsequent (possibly differently-routed) call.
+        class HomeOne(TemplateView):
+            template_name = 'apphook/one.html'
 
-        urlconf = _register_root_template_urlconf([path('', HomeView.as_view())])
-        app = self._make_app(urlconf)
+        class HomeTwo(TemplateView):
+            template_name = 'apphook/two.html'
 
-        self.assertEqual(app.get_root_template(), 'apphook/cached.html')
+        urlconf_one = _register_root_template_urlconf([path('', HomeOne.as_view())])
+        urlconf_two = _register_root_template_urlconf([path('', HomeTwo.as_view())])
 
-        # If the lookup ran a second time, it would now find no urlconfs and
-        # return None; the cached value should be returned instead.
-        app.get_urls = lambda *args, **kwargs: []
-        self.assertEqual(app.get_root_template(), 'apphook/cached.html')
+        urlconfs = iter([urlconf_one, urlconf_two])
+
+        class _App(CMSApp):
+            def get_urls(self, page=None, language=None, **kwargs):
+                return [next(urlconfs)]
+
+        app = _App()
+        self.assertEqual(app.get_root_template(), 'apphook/one.html')
+        self.assertEqual(app.get_root_template(), 'apphook/two.html')
 
     def test_invalid_urlconf_string_returns_none(self):
         # A urlconf that fails to import shouldn't crash the lookup.

--- a/docs/how_to/11-apphooks.rst
+++ b/docs/how_to/11-apphooks.rst
@@ -194,8 +194,8 @@ Telling the structure board which template the root view uses
 .............................................................
 
 When a content editor opens the structure board on an apphooked page, django CMS
-needs to know *which* template the apphook's root view renders should it be different
-to the page's template. This is so it can show the placeholders declared in that template. 
+needs to know *which* template the apphook's root view renders, should it be different
+from the page's template. This is so it can show the placeholders declared in that template. 
 The rendered template is provided by :meth:`~cms.app_base.CMSApp.get_root_template`.
 
 By default, ``get_root_template`` inspects the URL pattern matching the empty

--- a/docs/how_to/11-apphooks.rst
+++ b/docs/how_to/11-apphooks.rst
@@ -190,6 +190,52 @@ This works because django CMS sets ``request.current_page`` for apphook requests
     effect in this case). Set the toolbar object only when you want editors to work on
     that custom model rather than on the page.
 
+Telling the structure board which template the root view uses
+.............................................................
+
+When a content editor opens the structure board on an apphooked page, django CMS
+needs to know *which* template the apphook's root view renders should it be different
+to the page's template. This is so it can show the placeholders declared in that template. 
+The rendered template is provided by :meth:`~cms.app_base.CMSApp.get_root_template`.
+
+By default, ``get_root_template`` inspects the URL pattern matching the empty
+path inside :meth:`~cms.app_base.CMSApp.get_urls` and reads its ``template_name``.
+This works automatically for class-based views in either of these forms::
+
+    # template_name set on the class
+    class HomeView(TemplateView):
+        template_name = "myapp/home.html"
+
+    urlpatterns = [path("", HomeView.as_view())]
+
+    # or passed as an as_view() keyword argument
+    urlpatterns = [path("", TemplateView.as_view(template_name="myapp/home.html"))]
+
+Inference cannot work in some cases, in which the lookup falls back to ``None``:
+
+- function-based views — the template name lives inside the view body, not on
+  the callable
+- views that select their template at runtime
+- views that return a fully-rendered ``HttpResponse`` (for example via the
+  ``render()`` shortcut)
+
+For these cases, declare the template explicitly on the apphook class::
+
+    class MyApphook(CMSApp):
+        name = _("My Apphook")
+        _root_template = "myapp/home.html"
+
+        def get_urls(self, page=None, language=None, **kwargs):
+            return ["myapp.urls"]
+
+If the template depends on the page, language, or other request-time state,
+override :meth:`~cms.app_base.CMSApp.get_root_template` instead — it receives the
+same ``page`` and ``language`` arguments as ``get_urls``.
+
+Make sure that the template you declare here matches the one your root view
+actually renders, otherwise the placeholders shown in the structure board will
+diverge from those rendered on the page.
+
 Sub-pages of an apphooked page
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/how_to/11-apphooks.rst
+++ b/docs/how_to/11-apphooks.rst
@@ -219,20 +219,21 @@ Inference cannot work in some cases, in which the lookup falls back to ``None``:
 - views that return a fully-rendered ``HttpResponse`` (for example via the
   ``render()`` shortcut)
 
-For these cases, declare the template explicitly on the apphook class::
+For these cases, override :meth:`~cms.app_base.CMSApp.get_root_template` on the
+apphook class. The override receives the same ``page`` and ``language`` arguments
+as :meth:`~cms.app_base.CMSApp.get_urls`, so the returned template can vary per
+page or language::
 
     class MyApphook(CMSApp):
         name = _("My Apphook")
-        _root_template = "myapp/home.html"
 
         def get_urls(self, page=None, language=None, **kwargs):
             return ["myapp.urls"]
 
-If the template depends on the page, language, or other request-time state,
-override :meth:`~cms.app_base.CMSApp.get_root_template` instead — it receives the
-same ``page`` and ``language`` arguments as ``get_urls``.
+        def get_root_template(self, page=None, language=None, **kwargs):
+            return "myapp/home.html"
 
-Make sure that the template you declare here matches the one your root view
+Make sure that the template you return here matches the one your root view
 actually renders, otherwise the placeholders shown in the structure board will
 diverge from those rendered on the page.
 

--- a/docs/reference/app_base.rst
+++ b/docs/reference/app_base.rst
@@ -19,6 +19,18 @@ App Hooks
 
         list of menu classes: example: ``_menus = [MyAppMenu]``
 
+    .. attribute:: _root_template
+
+        .. versionadded:: 5.1
+
+        Template name used by the apphook's root view, consulted by the
+        structure board when rendering placeholders on an apphooked page.
+        If left as ``None`` (the default), :meth:`get_root_template` will
+        try to infer it from the root URL pattern. Set this explicitly
+        when inference is not possible — for example, when the root view
+        is a function-based view, or selects its template at runtime.
+        Example: ``_root_template = "myapp/home.html"``.
+
 
 **********
 App Config

--- a/docs/reference/app_base.rst
+++ b/docs/reference/app_base.rst
@@ -19,18 +19,6 @@ App Hooks
 
         list of menu classes: example: ``_menus = [MyAppMenu]``
 
-    .. attribute:: _root_template
-
-        .. versionadded:: 5.1
-
-        Template name used by the apphook's root view, consulted by the
-        structure board when rendering placeholders on an apphooked page.
-        If left as ``None`` (the default), :meth:`get_root_template` will
-        try to infer it from the root URL pattern. Set this explicitly
-        when inference is not possible — for example, when the root view
-        is a function-based view, or selects its template at runtime.
-        Example: ``_root_template = "myapp/home.html"``.
-
 
 **********
 App Config


### PR DESCRIPTION

## Summary by Sourcery

Extend CMS apphooks to expose a root template and make PageContent use it so the structure board reflects the apphook’s actual layout. Otherwise it shows the page content placeholders.

New Features:
- Add CMSApp.get_root_template to infer or override the template used by an apphook’s root view.
- Make PageContent.get_template prefer an attached apphook’s root template over the page’s own template when available.

Tests:
- Add unit tests covering CMSApp.get_root_template across class-based views, function-based views, includes, caching, and error cases.
- Add an integration test ensuring PageContent.get_template uses the apphook root template when provided.
## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* fixes #8616
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``main``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.
