### PR TITLE
feat: Accessibility update for wizards (#8674)

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -924,31 +924,22 @@ class PageContentAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
         if extra_context is None:
             extra_context = {}
 
-        if "duplicate" in request.path_info:
-            extra_context.update(
-                {
-                    "title": _("Add Page Copy"),
-                }
-            )
-        elif "parent_page" in request.GET:
-            extra_context.update(
-                {
-                    "title": _("New sub page"),
-                }
-            )
-        else:
-            extra_context.update(
-                {
-                    "title": _("New page"),
-                }
-            )
-
         try:
             page_id = request.GET.get("cms_page") or request.POST.get("cms_page")
             page_id = IntegerField().clean(page_id)
             cms_page = Page.objects.get(pk=page_id)
         except (ValidationError, Page.DoesNotExist):
             cms_page = None
+
+        if cms_page:
+            # Adding content for an existing page in a language it does not have yet
+            extra_context["title"] = _("Add Translation")
+        elif "duplicate" in request.path_info:
+            extra_context["title"] = _("Add Page Copy")
+        elif "parent_page" in request.GET:
+            extra_context["title"] = _("New sub page")
+        else:
+            extra_context["title"] = _("New page")
 
         if cms_page:
             extra_context["cms_page"] = cms_page

--- a/cms/static/cms/js/modules/cms.base.js
+++ b/cms/static/cms/js/modules/cms.base.js
@@ -545,6 +545,8 @@ export const KEYS = {
     TAB: 9,
     UP: 38,
     DOWN: 40,
+    LEFT: 37,
+    RIGHT: 39,
     ENTER: 13,
     SPACE: 32,
     ESC: 27,

--- a/cms/static/cms/js/modules/cms.pagetree.js
+++ b/cms/static/cms/js/modules/cms.pagetree.js
@@ -413,6 +413,15 @@ var PageTree = new Class({
             that._paste(e);
         });
 
+        // related-object lookup popup: clicking a node returns its id to the opener
+        this.ui.container.on(this.click, '.js-cms-pagetree-node-select', function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            if (window.opener) {
+                window.opener.dismissRelatedLookupPopup(window, $(this).data('id'));
+            }
+        });
+
         // advanced settings link handling
         this.ui.container.on(this.click, '.js-cms-tree-advanced-settings', function(e) {
             if (e.shiftKey) {

--- a/cms/static/cms/js/modules/cms.wizards.js
+++ b/cms/static/cms/js/modules/cms.wizards.js
@@ -28,8 +28,13 @@ document.addEventListener('DOMContentLoaded', function() {
                 return;
             }
 
-            // mark a choice as the selected radio of the group, keeping the
-            // ARIA state, the roving tabindex and the backing <input> in sync
+            /**
+             * Mark a choice as the selected radio of the group, keeping the
+             * ARIA state, the roving tabindex and the backing <input> in sync.
+             *
+             * @param {HTMLElement} choice the choice element to activate
+             * @param {Boolean} setFocus whether to move focus to the choice
+             */
             function activate(choice, setFocus) {
                 var i;
                 var radio;

--- a/cms/static/cms/js/modules/cms.wizards.js
+++ b/cms/static/cms/js/modules/cms.wizards.js
@@ -9,49 +9,110 @@
  */
 var CMS = window.CMS || {};
 
-// #############################################################################
-// MODAL
-(function($) {
+document.addEventListener('DOMContentLoaded', function() {
+    /**
+     * Adds internal methods for the creation wizard.
+     *
+     * @class Wizards
+     * @namespace CMS
+     */
     'use strict';
 
-    // shorthand for jQuery(document).ready();
-    $(function() {
-        /**
-         * Adds internal methods for the creation wizard.
-         *
-         * @class Wizards
-         * @namespace CMS
-         */
-        CMS.Wizards = {
-            _choice: function initialize() {
-                // set active element when making a choice
-                var form = $('form');
-                var choices = $('.choice');
+    CMS.Wizards = {
+        _choice: function initialize() {
+            // set active element when making a choice
+            const form = document.querySelector('form');
+            const choices = document.querySelectorAll('.choice');
 
-                choices.on('click keyup', function(e) {
-                    if (e.type === 'keydown' && e.keyCode !== CMS.KEYS.ENTER) {
-                        return;
+            if (!form || !choices.length) {
+                return;
+            }
+
+            // mark a choice as the selected radio of the group, keeping the
+            // ARIA state, the roving tabindex and the backing <input> in sync
+            function activate(choice, setFocus) {
+                var i;
+                var radio;
+
+                for (i = 0; i < choices.length; i++) {
+                    choices[i].classList.remove('active');
+                    choices[i].setAttribute('aria-checked', 'false');
+                    choices[i].setAttribute('tabindex', '-1');
+                    radio = choices[i].querySelector('input[type="radio"]');
+                    if (radio) {
+                        radio.checked = false;
                     }
+                }
 
-                    choices.removeClass('active').eq(choices.index(e.currentTarget)).addClass('active');
+                choice.classList.add('active');
+                choice.setAttribute('aria-checked', 'true');
+                choice.setAttribute('tabindex', '0');
+                radio = choice.querySelector('input[type="radio"]');
+                if (radio) {
+                    radio.checked = true;
+                }
 
-                    if (e.type === 'keyup' && e.keyCode === CMS.KEYS.ENTER) {
-                        form.submit();
+                if (setFocus) {
+                    choice.focus();
+                }
+            }
+
+            choices.forEach(function(choice) {
+                choice.addEventListener('click', function() {
+                    activate(choice, false);
+                });
+
+                choice.addEventListener('keydown', function(e) {
+                    var index = Array.prototype.indexOf.call(choices, choice);
+
+                    switch (e.keyCode) {
+                        case CMS.KEYS.ENTER:
+                            e.preventDefault();
+                            activate(choice, false);
+                            form.submit();
+                            break;
+                        case CMS.KEYS.SPACE:
+                            e.preventDefault();
+                            activate(choice, false);
+                            break;
+                        case CMS.KEYS.UP:
+                        case CMS.KEYS.LEFT:
+                            e.preventDefault();
+                            activate(
+                                choices[(index - 1 + choices.length) % choices.length],
+                                true
+                            );
+                            break;
+                        case CMS.KEYS.DOWN:
+                        case CMS.KEYS.RIGHT:
+                            e.preventDefault();
+                            activate(
+                                choices[(index + 1) % choices.length],
+                                true
+                            );
+                            break;
+                        default:
+                            break;
                     }
                 });
+
                 // submit the form on double click
-                choices.on('dblclick', function() {
+                choice.addEventListener('dblclick', function() {
+                    activate(choice, false);
                     form.submit();
                 });
+            });
 
-                // focus window so hitting "enter" doesnt trigger a refresh
-                choices.eq(0).focus();
-            }
-        };
+            // make sure the active (or first) choice is the tab stop and
+            // focus it so hitting "enter" doesn't trigger a refresh
+            const active = document.querySelector('.choice.active');
 
-        // directly initialize required methods
-        if ($('.choice').length) {
-            CMS.Wizards._choice();
+            activate(active || choices[0], true);
         }
-    });
-})(CMS.$);
+    };
+
+    // directly initialize required methods
+    if (document.querySelector('.choice')) {
+        CMS.Wizards._choice();
+    }
+});

--- a/cms/templates/admin/cms/page/change_form.html
+++ b/cms/templates/admin/cms/page/change_form.html
@@ -52,7 +52,8 @@
 {% endif %}
 
 <div id="lang_tab_content">
-{% if is_popup %}<input type="hidden" name="_popup" value="1" />{% endif %}
+{% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1" />{% endif %}
+{% if to_field %}<input type="hidden" name="{{ to_field_var }}" value="{{ to_field }}" />{% endif %}
 {% if save_on_top %}{% submit_row %}{% endif %}
 {% if errors %}
 <p class="errornote">

--- a/cms/templates/admin/cms/page/tree/menu.html
+++ b/cms/templates/admin/cms/page/tree/menu.html
@@ -15,8 +15,8 @@
             cms-tree-node-shared-false
         {% endif %}
     {% endblock %}
+    {% if is_popup %} js-cms-pagetree-node-select{% endif %}
     "
-    {% if is_popup %}onclick="opener.dismissRelatedLookupPopup(window, {{ page.pk|unlocalize }}); return false;"{% endif %}
     data-id="{{ page.pk|unlocalize }}"
     data-node-id="{{ page.pk|unlocalize }}"
     data-slug="{{ page_content.slug }}"

--- a/cms/templates/cms/wizards/base.html
+++ b/cms/templates/cms/wizards/base.html
@@ -3,6 +3,7 @@
 
 {% block extrastyle %}
     {{ block.super }}
+    <link rel="stylesheet" href="{% static "admin/css/forms.css" %}">
 {% endblock %}
 
 {% block bodyclass %}cms-admin cms-admin-modal{% endblock %}

--- a/cms/templates/cms/wizards/includes/form_fields.html
+++ b/cms/templates/cms/wizards/includes/form_fields.html
@@ -1,26 +1,10 @@
-{% load i18n %}
+{% load cms_admin %}
 
-{% csrf_token %}
+{# Non-field errors are not part of a fieldset, so render them separately. #}
+{{ form.non_field_errors }}
 
-{{ inlineformset.management_form }}
-
+{# Hidden fields are rendered outside the fieldset, mirroring django admin. #}
 {% for hidden in form.hidden_fields %}{{ hidden }}{% endfor %}
 
-<fieldset class="module aligned">
-    {% for field in form.visible_fields %}
-        <div class="form-row {{ field.name }}{% if field.errors %} errors{% endif %}">
-            {% if field.errors %}
-                <ul class="errorlist">
-                    {% for error in field.errors %}
-                        <li>{{ error }}</li>
-                    {% endfor %}
-                </ul>
-            {% endif %}
-            <div>
-                <label {% if field.field.required %}class="required" {% endif %}for="{{ field.id_for_label }}">{{ field.label }}</label>
-                {{ field }}{% if field.help_text %}
-                <p class="help">{{ field.help_text }}</p>{% endif %}
-            </div>
-        </div>
-    {% endfor %}
-</fieldset>
+{% admin_fieldset form as fieldset %}
+{% include "admin/includes/fieldset.html" with fieldset=fieldset heading_level=2 %}

--- a/cms/templates/cms/wizards/wizardoptionwidget.html
+++ b/cms/templates/cms/wizards/wizardoptionwidget.html
@@ -1,9 +1,29 @@
-{% for group, entries, index in widget.optgroups %}
-    {% for entry in entries %}
-        <label tabindex="0" class="choice{% if forloop.parentloop.first %} active{% endif %}">
-            <input type="radio" name="{{ entry.name }}" value="{{ entry.value }}"{% if forloop.parentloop.first %} checked{% endif %}>
-            <strong>{{ entry.label }}</strong>
-            <span class="info">{{ entry.attrs.description }}</span>
-        </label>
+{% load i18n %}
+{% comment %}
+Accessible radio group for the wizard's first step.
+
+Each ``.choice`` is a styled label exposed as ``role="radio"`` so screen
+readers announce it and its checked state, while the real (visually hidden)
+``<input type="radio">`` it wraps still carries the value on submit. Keyboard
+support (roving tabindex, arrow keys, enter/space) is provided by
+``cms/js/modules/cms.wizards.js``.
+{% endcomment %}
+<div class="choice-group" role="radiogroup" aria-label="{% translate "Select what you would like to create" %}">
+    {% for group, entries, index in widget.optgroups %}
+        {% for entry in entries %}
+            <label class="choice{% if entry.selected %} active{% endif %}"
+                   role="radio"
+                   tabindex="{% if entry.selected %}0{% else %}-1{% endif %}"
+                   aria-checked="{% if entry.selected %}true{% else %}false{% endif %}"
+                   {% if entry.attrs.description %}aria-describedby="{{ entry.attrs.id }}_description"{% endif %}>
+                <input type="radio" tabindex="-1" aria-hidden="true"
+                       name="{{ entry.name }}" value="{{ entry.value }}" id="{{ entry.attrs.id }}"
+                       {% if entry.selected %}checked{% endif %}>
+                <strong>{{ entry.label }}</strong>
+                {% if entry.attrs.description %}
+                    <span class="info" id="{{ entry.attrs.id }}_description">{{ entry.attrs.description }}</span>
+                {% endif %}
+            </label>
+        {% endfor %}
     {% endfor %}
-{% endfor %}
+</div>

--- a/cms/templatetags/cms_admin.py
+++ b/cms/templatetags/cms_admin.py
@@ -4,10 +4,13 @@ from classytags.helpers import AsTag, InclusionTag
 from django import template
 from django.conf import settings
 from django.contrib import admin
+from django.contrib.admin.helpers import Fieldset
+from django.contrib.admin.options import IS_POPUP_VAR, TO_FIELD_VAR
 from django.contrib.admin.views.main import ERROR_FLAG
 from django.template.loader import render_to_string
 from django.utils.encoding import force_str
 from django.utils.html import escape, format_html
+from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 from django.utils.translation import get_language, gettext_lazy as _
 
@@ -19,6 +22,24 @@ from cms.utils.urlutils import admin_reverse
 register = template.Library()
 
 CMS_ADMIN_ICON_BASE = f"{settings.STATIC_URL}admin/img/"
+
+
+@register.simple_tag
+def admin_fieldset(form, *fields):
+    """
+    Wrap a plain form in Django admin's ``Fieldset`` helper so it can be
+    rendered with ``admin/includes/fieldset.html``. This gives the form the
+    admin's field layout and accessibility features (label tags, help-text
+    association via ``*_helptext`` ids, checkbox rows, per-field error
+    placement) without depending on djangocms-admin-style.
+
+    No ``ModelAdmin`` is required: it is only consulted for readonly fields,
+    which plain forms do not declare. By default all visible fields are used;
+    pass field names to render a subset.
+    """
+    if not fields:
+        fields = [bound_field.name for bound_field in form.visible_fields()]
+    return Fieldset(form, fields=fields)
 
 
 class GetAdminUrlForLanguage(AsTag):
@@ -36,9 +57,25 @@ class GetAdminUrlForLanguage(AsTag):
         if language in page.get_languages():
             page_content = page.get_admin_content(language)
             if page_content:
-                return admin_reverse('cms_pagecontent_change', args=[page_content.pk])
+                admin_url = admin_reverse('cms_pagecontent_change', args=[page_content.pk])
+                return self._add_popup_params(context, admin_url)
         admin_url = admin_reverse('cms_pagecontent_add')
         admin_url += f'?cms_page={page.pk}&language={language}'
+        return self._add_popup_params(context, admin_url)
+
+    @staticmethod
+    def _add_popup_params(context, admin_url):
+        """Carry the related-object lookup popup state (``_popup``/``_to_field``)
+        onto the language switch url so the popup survives the navigation. These
+        come from the template context, which is preserved across invalid form
+        submissions (unlike the request url, which the form action strips)."""
+        params = {}
+        if context.get('is_popup'):
+            params[IS_POPUP_VAR] = 1
+        if context.get('to_field'):
+            params[TO_FIELD_VAR] = context['to_field']
+        if params:
+            admin_url += ('&' if '?' in admin_url else '?') + urlencode(params)
         return admin_url
 
 

--- a/cms/wizards/forms.py
+++ b/cms/wizards/forms.py
@@ -78,7 +78,6 @@ class WizardStep1Form(BaseFormMixin, forms.Form):
         choices = list(entry_choices(
             user=self._request.user,
             page=self._page,
-            site=self._site,
         ))
         self.fields['entry'].choices = choices
         # Preselect the first entry so the radio group always has an active

--- a/cms/wizards/forms.py
+++ b/cms/wizards/forms.py
@@ -75,10 +75,17 @@ class WizardStep1Form(BaseFormMixin, forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # set the entries here to get an up to date list of entries.
-        self.fields['entry'].choices = entry_choices(
+        choices = list(entry_choices(
             user=self._request.user,
             page=self._page,
-        )
+            site=self._site,
+        ))
+        self.fields['entry'].choices = choices
+        # Preselect the first entry so the radio group always has an active
+        # option. This keeps the historical wizard behaviour and lets the
+        # option template rely solely on each option's ``selected`` flag.
+        if choices and self.fields['entry'].initial is None:
+            self.fields['entry'].initial = choices[0][0]
 
     def get_wizard_entries(self):
         for entry in self['entry']:

--- a/cms/wizards/views.py
+++ b/cms/wizards/views.py
@@ -56,6 +56,10 @@ class WizardCreateView(SessionWizardView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
+        # The wizard is always shown inside the CMS modal. Surface ``is_popup`` to the
+        # template context so that ``admin/base.html`` natively omits the header.
+        context['is_popup'] = True
+
         if self.is_second_step():
             context['wizard_entry'] = self.get_selected_entry()
         return context


### PR DESCRIPTION
## Summary by Sourcery

Improve the accessibility and admin integration of the page creation wizards and related admin workflows.

New Features:
- Add accessible, keyboard-navigable radio-group styling and behavior for wizard entry selection.
- Introduce an admin_fieldset template tag to render plain forms with Django admin fieldset layout and semantics.
- Enable page tree nodes to act as selectable items in related-object lookup popups.

Bug Fixes:
- Ensure related-object lookup popup parameters (_popup, _to_field) are preserved when switching languages or submitting wizard forms.
- Fix the page add view title logic so translations, duplicates, and subpages show accurate titles in the admin modal.

Enhancements:
- Refactor wizard JS from jQuery to vanilla DOM APIs and align keyboard handling with ARIA radio group patterns.
- Update wizard option and form templates to use admin fieldset markup, labels, help text association, and non-field error rendering for better accessibility.
- Preselect the first wizard entry choice to maintain historical behavior and keep ARIA state consistent.
- Extend base keyboard constants to include LEFT and RIGHT arrow keys for reuse in keyboard interactions.
- Use standard admin popup handling in the page tree menu instead of inline onclick attributes for cleaner templates and better event handling.
- Mark wizard views as popups so admin base templates omit redundant headers inside CMS modals.
- Include Django admin form CSS in wizard templates to match admin styling and structure.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.