### PR TITLE
fix: GrouperAdmin only showed current content versions

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -954,7 +954,13 @@ class PageContentAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
             "language_tabs": get_language_tuple(site.pk),
             "filled_languages": self.get_filled_languages(request, obj.page),
         }
-        context["show_language_tabs"] = len(context["language_tabs"])
+        # Only offer the language selector for the latest content. Switching the language always
+        # navigates to the latest content of the target language, so for an older content object
+        # (e.g. an outdated version) switching languages back and forth would silently bring up a
+        # different (the latest) content object - confusing UX.
+        latest = obj.page.get_admin_content(obj.language)
+        is_latest_content = getattr(latest, "pk", None) == obj.pk
+        context["show_language_tabs"] = len(context["language_tabs"]) if is_latest_content else 0
         context.update(extra_context or {})
 
         if "basic_info" in extra_context:

--- a/cms/admin/utils.py
+++ b/cms/admin/utils.py
@@ -16,13 +16,15 @@ from django.db.models import DateField, OuterRef, Subquery, functions
 from django.db.models.functions import Cast
 from django.forms import modelform_factory
 from django.http import HttpRequest, HttpResponse
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import render_to_string
-from django.urls import NoReverseMatch
+from django.urls import NoReverseMatch, path
+from django.utils.decorators import method_decorator
 from django.utils.html import format_html_join
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 from django.utils.translation import get_language, gettext_lazy as _
+from django.views.decorators.http import require_GET
 
 from cms.models.managers import ContentAdminManager
 from cms.toolbar.utils import get_object_edit_url
@@ -164,7 +166,7 @@ CONTENT_PREFIX = "content__"
 class GrouperChangeListBase(ChangeList):
     """Subclass ChangeList to disregard grouping fields get parameter as filter"""
 
-    current_language: str = None
+    current_language: str | None = None
     available_languages: tuple[tuple[str, str], ...] = ()
     _extra_grouping_fields: list[str] = []
 
@@ -245,7 +247,7 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
     #: The content model class to be used. Defaults to the model class named like the grouper model class
     #: plus ``"Content"`` at the end from the same app as the grouper model class, e.g., ``BlogPostContent`` if
     #: the grouper is ``BlogPost``.
-    content_model: models.Model | None = None
+    content_model: type[models.Model] | None = None
     #: Name of the inverse relation field giving the set of content models belonging to a grouper model. Defaults to
     #: the first field found as an inverse relation. If you have more than one inverse relation please make sure
     #: to specify this field. An example would be if the blog post content model contained a many-to-many
@@ -267,6 +269,12 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
     CONTENT_OBJ_PK_ANNOTATION = "_content_obj_pk"
 
     _content_content_type = None
+
+    #: Name of the GET parameter that selects a specific content object (by primary key) to be shown
+    #: in the change view instead of the latest content. See :meth:`get_urls`.
+    content_pk_url_param = "cms_content"
+    #: Holds the specific content object requested via :attr:`content_pk_url_param` for the current request.
+    _requested_content_obj: models.Model | None = None
 
     def __init__(self, model, admin_site):
         self._content_subquery_fields = []
@@ -433,6 +441,27 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
             if value != getattr(self, field, None):
                 setattr(self, field, value)
 
+        # A specific content object may be requested by its primary key. If so, show exactly that
+        # content object (which may not be the latest one) and align the grouping fields with it so
+        # that the form, its hidden fields, and the edit URLs stay consistent.
+        self._requested_content_obj = self.get_requested_content_obj(request)
+        if self._requested_content_obj is not None:
+            for field in self.extra_grouping_fields:
+                setattr(self, field, getattr(self._requested_content_obj, field))
+
+    def get_requested_content_obj(self, request: HttpRequest) -> models.Model | None:
+        """Returns the content object requested by primary key via :attr:`content_pk_url_param`, or
+        ``None`` if no (valid) content object was requested. Uses the ``admin_manager`` so that
+        non-current content objects (e.g. older versions) can be shown."""
+        content_pk = request.GET.get(self.content_pk_url_param)
+        if not content_pk:
+            return None
+        try:
+            return self.content_model.admin_manager.filter(pk=content_pk).first()
+        except (ValueError, TypeError, ValidationError):
+            # Invalid primary key for the content model: ignore and fall back to the latest content.
+            return None
+
     @property
     def current_content_filters(self) -> dict[str, typing.Any]:
         """Filters needed to get the correct content model instance"""
@@ -463,6 +492,44 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
             (GrouperChangeListBase,),
             dict(_extra_grouping_fields=self.extra_grouping_fields),
         )
+
+    def get_urls(self) -> list:
+        """Adds a change URL for the content model that redirects to the grouper change view showing
+        the requested content object.
+
+        This gives every content object a stable admin change URL (``admin:<app>_<content>_change``)
+        that resolves through the unified grouper change form - without having to register a separate
+        admin for the content model. If the content model already has its own admin (and hence already
+        provides that URL name), the declaration is skipped so the existing admin keeps precedence.
+        """
+        urls = super().get_urls()
+        if not self.admin_site.is_registered(self.content_model):
+            opts = self.content_model._meta
+            urls = [
+                path(
+                    "content/<path:object_id>/change/",
+                    self.admin_site.admin_view(self.content_change_redirect_view),
+                    name=f"{opts.app_label}_{opts.model_name}_change",
+                ),
+            ] + urls
+        return urls
+
+    @method_decorator(require_GET)
+    def content_change_redirect_view(self, request: HttpRequest, object_id: str) -> HttpResponse:
+        """Redirects from a content object's change URL to the grouper change view, selecting exactly
+        that content object via the :attr:`content_pk_url_param` GET parameter.
+
+        Limited to ``GET``: this is a navigation entry point only. The editable form lives at the
+        grouper change view (which is where it is submitted), so a non-GET request here would
+        otherwise be silently turned into a ``GET`` by the redirect and its payload discarded.
+        """
+        content_obj = get_object_or_404(self.content_model.admin_manager.all(), pk=object_id)
+        grouper = getattr(content_obj, self.grouper_field_name)
+        opts = grouper._meta
+        url = admin_reverse(f"{opts.app_label}_{opts.model_name}_change", args=(grouper.pk,))
+        params = {field: getattr(content_obj, field) for field in self.extra_grouping_fields}
+        params[self.content_pk_url_param] = content_obj.pk
+        return redirect(f"{url}?{urlencode(params)}")
 
     def get_changelist_instance(self, request: HttpRequest) -> GrouperChangeListBase:
         """Update grouping field properties and get changelist instance"""
@@ -565,7 +632,12 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
                 filled_languages = []
 
             site = get_current_site(request)
-            extra_context["language_tabs"] = self.get_language_tuple(site=site)
+            if self.is_latest_content_obj(content_instance, obj):
+                # Only offer the language selector for the latest content. Switching the
+                # language always navigates to the latest content of the target language,
+                # so for an older content object switching languages back and forth would
+                # silently bring up a different (the latest) content object - confusing UX.
+                extra_context["language_tabs"] = self.get_language_tuple(site=site)
             extra_context["language"] = language
             extra_context["filled_languages"] = filled_languages
             readonly_message = self.get_content_readonly_message(request, content_instance)
@@ -672,6 +744,12 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
         if obj is None or self._is_content_obj(obj):
             return obj
 
+        # A specific content object was requested by primary key? Show exactly that object as long
+        # as it belongs to the grouper being edited (instead of the latest content).
+        requested = self._requested_content_obj
+        if requested is not None and getattr(requested, f"{self.grouper_field_name}_id", None) == obj.pk:
+            return requested
+
         if not hasattr(obj, "_grouper_admin_content_obj_cache"):
             # Check prefetch cache
             if hasattr(obj, "_admin_prefetch_cache"):
@@ -695,6 +773,22 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
             # Already content object? First get grouper and then all content objects
             return self.get_content_objects(self.get_grouper_obj(obj))
         return self._get_content_queryset(obj)
+
+    def is_latest_content_obj(self, content_obj: models.Model | None, obj: models.Model | None = None) -> bool:
+        """Hook to decide whether ``content_obj`` is the latest content for its grouper and the
+        current grouping fields (e.g. language).
+
+        By default :meth:`get_content_obj` returns the latest content, so this is always ``True``.
+        Versioning packages, however, may show an older content object in the change form. In that
+        case switching grouping fields (such as the language) navigates to the latest content of the
+        target value, so switching back and forth would not return to the same content object. The
+        change form therefore hides the grouping selectors when an older content object is shown.
+        """
+        if content_obj is None:
+            # The add view always edits the (still non-existing) latest content.
+            return True
+        latest = self.get_content_objects(obj or content_obj).filter(**self.current_content_filters).first()
+        return latest is None or latest.pk == content_obj.pk
 
     def clear_content_cache(self) -> None:
         # Content objects are now stored in the object, no cache clear for admin class necessary

--- a/cms/tests/test_grouper_admin.py
+++ b/cms/tests/test_grouper_admin.py
@@ -621,6 +621,18 @@ class GrouperChangeTestCase(SetupMixin, CMSTestCase):
         self.assertContains(response, content.secret_greeting)
         self.assertContains(response, 'id="page_form_lang_tabs"')
 
+    def test_nonexistent_content_pk_falls_back_to_latest(self) -> None:
+        """A syntactically valid but nonexistent content pk falls back to the latest content."""
+        param = self.admin.content_pk_url_param
+        content = self.createContentInstance("en")
+        nonexistent_pk = content.pk + 1
+        with self.login_user_context(self.admin_user):
+            response = self.client.get(
+                f"{self.change_url}?language=en&{param}={nonexistent_pk}"
+            )
+        self.assertContains(response, content.secret_greeting)
+        self.assertContains(response, 'id="page_form_lang_tabs"')
+
     @wo_content_permission
     def test_change_form_wo_write_permit(self) -> None:
         """If no change permission exists for content mark content fields readonly."""

--- a/cms/tests/test_grouper_admin.py
+++ b/cms/tests/test_grouper_admin.py
@@ -515,6 +515,112 @@ class GrouperChangeTestCase(SetupMixin, CMSTestCase):
             self.assertContains(response, 'name="content__language" value="de"')
             self.assertNotContains(response, 'name="content__language" value="en"')
 
+    def test_is_latest_content_obj(self) -> None:
+        """The latest content object is recognized as such, a stale one is not, and the
+        add view (no content object) counts as latest."""
+        content = self.createContentInstance("en")
+        self.admin.language = "en"
+        try:
+            # The actual content object is the latest
+            self.assertTrue(self.admin.is_latest_content_obj(content, self.grouper_instance))
+            # A stale content object (different pk) is not the latest
+            stale = copy.copy(content)
+            stale.pk = content.pk + 1000
+            self.assertFalse(self.admin.is_latest_content_obj(stale, self.grouper_instance))
+            # The add view (no content object) always counts as latest
+            self.assertTrue(self.admin.is_latest_content_obj(None))
+        finally:
+            del self.admin.language
+
+    def test_language_selector_shown_for_latest_content(self) -> None:
+        """The change form offers the language selector when the latest content is shown."""
+        self.createContentInstance("en")
+        with self.login_user_context(self.admin_user):
+            response = self.client.get(self.change_url + "?language=en")
+            self.assertContains(response, 'id="page_form_lang_tabs"')
+
+    def test_language_selector_hidden_for_non_latest_content(self) -> None:
+        """The change form drops the language selector when an older (non-latest) content
+        object is shown. Switching languages back and forth would otherwise silently bring
+        up the latest content instead - confusing UX."""
+        content = self.createContentInstance("en")
+        # Simulate a versioning package that shows an older (non-latest) content object
+        stale = copy.copy(content)
+        stale.pk = content.pk + 1000
+        with patch.object(type(self.admin), "get_content_obj", return_value=stale):
+            with self.login_user_context(self.admin_user):
+                response = self.client.get(self.change_url + "?language=en")
+                self.assertNotContains(response, 'id="page_form_lang_tabs"')
+
+    def test_get_urls_declares_content_change_when_unregistered(self) -> None:
+        """The grouper admin provides a change URL for the (unregistered) content model."""
+        names = [url.name for url in self.admin.get_urls()]
+        self.assertIn("sampleapp_groupermodelcontent_change", names)
+
+    def test_get_urls_skips_content_change_when_registered(self) -> None:
+        """The declaration is dropped when the content model has its own admin."""
+        site.register(GrouperModelContent)
+        try:
+            names = [url.name for url in self.admin.get_urls()]
+            self.assertNotIn("sampleapp_groupermodelcontent_change", names)
+        finally:
+            site.unregister(GrouperModelContent)
+
+    def test_content_change_url_redirects_to_grouper(self) -> None:
+        """A content object's change URL redirects to the grouper change view, selecting that
+        specific content object and its grouping fields."""
+        param = self.admin.content_pk_url_param
+        content = self.createContentInstance("en")
+        content_change_url = admin_reverse("sampleapp_groupermodelcontent_change", args=(content.pk,))
+        with self.login_user_context(self.admin_user):
+            response = self.client.get(content_change_url)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response.url.startswith(self.change_url))
+        self.assertIn(f"{param}={content.pk}", response.url)
+        self.assertIn("language=en", response.url)
+
+    def test_content_change_redirect_rejects_post(self) -> None:
+        """The redirect view is GET-only: a POST is rejected (405) rather than silently turned
+        into a GET that discards its payload."""
+        content = self.createContentInstance("en")
+        content_change_url = admin_reverse("sampleapp_groupermodelcontent_change", args=(content.pk,))
+        with self.login_user_context(self.admin_user):
+            response = self.client.post(content_change_url, data={"category_name": "changed"})
+        self.assertEqual(response.status_code, 405)
+
+    def test_specific_content_obj_shown_and_selector_dropped(self) -> None:
+        """Requesting a specific (non-latest) content object by pk shows exactly that object and
+        drops the language selector."""
+        param = self.admin.content_pk_url_param
+        latest = self.createContentInstance("en")  # lower pk: picked as latest by .first()
+        other = self.createContentInstance("en")  # higher pk: a different content object
+        with self.login_user_context(self.admin_user):
+            response = self.client.get(f"{self.change_url}?{param}={other.pk}")
+        # The requested (non-latest) content object is shown ...
+        self.assertContains(response, other.secret_greeting)
+        self.assertNotContains(response, latest.secret_greeting)
+        # ... and the language selector is dropped because it is not the latest content
+        self.assertNotContains(response, 'id="page_form_lang_tabs"')
+
+    def test_specific_latest_content_obj_keeps_selector(self) -> None:
+        """Requesting the latest content object by pk shows it and keeps the language selector."""
+        param = self.admin.content_pk_url_param
+        latest = self.createContentInstance("en")  # lower pk: picked as latest by .first()
+        self.createContentInstance("en")
+        with self.login_user_context(self.admin_user):
+            response = self.client.get(f"{self.change_url}?{param}={latest.pk}")
+        self.assertContains(response, latest.secret_greeting)
+        self.assertContains(response, 'id="page_form_lang_tabs"')
+
+    def test_invalid_content_pk_falls_back_to_latest(self) -> None:
+        """An invalid content pk is ignored and the latest content is shown."""
+        param = self.admin.content_pk_url_param
+        content = self.createContentInstance("en")
+        with self.login_user_context(self.admin_user):
+            response = self.client.get(f"{self.change_url}?language=en&{param}=not-a-pk")
+        self.assertContains(response, content.secret_greeting)
+        self.assertContains(response, 'id="page_form_lang_tabs"')
+
     @wo_content_permission
     def test_change_form_wo_write_permit(self) -> None:
         """If no change permission exists for content mark content fields readonly."""

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -1553,6 +1553,32 @@ class PageTest(PageTestBase):
                 content_admin.slug(content2)
                 content_admin.overwrite_url(content2)
 
+    def test_change_view_shows_language_tabs_for_latest_content(self):
+        """The page content change view offers the language selector for the latest content."""
+        superuser = self.get_superuser()
+        page = self.get_page()
+        content = self.get_pagecontent_obj(page, "en")
+        change_url = admin_reverse("cms_pagecontent_change", args=(content.pk,))
+        with self.login_user_context(superuser):
+            response = self.client.get(change_url)
+        self.assertContains(response, 'id="page_form_lang_tabs"')
+
+    def test_change_view_drops_language_tabs_for_non_latest_content(self):
+        """The page content change view drops the language selector when an older (non-latest)
+        content object is shown. Switching languages back and forth would otherwise silently bring
+        up the latest content instead - confusing UX."""
+        superuser = self.get_superuser()
+        page = self.get_page()
+        content = self.get_pagecontent_obj(page, "en")
+        change_url = admin_reverse("cms_pagecontent_change", args=(content.pk,))
+        # Simulate a versioning package: the latest content for this language differs from the
+        # content object being shown.
+        fake_latest = type("FakeContent", (), {"pk": content.pk + 1000})()
+        with patch("cms.models.pagemodel.Page.get_admin_content", return_value=fake_latest):
+            with self.login_user_context(superuser):
+                response = self.client.get(change_url)
+        self.assertNotContains(response, 'id="page_form_lang_tabs"')
+
     def _parse_page_tree(self, response, parser_class):
         content = response.content
         content = content.decode(response.charset)


### PR DESCRIPTION
## Summary by Sourcery

Improve grouper and page content admin behavior around outdated content versions and language switching.

Bug Fixes:
- Prevent language switching on outdated content from silently navigating to the latest version instead of the currently viewed version by hiding language selectors for non-latest content.

Enhancements:
- Allow selecting and displaying a specific content object (including non-latest versions) in the grouper change view via a dedicated GET parameter and a content change redirect URL.
- Expose a stable admin change URL for content models that redirects to the unified grouper change form when the content model is not separately registered.
- Add a hook to detect whether a content object is the latest version for its grouper and current grouping fields to control language selector visibility.

Tests:
- Add regression tests for grouper admin content selection, content change redirect behavior, and language selector visibility for latest vs non-latest content.
- Add tests for page content change views to assert language tabs are shown only for the latest content.

This PR fixes two issues:

* Unexpected user experience when switching languages on an outdated page version: Going back to original language does not return to the viewed content but to the latest content
* GrouperAdmin did not allow for viewing specific outdated content objects.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.