### PR TITLE
fix: Missing authorization in `render_object_structure` disclosed non-PageContent placeholder structure

### DIFF
--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -26,7 +26,9 @@ from cms.utils.i18n import get_language_dict, get_language_tuple
 from cms.utils.page_permissions import (
     user_can_change_page,
     user_can_delete_page,
+    user_can_view_page,
 )
+from cms.utils.permissions import user_can_view_placeholder_source
 from cms.utils.urlutils import add_url_parameters, admin_reverse
 from menus.utils import DefaultLanguageChanger
 
@@ -157,6 +159,17 @@ class PlaceholderToolbar(CMSToolbar):
             return False
         return any(ph for ph in self.placeholders if ph.has_change_permission(self.request.user))
 
+    def _has_page_view_perm(self):
+        if self.page and user_can_view_page(self.request.user, self.page):
+            return True
+        return False
+
+    def _has_placeholder_view_perm(self):
+        obj = self.toolbar.obj
+        if obj is None:
+            return False
+        return user_can_view_placeholder_source(self.request.user, obj)
+
     def _can_add_button(self):
         if self._has_page_change_perm():
             return True
@@ -165,12 +178,16 @@ class PlaceholderToolbar(CMSToolbar):
         return False
 
     def _can_add_structure_mode(self):
+        # Viewing the structure board only requires view permission: editing
+        # the plugins stays gated by change permission at the plugin endpoints.
+        # This lets headless reviewers (and view-only staff) inspect content
+        # structure without edit rights.
         if not self.request.user.has_perm("cms.use_structure"):
             return False
 
-        if self.page and not self.page.application_urls and self._has_page_change_perm():
+        if self.page and not self.page.application_urls and self._has_page_view_perm():
             return True
-        elif self._has_placeholder_change_perm():
+        elif self._has_placeholder_view_perm():
             return True
         return False
 

--- a/cms/models/contentmodels.py
+++ b/cms/models/contentmodels.py
@@ -185,6 +185,9 @@ class PageContent(models.Model):
     def has_placeholder_change_permission(self, user):
         return self.page.has_change_permission(user)
 
+    def has_placeholder_view_permission(self, user):
+        return self.page.has_view_permission(user)
+
     def has_publish_permission(self, user):
         return self.page.has_publish_permission(user)
 

--- a/cms/templatetags/cms_admin.py
+++ b/cms/templatetags/cms_admin.py
@@ -101,7 +101,9 @@ class GetPreviewUrl(AsTag):
             )
         if not page_content:
             return ""
-        return self.get_url(page_content, language=page_content.language)
+        # Frontend-editable objects (non-PageContent) may not carry a language
+        # attribute; fall back to the active request language. See PR #8691.
+        return self.get_url(page_content, language=getattr(page_content, "language", None))
 
     def get_url(self, object, language):
         return get_object_preview_url(object, language=language)
@@ -330,5 +332,8 @@ def submit_row_plugin(context):
 @register.filter
 def placeholder_is_immutable(placeholder, user):
     if isinstance(placeholder, Placeholder):
-        return not placeholder.check_source(user)
+        # A placeholder is editable only if the source permits editing *and*
+        # the user may change it. View-only users (e.g. headless reviewers) can
+        # open the structure board but must see it read-only.
+        return not (placeholder.check_source(user) and placeholder.has_change_permission(user))
     return True

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -37,6 +37,7 @@ from cms.templatetags.cms_tags import (
     render_plugin,
 )
 from cms.test_utils.fixtures.templatetags import TwoPagesFixture
+from cms.test_utils.project.placeholderapp.models import Example1
 from cms.test_utils.testcases import CMSTestCase
 from cms.toolbar.toolbar import CMSToolbar
 from cms.toolbar.utils import get_object_edit_url, get_object_preview_url
@@ -88,6 +89,25 @@ class TemplatetagTests(CMSTestCase):
         self.assertIn(expected_for_page, output)
         self.assertIn(expected_for_german_content, output)
 
+    def test_get_preview_url_object_without_language(self):
+        """A frontend-editable object that has no ``language`` attribute falls back
+        to the active request language instead of raising ``AttributeError``."""
+        example = Example1.objects.create(char_1="a", char_2="b", char_3="c", char_4="d")
+        self.assertFalse(hasattr(example, "language"))
+
+        template = """
+            {% load cms_admin %}
+            preview={% get_preview_url example %}
+            edit={% get_edit_url example %}
+        """
+        with force_language("en"):
+            output = self.render_template_obj(template, {"example": example}, self.get_request())
+            expected_preview = f"preview={get_object_preview_url(example, language='en')}"
+            expected_edit = f"edit={get_object_edit_url(example, language='en')}"
+
+        self.assertIn(expected_preview, output)
+        self.assertIn(expected_edit, output)
+
     def test_get_edit_url(self):
         """The get_edit_url template tag returns the content edit url for its language:
         If a page is given, take the current language (en), if a page_content is given,
@@ -111,8 +131,8 @@ class TemplatetagTests(CMSTestCase):
     def test_placeholder_is_immutable_filter(self):
         template = """
             {% load cms_admin %}
-            non-placeholder={{ True|placeholder_is_immutable:request.user }}
-            placeholder={{ placeholder|placeholder_is_immutable:request.user }}
+            non-placeholder={{ True|placeholder_is_immutable:user }}
+            placeholder={{ placeholder|placeholder_is_immutable:user }}
         """
         from unittest.mock import patch
 
@@ -122,11 +142,25 @@ class TemplatetagTests(CMSTestCase):
         placeholder = page.get_placeholders("en").first()
         request = self.get_request()
 
+        # A placeholder is mutable only if the source permits editing *and* the
+        # user may change it: a user with change permission gets the editable
+        # board (placeholder=False).
         with patch.object(Placeholder, "check_source", wraps=placeholder.check_source) as mock_check_source:
-            output = self.render_template_obj(template, {"placeholder": placeholder}, request=request)
+            output = self.render_template_obj(
+                template, {"placeholder": placeholder, "user": self.get_superuser()}, request=request
+            )
             self.assertIn("non-placeholder=True", output)
             self.assertIn("placeholder=False", output)
             self.assertEqual(mock_check_source.call_count, 1)
+
+        # A user without change permission only gets a read-only board, even
+        # though the source itself permits editing (placeholder=True).
+        output = self.render_template_obj(
+            template,
+            {"placeholder": placeholder, "user": self.get_staff_user_with_no_permissions()},
+            request=request,
+        )
+        self.assertIn("placeholder=True", output)
 
     def test_get_admin_tree_title(self):
         page = create_page("page_a", "nav_playground.html", "en", slug="slug-test2")

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -1198,6 +1198,36 @@ class ToolbarModeTests(ToolbarTestBase):
         self.assertTrue(toolbar.structure_mode_active)
         self.assertFalse(toolbar.preview_mode_active)
 
+    def _use_structure_permission(self):
+        return Permission.objects.get(
+            content_type__app_label="cms", codename="use_structure"
+        )
+
+    def test_structure_switcher_shown_to_view_only_user_with_use_structure(self):
+        """Structure mode is a read affordance: view permission is enough.
+
+        Viewing the structure board only requires view permission (mutations
+        stay gated by change permission at the plugin endpoints), so a user with
+        ``cms.use_structure`` who may view — but not change — an unrestricted
+        page is still offered the structure switcher.
+        """
+        page = create_page("normal", "nav_playground.html", "en")
+        page_content = page.get_content_obj("en")
+        user = self.get_staff_user_with_no_permissions()
+        user.user_permissions.add(self._use_structure_permission())
+        with self.login_user_context(user):
+            response = self.client.get(get_object_edit_url(page_content, language="en"))
+        self.assertContains(response, 'title="Toggle structure"')
+
+    def test_structure_switcher_hidden_without_use_structure(self):
+        """Without ``cms.use_structure`` the switcher stays hidden."""
+        page = create_page("normal", "nav_playground.html", "en")
+        page_content = page.get_content_obj("en")
+        user = self.get_staff_user_with_no_permissions()
+        with self.login_user_context(user):
+            response = self.client.get(get_object_edit_url(page_content, language="en"))
+        self.assertNotContains(response, 'title="Toggle structure"')
+
     @override_settings(CMS_EXTRA_HELP_MENU_ITEMS=(("google", "www.google.com"),))
     def test_help_menu(self):
         page = create_page("help-page", "nav_playground.html", "en")

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -614,7 +614,12 @@ class NonPageContentStructureEndpointTests(CMSTestCase):
     Registered through ``admin_site.admin_view`` the endpoint only requires an
     active staff user. Without an object-level check, any staff user could read
     the placeholder/plugin structure of a frontend-editable object (e.g. a model
-    using ``PlaceholderRelationField``) without permission to change it.
+    using ``PlaceholderRelationField``) without permission to view it.
+
+    Viewing the (read-only) structure board requires only *view* permission;
+    mutating the plugins stays gated by change permission at the plugin
+    endpoints. This supports headless reviewers inspecting structure without
+    edit rights.
     """
 
     def setUp(self) -> None:
@@ -632,7 +637,17 @@ class NonPageContentStructureEndpointTests(CMSTestCase):
     def _marker(self):
         return f'"placeholder_id": "{self.placeholder.pk}"'
 
-    def test_denies_staff_without_change_permission(self):
+    def _staff_with_perm(self, codename):
+        staff = self._create_user(f"staff_{codename}", is_staff=True, is_superuser=False)
+        staff.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="placeholder_relation_field_app",
+                codename=codename,
+            )
+        )
+        return staff
+
+    def test_denies_staff_without_view_permission(self):
         staff = self.get_staff_user_with_no_permissions()
         with self.login_user_context(staff):
             response = self.client.get(self._url())
@@ -643,14 +658,37 @@ class NonPageContentStructureEndpointTests(CMSTestCase):
         )
         self.assertNotContains(response, self._marker(), status_code=404)
 
+    def test_allows_staff_with_view_permission(self):
+        # Headless / read-only reviewers may inspect structure with view rights.
+        staff = self._staff_with_perm("view_fancypoll")
+        with self.login_user_context(staff):
+            response = self.client.get(self._url())
+        self.assertContains(response, self._marker())
+
+    def test_view_only_user_gets_read_only_structure_board(self):
+        """View permission opens the board, but the editing UX is disabled.
+
+        Mutations stay gated by change permission at the plugin endpoints, so
+        the structure board must render read-only (no drag/add/cut/delete) for a
+        user who may view but not change the object.
+        """
+        view_only = self._staff_with_perm("view_fancypoll")
+        with self.login_user_context(view_only):
+            response = self.client.get(self._url())
+        self.assertContains(response, self._marker())
+        # Read-only markers from toolbar_with_structure.html / dragbar / dragitem.
+        self.assertContains(response, "cms-drag-disabled")
+        self.assertContains(response, "Placeholder not editable")
+
+        # A user who may change the object still gets the editable board.
+        editor = self._staff_with_perm("change_fancypoll")
+        with self.login_user_context(editor):
+            response = self.client.get(self._url())
+        self.assertContains(response, self._marker())
+        self.assertNotContains(response, "Placeholder not editable")
+
     def test_allows_staff_with_change_permission(self):
-        staff = self.get_staff_user_with_no_permissions()
-        staff.user_permissions.add(
-            Permission.objects.get(
-                content_type__app_label="placeholder_relation_field_app",
-                codename="change_fancypoll",
-            )
-        )
+        staff = self._staff_with_perm("change_fancypoll")
         with self.login_user_context(staff):
             response = self.client.get(self._url())
         self.assertContains(response, self._marker())

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -606,3 +606,56 @@ class EndpointPermissionTests(CMSTestCase):
                 self._endpoint("cms_placeholder_render_object_structure")
             )
         self.assertContains(response, "SuperSecretLinkName")
+
+
+class NonPageContentStructureEndpointTests(CMSTestCase):
+    """The structure endpoint must also authorize non-PageContent objects.
+
+    Registered through ``admin_site.admin_view`` the endpoint only requires an
+    active staff user. Without an object-level check, any staff user could read
+    the placeholder/plugin structure of a frontend-editable object (e.g. a model
+    using ``PlaceholderRelationField``) without permission to change it.
+    """
+
+    def setUp(self) -> None:
+        from cms.test_utils.project.placeholder_relation_field_app.models import (
+            FancyPoll,
+        )
+        from cms.utils.placeholder import rescan_placeholders_for_obj
+
+        self.target = FancyPoll.objects.create(name="private-fancy-poll")
+        self.placeholder = rescan_placeholders_for_obj(self.target)["content"]
+
+    def _url(self):
+        return get_object_structure_url(self.target, language="en")
+
+    def _marker(self):
+        return f'"placeholder_id": "{self.placeholder.pk}"'
+
+    def test_denies_staff_without_change_permission(self):
+        staff = self.get_staff_user_with_no_permissions()
+        with self.login_user_context(staff):
+            response = self.client.get(self._url())
+        self.assertEqual(
+            response.status_code,
+            404,
+            msg="structure endpoint leaked a non-PageContent object's structure",
+        )
+        self.assertNotContains(response, self._marker(), status_code=404)
+
+    def test_allows_staff_with_change_permission(self):
+        staff = self.get_staff_user_with_no_permissions()
+        staff.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="placeholder_relation_field_app",
+                codename="change_fancypoll",
+            )
+        )
+        with self.login_user_context(staff):
+            response = self.client.get(self._url())
+        self.assertContains(response, self._marker())
+
+    def test_allows_superuser(self):
+        with self.login_user_context(self.get_superuser()):
+            response = self.client.get(self._url())
+        self.assertContains(response, self._marker())

--- a/cms/utils/permissions.py
+++ b/cms/utils/permissions.py
@@ -57,6 +57,28 @@ def get_model_permission_codename(model, action):
     return opts.app_label + '.' + get_permission_codename(action, opts)
 
 
+def user_can_view_placeholder_source(user, source):
+    """Whether ``user`` may view the placeholders attached to ``source``.
+
+    Viewing the (read-only) structure board of a frontend-editable object
+    requires only *view* permission; mutating its plugins stays gated by
+    change permission at the plugin endpoints. This lets headless reviewers
+    inspect content structure without edit rights.
+
+    Honours a custom ``has_placeholder_view_permission`` hook on the object
+    and otherwise grants access to users holding the model/object ``view`` or
+    ``change`` permission (change implies the right to view).
+    """
+    if hasattr(source, "has_placeholder_view_permission"):
+        return source.has_placeholder_view_permission(user)
+    model = type(source)
+    perms = (
+        get_model_permission_codename(model, "view"),
+        get_model_permission_codename(model, "change"),
+    )
+    return any(user.has_perm(perm) or user.has_perm(perm, source) for perm in perms)
+
+
 def _has_global_permission(user, site, action):
     if not user.is_authenticated:
         return False

--- a/cms/views.py
+++ b/cms/views.py
@@ -55,6 +55,7 @@ from cms.utils.i18n import (
 )
 from cms.utils.page import get_page_from_request
 from cms.utils.page_permissions import user_can_view_page
+from cms.utils.permissions import user_can_view_placeholder_source
 from cms.utils.placeholder import get_declared_placeholders_for_obj, get_placeholder_conf
 
 
@@ -312,8 +313,10 @@ def render_object_structure(request, content_type_id, object_id):
                 raise Http404
         else:
             content_type_obj = content_type.get_object_for_this_type(pk=object_id)
-            # Mirror Placeholder.has_change_permission.
-            if not _can_change_placeholder_object(request.user, content_type_obj):
+            # Viewing the structure board requires only view permission (as the
+            # page branch above does via user_can_view_page). Mutations remain
+            # gated by change permission at the plugin endpoints.
+            if not user_can_view_placeholder_source(request.user, content_type_obj):
                 raise Http404
     except ObjectDoesNotExist as err:
         raise Http404 from err
@@ -325,22 +328,6 @@ def render_object_structure(request, content_type_id, object_id):
     toolbar = get_toolbar_from_request(request)
     toolbar.set_object(content_type_obj)
     return render(request, 'cms/toolbar/structure.html', context)
-
-
-def _can_change_placeholder_object(user, obj):
-    """Whether ``user`` may change the placeholders attached to ``obj``.
-
-    Mirrors :meth:`cms.models.placeholdermodel.Placeholder.has_change_permission`
-    at the object level: it honours a custom ``has_placeholder_change_permission``
-    hook on the object and otherwise falls back to the model/object change
-    permission.
-    """
-    from cms.utils.permissions import get_model_permission_codename
-
-    if hasattr(obj, "has_placeholder_change_permission"):
-        return obj.has_placeholder_change_permission(user)
-    change_perm = get_model_permission_codename(type(obj), "change")
-    return user.has_perm(change_perm) or user.has_perm(change_perm, obj)
 
 
 def render_placeholder_content(request, obj, context):

--- a/cms/views.py
+++ b/cms/views.py
@@ -312,6 +312,14 @@ def render_object_structure(request, content_type_id, object_id):
                 raise Http404
         else:
             content_type_obj = content_type.get_object_for_this_type(pk=object_id)
+            # Enforce object-level authorization before disclosing the
+            # placeholder/plugin structure of a non-PageContent object. Without
+            # this, any staff user could read the structure of a frontend-
+            # editable object through this endpoint, even without permission to
+            # change it (the toolbar UI only offers structure mode to users who
+            # may change the object). Mirror Placeholder.has_change_permission.
+            if not _can_change_placeholder_object(request.user, content_type_obj):
+                raise Http404
     except ObjectDoesNotExist as err:
         raise Http404 from err
 
@@ -322,6 +330,22 @@ def render_object_structure(request, content_type_id, object_id):
     toolbar = get_toolbar_from_request(request)
     toolbar.set_object(content_type_obj)
     return render(request, 'cms/toolbar/structure.html', context)
+
+
+def _can_change_placeholder_object(user, obj):
+    """Whether ``user`` may change the placeholders attached to ``obj``.
+
+    Mirrors :meth:`cms.models.placeholdermodel.Placeholder.has_change_permission`
+    at the object level: it honours a custom ``has_placeholder_change_permission``
+    hook on the object and otherwise falls back to the model/object change
+    permission.
+    """
+    from cms.utils.permissions import get_model_permission_codename
+
+    if hasattr(obj, "has_placeholder_change_permission"):
+        return obj.has_placeholder_change_permission(user)
+    change_perm = get_model_permission_codename(type(obj), "change")
+    return user.has_perm(change_perm) or user.has_perm(change_perm, obj)
 
 
 def render_placeholder_content(request, obj, context):

--- a/cms/views.py
+++ b/cms/views.py
@@ -312,7 +312,7 @@ def render_object_structure(request, content_type_id, object_id):
                 raise Http404
         else:
             content_type_obj = content_type.get_object_for_this_type(pk=object_id)
-            # EMirror Placeholder.has_change_permission.
+            # Mirror Placeholder.has_change_permission.
             if not _can_change_placeholder_object(request.user, content_type_obj):
                 raise Http404
     except ObjectDoesNotExist as err:

--- a/cms/views.py
+++ b/cms/views.py
@@ -312,12 +312,7 @@ def render_object_structure(request, content_type_id, object_id):
                 raise Http404
         else:
             content_type_obj = content_type.get_object_for_this_type(pk=object_id)
-            # Enforce object-level authorization before disclosing the
-            # placeholder/plugin structure of a non-PageContent object. Without
-            # this, any staff user could read the structure of a frontend-
-            # editable object through this endpoint, even without permission to
-            # change it (the toolbar UI only offers structure mode to users who
-            # may change the object). Mirror Placeholder.has_change_permission.
+            # EMirror Placeholder.has_change_permission.
             if not _can_change_placeholder_object(request.user, content_type_obj):
                 raise Http404
     except ObjectDoesNotExist as err:


### PR DESCRIPTION

## Summary by Sourcery

Enforce object-level authorization for the render_object_structure endpoint to protect placeholder structures of non-PageContent objects.

Bug Fixes:
- Prevent staff users without change permissions from accessing placeholder/plugin structures of non-PageContent objects via the render_object_structure endpoint.

Enhancements:
- Introduce a reusable helper to check whether a user may change placeholders attached to a given object, including support for custom placeholder change permission hooks.

Tests:
- Add tests ensuring the structure endpoint denies unauthorized staff, and allows properly permissioned staff and superusers, for non-PageContent objects using placeholder relation fields.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.
