### PR TITLE
fix: Toolbar login followed an unverified redirect after authentication

### DIFF
--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -257,6 +257,40 @@ class ToolbarTests(ToolbarTestBase):
         self.assertRedirects(response, "/en/")
         self.assertTrue(settings.SESSION_COOKIE_NAME in response.cookies)
 
+    def test_toolbar_login_error_preserves_query_string(self):
+        # The error flag must be appended without clobbering an existing query.
+        admin = self.get_superuser()
+        endpoint = reverse("cms_login") + "?next=/en/admin/%3Ffoo%3Dbar"
+        username = getattr(admin, get_user_model().USERNAME_FIELD)
+        response = self.client.post(endpoint, data={"username": username, "password": "invalid"})
+        self.assertRedirects(
+            response,
+            "/en/admin/?foo=bar&cms_toolbar_login_error=1",
+            target_status_code=302,
+        )
+        self.assertFalse(settings.SESSION_COOKIE_NAME in response.cookies)
+
+    def test_toolbar_login_unresolvable_redirect_to(self):
+        # A same-host path that does not resolve against the URL configuration
+        # must not be used as a redirect target (open redirect protection).
+        admin = self.get_superuser()
+        endpoint = reverse("cms_login") + "?next=/not-a-language/does-not-resolve@@/"
+        username = getattr(admin, get_user_model().USERNAME_FIELD)
+        password = getattr(admin, get_user_model().USERNAME_FIELD)
+        response = self.client.post(endpoint, data={"username": username, "password": password})
+        self.assertRedirects(response, "/en/")
+        self.assertTrue(settings.SESSION_COOKIE_NAME in response.cookies)
+
+    def test_toolbar_login_resolvable_redirect_to(self):
+        # A same-host path that resolves to a project view is accepted.
+        admin = self.get_superuser()
+        endpoint = reverse("cms_login") + "?next=/en/admin/"
+        username = getattr(admin, get_user_model().USERNAME_FIELD)
+        password = getattr(admin, get_user_model().USERNAME_FIELD)
+        response = self.client.post(endpoint, data={"username": username, "password": password})
+        self.assertRedirects(response, "/en/admin/", target_status_code=200)
+        self.assertTrue(settings.SESSION_COOKIE_NAME in response.cookies)
+
     @override_settings(CMS_TOOLBARS=["cms.test_utils.project.sampleapp.cms_toolbars.ToolbarWithMedia"])
     def test_toolbar_media(self):
         """

--- a/cms/views.py
+++ b/cms/views.py
@@ -1,4 +1,4 @@
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit, urlunsplit
 
 from django.apps import apps
 from django.conf import settings
@@ -15,7 +15,13 @@ from django.http import (
 from django.shortcuts import render
 from django.template.defaultfilters import title
 from django.template.response import TemplateResponse
-from django.urls import NoReverseMatch, Resolver404, resolve, reverse
+from django.urls import (
+    NoReverseMatch,
+    Resolver404,
+    get_script_prefix,
+    resolve,
+    reverse,
+)
 from django.utils.cache import patch_cache_control
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.timezone import now
@@ -225,14 +231,46 @@ def details(request, slug):
     return render_pagecontent(request, content)
 
 
+def _get_login_redirect_url(request, redirect_to):
+    """Return a safe redirect target for the toolbar login view.
+
+    The ``next`` parameter is fully controlled by the client, so it must never
+    be trusted as-is (CWE-601, open redirect). A target is only accepted when
+
+    * it stays on the current host and uses an allowed scheme, and
+    * its path can be resolved against the project's URL configuration, i.e. it
+      actually points at a view served by this site.
+
+    Anything else falls back to the CMS root. The returned URL is rebuilt from
+    the validated, host-less components, so neither the scheme nor the host
+    supplied by the client is ever echoed back into the redirect.
+    """
+    fallback = reverse("pages-root")
+    if not redirect_to or not url_has_allowed_host_and_scheme(
+        url=redirect_to, allowed_hosts={request.get_host()}
+    ):
+        return fallback
+
+    parts = urlsplit(redirect_to)
+    # ``resolve()`` expects a path relative to the URL configuration, i.e.
+    # without the (optional) script prefix that the client-supplied URL carries.
+    path = parts.path
+    script_prefix = get_script_prefix()
+    if script_prefix != "/" and path.startswith(script_prefix):
+        path = "/" + path[len(script_prefix):]
+
+    try:
+        resolve(path)
+    except Resolver404:
+        return fallback
+
+    # Rebuild the redirect from the validated path only; drop scheme and host.
+    return urlunsplit(("", "", quote(parts.path), parts.query, parts.fragment))
+
+
 @require_POST
 def login(request):
-    redirect_to = request.GET.get(REDIRECT_FIELD_NAME)
-
-    if not url_has_allowed_host_and_scheme(url=redirect_to, allowed_hosts=request.get_host()):
-        redirect_to = reverse("pages-root")
-    else:
-        redirect_to = quote(redirect_to)
+    redirect_to = _get_login_redirect_url(request, request.GET.get(REDIRECT_FIELD_NAME))
 
     if request.user.is_authenticated:
         return HttpResponseRedirect(redirect_to)
@@ -242,7 +280,9 @@ def login(request):
     if form.is_valid():
         auth_login(request, form.user_cache)
     else:
-        redirect_to += '?cms_toolbar_login_error=1'
+        # Append the error flag, preserving any query string already present.
+        separator = '&' if urlsplit(redirect_to).query else '?'
+        redirect_to += f'{separator}cms_toolbar_login_error=1'
     return HttpResponseRedirect(redirect_to)
 
 

--- a/cms/views.py
+++ b/cms/views.py
@@ -23,6 +23,7 @@ from django.urls import (
     reverse,
 )
 from django.utils.cache import patch_cache_control
+from django.utils.encoding import iri_to_uri
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.timezone import now
 from django.utils.translation import activate
@@ -264,8 +265,12 @@ def _get_login_redirect_url(request, redirect_to):
     except Resolver404:
         return fallback
 
-    # Rebuild the redirect from the validated path only; drop scheme and host.
-    return urlunsplit(("", "", quote(parts.path), parts.query, parts.fragment))
+    # Rebuild the redirect from the validated components only, dropping the
+    # client-supplied scheme and host. ``parts.path`` keeps the script prefix
+    # (the browser needs it); only the copy passed to ``resolve()`` had it
+    # stripped. ``iri_to_uri`` encodes unsafe characters without
+    # double-encoding an already percent-encoded path.
+    return iri_to_uri(urlunsplit(("", "", parts.path, parts.query, parts.fragment)))
 
 
 @require_POST
@@ -280,9 +285,11 @@ def login(request):
     if form.is_valid():
         auth_login(request, form.user_cache)
     else:
-        # Append the error flag, preserving any query string already present.
-        separator = '&' if urlsplit(redirect_to).query else '?'
-        redirect_to += f'{separator}cms_toolbar_login_error=1'
+        # Add the error flag to the query component so it is preserved next to
+        # any existing parameters and stays ahead of a possible fragment.
+        parts = urlsplit(redirect_to)
+        query = f'{parts.query}&cms_toolbar_login_error=1' if parts.query else 'cms_toolbar_login_error=1'
+        redirect_to = urlunsplit((parts.scheme, parts.netloc, parts.path, query, parts.fragment))
     return HttpResponseRedirect(redirect_to)
 
 


### PR DESCRIPTION
## Summary by Sourcery

Harden toolbar login redirection to prevent open redirects and improve handling of error flags in redirect URLs.

Bug Fixes:
- Validate and normalize the toolbar login redirect target using URL resolution and allowed host checks to prevent open redirects.
- Ensure the toolbar login error flag is appended without overwriting existing query parameters.

Tests:
- Add regression tests covering safe and unsafe toolbar login redirect targets and preservation of existing query strings when adding the error flag.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* fixes https://github.com/django-cms/django-cms/security/code-scanning/1254
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.