### PR TITLE
fix: template-specific CMS_PLACEHOLDER_CONF keys ignored when renderi…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Features:
 
 Bug Fixes:
 ----------
+* Template-specific ``CMS_PLACEHOLDER_CONF`` keys were ignored when rendering page placeholders (#8649) -- Ralph Mueller
 * get_permissions failed for missing global permissions (#8468) (65d84a929) -- Fabian Braun
 * Create page wizard not available on empty install (#8463) -- Fabian Braun
 * Make Placeholder.add_plugin() set plugin.instance to self (#8442) (#8447) -- Jasper Bok

--- a/cms/plugin_rendering.py
+++ b/cms/plugin_rendering.py
@@ -429,7 +429,7 @@ class ContentRenderer(BaseRenderer):
                 placeholder,
                 context=context,
                 language=language,
-                page=placeholder.source,
+                page=current_page,
                 editable=editable,
                 use_cache=True,
                 nodelist=None,

--- a/cms/tests/test_rendering.py
+++ b/cms/tests/test_rendering.py
@@ -371,6 +371,19 @@ class RenderingTestCase(CMSTestCase):
             r = self.render(self.test_page4, template=t)
         self.assertEqual(r, self.test_data4['extra'])
 
+    def test_placeholder_extra_context_template_specific(self):
+        """Template-specific CMS_PLACEHOLDER_CONF keys must be respected (regression #8649)."""
+        t = '{% load cms_tags %}{% placeholder "extra_context" %}'
+        template_specific_conf = {
+            'extra_context.html extra_context': self.test_data4['placeholderconf']['extra_context'],
+        }
+        r = self.render(self.test_page4, template=t)
+        self.assertEqual(r, self.test_data4['no_extra'])
+        cache.clear()
+        with override_placeholder_conf(CMS_PLACEHOLDER_CONF=template_specific_conf):
+            r = self.render(self.test_page4, template=t)
+        self.assertEqual(r, self.test_data4['extra'])
+
     def test_placeholder_or(self):
         """
         Tests the {% placeholder %} templatetag.

--- a/cms/tests/test_rendering.py
+++ b/cms/tests/test_rendering.py
@@ -384,6 +384,18 @@ class RenderingTestCase(CMSTestCase):
             r = self.render(self.test_page4, template=t)
         self.assertEqual(r, self.test_data4['extra'])
 
+    def test_placeholder_extra_context_template_specific_takes_precedence(self):
+        """Template-specific CMS_PLACEHOLDER_CONF key takes precedence over generic slot key."""
+        t = '{% load cms_tags %}{% placeholder "extra_context" %}'
+        combined_conf = {
+            'extra_context': {'extra_context': {'extra_var': 'generic var'}},
+            'extra_context.html extra_context': self.test_data4['placeholderconf']['extra_context'],
+        }
+        cache.clear()
+        with override_placeholder_conf(CMS_PLACEHOLDER_CONF=combined_conf):
+            r = self.render(self.test_page4, template=t)
+        self.assertEqual(r, self.test_data4['extra'])  # template-specific wins, not 'generic var'
+
     def test_placeholder_or(self):
         """
         Tests the {% placeholder %} templatetag.


### PR DESCRIPTION
Description:
  When rendering a page placeholder, `render_placeholder()` was called with
  `page=placeholder.source` instead of `page=current_page`. This meant
  `get_template()` could not resolve the page template, so template-specific
  `CMS_PLACEHOLDER_CONF` keys (e.g. `'mytemplate.html myslot'`) were silently
  ignored and all plugins shown without restriction.

  Fix: pass `page=current_page` — already resolved as `page or self.current_page`
  on line 413.

  Related resources:
  * #8649

  Checklist — tick these three:
  - [x] I have opened this pull request against main
  - [x] I have added or modified the tests when changing logic
  - [x] I have followed the conventional commits guidelines to add meaningful information into the changelog

## Summary by Sourcery

Ensure template-specific placeholder configuration is respected when rendering page placeholders.

Bug Fixes:
- Fix placeholder rendering to use the current page so template-specific CMS_PLACEHOLDER_CONF keys are applied correctly.

Tests:
- Add regression test covering template-specific CMS_PLACEHOLDER_CONF behavior for placeholder extra context.