### PR TITLE
fix: Language selector triggered wrong toolbar (#8687)

### DIFF
--- a/cms/tests/test_menu_utils.py
+++ b/cms/tests/test_menu_utils.py
@@ -1,8 +1,11 @@
+from urllib.parse import urlencode
+
 from django.http import HttpResponse
 
 from cms.api import create_page, create_page_content
 from cms.test_utils.testcases import CMSTestCase
 from cms.test_utils.util.mock import AttributeObject
+from cms.toolbar.toolbar import CMSToolbar
 from cms.utils.i18n import get_language_list
 from menus.templatetags.menu_tags import PageLanguageUrl
 from menus.utils import (
@@ -59,6 +62,95 @@ class MenuUtilsTests(CMSTestCase):
         urls_found = [DefaultLanguageChanger(request)(code)
                       for code in get_language_list(site_id=1)]
         self.assertSequenceEqual(urls_expected, urls_found)
+
+    def test_default_language_changer_uses_cms_path(self):
+        """
+        On asynchronous toolbar/structure requests ``request.path_info`` points at
+        an internal admin/AJAX endpoint, while the viewed page is reported via the
+        ``cms_path`` GET query. The language changer must build URLs for the viewed
+        page rather than the AJAX endpoint (#8465).
+        """
+        cms_page = create_page('en-page', 'nav_playground.html', 'en')
+
+        for language in get_language_list(site_id=1):
+            if language not in ('en', 'pt-br', 'es-mx'):
+                create_page_content(language, '%s-page' % language, cms_page)
+
+        page_url = cms_page.get_absolute_url()
+        # Simulate the async toolbar endpoint: ``path_info`` is an admin endpoint
+        # and the viewed page is reported via the ``cms_path`` GET query.
+        async_path = '/admin/cms/placeholder/object/{pk}/structure/?{query}'.format(
+            pk=cms_page.pk,
+            query=urlencode({'cms_path': page_url}),
+        )
+        request = self.get_request(path=async_path, language='en', page=cms_page)
+        request.toolbar = CMSToolbar(request)
+
+        urls_expected = [
+            '/en/en-page/',
+            '/de/de-page/',
+            '/fr/fr-page/',
+            '/en/en-page/',  # the pt-br url is en because that's a fallback
+            '/en/en-page/',  # the es-mx url is en because that's a fallback
+        ]
+        urls_found = [DefaultLanguageChanger(request)(code)
+                      for code in get_language_list(site_id=1)]
+        self.assertSequenceEqual(urls_expected, urls_found)
+
+    def test_language_changer_request_path_prefers_toolbar(self):
+        """
+        ``DefaultLanguageChanger.request_path`` prefers the toolbar's
+        ``request_path`` (the viewed page) and falls back to ``path_info``.
+        """
+        request = self.get_request(path='/admin/some/endpoint/', language='en')
+
+        # No toolbar attached -> falls back to the actual request path.
+        self.assertEqual(
+            DefaultLanguageChanger(request).request_path,
+            '/admin/some/endpoint/',
+        )
+
+        # Toolbar request_path (viewed page) takes precedence.
+        request.toolbar = CMSToolbar(request, request_path='/en/viewed-page/')
+        self.assertEqual(
+            DefaultLanguageChanger(request).request_path,
+            '/en/viewed-page/',
+        )
+
+    def test_toolbar_request_path_honours_cms_path(self):
+        """
+        ``CMSToolbar.request_path`` is derived from the ``cms_path`` GET query when
+        present, falls back to ``path_info`` otherwise, and an explicit
+        ``request_path`` always wins.
+        """
+        cms_page = create_page('en-page', 'nav_playground.html', 'en')
+        page_url = cms_page.get_absolute_url()
+
+        async_path = '/admin/cms/placeholder/object/{pk}/structure/?{query}'.format(
+            pk=cms_page.pk,
+            query=urlencode({'cms_path': page_url}),
+        )
+        request = self.get_request(path=async_path, language='en', page=cms_page)
+        self.assertEqual(CMSToolbar(request).request_path, page_url)
+
+        # A cms_path that carries its own query string/fragment is reduced to the
+        # bare path (``_get_request_path`` uses ``urlparse(cms_path).path``).
+        async_path_with_query = '/admin/cms/placeholder/object/{pk}/structure/?{query}'.format(
+            pk=cms_page.pk,
+            query=urlencode({'cms_path': '%s?foo=bar#frag' % page_url}),
+        )
+        request = self.get_request(path=async_path_with_query, language='en', page=cms_page)
+        self.assertEqual(CMSToolbar(request).request_path, page_url)
+
+        # Without a cms_path query it falls back to the request path.
+        request = self.get_request(path=page_url, language='en', page=cms_page)
+        self.assertEqual(CMSToolbar(request).request_path, page_url)
+
+        # An explicitly passed request_path always wins.
+        self.assertEqual(
+            CMSToolbar(request, request_path='/explicit/').request_path,
+            '/explicit/',
+        )
 
     def test_language_changer_decorator(self):
         def lang_changer(lang):

--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -1,6 +1,7 @@
 import functools
 import operator
 from collections import OrderedDict
+from urllib.parse import urlparse
 
 from classytags.utils import flatten_context
 from django.apps import apps
@@ -210,9 +211,25 @@ class CMSToolbarBase(BaseToolbar):
             )
             self.toolbars[key] = toolbar
 
+    @staticmethod
+    def _get_request_path(request):
+        # The viewed page path, reported via the ``cms_path`` GET query on
+        # asynchronous toolbar/structure requests, falls back to the actual
+        # request path for regular page requests.
+        cms_path = request.GET.get('cms_path')
+        if cms_path:
+            return urlparse(cms_path).path
+        return request.path_info
+
     def init_toolbar(self, request, request_path=None):
         self.request = request
-        self.request_path = request_path or request.path_info  # TODO: Used to be request.path. Why?
+        # ``request_path`` is the path of the page the user is *viewing*. For regular
+        # page requests this is identical to ``request.path_info``. For asynchronous
+        # toolbar/structure requests, however, ``request.path_info`` points at an
+        # internal admin/AJAX endpoint while the viewed page is reported via the
+        # ``cms_path`` GET query. Honour ``cms_path`` so that everything relying on
+        # ``request_path`` (e.g. the language menu) builds URLs for the viewed page.
+        self.request_path = request_path or self._get_request_path(request)
         self.is_staff = self.request.user.is_staff
         self.show_toolbar = self.is_staff
 

--- a/menus/utils.py
+++ b/menus/utils.py
@@ -155,6 +155,22 @@ class DefaultLanguageChanger:
         self._app_path = None
 
     @property
+    def request_path(self):
+        """
+        The path of the page the user is *viewing*.
+
+        For regular page requests this equals ``request.path_info``. For
+        asynchronous toolbar/structure requests, ``request.path_info`` points at
+        an internal admin/AJAX endpoint, while the viewed page is reported via the
+        ``cms_path`` GET query and stored on ``toolbar.request_path``. Prefer the
+        latter so that language URLs are built for the viewed page rather than the
+        AJAX endpoint.
+        """
+        toolbar = getattr(self.request, 'toolbar', None)
+        request_path = getattr(toolbar, 'request_path', None)
+        return request_path or self.request.path_info
+
+    @property
     def app_path(self):
         """
         Returns the app path based on the current request.
@@ -172,8 +188,8 @@ class DefaultLanguageChanger:
             If the USE_I18N setting is True, the function tries to get the page path based on the language
             extracted from the current request. Otherwise, it uses the default LANGUAGE_CODE setting.
             If a valid page path is found, the app path is determined by removing the page path from the
-            request's path_info attribute. If no page path is found, the app path is same as the request's
-            path_info attribute.
+            viewed page path (see :attr:`request_path`). If no page path is found, the app path is the
+            same as the viewed page path.
         """
         if self._app_path is None:
             if settings.USE_I18N:
@@ -181,9 +197,11 @@ class DefaultLanguageChanger:
             else:
                 page_path = self.get_page_path(settings.LANGUAGE_CODE)
             if page_path:
-                self._app_path = self.request.path_info[len(page_path):]
-            else:
-                self._app_path = self.request.path_info
+                self._app_path = self.request_path[len(page_path):]
+            else:  # pragma: no cover
+                # Defensive fallback: ``get_page_path`` always returns a
+                # non-empty path, so this branch is effectively unreachable.
+                self._app_path = self.request_path
         return self._app_path
 
     def get_page_path(self, lang):
@@ -262,7 +280,7 @@ class DefaultLanguageChanger:
         """
         with force_language(self.request_language):
             try:
-                view = resolve(self.request.path_info)
+                view = resolve(self.request_path)
             except (NoReverseMatch, Resolver404):  # NOQA
                 view = None
         if (


### PR DESCRIPTION
## Summary by Sourcery

Fix language selector and toolbar URL handling so they use the viewed page path instead of admin/AJAX endpoints, including asynchronous toolbar requests.

Bug Fixes:
- Ensure the default language changer builds language URLs for the viewed page when the toolbar is loaded via async admin/AJAX endpoints.
- Make CMSToolbar derive the viewed page path from the cms_path query parameter when present, preventing the wrong toolbar/language menu from being triggered.

Enhancements:
- Introduce a request_path property on DefaultLanguageChanger that prefers the toolbar's viewed page path and update app_path resolution and URL resolving logic to use it.
- Refine CMSToolbar.request_path computation to consistently prefer cms_path, normalize it, and allow explicit overrides.

Tests:
- Add tests covering DefaultLanguageChanger behavior with cms_path-based toolbar requests and CMSToolbar.request_path precedence rules.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.