### PR TITLE
fix: Subpage wizard failed

### DIFF
--- a/cms/tests/test_wizards.py
+++ b/cms/tests/test_wizards.py
@@ -617,6 +617,43 @@ class TestPageWizardSubmission(CMSTestCase):
         edit_endpoint = get_object_edit_url(Page.objects.exclude(pk=page.pk).last().get_content_obj("en"), "en")
         self.assertContains(response, MODAL_HTML_REDIRECT.format(url=edit_endpoint))
 
+    def test_subpage_wizard_submission(self):
+        """Regression test for #8697: the subpage wizard must run through both
+        steps and create the new page as a child of the origin page.
+
+        The subpage entry is only offered while the wizard knows the origin
+        page, so a regression that drops the page between steps both hides the
+        entry (step 0 fails to validate) and detaches the created page.
+        """
+        parent = create_page("home", "nav_playground.html", "en")
+        entry_id = cms_subpage_wizard.id
+        endpoint = admin_reverse("cms_wizard_create")
+        data_step1 = {
+            "wizard_create_view-current_step": "0",
+            "0-entry": entry_id,
+            "0-language": "en",
+            "0-page": parent.pk,
+        }
+        data_step2 = {
+            "wizard_create_view-current_step": "1",
+            "1-title": "my child page",
+            "1-slug": "my-child-page",
+            "1-content": "",
+        }
+
+        with self.login_user_context(self.get_superuser()):
+            # Step 0 must advance to step 1 -- i.e. the subpage entry stays a
+            # valid choice because the origin page survives the transition.
+            response = self.client.post(endpoint, data_step1, follow=True)
+            self.assertEqual(response.status_code, 200)
+            self.assertNotContains(response, "Please choose an option")
+            response = self.client.post(endpoint, data_step2)
+
+        new_page = Page.objects.exclude(pk=parent.pk).get()
+        self.assertEqual(new_page.parent_id, parent.pk)
+        edit_endpoint = get_object_edit_url(new_page.get_content_obj("en"), "en")
+        self.assertContains(response, MODAL_HTML_REDIRECT.format(url=edit_endpoint))
+
 
 class TestWizardHelpers(CMSTestCase):
     def setUp(self):

--- a/cms/wizards/views.py
+++ b/cms/wizards/views.py
@@ -94,12 +94,22 @@ class WizardCreateView(SessionWizardView):
 
         # We need to grab the page from pre-validated data so that the wizard
         # has it to prepare the list of valid entries.
+        #
+        # ``get_form`` is re-entered while a form is built: resolving the step-2
+        # form list (``get_form_list``) calls ``get_cleaned_data_for_step('0')``,
+        # which rebuilds the step-0 form -- and, with empty storage, would reset
+        # ``page_pk`` to ``None``. Save and restore it so the inner call can't
+        # clobber the value the outer call still needs in ``get_form_kwargs``.
+        previous_page_pk = getattr(self, 'page_pk', None)
         if data:
             page_key = f"{step}-page"
             self.page_pk = data.get(page_key, None)
         else:
             self.page_pk = None
-        return super().get_form(step, data, files)
+        try:
+            return super().get_form(step, data, files)
+        finally:
+            self.page_pk = previous_page_pk
 
     def get_form_kwargs(self, step=None):
         """This is called by self.get_form()"""


### PR DESCRIPTION
## Summary by Sourcery

Ensure the subpage creation wizard correctly preserves the origin page across steps so child pages are created under the intended parent.

Bug Fixes:
- Fix subpage wizard state handling so the origin page reference is not lost when building multi-step forms, preventing detached child pages and validation failures.

Tests:
- Add a regression test covering subpage wizard submission to verify the new page is created as a child of the selected origin page and the flow completes successfully.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* fixes #8697 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.