### PR TITLE
fix: Missing authorization in `render_object_structure` disclosed non-PageContent placeholder structure (#8692)

### DIFF
--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -27,7 +27,9 @@ from cms.utils.i18n import get_language_dict, get_language_tuple
 from cms.utils.page_permissions import (
     user_can_change_page,
     user_can_delete_page,
+    user_can_view_page,
 )
+from cms.utils.permissions import user_can_view_placeholder_source
 from cms.utils.urlutils import add_url_parameters, admin_reverse
 from menus.utils import DefaultLanguageChanger
 
@@ -149,6 +151,17 @@ class PlaceholderToolbar(CMSToolbar):
             if ph.has_change_permission(self.request.user)
         )
 
+    def _has_page_view_perm(self):
+        if self.page and user_can_view_page(self.request.user, self.page):
+            return True
+        return False
+
+    def _has_placeholder_view_perm(self):
+        obj = self.toolbar.obj
+        if obj is None:
+            return False
+        return user_can_view_placeholder_source(self.request.user, obj)
+
     def _can_add_button(self):
         if self._has_page_change_perm():
             return True
@@ -157,12 +170,16 @@ class PlaceholderToolbar(CMSToolbar):
         return False
 
     def _can_add_structure_mode(self):
-        if not self.request.user.has_perm('cms.use_structure'):
+        # Viewing the structure board only requires view permission: editing
+        # the plugins stays gated by change permission at the plugin endpoints.
+        # This lets headless reviewers (and view-only staff) inspect content
+        # structure without edit rights.
+        if not self.request.user.has_perm("cms.use_structure"):
             return False
 
-        if self.page and not self.page.application_urls and self._has_page_change_perm():
+        if self.page and not self.page.application_urls and self._has_page_view_perm():
             return True
-        elif self._has_placeholder_change_perm():
+        elif self._has_placeholder_view_perm():
             return True
         return False
 

--- a/cms/models/contentmodels.py
+++ b/cms/models/contentmodels.py
@@ -192,6 +192,9 @@ class PageContent(models.Model):
     def has_placeholder_change_permission(self, user):
         return self.page.has_change_permission(user)
 
+    def has_placeholder_view_permission(self, user):
+        return self.page.has_view_permission(user)
+
     def has_publish_permission(self, user):
         return self.page.has_publish_permission(user)
 

--- a/cms/templatetags/cms_admin.py
+++ b/cms/templatetags/cms_admin.py
@@ -101,7 +101,9 @@ class GetPreviewUrl(AsTag):
             )
         if not page_content:
             return ""
-        return self.get_url(page_content, language=page_content.language)
+        # Frontend-editable objects (non-PageContent) may not carry a language
+        # attribute; fall back to the active request language. See PR #8691.
+        return self.get_url(page_content, language=getattr(page_content, "language", None))
 
     def get_url(self, object, language):
         return get_object_preview_url(object, language=language)
@@ -329,5 +331,8 @@ def submit_row_plugin(context):
 @register.filter
 def placeholder_is_immutable(placeholder, user):
     if isinstance(placeholder, Placeholder):
-        return not placeholder.check_source(user)
+        # A placeholder is editable only if the source permits editing *and*
+        # the user may change it. View-only users (e.g. headless reviewers) can
+        # open the structure board but must see it read-only.
+        return not (placeholder.check_source(user) and placeholder.has_change_permission(user))
     return True

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -36,6 +36,7 @@ from cms.templatetags.cms_tags import (
     render_plugin,
 )
 from cms.test_utils.fixtures.templatetags import TwoPagesFixture
+from cms.test_utils.project.placeholderapp.models import Example1
 from cms.test_utils.testcases import CMSTestCase
 from cms.toolbar.toolbar import CMSToolbar
 from cms.toolbar.utils import get_object_edit_url, get_object_preview_url
@@ -87,6 +88,25 @@ class TemplatetagTests(CMSTestCase):
         self.assertIn(expected_for_page, output)
         self.assertIn(expected_for_german_content, output)
 
+    def test_get_preview_url_object_without_language(self):
+        """A frontend-editable object that has no ``language`` attribute falls back
+        to the active request language instead of raising ``AttributeError``."""
+        example = Example1.objects.create(char_1="a", char_2="b", char_3="c", char_4="d")
+        self.assertFalse(hasattr(example, "language"))
+
+        template = """
+            {% load cms_admin %}
+            preview={% get_preview_url example %}
+            edit={% get_edit_url example %}
+        """
+        with force_language("en"):
+            output = self.render_template_obj(template, {"example": example}, self.get_request())
+            expected_preview = f"preview={get_object_preview_url(example, language='en')}"
+            expected_edit = f"edit={get_object_edit_url(example, language='en')}"
+
+        self.assertIn(expected_preview, output)
+        self.assertIn(expected_edit, output)
+
     def test_get_edit_url(self):
         """The get_edit_url template tag returns the content edit url for its language:
         If a page is given, take the current language (en), if a page_content is given,
@@ -110,8 +130,8 @@ class TemplatetagTests(CMSTestCase):
     def test_placeholder_is_immutable_filter(self):
         template = """
             {% load cms_admin %}
-            non-placeholder={{ True|placeholder_is_immutable:request.user }}
-            placeholder={{ placeholder|placeholder_is_immutable:request.user }}
+            non-placeholder={{ True|placeholder_is_immutable:user }}
+            placeholder={{ placeholder|placeholder_is_immutable:user }}
         """
         from unittest.mock import patch
 
@@ -121,11 +141,25 @@ class TemplatetagTests(CMSTestCase):
         placeholder = page.get_placeholders("en").first()
         request = self.get_request()
 
+        # A placeholder is mutable only if the source permits editing *and* the
+        # user may change it: a user with change permission gets the editable
+        # board (placeholder=False).
         with patch.object(Placeholder, "check_source", wraps=placeholder.check_source) as mock_check_source:
-            output = self.render_template_obj(template, {"placeholder": placeholder}, request=request)
+            output = self.render_template_obj(
+                template, {"placeholder": placeholder, "user": self.get_superuser()}, request=request
+            )
             self.assertIn("non-placeholder=True", output)
             self.assertIn("placeholder=False", output)
             self.assertEqual(mock_check_source.call_count, 1)
+
+        # A user without change permission only gets a read-only board, even
+        # though the source itself permits editing (placeholder=True).
+        output = self.render_template_obj(
+            template,
+            {"placeholder": placeholder, "user": self.get_staff_user_with_no_permissions()},
+            request=request,
+        )
+        self.assertIn("placeholder=True", output)
 
     def test_get_admin_tree_title(self):
         page = create_page("page_a", "nav_playground.html", "en", slug="slug-test2")

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -1133,6 +1133,36 @@ class ToolbarModeTests(ToolbarTestBase):
         self.assertTrue(toolbar.structure_mode_active)
         self.assertFalse(toolbar.preview_mode_active)
 
+    def _use_structure_permission(self):
+        return Permission.objects.get(
+            content_type__app_label="cms", codename="use_structure"
+        )
+
+    def test_structure_switcher_shown_to_view_only_user_with_use_structure(self):
+        """Structure mode is a read affordance: view permission is enough.
+
+        Viewing the structure board only requires view permission (mutations
+        stay gated by change permission at the plugin endpoints), so a user with
+        ``cms.use_structure`` who may view — but not change — an unrestricted
+        page is still offered the structure switcher.
+        """
+        page = create_page("normal", "nav_playground.html", "en")
+        page_content = page.get_content_obj("en")
+        user = self.get_staff_user_with_no_permissions()
+        user.user_permissions.add(self._use_structure_permission())
+        with self.login_user_context(user):
+            response = self.client.get(get_object_edit_url(page_content, language="en"))
+        self.assertContains(response, 'title="Toggle structure"')
+
+    def test_structure_switcher_hidden_without_use_structure(self):
+        """Without ``cms.use_structure`` the switcher stays hidden."""
+        page = create_page("normal", "nav_playground.html", "en")
+        page_content = page.get_content_obj("en")
+        user = self.get_staff_user_with_no_permissions()
+        with self.login_user_context(user):
+            response = self.client.get(get_object_edit_url(page_content, language="en"))
+        self.assertNotContains(response, 'title="Toggle structure"')
+
 
 @override_settings(ROOT_URLCONF="cms.test_utils.project.placeholderapp_urls")
 class EditModelTemplateTagTest(ToolbarTestBase):

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -606,3 +606,94 @@ class EndpointPermissionTests(CMSTestCase):
                 self._endpoint("cms_placeholder_render_object_structure")
             )
         self.assertContains(response, "SuperSecretLinkName")
+
+
+class NonPageContentStructureEndpointTests(CMSTestCase):
+    """The structure endpoint must also authorize non-PageContent objects.
+
+    Registered through ``admin_site.admin_view`` the endpoint only requires an
+    active staff user. Without an object-level check, any staff user could read
+    the placeholder/plugin structure of a frontend-editable object (e.g. a model
+    using ``PlaceholderRelationField``) without permission to view it.
+
+    Viewing the (read-only) structure board requires only *view* permission;
+    mutating the plugins stays gated by change permission at the plugin
+    endpoints. This supports headless reviewers inspecting structure without
+    edit rights.
+    """
+
+    def setUp(self) -> None:
+        from cms.test_utils.project.placeholder_relation_field_app.models import (
+            FancyPoll,
+        )
+        from cms.utils.placeholder import rescan_placeholders_for_obj
+
+        self.target = FancyPoll.objects.create(name="private-fancy-poll")
+        self.placeholder = rescan_placeholders_for_obj(self.target)["content"]
+
+    def _url(self):
+        return get_object_structure_url(self.target, language="en")
+
+    def _marker(self):
+        return f'"placeholder_id": "{self.placeholder.pk}"'
+
+    def _staff_with_perm(self, codename):
+        staff = self._create_user(f"staff_{codename}", is_staff=True, is_superuser=False)
+        staff.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="placeholder_relation_field_app",
+                codename=codename,
+            )
+        )
+        return staff
+
+    def test_denies_staff_without_view_permission(self):
+        staff = self.get_staff_user_with_no_permissions()
+        with self.login_user_context(staff):
+            response = self.client.get(self._url())
+        self.assertEqual(
+            response.status_code,
+            404,
+            msg="structure endpoint leaked a non-PageContent object's structure",
+        )
+        self.assertNotContains(response, self._marker(), status_code=404)
+
+    def test_allows_staff_with_view_permission(self):
+        # Headless / read-only reviewers may inspect structure with view rights.
+        staff = self._staff_with_perm("view_fancypoll")
+        with self.login_user_context(staff):
+            response = self.client.get(self._url())
+        self.assertContains(response, self._marker())
+
+    def test_view_only_user_gets_read_only_structure_board(self):
+        """View permission opens the board, but the editing UX is disabled.
+
+        Mutations stay gated by change permission at the plugin endpoints, so
+        the structure board must render read-only (no drag/add/cut/delete) for a
+        user who may view but not change the object.
+        """
+        view_only = self._staff_with_perm("view_fancypoll")
+        with self.login_user_context(view_only):
+            response = self.client.get(self._url())
+        self.assertContains(response, self._marker())
+        # Read-only markers from toolbar_with_structure.html / dragbar / dragitem.
+        self.assertContains(response, "cms-drag-disabled")
+        self.assertContains(response, "Placeholder not editable")
+
+        # A user who may change the object still gets the editable board.
+        editor = self._staff_with_perm("change_fancypoll")
+        with self.login_user_context(editor):
+            response = self.client.get(self._url())
+        self.assertContains(response, self._marker())
+        self.assertNotContains(response, "Placeholder not editable")
+
+    def test_allows_staff_with_change_permission(self):
+        staff = self._staff_with_perm("change_fancypoll")
+        with self.login_user_context(staff):
+            response = self.client.get(self._url())
+        self.assertContains(response, self._marker())
+
+    def test_allows_superuser(self):
+        with self.login_user_context(self.get_superuser()):
+            response = self.client.get(self._url())
+        self.assertContains(response, self._marker())

--- a/cms/utils/permissions.py
+++ b/cms/utils/permissions.py
@@ -58,6 +58,28 @@ def get_model_permission_codename(model, action):
     return opts.app_label + '.' + get_permission_codename(action, opts)
 
 
+def user_can_view_placeholder_source(user, source):
+    """Whether ``user`` may view the placeholders attached to ``source``.
+
+    Viewing the (read-only) structure board of a frontend-editable object
+    requires only *view* permission; mutating its plugins stays gated by
+    change permission at the plugin endpoints. This lets headless reviewers
+    inspect content structure without edit rights.
+
+    Honours a custom ``has_placeholder_view_permission`` hook on the object
+    and otherwise grants access to users holding the model/object ``view`` or
+    ``change`` permission (change implies the right to view).
+    """
+    if hasattr(source, "has_placeholder_view_permission"):
+        return source.has_placeholder_view_permission(user)
+    model = type(source)
+    perms = (
+        get_model_permission_codename(model, "view"),
+        get_model_permission_codename(model, "change"),
+    )
+    return any(user.has_perm(perm) or user.has_perm(perm, source) for perm in perms)
+
+
 def _has_global_permission(user, site, action):
     if not user.is_authenticated:
         return False

--- a/cms/views.py
+++ b/cms/views.py
@@ -48,6 +48,7 @@ from cms.utils.i18n import (
 )
 from cms.utils.page import get_page_from_request
 from cms.utils.page_permissions import user_can_view_page
+from cms.utils.permissions import user_can_view_placeholder_source
 from cms.utils.placeholder import get_declared_placeholders_for_obj, get_placeholder_conf
 
 
@@ -264,6 +265,11 @@ def render_object_structure(request, content_type_id, object_id):
                 raise Http404
         else:
             content_type_obj = content_type.get_object_for_this_type(pk=object_id)
+            # Viewing the structure board requires only view permission (as the
+            # page branch above does via user_can_view_page). Mutations remain
+            # gated by change permission at the plugin endpoints.
+            if not user_can_view_placeholder_source(request.user, content_type_obj):
+                raise Http404
     except ObjectDoesNotExist as err:
         raise Http404 from err
 


### PR DESCRIPTION
## Summary by Sourcery

Tighten authorization around the structure board for non-PageContent objects while allowing view-only users to inspect content structure, and fix preview/edit URL handling for frontend-editable objects without a language field.

New Features:
- Allow staff users with view permission and the cms.use_structure permission to access the structure mode switcher and inspect a read-only structure board for pages and frontend-editable objects.
- Support preview and edit URLs for frontend-editable objects that do not define a language attribute by falling back to the active request language.

Bug Fixes:
- Ensure the render_object_structure endpoint authorizes non-PageContent objects using view/change permissions and no longer leaks placeholder structure to unauthorized staff users.
- Make placeholder_is_immutable respect both the source editability and the user’s change permission so view-only users see a read-only structure board instead of an editable one.

Enhancements:
- Introduce user_can_view_placeholder_source and related toolbar permission helpers to consistently determine when a user may view placeholders attached to a content source without granting edit rights.

Tests:
- Add view, change, superuser, and unauthorized access tests for the non-PageContent structure endpoint.
- Extend template tag tests to cover preview/edit URLs for objects without language and read-only vs editable placeholder behavior based on user permissions.
- Add toolbar tests verifying visibility of the structure mode switcher depending on cms.use_structure and view permissions.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.