### PR TITLE
feat: Allow toolbar ajax items to return a data bridge structure

### DIFF
--- a/cms/static/cms/js/modules/cms.toolbar.js
+++ b/cms/static/cms/js/modules/cms.toolbar.js
@@ -1,7 +1,8 @@
 /*
- * Copyright https://github.com/divio/django-cms
+ * Copyright https://github.com/django-cms/django-cms
  */
 
+/* global DOMParser */
 import $ from 'jquery';
 import Navigation from './cms.navigation';
 import Sideframe from './cms.sideframe';
@@ -523,6 +524,9 @@ class Toolbar {
                     } else {
                         Helpers.reloadBrowser(onSuccess);
                     }
+                } else if (that._evaluateDataBridge(response)) {
+                    // response carried a data bridge that was evaluated in-place
+                    hideLoader();
                 } else {
                     // reload
                     Helpers.reloadBrowser();
@@ -536,6 +540,47 @@ class Toolbar {
                     error: true
                 });
             });
+    }
+
+    /**
+     * Checks whether an ajax response carries a valid data bridge - either as
+     * an HTML document containing a `script#data-bridge` element or as a JSON
+     * object that is itself the data bridge - and, if so, triggers its
+     * evaluation (in-place structure/content update) instead of a full reload.
+     *
+     * @method _evaluateDataBridge
+     * @private
+     * @param {Object|String} response ajax response (parsed JSON or HTML string)
+     * @returns {Boolean} true if a valid data bridge was found and evaluated
+     */
+    _evaluateDataBridge(response) {
+        var dataBridge;
+
+        if (typeof response === 'string') {
+            // response is HTML - look for the embedded data bridge script
+            var node = new DOMParser()
+                .parseFromString(response, 'text/html')
+                .querySelector('script#data-bridge');
+
+            if (node) {
+                try {
+                    dataBridge = JSON.parse(node.textContent);
+                } catch {
+                    return false;
+                }
+            }
+        } else if (response && typeof response === 'object' && response.action) {
+            // response is already parsed JSON and looks like a data bridge
+            dataBridge = response;
+        }
+
+        if (!dataBridge || !dataBridge.action) {
+            return false;
+        }
+
+        CMS.API.Helpers.dataBridge = dataBridge;
+        CMS.API.Helpers.onPluginSave();
+        return true;
     }
 
     /**

--- a/cms/static/cms/js/modules/cms.toolbar.js
+++ b/cms/static/cms/js/modules/cms.toolbar.js
@@ -577,9 +577,7 @@ class Toolbar {
         if (!dataBridge || !dataBridge.action) {
             return false;
         }
-
-        CMS.API.Helpers.dataBridge = dataBridge;
-        CMS.API.Helpers.onPluginSave();
+        CMS.API.StructureBoard.invalidateState(dataBridge.action.toUpperCase(), dataBridge);
         return true;
     }
 

--- a/cms/tests/frontend/unit/cms.toolbar.test.js
+++ b/cms/tests/frontend/unit/cms.toolbar.test.js
@@ -280,8 +280,7 @@ describe('CMS.Toolbar', function () {
 
             toolbar.openAjax({ url: '/url' });
 
-            expect(CMS.API.Helpers.dataBridge).toEqual(dataBridge);
-            expect(CMS.API.Helpers.onPluginSave).toHaveBeenCalled();
+            expect(CMS.API.StructureBoard.invalidateState).toHaveBeenCalled();
             expect(CMS.API.Helpers.reloadBrowser).not.toHaveBeenCalled();
             expect(hideLoader).toHaveBeenCalled();
         });
@@ -306,8 +305,7 @@ describe('CMS.Toolbar', function () {
 
             toolbar.openAjax({ url: '/url' });
 
-            expect(CMS.API.Helpers.dataBridge).toEqual(dataBridge);
-            expect(CMS.API.Helpers.onPluginSave).toHaveBeenCalled();
+            expect(CMS.API.StructureBoard.invalidateState).toHaveBeenCalled();
             expect(CMS.API.Helpers.reloadBrowser).not.toHaveBeenCalled();
         });
 

--- a/cms/tests/frontend/unit/cms.toolbar.test.js
+++ b/cms/tests/frontend/unit/cms.toolbar.test.js
@@ -263,6 +263,92 @@ describe('CMS.Toolbar', function () {
             expect(CMS.API.Helpers.reloadBrowser).toHaveBeenCalledWith();
         });
 
+        it('evaluates a JSON data bridge from the response instead of reloading', function () {
+            var dataBridge = { action: 'edit', plugin_id: 1 };
+
+            spyOn($, 'ajax').and.callFake(function () {
+                return {
+                    done: function (callback) {
+                        callback(dataBridge);
+                        return { fail: $.noop };
+                    }
+                };
+            });
+
+            spyOn(CMS.API.Helpers, 'reloadBrowser');
+            spyOn(CMS.API.Helpers, 'onPluginSave');
+
+            toolbar.openAjax({ url: '/url' });
+
+            expect(CMS.API.Helpers.dataBridge).toEqual(dataBridge);
+            expect(CMS.API.Helpers.onPluginSave).toHaveBeenCalled();
+            expect(CMS.API.Helpers.reloadBrowser).not.toHaveBeenCalled();
+            expect(hideLoader).toHaveBeenCalled();
+        });
+
+        it('evaluates an HTML data bridge from the response instead of reloading', function () {
+            var dataBridge = { action: 'delete', plugin_id: 2 };
+            var html = '<!DOCTYPE html><html><body class="cms-close-frame">' +
+                '<script id="data-bridge" type="application/json">' +
+                JSON.stringify(dataBridge) + '</script></body></html>';
+
+            spyOn($, 'ajax').and.callFake(function () {
+                return {
+                    done: function (callback) {
+                        callback(html);
+                        return { fail: $.noop };
+                    }
+                };
+            });
+
+            spyOn(CMS.API.Helpers, 'reloadBrowser');
+            spyOn(CMS.API.Helpers, 'onPluginSave');
+
+            toolbar.openAjax({ url: '/url' });
+
+            expect(CMS.API.Helpers.dataBridge).toEqual(dataBridge);
+            expect(CMS.API.Helpers.onPluginSave).toHaveBeenCalled();
+            expect(CMS.API.Helpers.reloadBrowser).not.toHaveBeenCalled();
+        });
+
+        it('reloads if the response is a JSON object without a valid data bridge', function () {
+            spyOn($, 'ajax').and.callFake(function () {
+                return {
+                    done: function (callback) {
+                        callback({ foo: 'bar' });
+                        return { fail: $.noop };
+                    }
+                };
+            });
+
+            spyOn(CMS.API.Helpers, 'reloadBrowser');
+            spyOn(CMS.API.Helpers, 'onPluginSave');
+
+            toolbar.openAjax({ url: '/url' });
+
+            expect(CMS.API.Helpers.onPluginSave).not.toHaveBeenCalled();
+            expect(CMS.API.Helpers.reloadBrowser).toHaveBeenCalledWith();
+        });
+
+        it('reloads if the HTML response does not contain a data bridge', function () {
+            spyOn($, 'ajax').and.callFake(function () {
+                return {
+                    done: function (callback) {
+                        callback('<html><body>no bridge here</body></html>');
+                        return { fail: $.noop };
+                    }
+                };
+            });
+
+            spyOn(CMS.API.Helpers, 'reloadBrowser');
+            spyOn(CMS.API.Helpers, 'onPluginSave');
+
+            toolbar.openAjax({ url: '/url' });
+
+            expect(CMS.API.Helpers.onPluginSave).not.toHaveBeenCalled();
+            expect(CMS.API.Helpers.reloadBrowser).toHaveBeenCalledWith();
+        });
+
         it('handles parameters', function () {
             spyOn($, 'ajax').and.callFake(function (param) {
                 expect(param.data).toEqual({ param1: true, param2: false, param3: 150, param4: 'alala' });

--- a/cms/toolbar/items.py
+++ b/cms/toolbar/items.py
@@ -208,12 +208,27 @@ class ToolbarAPIMixin(metaclass=ABCMeta):
     def add_ajax_item(self, name, action, active=False, disabled=False,
                       extra_classes=None, data=None, question=None,
                       side=LEFT, position=None, on_success=None, method='POST'):
-        """Adds :class:`~cms.toolbar.items.AjaxItem` that sends a POST request to ``action`` with ``data``, and returns
-        it. ``data`` should be ``None`` or a dictionary. The CSRF token will automatically be added
-        to the item.
+        """Adds :class:`~cms.toolbar.items.AjaxItem` that sends a request to ``action`` with ``data``, and returns
+        it. ``data`` should be ``None`` or a dictionary. By default a ``POST`` request is sent; pass ``method`` to use
+        a different HTTP method. For unsafe methods (anything other than ``GET``, ``HEAD``, ``OPTIONS`` and ``TRACE``)
+        the CSRF token is automatically added to the item.
 
         If a string is provided for ``question``, it will be presented to the user to allow
-        confirmation before the request is sent."""
+        confirmation before the request is sent.
+
+        Once the request succeeds, the response is inspected:
+
+        * If ``on_success`` is given, the browser navigates to that URL. The special values
+          ``REFRESH_PAGE`` reloads the current page and ``"FOLLOW_REDIRECT"`` redirects to the ``url``
+          returned in the (JSON) response instead.
+        * Otherwise, if the response carries a *data bridge* -- either an HTML document containing a
+          ``<script id="data-bridge">`` element or a JSON object with an ``action`` key -- the data bridge is
+          evaluated and the structure board is updated in place, without a full page reload.
+        * If neither applies, the page is reloaded.
+
+        ..  versionadded:: 5.1
+            Evaluating a *data bridge* returned by the AJAX response, updating the structure board in
+            place instead of reloading the page."""
 
         item = AjaxItem(
             name, action, self.csrf_token,

--- a/docs/how_to/13-toolbar.rst
+++ b/docs/how_to/13-toolbar.rst
@@ -168,6 +168,45 @@ the modal or sideframe. Note that protocols may need to match and the requested 
 it.
 
 
+..  _create-toolbar-ajax-item:
+
+Triggering an AJAX action
+-------------------------
+
+Use :meth:`~cms.toolbar.items.ToolbarAPIMixin.add_ajax_item` for an item that performs an action on
+the server rather than navigating to a page. It sends a request (``POST`` by default) to ``action``,
+optionally asking the user to confirm first:
+
+..  code-block:: python
+    :emphasize-lines: 7-13
+
+    from cms.utils.urlutils import admin_reverse
+
+    class PollToolbar(CMSToolbar):
+
+        def populate(self):
+
+            self.toolbar.add_ajax_item(
+                name='Reset votes',
+                action=admin_reverse('polls_poll_reset', args=[self.poll.pk]),
+                data={'confirm': True},
+                question='Reset all votes for this poll?',
+                on_success=self.toolbar.REFRESH_PAGE,
+            )
+
+The ``data`` dictionary is sent with the request; the CSRF token is added automatically for unsafe
+HTTP methods. Use ``on_success`` to control what happens after a successful response: pass a URL to
+navigate to it, ``REFRESH_PAGE`` to reload the current page, or ``"FOLLOW_REDIRECT"`` to redirect to
+the ``url`` returned in a JSON response.
+
+..  versionadded:: 5.1
+
+    If ``on_success`` is not given and the response carries a *data bridge* -- either an HTML document
+    containing a ``<script id="data-bridge">`` element or a JSON object with an ``action`` key -- the
+    data bridge is evaluated and the structure board is updated in place, without a full page reload.
+    This is the same mechanism used when a plugin is saved in a modal.
+
+
 ..  _create-toolbar-button:
 
 Adding buttons to the toolbar


### PR DESCRIPTION
## Summary by Sourcery

Allow toolbar AJAX items to handle data-bridge responses for in-place updates instead of always reloading the page. This allows 3rd-party actions to avoid full page reloading by using a plugin's `render_close_frame`.

Enhancements:
- Introduce data-bridge evaluation in the toolbar to update the structure board in place when AJAX responses include a bridge payload, falling back to full reload otherwise.

Documentation:
- Document the behaviour of toolbar AJAX items, including support for different HTTP methods, CSRF handling, and the new data-bridge based in-place update flow.

Tests:
- Add unit tests covering toolbar AJAX behaviour with JSON and HTML data-bridge responses and fallback to page reload when no valid data bridge is present.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.