### PR TITLE
chore: Add Django 6.1 to test matrix, remove Django 5.0, 5.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,8 @@ jobs:
         ]
         exclude:
           # Python 3.14 only works with Django 5.2+
+          - python-version: '3.14'
+            requirements-file: django-4.2.txt
           # Python 3.10 and 3.11 only supported until Django 5.2
           - python-version: '3.10'
             requirements-file: django-6.0.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,9 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         requirements-file: [
           django-4.2.txt,
-          django-5.0.txt,
-          django-5.1.txt,
           django-5.2.txt,
           django-6.0.txt,
+          django-6.1.txt
         ]
         # On nightly runs, test all postgres versions. On push/PR, only test latest.
         postgres-version: ${{ github.event_name == 'schedule' && fromJSON('["16", "17", "18"]') || fromJSON('["16"]') }}
@@ -34,17 +33,15 @@ jobs:
         ]
         exclude:
           # Python 3.14 only works with Django 5.2+
-          - python-version: '3.14'
-            requirements-file: django-4.2.txt
-          - python-version: '3.14'
-            requirements-file: django-5.0.txt
-          - python-version: '3.14'
-            requirements-file: django-5.1.txt
           # Python 3.10 and 3.11 only supported until Django 5.2
           - python-version: '3.10'
             requirements-file: django-6.0.txt
           - python-version: '3.11'
             requirements-file: django-6.0.txt
+          - python-version: '3.10'
+            requirements-file: django-6.1.txt
+          - python-version: '3.11'
+            requirements-file: django-6.1.txt
 
     services:
       postgres:
@@ -96,10 +93,9 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         requirements-file: [
           django-4.2.txt,
-          django-5.0.txt,
-          django-5.1.txt,
           django-5.2.txt,
           django-6.0.txt,
+          django-6.1.txt
         ]
         # On nightly runs, test all mysql versions. On push/PR, only test latest.
         mysql-version: ${{ github.event_name == 'schedule' && fromJSON('["8.4", "9.5"]') || fromJSON('["8.4"]') }}
@@ -110,15 +106,15 @@ jobs:
           # Python 3.14 only works with Django 5.2+
           - python-version: '3.14'
             requirements-file: django-4.2.txt
-          - python-version: '3.14'
-            requirements-file: django-5.0.txt
-          - python-version: '3.14'
-            requirements-file: django-5.1.txt
           # Python 3.10 and 3.11 only supported until Django 5.2
           - python-version: '3.10'
             requirements-file: django-6.0.txt
           - python-version: '3.11'
             requirements-file: django-6.0.txt
+          - python-version: '3.10'
+            requirements-file: django-6.1.txt
+          - python-version: '3.11'
+            requirements-file: django-6.1.txt
 
     services:
       mysql:
@@ -169,11 +165,10 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         requirements-file: [
           django-4.2.txt,
-          django-5.0.txt,
-          django-5.1.txt,
           django-5.2.txt,
           django-6.0.txt,
-        ]
+          django-6.1.txt,
+          ]
         os: [
           ubuntu-latest,
         ]
@@ -181,15 +176,15 @@ jobs:
           # Python 3.14 only works with Django 5.2+
           - python-version: '3.14'
             requirements-file: django-4.2.txt
-          - python-version: '3.14'
-            requirements-file: django-5.0.txt
-          - python-version: '3.14'
-            requirements-file: django-5.1.txt
           # Python 3.10 and 3.11 only supported until Django 5.2
           - python-version: '3.10'
             requirements-file: django-6.0.txt
           - python-version: '3.11'
             requirements-file: django-6.0.txt
+          - python-version: '3.10'
+            requirements-file: django-6.1.txt
+          - python-version: '3.11'
+            requirements-file: django-6.1.txt
 
     steps:
     - uses: actions/checkout@v6

--- a/test_requirements/django-5.1.txt
+++ b/test_requirements/django-5.1.txt
@@ -1,2 +1,0 @@
--r requirements_base.txt
-Django>=5.1,<5.2

--- a/test_requirements/django-6.1.txt
+++ b/test_requirements/django-6.1.txt
@@ -1,2 +1,2 @@
 -r requirements_base.txt
-Django>=5.0,<5.1
+Django>=6.1a1,<6.2


### PR DESCRIPTION

## Summary by Sourcery

Update supported Django versions in the test matrix and requirements to drop 5.0/5.1 and add 6.1.

Build:
- Update GitHub Actions test matrix to replace Django 5.0/5.1 with Django 6.1 across postgres, mysql, and sqlite jobs.
- Adjust Python/Django exclusion matrix so Django 6.1 is not tested with unsupported Python 3.10 and 3.11 combinations.

Tests:
- Replace Django 5.0 test requirements file with a Django 6.1 requirements file and remove the obsolete Django 5.1 test requirements file.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.
