### PR TITLE
fix: Single phased CMSAppExtension could extensions with contracts

### DIFF
--- a/cms/app_registration.py
+++ b/cms/app_registration.py
@@ -95,9 +95,9 @@ def autodiscover_cms_configs():
             extension = _find_extension(cms_module)
             if not config and not extension:
                 raise ImproperlyConfigured(
-                    "cms_config.py files must define at least one "
-                    "class which inherits from CMSAppConfig or "
-                    "CMSAppExtension")
+                    f"The cms_config.py file of the '{app_config.label}' app "
+                    "must define at least one class which inherits from "
+                    "CMSAppConfig or CMSAppExtension")
             # We are adding these attributes here rather than in
             # django's app config definition because there are
             # all kinds of limitations as to what can be imported

--- a/cms/app_registration.py
+++ b/cms/app_registration.py
@@ -68,7 +68,18 @@ def autodiscover_cms_configs():
     """
     Find and import all cms_config.py files. Add a cms_app attribute
     to django's app config with an instance of the cms config.
+
+    This runs in two passes: all CMSAppExtension instances are attached
+    first, then the CMSAppConfig objects are instantiated. A config's
+    ``__init__`` may query registered extensions via
+    ``CMSAppConfig.get_contract()`` (which caches the result of
+    ``get_cms_extension_apps()``), so every extension must be registered
+    before any config is instantiated. Otherwise the order of apps in
+    INSTALLED_APPS could cause a config to cache an incomplete extension
+    list (e.g. djangocms_alias not finding djangocms_versioning).
     """
+    discovered = []
+    # First pass: import every cms_config module and attach the extensions.
     for app_config in apps.get_app_configs():
         try:
             cms_module = import_module(
@@ -82,20 +93,30 @@ def autodiscover_cms_configs():
         else:
             config = _find_config(cms_module)
             extension = _find_extension(cms_module)
-            # We are adding these attributes here rather than in
-            # django's app config definition because there are
-            # all kinds of limitations as to what can be imported
-            # in django's apps.py and leaving it to devs to define this
-            # there could cause issues
-            if config:
-                app_config.cms_config = config(app_config)
-            if extension:
-                app_config.cms_extension = extension()
             if not config and not extension:
                 raise ImproperlyConfigured(
                     "cms_config.py files must define at least one "
                     "class which inherits from CMSAppConfig or "
                     "CMSAppExtension")
+            # We are adding these attributes here rather than in
+            # django's app config definition because there are
+            # all kinds of limitations as to what can be imported
+            # in django's apps.py and leaving it to devs to define this
+            # there could cause issues
+            if extension:
+                app_config.cms_extension = extension()
+            discovered.append((app_config, config))
+
+    # All extensions are now attached; drop any extension lookup that was
+    # cached before every extension was registered, so the configs below
+    # see the complete list.
+    get_cms_extension_apps.cache_clear()
+
+    # Second pass: instantiate the configs, which may now safely look up
+    # any registered extension via get_contract().
+    for app_config, config in discovered:
+        if config:
+            app_config.cms_config = config(app_config)
 
 
 @cache


### PR DESCRIPTION

## Summary by Sourcery

Ensure CMS configuration discovery attaches all CMSAppExtension instances before instantiating CMSAppConfig objects to avoid incomplete extension registration caused by app load order.

Bug Fixes:
- Prevent CMSAppConfig instances from caching incomplete CMSAppExtension sets when configs query contracts during initialization.

Enhancements:
- Document and enforce a two-pass cms_config discovery process, requiring each cms_config.py to define at least one CMSAppConfig or CMSAppExtension and clearing cached extension lookups before config instantiation.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.
