### PR TITLE
test: placeholder source availability for CMS_PLACEHOLDER_CONFIG was not covered by tests

### DIFF
--- a/cms/tests/test_rendering.py
+++ b/cms/tests/test_rendering.py
@@ -371,6 +371,31 @@ class RenderingTestCase(CMSTestCase):
             r = self.render(self.test_page4, template=t)
         self.assertEqual(r, self.test_data4['extra'])
 
+    def test_placeholder_extra_context_template_specific(self):
+        """Template-specific CMS_PLACEHOLDER_CONF keys must be respected (regression #8649)."""
+        t = '{% load cms_tags %}{% placeholder "extra_context" %}'
+        template_specific_conf = {
+            'extra_context.html extra_context': self.test_data4['placeholderconf']['extra_context'],
+        }
+        r = self.render(self.test_page4, template=t)
+        self.assertEqual(r, self.test_data4['no_extra'])
+        cache.clear()
+        with override_placeholder_conf(CMS_PLACEHOLDER_CONF=template_specific_conf):
+            r = self.render(self.test_page4, template=t)
+        self.assertEqual(r, self.test_data4['extra'])
+
+    def test_placeholder_extra_context_template_specific_takes_precedence(self):
+        """Template-specific CMS_PLACEHOLDER_CONF key takes precedence over generic slot key."""
+        t = '{% load cms_tags %}{% placeholder "extra_context" %}'
+        combined_conf = {
+            'extra_context': {'extra_context': {'extra_var': 'generic var'}},
+            'extra_context.html extra_context': self.test_data4['placeholderconf']['extra_context'],
+        }
+        cache.clear()
+        with override_placeholder_conf(CMS_PLACEHOLDER_CONF=combined_conf):
+            r = self.render(self.test_page4, template=t)
+        self.assertEqual(r, self.test_data4['extra'])  # template-specific wins, not 'generic var'
+
     def test_placeholder_or(self):
         """
         Tests the {% placeholder %} templatetag.


### PR DESCRIPTION

## Summary by Sourcery

Add regression tests to verify template-specific CMS_PLACEHOLDER_CONF behavior and precedence over generic placeholder configuration.

Tests:
- Add test ensuring template-specific CMS_PLACEHOLDER_CONF keys are applied when rendering placeholders.
- Add test ensuring template-specific CMS_PLACEHOLDER_CONF entries take precedence over generic slot-level configuration.

In django CMS 5.0.7 this missing tests caused a regression.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8652 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.
