### PR TITLE
fix: Honour plugin-declared Vary headers in the page cache key

### DIFF
--- a/cms/cache/page.py
+++ b/cms/cache/page.py
@@ -20,10 +20,16 @@ from cms.utils.helpers import get_timezone_name
 from cms.utils.i18n import get_default_language_for_site
 
 
-def _page_cache_key(request):
+def _page_cache_key(request, vary_on=None):
     """
     Generate a cache key based on the request path and language.
     The language is determined following django-cms's language resolution order.
+
+    ``vary_on`` is an optional iterable of header names declared by plugins via
+    ``get_vary_cache_on()``. When given, the request's values for those headers
+    are folded into the key so that responses varying on those headers are
+    cached separately per value (instead of the first variant being served to
+    everyone).
     """
     site = get_current_site(request)
     if hasattr(request, "LANGUAGE_CODE"):
@@ -39,7 +45,30 @@ def _page_cache_key(request):
     )
     if settings.USE_TZ:
         cache_key += ".%s" % get_timezone_name()
+    if vary_on:
+        cache_key += ".%s" % _vary_on_hash(request, vary_on)
     return cache_key
+
+
+def _vary_on_hash(request, vary_on):
+    """Hash of the request's values for the given (plugin-declared) headers."""
+    ctx = hashlib.sha1()
+    for header in sorted(header.lower() for header in vary_on):
+        # Mirror Django's translation of header names to ``request.META`` keys.
+        meta_key = "HTTP_" + header.upper().replace("-", "_")
+        value = request.META.get(meta_key, "")
+        ctx.update(("%s=%s&" % (header, iri_to_uri(value))).encode("utf-8"))
+    return ctx.hexdigest()
+
+
+def _page_vary_headers_cache_key(request):
+    """Key under which the list of plugin-declared vary headers is stored.
+
+    The list cannot be known on a cache read until the page is rendered, so it
+    is persisted on write and looked up first on read (mirroring Django's
+    ``learn_cache_key`` / ``get_cache_key`` two-step approach).
+    """
+    return _page_cache_key(request) + ".vary-on"
 
 
 def set_page_cache(response):
@@ -82,16 +111,25 @@ def set_page_cache(response):
 
         if ttl > 0:
             # Adds expiration, etc. to headers
+            vary_on = sorted(vary_cache_on_set)
             patch_response_headers(response, cache_timeout=ttl)
-            patch_vary_headers(response, sorted(vary_cache_on_set))
+            patch_vary_headers(response, vary_on)
 
             version = _get_cache_version()
             # We also store the absolute expiration timestamp to avoid
             # recomputing it on cache-reads.
             expires_datetime = timestamp + timedelta(seconds=ttl)
             response_headers = get_response_headers(response)
+            # Persist the list of plugin-declared vary headers so the read path
+            # can rebuild the same (header-value aware) content key.
             cache.set(
-                _page_cache_key(request),
+                _page_vary_headers_cache_key(request),
+                vary_on,
+                ttl,
+                version=version,
+            )
+            cache.set(
+                _page_cache_key(request, vary_on),
                 (
                     response.content,
                     response_headers,
@@ -108,7 +146,11 @@ def set_page_cache(response):
 def get_page_cache(request):
     from django.core.cache import cache
 
-    return cache.get(_page_cache_key(request), version=_get_cache_version())
+    version = _get_cache_version()
+    # First resolve which headers (if any) the cached page varies on, then
+    # build the content key from this request's values for those headers.
+    vary_on = cache.get(_page_vary_headers_cache_key(request), version=version)
+    return cache.get(_page_cache_key(request, vary_on), version=version)
 
 
 def get_xframe_cache(page):

--- a/cms/cache/page.py
+++ b/cms/cache/page.py
@@ -26,10 +26,10 @@ def _page_cache_key(request, vary_on=None):
     The language is determined following django-cms's language resolution order.
 
     ``vary_on`` is an optional iterable of header names declared by plugins via
-    ``get_vary_cache_on()``. When given, the request's values for those headers
-    are folded into the key so that responses varying on those headers are
-    cached separately per value (instead of the first variant being served to
-    everyone).
+    ``get_vary_cache_on()``. The request's values for those headers are always
+    folded into the key so that responses varying on those headers are cached
+    separately per value (instead of the first variant being served to
+    everyone). A missing (``None``) or empty ``vary_on`` hashes to a constant.
     """
     site = get_current_site(request)
     if hasattr(request, "LANGUAGE_CODE"):
@@ -45,8 +45,7 @@ def _page_cache_key(request, vary_on=None):
     )
     if settings.USE_TZ:
         cache_key += ".%s" % get_timezone_name()
-    if vary_on:
-        cache_key += ".%s" % _vary_on_hash(request, vary_on)
+    cache_key += ".%s" % _vary_on_hash(request, vary_on or [])
     return cache_key
 
 

--- a/cms/tests/test_cache.py
+++ b/cms/tests/test_cache.py
@@ -452,6 +452,49 @@ class CacheTestCase(CMSTestCase):
                     response = self.client.get(page1_url)
                 self.assertEqual(response.status_code, 200)
 
+    def test_page_cache_varies_on_plugin_vary_headers(self):
+        """The page cache must honour headers declared by plugins through
+        get_vary_cache_on().
+
+        Otherwise the variant cached for the first visitor is served to every
+        subsequent visitor regardless of their header values, leaking
+        request-specific content across users (and allowing cache poisoning).
+        """
+        try:
+            plugin_pool.register_plugin(VaryCacheOnPlugin)
+        except PluginAlreadyRegistered:
+            pass
+        self.addCleanup(plugin_pool.unregister_plugin, VaryCacheOnPlugin)
+
+        # Ensure that we're testing the CMS page cache, not Django's MW cache.
+        exclude = [
+            "django.middleware.cache.UpdateCacheMiddleware",
+            "django.middleware.cache.FetchFromCacheMiddleware",
+        ]
+        overrides = {
+            "MIDDLEWARE": [mw for mw in settings.MIDDLEWARE if mw not in exclude]
+        }
+        with self.settings(**overrides):
+            self.assertTrue(get_cms_setting("PAGE_CACHE"))
+
+            page = create_page("vary page", "nav_playground.html", "en")
+            placeholder = page.get_placeholders("en").filter(slot="body")[0]
+            # This plugin varies its output on the "Country-Code" header.
+            add_plugin(placeholder, "VaryCacheOnPlugin", "en")
+            url = page.get_absolute_url()
+
+            # First anonymous visitor primes the cache with their header value.
+            response_us = self.client.get(url, headers={"country-code": "US"})
+            self.assertEqual(response_us.status_code, 200)
+            self.assertContains(response_us, "$$$US$$$")
+
+            # A second visitor with a different header value must not be served
+            # the first visitor's cached variant.
+            response_fr = self.client.get(url, headers={"country-code": "FR"})
+            self.assertEqual(response_fr.status_code, 200)
+            self.assertContains(response_fr, "$$$FR$$$")
+            self.assertNotContains(response_fr, "$$$US$$$")
+
     def test_no_page_cache_on_toolbar_edit(self):
         with self.settings(CMS_PAGE_CACHE=True):
             superuser = self.get_superuser()


### PR DESCRIPTION

## Summary by Sourcery

Ensure the page cache key incorporates plugin-declared Vary headers so cached responses respect per-header variants and avoid cross-user leakage.

Bug Fixes:
- Include plugin-declared Vary headers in the page cache key so responses varying on those headers are cached separately per header value, preventing cache poisoning and data leakage between users.

Enhancements:
- Persist plugin-declared Vary header names alongside the page cache entry and use them on cache reads to reconstruct the correct, header-aware cache key.

Tests:
- Add a regression test verifying that pages using a plugin that declares Vary headers return different cached content for different header values and do not serve the first visitor’s variant to others.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.
