### PR TITLE
feat: Add extra key to get/set_page_url_cache

### DIFF
--- a/cms/cache/page.py
+++ b/cms/cache/page.py
@@ -168,7 +168,7 @@ def set_page_cache(response: HttpResponse) -> HttpResponse:
     return response
 
 
-def get_page_cache(request: HttpRequest) -> tuple | None:
+def get_page_cache(request: HttpRequest) -> tuple[bytes, Mapping[str, str], datetime] | None:
     """Return the cached page response for ``request`` or ``None``.
 
     Mirrors Django's two-step ``get_cache_key`` lookup: first the list of

--- a/cms/cache/page.py
+++ b/cms/cache/page.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Mapping
 
 from django.conf import settings
 from django.utils.cache import (

--- a/cms/cache/page.py
+++ b/cms/cache/page.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import hashlib
 from datetime import timedelta
+from typing import TYPE_CHECKING, Any
 
 from django.conf import settings
 from django.utils.cache import (
@@ -19,8 +22,15 @@ from cms.utils.conf import get_cms_setting
 from cms.utils.helpers import get_timezone_name
 from cms.utils.i18n import get_default_language_for_site
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
-def _page_cache_key(request, vary_on=None):
+    from django.http import HttpRequest, HttpResponse
+
+    from cms.models import Page
+
+
+def _page_cache_key(request: HttpRequest, vary_on: Iterable[str] | None = None) -> str:
     """
     Generate a cache key based on the request path and language.
     The language is determined following django-cms's language resolution order.
@@ -49,7 +59,7 @@ def _page_cache_key(request, vary_on=None):
     return cache_key
 
 
-def _vary_on_hash(request, vary_on):
+def _vary_on_hash(request: HttpRequest, vary_on: Iterable[str]) -> str:
     """Hash of the request's values for the given (plugin-declared) headers."""
     ctx = hashlib.sha1()
     for header in sorted(header.lower() for header in vary_on):
@@ -60,7 +70,7 @@ def _vary_on_hash(request, vary_on):
     return ctx.hexdigest()
 
 
-def _page_vary_headers_cache_key(request):
+def _page_vary_headers_cache_key(request: HttpRequest) -> str:
     """Key under which the list of plugin-declared vary headers is stored.
 
     The list cannot be known on a cache read until the page is rendered, so it
@@ -70,7 +80,23 @@ def _page_vary_headers_cache_key(request):
     return _page_cache_key(request) + ".vary-on"
 
 
-def set_page_cache(response):
+def set_page_cache(response: HttpResponse) -> HttpResponse:
+    """Store a rendered page response in the CMS page cache.
+
+    The response is only cached for anonymous requests when the page cache is
+    enabled and the toolbar has not disabled caching. The cache timeout is the
+    smallest of the configured ``content`` duration and every cache-able
+    placeholder's TTL (as returned by ``get_cache_expiration()``); if any
+    placeholder requests ``EXPIRE_NOW`` the response is not cached at all.
+
+    When the response is cacheable, expiration and ``Vary`` headers are patched
+    onto it and two entries are written: the list of plugin-declared vary
+    headers (see :func:`_page_vary_headers_cache_key`) and the response payload
+    (content, headers and absolute expiry timestamp) under the header-aware
+    content key. Otherwise ``never cache`` headers are added.
+
+    Returns the (possibly header-patched) ``response``.
+    """
     from django.core.cache import cache
 
     request = response._request
@@ -142,7 +168,15 @@ def set_page_cache(response):
     return response
 
 
-def get_page_cache(request):
+def get_page_cache(request: HttpRequest) -> tuple | None:
+    """Return the cached page response for ``request`` or ``None``.
+
+    Mirrors Django's two-step ``get_cache_key`` lookup: first the list of
+    plugin-declared vary headers is read, then the request's values for those
+    headers are folded into the content key so the matching variant is
+    returned. The cached value is the ``(content, headers, expires_datetime)``
+    tuple stored by :func:`set_page_cache`, or ``None`` on a cache miss.
+    """
     from django.core.cache import cache
 
     version = _get_cache_version()
@@ -152,20 +186,39 @@ def get_page_cache(request):
     return cache.get(_page_cache_key(request, vary_on), version=version)
 
 
-def get_xframe_cache(page):
+def get_xframe_cache(page: Page) -> int | None:
+    """Return the cached ``X-Frame-Options`` value for ``page`` or ``None``."""
     from django.core.cache import cache
 
     return cache.get("cms:xframe_options:%s" % page.pk)
 
 
-def set_xframe_cache(page, xframe_options):
+def set_xframe_cache(page: Page, xframe_options: int) -> None:
+    """Cache the resolved ``X-Frame-Options`` value for ``page``.
+
+    The cache version is re-written afterwards so the version key always
+    outlives the entries written against it (see
+    :func:`cms.cache.invalidate_cms_page_cache`).
+    """
     from django.core.cache import cache
 
     cache.set("cms:xframe_options:%s" % page.pk, xframe_options, version=_get_cache_version())
     _set_cache_version(_get_cache_version())
 
 
-def _page_url_key(page_lookup, lang, site_id, extra_key):
+def _page_url_key(
+    page_lookup: Any,
+    lang: str,
+    site_id: int,
+    extra_key: str | None,
+) -> str:
+    """Build the cache key for a page's absolute URL.
+
+    ``page_lookup`` is the untyped page reference accepted by the ``page_url``
+    template tag (a :class:`~cms.models.Page`, pk, reverse id, ...). When
+    ``extra_key`` is a string it is folded into the key so callers can cache
+    distinct URLs (e.g. per query string) for the same page.
+    """
     return "".join([
         _get_cache_key("page_url", page_lookup, lang, site_id),
         f"_key:{extra_key}" if isinstance(extra_key, str) else "",
@@ -173,7 +226,19 @@ def _page_url_key(page_lookup, lang, site_id, extra_key):
     ])
 
 
-def set_page_url_cache(page_lookup, lang, site_id, url, extra_key=None):
+def set_page_url_cache(
+    page_lookup: Any,
+    lang: str,
+    site_id: int,
+    url: str,
+    extra_key: str | None = None,
+) -> None:
+    """Cache the absolute ``url`` of a page for the ``content`` duration.
+
+    The cache version is re-written afterwards so the version key always
+    outlives the entries written against it (see
+    :func:`cms.cache.invalidate_cms_page_cache`).
+    """
     from django.core.cache import cache
 
     cache.set(
@@ -185,7 +250,13 @@ def set_page_url_cache(page_lookup, lang, site_id, url, extra_key=None):
     _set_cache_version(_get_cache_version())
 
 
-def get_page_url_cache(page_lookup, lang, site_id, extra_key=None):
+def get_page_url_cache(
+    page_lookup: Any,
+    lang: str,
+    site_id: int,
+    extra_key: str | None = None,
+) -> str | None:
+    """Return the cached absolute URL for a page lookup, or ``None`` on a miss."""
     from django.core.cache import cache
 
     return cache.get(_page_url_key(page_lookup, lang, site_id, extra_key), version=_get_cache_version())

--- a/cms/cache/page.py
+++ b/cms/cache/page.py
@@ -165,15 +165,19 @@ def set_xframe_cache(page, xframe_options):
     _set_cache_version(_get_cache_version())
 
 
-def _page_url_key(page_lookup, lang, site_id):
-    return _get_cache_key("page_url", page_lookup, lang, site_id) + "_type:absolute_url"
+def _page_url_key(page_lookup, lang, site_id, extra_key):
+    return "".join([
+        _get_cache_key("page_url", page_lookup, lang, site_id),
+        f"_key:{extra_key}" if isinstance(extra_key, str) else "",
+        "_type:absolute_url",
+    ])
 
 
-def set_page_url_cache(page_lookup, lang, site_id, url):
+def set_page_url_cache(page_lookup, lang, site_id, url, extra_key=None):
     from django.core.cache import cache
 
     cache.set(
-        _page_url_key(page_lookup, lang, site_id),
+        _page_url_key(page_lookup, lang, site_id, extra_key),
         url,
         get_cms_setting("CACHE_DURATIONS")["content"],
         version=_get_cache_version(),
@@ -181,7 +185,7 @@ def set_page_url_cache(page_lookup, lang, site_id, url):
     _set_cache_version(_get_cache_version())
 
 
-def get_page_url_cache(page_lookup, lang, site_id):
+def get_page_url_cache(page_lookup, lang, site_id, extra_key=None):
     from django.core.cache import cache
 
-    return cache.get(_page_url_key(page_lookup, lang, site_id), version=_get_cache_version())
+    return cache.get(_page_url_key(page_lookup, lang, site_id, extra_key), version=_get_cache_version())

--- a/cms/cache/page.py
+++ b/cms/cache/page.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import datetime
 import hashlib
+from collections.abc import Mapping
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import TYPE_CHECKING, Any
 
 from django.conf import settings
 from django.utils.cache import (

--- a/cms/tests/test_cache.py
+++ b/cms/tests/test_cache.py
@@ -6,6 +6,17 @@ from sekizai.context import SekizaiContext
 
 from cms.api import add_plugin, create_page, create_page_content
 from cms.cache import invalidate_cms_page_cache
+from cms.cache.page import (
+    _page_cache_key,
+    _page_url_key,
+    _page_vary_headers_cache_key,
+    _vary_on_hash,
+    get_page_cache,
+    get_page_url_cache,
+    get_xframe_cache,
+    set_page_url_cache,
+    set_xframe_cache,
+)
 from cms.cache.placeholder import (
     _get_placeholder_cache_key,
     _get_placeholder_cache_version,
@@ -32,8 +43,10 @@ from cms.test_utils.testcases import CMSTestCase
 from cms.test_utils.util.fuzzy_int import FuzzyInt
 from cms.toolbar.toolbar import CMSToolbar
 from cms.toolbar.utils import get_object_edit_url
+from cms.utils import get_current_site
 from cms.utils.conf import get_cms_setting
 from cms.utils.helpers import get_timezone_name
+from cms.utils.i18n import get_default_language_for_site
 
 
 class CacheTestCase(CMSTestCase):
@@ -870,3 +883,232 @@ class PlaceholderCacheTestCase(CMSTestCase):
                 self.placeholder_en, "en", 1, en_crazy_request
             )
             self.assertEqual(en_crazy_content, cached_en_crazy_content)
+
+
+class PageCacheKeyTestCase(CMSTestCase):
+    """Direct unit tests for the page-cache key helpers."""
+
+    def test_page_cache_key_includes_prefix_site_language(self):
+        request = self.get_request("/en/", language="en")
+        key = _page_cache_key(request)
+
+        prefix = get_cms_setting("CACHE_PREFIX")
+        site = get_current_site(request)
+        self.assertTrue(key.startswith(f"{prefix}:{site.pk}:en:"))
+
+    def test_page_cache_key_varies_on_language(self):
+        en_request = self.get_request("/en/", language="en")
+        de_request = self.get_request("/en/", language="de")
+        self.assertNotEqual(
+            _page_cache_key(en_request), _page_cache_key(de_request)
+        )
+
+    def test_page_cache_key_varies_on_path(self):
+        request_a = self.get_request("/en/page-a/", language="en")
+        request_b = self.get_request("/en/page-b/", language="en")
+        self.assertNotEqual(
+            _page_cache_key(request_a), _page_cache_key(request_b)
+        )
+
+    def test_page_cache_key_includes_timezone_when_use_tz(self):
+        request = self.get_request("/en/", language="en")
+        with self.settings(USE_TZ=True):
+            key = _page_cache_key(request)
+        self.assertIn(".%s" % get_timezone_name(), key)
+
+    def test_page_cache_key_falls_back_to_default_language(self):
+        """Without ``request.LANGUAGE_CODE`` the site default language is used."""
+        request = self.get_request("/en/", language="en")
+        del request.LANGUAGE_CODE
+        site = get_current_site(request)
+        default_language = get_default_language_for_site(site.pk)
+        key = _page_cache_key(request)
+        self.assertIn(f":{default_language}:", key)
+
+    def test_page_cache_key_varies_on_declared_headers(self):
+        """The same request yields different keys per declared header value."""
+        request_us = self.get_request("/en/", language="en")
+        request_us.META["HTTP_COUNTRY_CODE"] = "US"
+        request_fr = self.get_request("/en/", language="en")
+        request_fr.META["HTTP_COUNTRY_CODE"] = "FR"
+
+        self.assertNotEqual(
+            _page_cache_key(request_us, ["Country-Code"]),
+            _page_cache_key(request_fr, ["Country-Code"]),
+        )
+
+    def test_page_cache_key_ignores_undeclared_headers(self):
+        """Header values only matter when the header is in ``vary_on``."""
+        request_us = self.get_request("/en/", language="en")
+        request_us.META["HTTP_COUNTRY_CODE"] = "US"
+        request_fr = self.get_request("/en/", language="en")
+        request_fr.META["HTTP_COUNTRY_CODE"] = "FR"
+
+        self.assertEqual(
+            _page_cache_key(request_us), _page_cache_key(request_fr)
+        )
+
+    def test_vary_on_hash_is_constant_for_empty(self):
+        request = self.get_request("/en/", language="en")
+        self.assertEqual(_vary_on_hash(request, []), _vary_on_hash(request, []))
+
+    def test_vary_on_hash_is_order_and_case_insensitive(self):
+        request = self.get_request("/en/", language="en")
+        request.META["HTTP_COUNTRY_CODE"] = "US"
+        request.META["HTTP_X_REGION"] = "EU"
+
+        self.assertEqual(
+            _vary_on_hash(request, ["Country-Code", "X-Region"]),
+            _vary_on_hash(request, ["x-region", "country-code"]),
+        )
+
+    def test_vary_on_hash_varies_on_value(self):
+        request_us = self.get_request("/en/", language="en")
+        request_us.META["HTTP_COUNTRY_CODE"] = "US"
+        request_fr = self.get_request("/en/", language="en")
+        request_fr.META["HTTP_COUNTRY_CODE"] = "FR"
+
+        self.assertNotEqual(
+            _vary_on_hash(request_us, ["Country-Code"]),
+            _vary_on_hash(request_fr, ["Country-Code"]),
+        )
+
+    def test_page_vary_headers_cache_key_suffix(self):
+        request = self.get_request("/en/", language="en")
+        self.assertEqual(
+            _page_vary_headers_cache_key(request),
+            _page_cache_key(request) + ".vary-on",
+        )
+
+
+class PageCacheRoundTripTestCase(CMSTestCase):
+    def setUp(self):
+        from django.core.cache import cache
+
+        super().setUp()
+        cache.clear()
+
+    def tearDown(self):
+        from django.core.cache import cache
+
+        super().tearDown()
+        cache.clear()
+
+    def test_get_page_cache_miss_returns_none(self):
+        request = self.get_request("/en/never-cached/", language="en")
+        self.assertIsNone(get_page_cache(request))
+
+    def test_set_and_get_page_cache_round_trip(self):
+        """A primed page response can be read back via ``get_page_cache``."""
+        exclude = [
+            "django.middleware.cache.UpdateCacheMiddleware",
+            "django.middleware.cache.FetchFromCacheMiddleware",
+        ]
+        overrides = {
+            "MIDDLEWARE": [mw for mw in settings.MIDDLEWARE if mw not in exclude]
+        }
+        with self.settings(**overrides):
+            page = create_page("cached page", "nav_playground.html", "en")
+            placeholder = page.get_placeholders("en").get(slot="body")
+            add_plugin(placeholder, "TextPlugin", "en", body="Cached body")
+            page_url = page.get_absolute_url()
+
+            # Prime the cache (set_page_cache runs as a post-render callback).
+            response = self.client.get(page_url)
+            self.assertEqual(response.status_code, 200)
+
+            request = self.get_request(page_url, language="en")
+            cached = get_page_cache(request)
+            self.assertIsNotNone(cached)
+            content, headers, expires_datetime = cached
+            self.assertIn(b"Cached body", content)
+            self.assertIsNotNone(expires_datetime)
+
+
+class XFrameCacheTestCase(CMSTestCase):
+    def setUp(self):
+        from django.core.cache import cache
+
+        super().setUp()
+        cache.clear()
+
+    def tearDown(self):
+        from django.core.cache import cache
+
+        super().tearDown()
+        cache.clear()
+
+    def test_get_xframe_cache_miss_returns_none(self):
+        page = create_page("xframe page", "nav_playground.html", "en")
+        self.assertIsNone(get_xframe_cache(page))
+
+    def test_set_and_get_xframe_cache(self):
+        page = create_page("xframe page", "nav_playground.html", "en")
+        set_xframe_cache(page, 1)
+        self.assertEqual(get_xframe_cache(page), 1)
+
+    def test_xframe_cache_is_per_page(self):
+        page1 = create_page("xframe page 1", "nav_playground.html", "en")
+        page2 = create_page("xframe page 2", "nav_playground.html", "en")
+        set_xframe_cache(page1, 1)
+        self.assertEqual(get_xframe_cache(page1), 1)
+        self.assertIsNone(get_xframe_cache(page2))
+
+
+class PageURLCacheTestCase(CMSTestCase):
+    def setUp(self):
+        from django.core.cache import cache
+
+        super().setUp()
+        cache.clear()
+
+    def tearDown(self):
+        from django.core.cache import cache
+
+        super().tearDown()
+        cache.clear()
+
+    def test_page_url_key_is_absolute_url_type(self):
+        key = _page_url_key("my-page", "en", 1, None)
+        self.assertTrue(key.endswith("_type:absolute_url"))
+
+    def test_page_url_key_omits_extra_key_when_none(self):
+        key = _page_url_key("my-page", "en", 1, None)
+        self.assertNotIn("_key:", key)
+
+    def test_page_url_key_includes_extra_key(self):
+        key = _page_url_key("my-page", "en", 1, "preview")
+        self.assertIn("_key:preview", key)
+
+    def test_page_url_key_varies_on_extra_key(self):
+        self.assertNotEqual(
+            _page_url_key("my-page", "en", 1, "a"),
+            _page_url_key("my-page", "en", 1, "b"),
+        )
+
+    def test_page_url_key_varies_on_language_and_site(self):
+        base = _page_url_key("my-page", "en", 1, None)
+        self.assertNotEqual(base, _page_url_key("my-page", "de", 1, None))
+        self.assertNotEqual(base, _page_url_key("my-page", "en", 2, None))
+
+    def test_get_page_url_cache_miss_returns_none(self):
+        self.assertIsNone(get_page_url_cache("missing-page", "en", 1))
+
+    def test_set_and_get_page_url_cache(self):
+        set_page_url_cache("my-page", "en", 1, "/en/my-page/")
+        self.assertEqual(get_page_url_cache("my-page", "en", 1), "/en/my-page/")
+
+    def test_set_and_get_page_url_cache_with_extra_key(self):
+        set_page_url_cache("my-page", "en", 1, "/en/my-page/", extra_key="preview")
+        # The extra-key variant is isolated from the default variant.
+        self.assertEqual(
+            get_page_url_cache("my-page", "en", 1, extra_key="preview"),
+            "/en/my-page/",
+        )
+        self.assertIsNone(get_page_url_cache("my-page", "en", 1))
+
+    def test_page_url_cache_is_invalidated_by_version_bump(self):
+        set_page_url_cache("my-page", "en", 1, "/en/my-page/")
+        self.assertEqual(get_page_url_cache("my-page", "en", 1), "/en/my-page/")
+        invalidate_cms_page_cache()
+        self.assertIsNone(get_page_url_cache("my-page", "en", 1))


### PR DESCRIPTION
## Description

Add extra key to `get_page_url_cache` and `set_page_url_cache`.

## Related resources

* #8695 

## Checklist

* [x] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Extend page caching utilities with header-aware keys and support for keyed page URL cache variants.

New Features:
- Allow page URL cache entries to be differentiated via an optional extra key parameter in the get/set_page_url_cache helpers.

Enhancements:
- Add type annotations and documentation to page cache, X-Frame-Options cache, and page URL cache helpers for clearer behavior and usage.
- Introduce direct unit tests covering page cache key generation, page cache round-trip behavior, X-Frame-Options cache behavior, and page URL cache behavior, including extra-key variants.

Tests:
- Add comprehensive tests for page cache key generation, vary-on header handling, page cache round-trip, X-Frame-Options cache behavior, and page URL cache behavior including extra-key variants.