### PR TITLE
fix: Missing redirect_url in CMSNavigationNode.attr

### DIFF
--- a/cms/cms_menus.py
+++ b/cms/cms_menus.py
@@ -231,6 +231,7 @@ class CMSMenu(Menu):
         attr = {
             "is_page": True,
             "soft_root": page_content.soft_root,
+            "redirect_url": page_content.redirect,
             "auth_required": page.login_required,
             "reverse_id": page.reverse_id,
             "is_home": page.is_home,
@@ -334,6 +335,7 @@ class CMSMenu(Menu):
                 "limit_visibility_in_menu",
                 "soft_root",
                 "in_navigation",
+                "redirect",
                 "page__site_id",
                 "page__parent_id",
                 "page__is_home",

--- a/cms/test_utils/project/templates/menu/menu.html
+++ b/cms/test_utils/project/templates/menu/menu.html
@@ -1,9 +1,9 @@
 {% load menu_tags cache %}
 {% for child in children %}
-				
+
 <li>
-	<a href="{{ child.get_absolute_url }}" class="menu {% if child.selected %} selected{% endif %}{% if child.ancestor %} ancestor{% endif %}">{% if not child.is_leaf_node %}+{% endif %}{{ child.get_menu_title }}
-	<span>	
+	<a href="{{ child.attr.redirect_url|default:child.get_absolute_url }}" class="menu {% if child.selected %} selected{% endif %}{% if child.ancestor %} ancestor{% endif %}">{% if not child.is_leaf_node %}+{% endif %}{{ child.get_menu_title }}
+	<span>
 	{% if child.selected %}selected{% endif %}
 	{% if child.ancestor %}ancestor{% endif %}
 	{% if child.sibling %}sibling{% endif %}
@@ -18,5 +18,5 @@
     </ul>
     {% endif %}
 </li>
-				
+
 {% endfor %}

--- a/cms/tests/test_menu.py
+++ b/cms/tests/test_menu.py
@@ -1208,6 +1208,53 @@ class MenuTests(BaseMenuTest):
         expected_language = get_default_language_for_site(site.pk)
         self.assertEqual(renderer.request_language, expected_language)
 
+    def test_cmsnavigationnode_attr(self):
+        """
+        Test population of the attr object of the CMSNavigationNode from pages
+        """
+        page_defaults = {
+            "template": "nav_playground.html",
+            "language": "en",
+        }
+        home = create_page("Normal Page", in_navigation=True, reverse_id="normal-page", **page_defaults)
+        home.set_as_homepage()
+        create_page("Redirected Page", in_navigation=True, reverse_id="redirected-page", redirect='https://redirect.example.com', **page_defaults)
+
+        request = self.get_request("/en/")
+        context = Context()
+        context["request"] = request
+        tpl = Template("{% load menu_tags %}{% show_menu 0 100 100 100 %}")
+        tpl.render(context)
+        nodes = context["children"]
+
+        expected_normal_attr = {
+            "is_page": True,
+            "soft_root": False,
+            "redirect_url": None,
+            "auth_required": False,
+            "reverse_id": "normal-page",
+            "is_home": True,
+            "visible_for_authenticated": True,
+            "visible_for_anonymous": True,
+            "navigation_extenders": [],
+        }
+
+        expected_redirect_attr = {
+            "is_page": True,
+            "soft_root": False,
+            "redirect_url": "https://redirect.example.com",
+            "auth_required": False,
+            "reverse_id": "redirected-page",
+            "is_home": False,
+            "visible_for_authenticated": True,
+            "visible_for_anonymous": True,
+            "navigation_extenders": [],
+        }
+
+        self.assertEqual(2, len(nodes))
+        self.assertEqual(expected_normal_attr, nodes[0].attr)
+        self.assertEqual(expected_redirect_attr, nodes[1].attr)
+
 
 @override_settings(CMS_PERMISSION=False)
 class AdvancedSoftrootTests(SoftrootFixture, CMSTestCase):


### PR DESCRIPTION
## Description

This fixes a regression in CMS 5.0

## Related resources

* #8624

## Checklist

* [ ] I have opened this pull request against ``main``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Ensure navigation nodes correctly expose page redirect URLs and use them when rendering menus.

Bug Fixes:
- Populate CMSNavigationNode.attr with the page redirect URL to restore correct behavior for redirected pages in menus.

Enhancements:
- Update the menu template to prefer a node's redirect URL over its absolute URL when generating menu links.

Tests:
- Add a regression test verifying CMSNavigationNode.attr includes redirect_url for normal and redirected pages in the menu context.