### PR TITLE
fix: get_preview_url failed on frontend-editable objects without language attribute

### DIFF
--- a/cms/templatetags/cms_admin.py
+++ b/cms/templatetags/cms_admin.py
@@ -101,7 +101,7 @@ class GetPreviewUrl(AsTag):
             )
         if not page_content:
             return ""
-        return self.get_url(page_content, language=page_content.language)
+        return self.get_url(page_content, language=getattr(page_content, "language", None))
 
     def get_url(self, object, language):
         return get_object_preview_url(object, language=language)

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -36,6 +36,7 @@ from cms.templatetags.cms_tags import (
     _show_placeholder_by_id,
     render_plugin,
 )
+from cms.test_utils.project.placeholderapp.models import Example1
 from cms.test_utils.fixtures.templatetags import TwoPagesFixture
 from cms.test_utils.testcases import CMSTestCase
 from cms.toolbar.toolbar import CMSToolbar
@@ -87,6 +88,25 @@ class TemplatetagTests(CMSTestCase):
 
         self.assertIn(expected_for_page, output)
         self.assertIn(expected_for_german_content, output)
+
+    def test_get_preview_url_object_without_language(self):
+        """A frontend-editable object that has no ``language`` attribute falls back
+        to the active request language instead of raising ``AttributeError``."""
+        example = Example1.objects.create(char_1="a", char_2="b", char_3="c", char_4="d")
+        self.assertFalse(hasattr(example, "language"))
+
+        template = """
+            {% load cms_admin %}
+            preview={% get_preview_url example %}
+            edit={% get_edit_url example %}
+        """
+        with force_language("en"):
+            output = self.render_template_obj(template, {"example": example}, self.get_request())
+            expected_preview = f"preview={get_object_preview_url(example, language='en')}"
+            expected_edit = f"edit={get_object_edit_url(example, language='en')}"
+
+        self.assertIn(expected_preview, output)
+        self.assertIn(expected_edit, output)
 
     def test_get_edit_url(self):
         """The get_edit_url template tag returns the content edit url for its language:

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -36,8 +36,8 @@ from cms.templatetags.cms_tags import (
     _show_placeholder_by_id,
     render_plugin,
 )
-from cms.test_utils.project.placeholderapp.models import Example1
 from cms.test_utils.fixtures.templatetags import TwoPagesFixture
+from cms.test_utils.project.placeholderapp.models import Example1
 from cms.test_utils.testcases import CMSTestCase
 from cms.toolbar.toolbar import CMSToolbar
 from cms.toolbar.utils import get_object_edit_url, get_object_preview_url


### PR DESCRIPTION
## Summary by Sourcery

Handle frontend-editable objects without a language attribute when generating preview URLs from template tags.

Bug Fixes:
- Ensure get_preview_url and get_edit_url template tags fall back to the active request language when the object lacks a language attribute instead of raising an AttributeError.

Tests:
- Add a regression test verifying preview and edit URLs are correctly generated for objects without a language attribute using the active request language.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.