### PR TITLE
fix: Slugs of published pages could be changed (#8640)

### DIFF
--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -519,6 +519,27 @@ class DuplicatePageForm(AddPageForm):
     )
 
 
+def url_is_locked(page_content):
+    """Return whether ``page_content``'s URL is shared with a published
+    (publicly visible) version of the same page and language.
+
+    With a versioning package installed the slug and path live on the
+    (unversioned) :class:`~cms.models.pagemodel.PageUrl` and are therefore
+    shared across all versions of a page. Editing the slug of a draft would
+    silently change the URL of the already published version. Without versioning
+    the content being edited *is* the public version, so the URL is never
+    locked.
+    """
+    if page_content is None or page_content.pk is None:
+        return False
+    public_pk = (
+        PageContent.objects.filter(page=page_content.page_id, language=page_content.language)
+        .values_list("pk", flat=True)
+        .first()
+    )
+    return public_pk is not None and public_pk != page_content.pk
+
+
 class ChangePageForm(BasePageContentForm):
     overwrite_url = forms.CharField(
         label=_("Overwrite URL"),
@@ -601,6 +622,19 @@ class ChangePageForm(BasePageContentForm):
         if not self.url_obj.managed:
             self.fields["overwrite_url"].initial = self.url_obj.path
 
+        if self._url_is_locked:
+            # The URL is shared with a published version of this page (only
+            # possible with a versioning package installed). Changing the slug
+            # or overwrite URL would silently change the live URL, so drop those
+            # fields from the editable form. PageContentAdmin renders them as
+            # read-only instead (see PageContentAdmin.get_readonly_fields()).
+            self.fields.pop("slug", None)
+            self.fields.pop("overwrite_url", None)
+
+    @cached_property
+    def _url_is_locked(self):
+        return url_is_locked(self.instance)
+
     @cached_property
     def _language(self):
         return self.instance.language
@@ -614,6 +648,10 @@ class ChangePageForm(BasePageContentForm):
             return data
 
         page = self.instance.page
+
+        if self._url_is_locked:
+            # The slug and overwrite URL are read-only; the URL must not change.
+            return data
 
         if page.is_home:
             data["path"] = ""
@@ -683,16 +721,21 @@ class ChangePageForm(BasePageContentForm):
             changed_date=timezone.now(),
             **data,
         )
-        page.update_urls(
-            self._language,
-            path=page_path,
-            slug=page_slug,
-            managed=not bool(page_overwrite_url),
-        )
-        page._update_url_path_recursive(self._language)
+        from cms.models.pagemodel import _lock_tree_roots
+
+        if not self._url_is_locked:
+            # When the URL is shared with a published version the slug/path must
+            # not change, so the (read-only) URL fields are ignored on save.
+            page.update_urls(
+                self._language,
+                path=page_path,
+                slug=page_slug,
+                managed=not bool(page_overwrite_url),
+            )
+            page._update_url_path_recursive(self._language)
         page.clear_cache(menu=True)
 
-        if page.application_urls and "slug" in self.changed_data:
+        if not self._url_is_locked and page.application_urls and "slug" in self.changed_data:
             # Connects the apphook restart handler to the request finished signal
             set_restart_trigger()
         send_post_page_operation(

--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -532,12 +532,11 @@ def url_is_locked(page_content):
     """
     if page_content is None or page_content.pk is None:
         return False
-    public_pk = (
+    return (
         PageContent.objects.filter(page=page_content.page_id, language=page_content.language)
         .values_list("pk", flat=True)
-        .first()
+        .exclude(pk=page_content.pk).exists()
     )
-    return public_pk is not None and public_pk != page_content.pk
 
 
 class ChangePageForm(BasePageContentForm):

--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -720,8 +720,6 @@ class ChangePageForm(BasePageContentForm):
             changed_date=timezone.now(),
             **data,
         )
-        from cms.models.pagemodel import _lock_tree_roots
-
         if not self._url_is_locked:
             # When the URL is shared with a published version the slug/path must
             # not change, so the (read-only) URL fields are ignored on save.

--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -519,7 +519,7 @@ class DuplicatePageForm(AddPageForm):
     )
 
 
-def url_is_locked(page_content):
+def url_is_locked(page_content: PageContent) -> bool:
     """Return whether ``page_content``'s URL is shared with a published
     (publicly visible) version of the same page and language.
 

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -37,7 +37,7 @@ from django.utils.decorators import method_decorator
 from django.utils.encoding import force_str
 from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext as _, gettext_lazy
 from django.views.decorators.http import require_POST
 
 from cms import operations
@@ -50,6 +50,7 @@ from cms.admin.forms import (
     CopyPermissionForm,
     DuplicatePageForm,
     MovePageForm,
+    url_is_locked,
 )
 from cms.admin.permissionadmin import PERMISSION_ADMIN_INLINES
 from cms.cache.permissions import clear_permission_cache
@@ -855,18 +856,36 @@ class PageContentAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
         form._request = request
         return form
 
+    def get_readonly_fields(self, request, obj=None):
+        readonly_fields = super().get_readonly_fields(request, obj)
+        if obj is not None and url_is_locked(obj):
+            # The page's URL is shared with a published version (only possible
+            # with a versioning package installed). Editing the slug here would
+            # silently change the live URL, so render the slug and overwrite URL
+            # read-only. The values are supplied by the matching display methods.
+            readonly_fields = (*readonly_fields, "slug", "overwrite_url")
+        return readonly_fields
+
+    @admin.display(
+        description=gettext_lazy("Slug (to change it, first unpublish the currently published version of this page)")
+    )
     def slug(self, obj):
         # For read-only views: Get slug from the page content object
         if not hasattr(obj, "_url_obj"):
             obj._url_obj = obj.page.get_url(obj.language)
         return obj._url_obj.slug
 
+    @admin.display(
+        description=gettext_lazy(
+            "Overwrite URL (to change it, first unpublish the currently published version of this page)"
+        )
+    )
     def overwrite_url(self, obj):
-        # For read-only views: Get slug from the page content object
+        # For read-only views: Get the overwrite URL from the page content object
         if not hasattr(obj, "_url_obj"):
             obj._url_obj = obj.page.get_url(obj.language)
         if obj._url_obj.managed:
-            return None
+            return ""
         return obj._url_obj.path
 
     def duplicate(self, request, object_id):

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -35,6 +35,8 @@ from django.template.response import SimpleTemplateResponse, TemplateResponse
 from django.urls import re_path
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_str
+from django.utils.functional import lazy
+from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
 from django.utils.translation import gettext as _, gettext_lazy
@@ -86,6 +88,10 @@ from cms.utils.plugins import copy_plugins_to_placeholder
 from cms.utils.urlutils import admin_reverse
 
 require_POST = method_decorator(require_POST)
+
+# Lazily-evaluated format_html so translatable admin labels containing markup are
+# resolved at render time (and in the active language), not at import time.
+format_html_lazy = lazy(format_html, str)
 
 
 def get_site(request):
@@ -867,7 +873,11 @@ class PageContentAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
         return readonly_fields
 
     @admin.display(
-        description=gettext_lazy("Slug (to change it, first unpublish the currently published version of this page)")
+        description=format_html_lazy(
+            '{} <small class="help">{}</small>',
+            gettext_lazy("Slug"),
+            gettext_lazy("(to change it, first unpublish the currently published version of this page)"),
+        )
     )
     def slug(self, obj):
         # For read-only views: Get slug from the page content object
@@ -876,8 +886,10 @@ class PageContentAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
         return obj._url_obj.slug
 
     @admin.display(
-        description=gettext_lazy(
-            "Overwrite URL (to change it, first unpublish the currently published version of this page)"
+        description=format_html_lazy(
+            '{} <small class="help">{}</small>',
+            gettext_lazy("Overwrite URL"),
+            gettext_lazy("(to change it, first unpublish the currently published version of this page)"),
         )
     )
     def overwrite_url(self, obj):

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -1,7 +1,9 @@
 import datetime
 import json
 import sys
+from contextlib import contextmanager
 from unittest import skipUnless
+from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib import admin
@@ -17,6 +19,7 @@ from django.utils.timezone import now as tz_now
 from django.utils.translation import override as force_language
 
 from cms import constants
+from cms.admin.forms import ChangePageForm
 from cms.admin.pageadmin import PageContentAdmin
 from cms.api import add_plugin, create_page, create_page_content
 from cms.appresolver import clear_app_resolvers
@@ -1194,6 +1197,88 @@ class PageTest(PageTestBase):
         with self.login_user_context(superuser):
             response = self.client.get(endpoint)
             self.assertContains(response, expected, html=True)
+
+    @override_settings(CMS_PERMISSION=False)
+    def test_slug_readonly_when_url_locked(self):
+        # When the page URL is shared with a published version (only possible
+        # with a versioning package installed), the slug and overwrite URL are
+        # rendered read-only: they are dropped from the editable form and shown
+        # as static text by PageContentAdmin instead.
+        superuser = self.get_superuser()
+        cms_page = create_page("page", "nav_playground.html", "en")
+        endpoint = self.get_page_change_uri("en", cms_page)
+
+        with self.login_user_context(superuser), self._url_locked():
+            response = self.client.get(endpoint)
+
+            self.assertEqual(response.status_code, 200)
+            adminform = response.context["adminform"]
+            # Rendered read-only by the admin (so no editable form field) ...
+            self.assertIn("slug", adminform.readonly_fields)
+            self.assertIn("overwrite_url", adminform.readonly_fields)
+            self.assertNotIn("slug", adminform.form.fields)
+            self.assertNotIn("overwrite_url", adminform.form.fields)
+            # ... while still displaying the current value ...
+            self.assertContains(response, "page")
+            # ... and explaining in the label how to make it editable.
+            self.assertContains(response, "first unpublish the currently published version")
+
+    @override_settings(CMS_PERMISSION=False)
+    def test_slug_editable_when_url_not_locked(self):
+        # Without a published version sharing the URL (the default in core
+        # django-CMS) the slug stays editable.
+        superuser = self.get_superuser()
+        cms_page = create_page("page", "nav_playground.html", "en")
+        endpoint = self.get_page_change_uri("en", cms_page)
+
+        with self.login_user_context(superuser):
+            response = self.client.get(endpoint)
+
+            self.assertEqual(response.status_code, 200)
+            adminform = response.context["adminform"]
+            self.assertNotIn("slug", adminform.readonly_fields)
+            self.assertIn("slug", adminform.form.fields)
+            self.assertIn("overwrite_url", adminform.form.fields)
+
+    @override_settings(CMS_PERMISSION=False)
+    def test_locked_url_unchanged_on_save(self):
+        # A locked URL must not change even if a different slug is posted, but
+        # other (non-URL) page content fields are still saved.
+        superuser = self.get_superuser()
+        cms_page = create_page("page", "nav_playground.html", "en")
+        translation = cms_page.get_content_obj("en", fallback=False)
+        changelist = self.get_pages_admin_list_uri()
+        endpoint = self.get_page_change_uri("en", cms_page)
+
+        with self.login_user_context(superuser):
+            page_data = {
+                "title": "A new title",
+                "slug": "a-changed-slug",
+                "overwrite_url": "",
+                "template": translation.template,
+            }
+            with self._url_locked():
+                response = self.client.post(endpoint, page_data)
+            self.assertRedirects(response, changelist)
+
+        # The slug/path are untouched ...
+        self.assertEqual(cms_page.get_slug("en"), "page")
+        self.assertFalse(cms_page.urls.filter(slug="a-changed-slug").exists())
+        # ... while other content fields were saved.
+        translation.refresh_from_db()
+        self.assertEqual(translation.title, "A new title")
+
+    @staticmethod
+    @contextmanager
+    def _url_locked():
+        # Simulate a shared, published page URL (as a versioning package would
+        # produce) without versioning installed. The helper is imported into
+        # both the forms and the pageadmin namespaces, so both must be patched.
+        with (
+            patch("cms.admin.forms.url_is_locked", return_value=True),
+            patch("cms.admin.pageadmin.url_is_locked", return_value=True),
+        ):
+            yield
 
     @override_settings(CMS_PERMISSION=False)
     def test_advanced_settings_form_apphook(self):


### PR DESCRIPTION

## Summary by Sourcery

Prevent admin edits from changing the URL of pages whose slug/path is shared with a published version, while keeping other page content editable.

Bug Fixes:
- Make slug and overwrite URL fields read-only in the admin when the page URL is shared with a published version to avoid silently changing live URLs.
- Ensure locked URLs are not updated on save even if different slug data is posted.

Enhancements:
- Introduce a reusable helper to detect when a page content’s URL is locked because it is shared across versions and adjust form behavior accordingly.
- Improve admin slug and overwrite URL display with explanatory, localized help text about how to make the fields editable.

Tests:
- Add admin tests to verify slug/overwrite URL fields become read-only when URLs are locked, remain editable otherwise, and that locked URLs stay unchanged on save.
## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8640 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.
