### PR TITLE
fix: GrouperModelAdmin shadowed prepopulated_fields class attribute (#8636)

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -20,7 +20,20 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
-    - run: npm install -g gulp@4.0.2
+    - name: Resolve Chrome binary and export its path
+      run: |
+        # Prefer the Chrome that ships preinstalled on the runner image.
+        CHROME_BIN="$(command -v google-chrome || command -v google-chrome-stable || command -v chromium-browser || true)"
+        # Fall back to downloading Chrome for Testing via puppeteer.
+        if [ -z "$CHROME_BIN" ]; then
+          rm -rf ~/.cache/puppeteer/chrome
+          npx puppeteer browsers install chrome
+          CHROME_BIN="$(node -e "console.log(require('puppeteer').executablePath())")"
+        fi
+        echo "Using Chrome at: $CHROME_BIN"
+        test -x "$CHROME_BIN"
+        echo "CHROME_BIN=$CHROME_BIN" >> "$GITHUB_ENV"
+    - run: npm install -g  gulp@4.0.2
     - run: gulp unitTest
     - run: gulp lint
     - run: gulp icons

--- a/cms/admin/utils.py
+++ b/cms/admin/utils.py
@@ -700,6 +700,20 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
             ]
         return fields
 
+    def get_prepopulated_fields(self, request: HttpRequest, obj: models.Model | None = None) -> dict:
+        """Drop prepopulated entries whose key is read-only.
+
+        ``AdminForm`` looks up every prepopulated key in the rendered form, so an entry
+        keyed on a field that ``get_readonly_fields`` returns would raise ``KeyError``.
+        Filter dynamically against the class attribute so subclasses can keep declaring
+        ``prepopulated_fields`` the normal way.
+        """
+        prepopulated_fields = super().get_prepopulated_fields(request, obj)
+        if not prepopulated_fields:
+            return prepopulated_fields
+        readonly = set(self.get_readonly_fields(request, obj))
+        return {key: value for key, value in prepopulated_fields.items() if key not in readonly}
+
     def save_model(self, request: HttpRequest, obj: models.Model, form: forms.Form, change: bool) -> None:
         """Save/create both grouper and content object"""
         super().save_model(request, obj or form.instance, form, change)

--- a/cms/tests/frontend/karma.conf.js
+++ b/cms/tests/frontend/karma.conf.js
@@ -7,7 +7,7 @@
 'use strict';
 
 process.env.NODE_ENV = 'test';
-process.env.CHROME_BIN = require('puppeteer').executablePath();
+process.env.CHROME_BIN = process.env.CHROME_BIN || require('puppeteer').executablePath();
 
 
 var baseConf = require('./base.conf');

--- a/cms/tests/test_grouper_admin.py
+++ b/cms/tests/test_grouper_admin.py
@@ -264,16 +264,6 @@ class GrouperModelAdminTestCase(SetupMixin, CMSTestCase):
         # Assert: no shadow instance attribute hides the class-level value.
         self.assertEqual(prepopulated, {"category_name": ["content__secret_greeting"]})
 
-    def test_changelist_view_does_not_call_get_content_obj(self):
-        self.createContentInstance("en")
-
-        with self.login_user_context(self.admin_user):
-            with patch.object(self.admin, "get_content_obj", wraps=self.admin.get_content_obj) as mocked_get_content_obj:
-                response = self.client.get(f"{self.changelist_url}?language=en", follow=True)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(mocked_get_content_obj.call_count, 0)
-
     def test_change_view_calls_get_content_obj(self):
         self.createContentInstance("en")
 

--- a/cms/tests/test_grouper_admin.py
+++ b/cms/tests/test_grouper_admin.py
@@ -229,7 +229,50 @@ class GrouperModelAdminTestCase(SetupMixin, CMSTestCase):
         check_results = admin.check()
 
         # Assert
-        self.assertEqual(len(check_results), 4)  # No errors
+        self.assertEqual(len(check_results), 4)  # 4 errors expected (see above)
+
+    @wo_content_permission
+    def test_prepopulated_fields_exclude_readonly_fields(self):
+        """Read-only fields are removed from prepopulated field keys."""
+        # Arrange
+        admin = copy.copy(self.admin)
+        admin.prepopulated_fields = {
+            "content__secret_greeting": ["category_name"],
+            "category_name": ["content__secret_greeting"],
+        }
+
+        # Act
+        readonly_fields = admin.get_readonly_fields(None)
+        prepopulated = admin.get_prepopulated_fields(None)
+
+        # Assert
+        self.assertIn("content__secret_greeting", readonly_fields)
+        self.assertNotIn("content__secret_greeting", prepopulated)
+        self.assertIn("category_name", prepopulated)
+        # The class attribute is not mutated by get_readonly_fields/get_prepopulated_fields.
+        self.assertIn("content__secret_greeting", admin.prepopulated_fields)
+
+    def test_prepopulated_fields_respects_class_attribute_after_init(self):
+        """``cls.prepopulated_fields`` set after the admin is instantiated is honored."""
+        # Arrange
+        admin = copy.copy(self.admin)
+        admin.prepopulated_fields = {"category_name": ["content__secret_greeting"]}
+
+        # Act
+        prepopulated = admin.get_prepopulated_fields(None)
+
+        # Assert: no shadow instance attribute hides the class-level value.
+        self.assertEqual(prepopulated, {"category_name": ["content__secret_greeting"]})
+
+    def test_changelist_view_does_not_call_get_content_obj(self):
+        self.createContentInstance("en")
+
+        with self.login_user_context(self.admin_user):
+            with patch.object(self.admin, "get_content_obj", wraps=self.admin.get_content_obj) as mocked_get_content_obj:
+                response = self.client.get(f"{self.changelist_url}?language=en", follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(mocked_get_content_obj.call_count, 0)
 
     def test_change_view_calls_get_content_obj(self):
         self.createContentInstance("en")

--- a/cms/tests/test_grouper_admin.py
+++ b/cms/tests/test_grouper_admin.py
@@ -253,7 +253,7 @@ class GrouperModelAdminTestCase(SetupMixin, CMSTestCase):
         self.assertIn("content__secret_greeting", admin.prepopulated_fields)
 
     def test_prepopulated_fields_respects_class_attribute_after_init(self):
-        """``cls.prepopulated_fields`` set after the admin is instantiated is honored."""
+        """``prepopulated_fields`` set after the admin is instantiated is honored."""
         # Arrange
         admin = copy.copy(self.admin)
         admin.prepopulated_fields = {"category_name": ["content__secret_greeting"]}

--- a/cms/wizards/views.py
+++ b/cms/wizards/views.py
@@ -60,6 +60,30 @@ class WizardCreateView(SessionWizardView):
             context['wizard_entry'] = self.get_selected_entry()
         return context
 
+    def get_form_list(self):
+        """
+        Resolve the wizard's form list.
+
+        Step ``'1'`` is declared with a placeholder ``Form`` because the real
+        form depends on the entry chosen in step ``'0'``. Once step 0 has been
+        completed, the real form is built and substituted here. Doing the
+        substitution in ``get_form_list`` -- instead of mutating the shared
+        ``self.form_list`` -- keeps the swap visible to django-formtools 2.6+,
+        which caches ``get_form_list`` results.
+        """
+        form_list = super().get_form_list()
+        # ``_building_step_2`` guards against infinite recursion: building the
+        # step-2 form needs step 0's cleaned data, which itself resolves the
+        # form list again.
+        if '1' in form_list and not getattr(self, '_building_step_2', False):
+            self._building_step_2 = True
+            try:
+                if self.get_cleaned_data_for_step('0') is not None:
+                    form_list['1'] = self.get_step_2_form()
+            finally:
+                self._building_step_2 = False
+        return form_list
+
     def get_form(self, step=None, data=None, files=None):
         if step is None:
             step = self.steps.current
@@ -71,9 +95,6 @@ class WizardCreateView(SessionWizardView):
             self.page_pk = data.get(page_key, None)
         else:
             self.page_pk = None
-
-        if self.is_second_step(step):
-            self.form_list[step] = self.get_step_2_form(step, data, files)
         return super().get_form(step, data, files)
 
     def get_form_kwargs(self, step=None):


### PR DESCRIPTION
* fix: GrouperModelAdmin shadowed prepopulated_fields class attribute

Move the readonly-aware filtering of ``prepopulated_fields`` from ``get_readonly_fields`` (which assigned a derived dict to ``self.prepopulated_fields``) into a proper ``get_prepopulated_fields`` override. The snapshot stored at ``__init__`` time is no longer needed and has been dropped.

Previously, ``GrouperModelAdmin.__init__`` captured ``self._prepopulated_fields = self.prepopulated_fields`` once, and every ``get_readonly_fields`` call wrote a derived dict back into ``self.prepopulated_fields``. That instance attribute permanently shadowed the class attribute, so any code that mutated ``cls.prepopulated_fields`` after the admin had been instantiated (test setup, dynamic configuration, downstream subclasses) was silently ignored.

Reading ``self.prepopulated_fields`` dynamically via the documented ``get_prepopulated_fields`` hook preserves the original fix (read-only keys are still stripped before ``AdminForm`` renders them) without breaking the normal ``ModelAdmin`` class-attribute contract.

Refs #8634, supersedes the mechanism introduced in #8471.

* fix: Frontend test did not find chrome

* fix: Remove previously downloaded test browsers

* refactor binary search for frontend test

* fix karma config for chrome

---------

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Ensure GrouperModelAdmin filters prepopulated fields against readonly fields without mutating class attributes and stabilize frontend tests by reliably resolving the Chrome binary in CI.

Bug Fixes:
- Prevent GrouperModelAdmin from shadowing the prepopulated_fields class attribute and exclude readonly fields from prepopulated field definitions to avoid AdminForm errors.
- Allow Karma to reuse an externally provided CHROME_BIN value instead of always overriding it with Puppeteer's Chrome path.
- Fix frontend CI failures by reliably locating or installing a Chrome binary and exporting its path for tests.

Tests:
- Add regression tests verifying that readonly fields are excluded from prepopulated field keys and that GrouperModelAdmin respects class-level prepopulated_fields after instantiation.