### PR TITLE
fix: check and delete-orphaned-plugins had an n+1 issue

### DIFF
--- a/cms/management/commands/subcommands/list.py
+++ b/cms/management/commands/subcommands/list.py
@@ -50,27 +50,47 @@ def plugin_report():
     ]
     """
     plugin_report = []
-    all_plugins = CMSPlugin.objects.order_by('plugin_type')
-    plugin_types = list(set(all_plugins.values_list('plugin_type', flat=True)))
-    plugin_types.sort()
+    plugin_types = list(
+        CMSPlugin.objects.order_by('plugin_type')
+        .values_list('plugin_type', flat=True)
+        .distinct()
+    )
 
     for plugin_type in plugin_types:
-        plugin = {}
-        plugin['type'] = plugin_type
-        try:
-            # get all plugins of this type
-            plugins = CMSPlugin.objects.filter(plugin_type=plugin_type)
-            plugin['instances'] = plugins
-            # does this plugin have a model? report unsaved instances
-            plugin['model'] = plugin_pool.get_plugin(name=plugin_type).model
-            unsaved_instances = [p for p in plugins if not p.get_plugin_instance()[0]]
-            plugin['unsaved_instances'] = unsaved_instances
+        # get all plugins of this type
+        plugins = CMSPlugin.objects.filter(plugin_type=plugin_type)
+        plugin = {
+            'type': plugin_type,
+            'instances': plugins,
+        }
 
+        try:
+            # does this plugin have a model? report unsaved instances
+            model = plugin_pool.get_plugin(name=plugin_type).model
         # catch uninstalled plugins
         except KeyError:
             plugin['model'] = None
-            plugin['instances'] = plugins
             plugin['unsaved_instances'] = []
+            plugin_report.append(plugin)
+            continue
+
+        plugin['model'] = model
+
+        if model._meta.concrete_model == CMSPlugin._meta.concrete_model:
+            # Model-less plugin: the bound instance is the CMSPlugin row
+            # itself, so there can never be unsaved instances.
+            plugin['unsaved_instances'] = []
+        else:
+            # An instance is "unsaved" when its CMSPlugin row has no matching
+            # row in the plugin's own (child) table. Resolve this with a single
+            # bulk query for the saved ids instead of one query per instance.
+            saved_ids = set(
+                model.objects.filter(cmsplugin_ptr__in=plugins)
+                .values_list('cmsplugin_ptr_id', flat=True)
+            )
+            plugin['unsaved_instances'] = [
+                instance for instance in plugins if instance.pk not in saved_ids
+            ]
 
         plugin_report.append(plugin)
 

--- a/cms/tests/test_management.py
+++ b/cms/tests/test_management.py
@@ -5,8 +5,8 @@ from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core import management
 from django.core.management import CommandError
-from django.db import models
-from django.test.utils import override_settings
+from django.db import connection, models
+from django.test.utils import CaptureQueriesContext, override_settings
 from djangocms_text.cms_plugins import TextPlugin
 
 from cms.api import add_plugin, create_page, create_page_content
@@ -287,6 +287,39 @@ class ManagementTestCase(CMSTestCase):
         # No gaps in plugin tree
         max_position = placeholder.cmsplugin_set.aggregate(models.Max('position'))['position__max']
         self.assertEqual(max_position, 3)
+
+    @override_settings(INSTALLED_APPS=TEST_INSTALLED_APPS)
+    def test_plugin_report_query_count_does_not_scale_with_instances(self):
+        """
+        plugin_report() must resolve unsaved instances with bulk queries.
+
+        It previously called get_plugin_instance() once per plugin row, an
+        N+1 that made ``cms check`` and ``cms delete-orphaned-plugins`` appear
+        to hang on databases with many plugins. Guard against a regression by
+        asserting the query count is independent of the number of instances.
+        """
+        placeholder = Placeholder.objects.create(slot="test")
+
+        def count_queries():
+            with CaptureQueriesContext(connection) as ctx:
+                # Force full evaluation so deferred querysets are counted too.
+                for plugin in plugin_report():
+                    list(plugin["instances"])
+                    list(plugin["unsaved_instances"])
+            return len(ctx.captured_queries)
+
+        add_plugin(placeholder, TextPlugin, "en", body="en body")
+        baseline = count_queries()
+
+        for _ in range(10):
+            add_plugin(placeholder, TextPlugin, "en", body="en body")
+        scaled = count_queries()
+
+        self.assertEqual(
+            baseline,
+            scaled,
+            "plugin_report() issues a query per plugin instance (N+1 regression)",
+        )
 
     @override_settings(INSTALLED_APPS=TEST_INSTALLED_APPS)
     def test_delete_orphaned_plugins_keeps_positions_consecutive(self):


### PR DESCRIPTION
## Description

This PR fixes a N+1 issue in the management commands `./manage.py cms check` and `./manage.py cms delete-orphaned-plugins`. Both create a plugin report. With django CMS versioning keeping long version histories the number of plugins per installation grows rapidly. This PR makes the reports performant for large installations again.

## Summary by Sourcery

Optimize plugin reporting in management commands to avoid N+1 database queries when resolving plugin instances.

Bug Fixes:
- Fix N+1 query behaviour in plugin_report() used by `cms check` and `cms delete-orphaned-plugins`, restoring performance on large installations.

Tests:
- Add regression test ensuring plugin_report() query count remains constant regardless of the number of plugin instances.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.