### PR TITLE
fix: get_child_classes was always cached (#8677)

### DIFF
--- a/cms/plugin_pool.py
+++ b/cms/plugin_pool.py
@@ -267,7 +267,12 @@ class PluginPool:
             return self.global_restrictions_cache[slot]
         return self.global_restrictions_cache[None]
 
-    restriction_methods = ("get_require_parent", "get_child_class_overrides", "get_parent_classes")
+    restriction_methods = (
+        "get_require_parent",
+        "get_child_class_overrides",
+        "get_parent_classes",
+        "get_child_classes",
+    )
 
     def can_cache_globally(self, plugin_class: CMSPluginBase) -> bool:
         """


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure get_child_classes-based restrictions participate correctly in the global restrictions cache.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.