### PR TITLE
fix: Transifex upload script failed

### DIFF
--- a/scripts/make-release
+++ b/scripts/make-release
@@ -187,10 +187,7 @@ cd cms
 
 # 2.2: make messages and push them
 
-status "- Sending messages to transifex does not work currently"
-status "  Send them manually before creating a version"
-# status "- Creating transifex messages!"
-"$SCRIPTS/tx" --token "$TX_TOKEN" status
+status "- Creating transifex messages and pushing source strings"
 "$SCRIPTS/transifex-send-strings"
 
 git diff-index --quiet HEAD locale || git commit locale -m "${COMMIT_PREFIX}Building locales" --allow-empty

--- a/scripts/transifex-send-strings
+++ b/scripts/transifex-send-strings
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 SCRIPTS=$(dirname "$(realpath "$0")")
 ROOT=$(git rev-parse --show-toplevel)
 
@@ -9,4 +12,10 @@ django-admin makemessages -l en -d djangojs --no-location
 
 
 "${SCRIPTS}/filter-locale-changes"
-"${SCRIPTS}/tx" --token "$TX_TOKEN" push -s --skip
+
+# tx resolves the paths in .tx/config relative to the current directory, and
+# those paths are repo-root relative (cms/locale/...). Run tx from the root,
+# mirroring transifex-pull-strings, otherwise it looks for cms/cms/locale/...
+# and fails to find the source files.
+cd "${ROOT}"
+"${SCRIPTS}/tx" --token "$TX_TOKEN" push -s


### PR DESCRIPTION

## Summary by Sourcery

Fix the Transifex string upload script used in the release tooling so that translations can be correctly sent during the release process.

Bug Fixes:
- Resolve failures in the Transifex string upload script invoked by the release tooling.

Build:
- Adjust release scripts to correctly integrate the fixed Transifex upload step.
## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.
