### PR TITLE
fix: Harden page duplication, group permissions and URL validator

### DIFF
--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -49,8 +49,10 @@ from cms.utils.compat.forms import UserChangeForm
 from cms.utils.conf import get_cms_setting
 from cms.utils.i18n import get_language_list, get_site_language_from_request
 from cms.utils.page import get_clean_username
+from cms.utils.page_permissions import user_can_view_page
 from cms.utils.permissions import (
     get_current_user,
+    get_model_permission_codename,
     get_subordinate_groups,
     get_subordinate_users,
     get_user_permission_level,
@@ -515,6 +517,22 @@ class DuplicatePageForm(AddPageForm):
         required=True,
         widget=forms.HiddenInput(),
     )
+
+    def clean_source(self):
+        source = self.cleaned_data.get("source")
+        # ``source`` is a hidden field whose value is fully controlled by the
+        # client on POST and whose queryset spans every page on every site.
+        # ``has_add_permission`` only checks that the user may create *a* page,
+        # not that they may read ``source``. Without an explicit object-level
+        # check, a staff user with only "add page" rights could duplicate (and
+        # thereby read the plugin content of) any page -- bypassing per-page
+        # view restrictions and multi-site isolation (CWE-639 / CWE-862).
+        # ``copy(..., permissions=False)`` even strips the source's view
+        # restrictions, leaving the copy fully readable. Require that the user
+        # is actually allowed to view the page they are copying.
+        if source and not user_can_view_page(self._user, source):
+            raise ValidationError(_("You do not have permission to copy this page."))
+        return source
 
 
 def url_is_locked(page_content: PageContent) -> bool:
@@ -1289,6 +1307,11 @@ class GenericCmsPermissionForm(forms.ModelForm):
     can_change_pagepermission = forms.BooleanField(label=_("Change"), required=False)
     can_delete_pagepermission = forms.BooleanField(label=_("Delete"), required=False)
 
+    # Maps the ``can_<action>_<name>`` permission fields to the model whose
+    # permission they grant. Mirrors ``save_permissions`` and the fieldsets
+    # rendered by ``PageUserGroupAdmin``/``PageUserAdmin``.
+    _permission_models = ((Page, "page"), (PageUser, "pageuser"), (PagePermission, "pagepermission"))
+
     def __init__(self, *args, **kwargs):
         instance = kwargs.get("instance")
         initial = kwargs.get("initial") or {}
@@ -1345,6 +1368,33 @@ class GenericCmsPermissionForm(forms.ModelForm):
                     "to change permissions. Edit permissions required."
                 )
                 raise ValidationError(message)
+
+        # Enforce "nobody can grant more than they have" at the data layer.
+        self._drop_unauthorized_permissions(data)
+        return data
+
+    def _drop_unauthorized_permissions(self, data):
+        """Remove ``can_*`` entries the current manager is not allowed to manage.
+
+        ``PageUserGroupAdmin.get_fieldsets`` only *renders* the permission
+        checkboxes the manager actually holds, but the ``can_*`` fields are
+        declared on this form and therefore stay in ``base_fields`` regardless
+        of the admin's ``fields=`` restriction. A crafted POST can set the
+        hidden ones, and ``save_permissions`` would then grant them -- letting a
+        delegated manager escalate a group beyond their own rights (CWE-269).
+        Dropping the unauthorized entries here means they are neither granted
+        nor revoked, so any existing value the manager may not touch is left
+        untouched as well.
+        """
+        user = self._current_user
+        for model, name in self._permission_models:
+            for action in ("add", "change", "delete"):
+                field = f"can_{action}_{name}"
+                if field not in self.fields:
+                    continue
+                if user is None or not user.has_perm(get_model_permission_codename(model, action)):
+                    data.pop(field, None)
+        return data
 
     def populate_initials(self, obj):
         """Read out permissions from permission system."""

--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -52,7 +52,7 @@ from cms.utils.compat.forms import UserChangeForm
 from cms.utils.conf import get_cms_setting
 from cms.utils.i18n import get_language_list, get_site_language_from_request
 from cms.utils.page import get_clean_username
-from cms.utils.page_permissions import user_can_view_page
+from cms.utils.page_permissions import user_can_change_page, user_can_view_page
 from cms.utils.permissions import (
     get_current_user,
     get_model_permission_codename,
@@ -288,15 +288,14 @@ class AddPageForm(BasePageContentForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        page_field = self.fields.get("cms_page")
+        if page_field:
+            page_field.queryset = page_field.queryset.filter(site=self._site)
+
         source_field = self.fields.get("source")
 
         if not source_field or source_field.widget.is_hidden:
             return
-
-        page_field = self.fields.get("cms_page")
-
-        if page_field:
-            page_field.queryset = page_field.queryset.filter(site=self._site)
 
         root_page = PageType.get_root_page(site=self._site)
 
@@ -348,6 +347,12 @@ class AddPageForm(BasePageContentForm):
         if parent_page and parent_page.site_id != self._site.pk:
             raise ValidationError("Site doesn't match the parent's page site")
         return parent_page
+
+    def clean_cms_page(self):
+        page = self.cleaned_data.get("cms_page")
+        if page and not user_can_change_page(self._user, page, site=page.site):
+            raise ValidationError(_("You do not have permission to change this page."))
+        return page
 
     def create_translation(self, page, main_language_page_content_template=None):
         data = self.cleaned_data

--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -110,13 +110,22 @@ def get_main_language_page_content_template(new_page):
     return None
 
 
+# Permission actions managed by the CMS permission forms (Django's defaults).
+CMS_PERMISSION_ACTIONS = ("add", "change", "delete")
+
+# Maps each ``can_<action>_<name>`` permission group to the model whose
+# permission governs it. Used to render, read and authorize the checkboxes.
+CMS_PERMISSION_MODELS = (
+    (Page, "page"),
+    (PageUser, "pageuser"),
+    (PagePermission, "pagepermission"),
+)
+
+
 def save_permissions(data, obj):
-    models = (
-        (Page, "page"),
-        (PageUser, "pageuser"),
-        (PageUserGroup, "pageuser"),
-        (PagePermission, "pagepermission"),
-    )
+    # ``PageUserGroup`` shares the ``pageuser`` field with ``PageUser`` but has
+    # its own content type, so the permission must be (un)assigned on both.
+    models = (*CMS_PERMISSION_MODELS, (PageUserGroup, "pageuser"))
 
     if not obj.pk:
         # save obj, otherwise we can't assign permissions to him
@@ -126,7 +135,7 @@ def save_permissions(data, obj):
 
     for model, name in models:
         content_type = ContentType.objects.get_for_model(model)
-        for key in ("add", "change", "delete"):
+        for key in CMS_PERMISSION_ACTIONS:
             # add permission `key` for model `model`
             codename = get_permission_codename(key, model._meta)
             permission = Permission.objects.get(content_type=content_type, codename=codename)
@@ -1304,7 +1313,6 @@ class GenericCmsPermissionForm(forms.ModelForm):
     # Maps the ``can_<action>_<name>`` permission fields to the model whose
     # permission they grant. Mirrors ``save_permissions`` and the fieldsets
     # rendered by ``PageUserGroupAdmin``/``PageUserAdmin``.
-    _permission_models = ((Page, "page"), (PageUser, "pageuser"), (PagePermission, "pagepermission"))
 
     def __init__(self, *args, **kwargs):
         instance = kwargs.get("instance")
@@ -1381,8 +1389,8 @@ class GenericCmsPermissionForm(forms.ModelForm):
         untouched as well.
         """
         user = self._current_user
-        for model, name in self._permission_models:
-            for action in ("add", "change", "delete"):
+        for model, name in CMS_PERMISSION_MODELS:
+            for action in CMS_PERMISSION_ACTIONS:
                 field = f"can_{action}_{name}"
                 if field not in self.fields:
                     continue
@@ -1395,11 +1403,10 @@ class GenericCmsPermissionForm(forms.ModelForm):
         initials = {}
         permission_accessor = get_permission_accessor(obj)
 
-        for model in (Page, PageUser, PagePermission):
-            name = model.__name__.lower()
+        for model, name in CMS_PERMISSION_MODELS:
             content_type = ContentType.objects.get_for_model(model)
             permissions = permission_accessor.filter(content_type=content_type).values_list("codename", flat=True)
-            for key in ("add", "change", "delete"):
+            for key in CMS_PERMISSION_ACTIONS:
                 codename = get_permission_codename(key, model._meta)
                 initials[f"can_{key}_{name}"] = codename in permissions
         return initials

--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -523,13 +523,7 @@ class DuplicatePageForm(AddPageForm):
         # ``source`` is a hidden field whose value is fully controlled by the
         # client on POST and whose queryset spans every page on every site.
         # ``has_add_permission`` only checks that the user may create *a* page,
-        # not that they may read ``source``. Without an explicit object-level
-        # check, a staff user with only "add page" rights could duplicate (and
-        # thereby read the plugin content of) any page -- bypassing per-page
-        # view restrictions and multi-site isolation (CWE-639 / CWE-862).
-        # ``copy(..., permissions=False)`` even strips the source's view
-        # restrictions, leaving the copy fully readable. Require that the user
-        # is actually allowed to view the page they are copying.
+        # not that they may read ``source``.
         if source and not user_can_view_page(self._user, source):
             raise ValidationError(_("You do not have permission to copy this page."))
         return source

--- a/cms/admin/settingsadmin.py
+++ b/cms/admin/settingsadmin.py
@@ -21,6 +21,8 @@ from cms.admin.forms import RequestToolbarForm
 from cms.models import UserSettings
 from cms.models.contentmodels import PageContent
 from cms.utils.page import get_page_from_request
+from cms.utils.page_permissions import user_can_view_page
+from cms.utils.permissions import user_can_view_placeholder_source
 from cms.utils.urlutils import admin_reverse
 
 
@@ -85,6 +87,21 @@ class SettingsAdmin(admin.ModelAdmin):
             current_page = attached_obj.page
         else:
             current_page = get_page_from_request(request, use_path=origin_url.path, clean_path=True)
+
+        # The object id/type come straight from the client, so enforce an
+        # object-level view check before rendering a toolbar for it. Without
+        # this, any staff user could read the title/breadcrumb/edit URLs of
+        # pages on other sites or of view-restricted pages they cannot access.
+        # Deny with the same generic response as an unknown object so this does
+        # not become an existence oracle.
+        if isinstance(attached_obj, PageContent):
+            if not user_can_view_page(request.user, current_page):
+                return HttpResponseBadRequest('Invalid parameters')
+        elif attached_obj is not None:
+            if not user_can_view_placeholder_source(request.user, attached_obj):
+                return HttpResponseBadRequest('Invalid parameters')
+        elif current_page is not None and not user_can_view_page(request.user, current_page):
+            return HttpResponseBadRequest('Invalid parameters')
 
         data = QueryDict(query_string=origin_url.query, mutable=True)
         placeholders = request.GET.getlist("placeholders[]")

--- a/cms/api.py
+++ b/cms/api.py
@@ -238,50 +238,57 @@ def create_page(
     else:
         application_urls = None
 
-    # ugly permissions hack
+    # ugly permissions hack: expose the creator through the _current_user
+    # context variable for the duration of the creation, then restore the
+    # previous value. Capturing the token and resetting (instead of blindly
+    # setting None at the end) avoids clobbering a user set by
+    # CurrentUserMiddleware and prevents leaking the creator into the next
+    # operation on the same thread. See cms.utils.permissions.reset_current_user.
     if created_by and isinstance(created_by, get_user_model()):
-        _current_user.set(created_by)
+        user_token = _current_user.set(created_by)
         created_by = get_clean_username(created_by)
     else:
-        _current_user.set(None)
+        user_token = _current_user.set(None)
 
-    if reverse_id:
-        if Page.objects.filter(reverse_id=reverse_id, site=site).exists():
-            raise FieldError('A page with the reverse_id="%s" already exist.' % reverse_id)
+    try:
+        if reverse_id:
+            if Page.objects.filter(reverse_id=reverse_id, site=site).exists():
+                raise FieldError('A page with the reverse_id="%s" already exist.' % reverse_id)
 
-    page = Page(
-        parent=parent,
-        created_by=created_by,
-        changed_by=created_by,
-        reverse_id=reverse_id,
-        navigation_extenders=navigation_extenders,
-        application_urls=application_urls,
-        application_namespace=apphook_namespace,
-        login_required=login_required,
-        site=site,
-    )
-    page.add_to_tree(position=position)
-    page.save()
+        page = Page(
+            parent=parent,
+            created_by=created_by,
+            changed_by=created_by,
+            reverse_id=reverse_id,
+            navigation_extenders=navigation_extenders,
+            application_urls=application_urls,
+            application_namespace=apphook_namespace,
+            login_required=login_required,
+            site=site,
+        )
+        page.add_to_tree(position=position)
+        page.save()
 
-    create_page_content(
-        language=language,
-        title=title,
-        menu_title=menu_title,
-        page_title=page_title,
-        slug=slug,
-        created_by=created_by,
-        redirect=redirect,
-        meta_description=meta_description,
-        page=page,
-        overwrite_url=overwrite_url,
-        soft_root=soft_root,
-        in_navigation=in_navigation,
-        template=template,
-        limit_visibility_in_menu=limit_visibility_in_menu,
-        xframe_options=xframe_options,
-    )
-    _current_user.set(None)
-    return page
+        create_page_content(
+            language=language,
+            title=title,
+            menu_title=menu_title,
+            page_title=page_title,
+            slug=slug,
+            created_by=created_by,
+            redirect=redirect,
+            meta_description=meta_description,
+            page=page,
+            overwrite_url=overwrite_url,
+            soft_root=soft_root,
+            in_navigation=in_navigation,
+            template=template,
+            limit_visibility_in_menu=limit_visibility_in_menu,
+            xframe_options=xframe_options,
+        )
+        return page
+    finally:
+        _current_user.reset(user_token)
 
 
 @transaction.atomic
@@ -348,49 +355,61 @@ def create_page_content(
     elif path is None:
         path = page.get_path_for_slug(slug, language)
 
+    # When called directly (not via create_page) with a user instance, expose
+    # it through the _current_user context variable so signal handlers and
+    # PageContent.objects.with_user() attribute the creation correctly. Capture
+    # the token so we can restore the previous value at the end -- otherwise the
+    # user leaks into the next operation on the same thread when
+    # CurrentUserMiddleware is not installed (it only resets at the request
+    # boundary). See cms.utils.permissions.reset_current_user.
+    user_token = None
     if created_by and isinstance(created_by, get_user_model()):
-        _current_user.set(created_by)
+        user_token = _current_user.set(created_by)
         created_by = get_clean_username(created_by)
 
     try:
-        from cms.forms.validators import validate_url_uniqueness
+        try:
+            from cms.forms.validators import validate_url_uniqueness
 
-        validate_url_uniqueness(page.site, path, language, exclude_page=page.parent)
-    except ValidationError as e:
-        raise IntegrityError(e)
+            validate_url_uniqueness(page.site, path, language, exclude_page=page.parent)
+        except ValidationError as e:
+            raise IntegrityError(e)
 
-    page.urls.update_or_create(
-        page=page,
-        language=language,
-        defaults=dict(
-            slug=slug,
-            path=path,
-            managed=not bool(overwrite_url),
-        ),
-    )
+        page.urls.update_or_create(
+            page=page,
+            language=language,
+            defaults=dict(
+                slug=slug,
+                path=path,
+                managed=not bool(overwrite_url),
+            ),
+        )
 
-    # E.g., djangocms-versioning needs an User object to be passed when creating a versioned Object
-    user = _current_user.get(None)
-    page_content = PageContent.objects.with_user(user).create(
-        language=language,
-        title=title,
-        menu_title=menu_title,
-        page_title=page_title,
-        redirect=redirect,
-        meta_description=meta_description,
-        page=page,
-        created_by=created_by,
-        changed_by=created_by,
-        soft_root=soft_root,
-        in_navigation=in_navigation,
-        template=template,
-        limit_visibility_in_menu=limit_visibility_in_menu,
-        xframe_options=xframe_options,
-    )
-    page_content.rescan_placeholders()
-    page._clear_internal_cache()
+        # E.g., djangocms-versioning needs an User object to be passed when creating a versioned Object
+        user = _current_user.get(None)
+        page_content = PageContent.objects.with_user(user).create(
+            language=language,
+            title=title,
+            menu_title=menu_title,
+            page_title=page_title,
+            redirect=redirect,
+            meta_description=meta_description,
+            page=page,
+            created_by=created_by,
+            changed_by=created_by,
+            soft_root=soft_root,
+            in_navigation=in_navigation,
+            template=template,
+            limit_visibility_in_menu=limit_visibility_in_menu,
+            xframe_options=xframe_options,
+        )
+        page_content.rescan_placeholders()
+        page._clear_internal_cache()
 
-    return page_content
+        return page_content
+    finally:
+        if user_token is not None:
+            _current_user.reset(user_token)
 
 
 @transaction.atomic

--- a/cms/cache/page.py
+++ b/cms/cache/page.py
@@ -119,6 +119,13 @@ def set_page_cache(response):
             # recomputing it on cache-reads.
             expires_datetime = timestamp + timedelta(seconds=ttl)
             response_headers = get_response_headers(response)
+            # Persist whether this page opted out of Django's clickjacking
+            # middleware. Only "Allow" pages (no X-Frame-Options header) set
+            # xframe_options_exempt; "Inherit" pages leave it unset so the
+            # middleware adds the site default. The read path must replay this
+            # decision -- unconditionally exempting a cached response would drop
+            # X-Frame-Options from every inherit-default page (clickjacking).
+            xframe_options_exempt = getattr(response, "xframe_options_exempt", False)
             # Persist the list of plugin-declared vary headers so the read path
             # can rebuild the same (header-value aware) content key.
             cache.set(
@@ -133,6 +140,7 @@ def set_page_cache(response):
                     response.content,
                     response_headers,
                     expires_datetime,
+                    xframe_options_exempt,
                 ),
                 ttl,
                 version=version,

--- a/cms/forms/validators.py
+++ b/cms/forms/validators.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING, Optional
+from urllib.parse import urlsplit
 
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator, URLValidator
@@ -24,6 +25,21 @@ def validate_url(value):
     except ValidationError:
         # Fallback to absolute urls
         URLValidator()(value)
+    else:
+        # ``relative_url_regex`` only constrains the *characters* of a relative
+        # path, not the part before the first slash. Values such as
+        # ``javascript:alert(1)/x``, ``data:text/html,...`` or ``vbscript:.../x``
+        # therefore match the relative branch while still carrying a scheme that
+        # executes script when the value is later rendered into an ``href``
+        # (CWE-79). A genuine relative URL has no scheme, so reject any value
+        # that does. (Off-site targets such as ``https://example.com`` or
+        # ``//example.com`` are intentionally permitted -- this field allows
+        # absolute redirects -- and navigate rather than execute script.)
+        if urlsplit(value).scheme:
+            raise ValidationError(
+                gettext("Enter a valid relative or absolute URL."),
+                code="invalid",
+            )
 
 
 def validate_url_uniqueness(

--- a/cms/middleware/user.py
+++ b/cms/middleware/user.py
@@ -10,7 +10,12 @@ class CurrentUserMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        from cms.utils.permissions import set_current_user
+        from cms.utils.permissions import reset_current_user, set_current_user
 
-        set_current_user(getattr(request, 'user', None))
-        return self.get_response(request)
+        token = set_current_user(getattr(request, 'user', None))
+        try:
+            return self.get_response(request)
+        finally:
+            # Reset at the request boundary so the current user does not leak
+            # into the next request handled by a reused worker thread.
+            reset_current_user(token)

--- a/cms/tests/test_api.py
+++ b/cms/tests/test_api.py
@@ -15,6 +15,7 @@ from cms.api import (
     add_plugin,
     assign_user_to_page,
     create_page,
+    create_page_content,
 )
 from cms.apphook_pool import apphook_pool
 from cms.constants import TEMPLATE_INHERITANCE_MAGIC
@@ -46,6 +47,43 @@ class PythonAPITests(CMSTestCase):
             self.assertRaises(TemplateDoesNotExist, create_page, **kwargs)
             kwargs["template"] = TEMPLATE_INHERITANCE_MAGIC
         create_page(**kwargs)
+
+    def test_create_page_restores_current_user(self):
+        # create_page must not leave the creator in the _current_user context
+        # variable, and must restore (not clobber) a user set by a surrounding
+        # request context. Otherwise the creator leaks into the next operation
+        # on the same thread when CurrentUserMiddleware is not installed.
+        from cms.utils.permissions import get_current_user, set_current_user
+
+        prior_user = self.get_superuser()
+        creator = get_user_model().objects.create_user(
+            username="creator", email="creator@django-cms.org", password="creator", is_staff=True,
+        )
+
+        set_current_user(prior_user)
+        try:
+            create_page(created_by=creator, **self._get_default_create_page_arguments())
+            self.assertEqual(get_current_user(), prior_user)
+        finally:
+            set_current_user(None)
+
+    def test_create_page_content_restores_current_user(self):
+        # Same guarantee for a direct create_page_content() call, which sets
+        # _current_user for attribution but must restore the previous value.
+        from cms.utils.permissions import get_current_user, set_current_user
+
+        prior_user = self.get_superuser()
+        creator = get_user_model().objects.create_user(
+            username="creator", email="creator@django-cms.org", password="creator", is_staff=True,
+        )
+        page = create_page(**self._get_default_create_page_arguments())
+
+        set_current_user(prior_user)
+        try:
+            create_page_content("de", "Titel", page, created_by=creator)
+            self.assertEqual(get_current_user(), prior_user)
+        finally:
+            set_current_user(None)
 
     def test_apphook_by_class(self):
         if APP_MODULE in sys.modules:

--- a/cms/tests/test_api.py
+++ b/cms/tests/test_api.py
@@ -80,7 +80,7 @@ class PythonAPITests(CMSTestCase):
 
         set_current_user(prior_user)
         try:
-            create_page_content("de", "Titel", page, created_by=creator)
+            create_page_content("de", "Überschrift", page, created_by=creator)
             self.assertEqual(get_current_user(), prior_user)
         finally:
             set_current_user(None)

--- a/cms/tests/test_cache.py
+++ b/cms/tests/test_cache.py
@@ -1020,7 +1020,7 @@ class PageCacheRoundTripTestCase(CMSTestCase):
             request = self.get_request(page_url, language="en")
             cached = get_page_cache(request)
             self.assertIsNotNone(cached)
-            content, headers, expires_datetime = cached
+            content, headers, expires_datetime, xframe_options_exempt = cached
             self.assertIn(b"Cached body", content)
             self.assertIsNotNone(expires_datetime)
 

--- a/cms/tests/test_forms.py
+++ b/cms/tests/test_forms.py
@@ -24,12 +24,12 @@ from cms.forms.utils import (
 )
 from cms.forms.widgets import ApplicationConfigSelect
 from cms.models import ACCESS_PAGE, ACCESS_PAGE_AND_CHILDREN
-from cms.utils.permissions import current_user
 from cms.test_utils.testcases import (
     URL_CMS_PAGE_ADVANCED_CHANGE,
     URL_CMS_PAGE_PERMISSIONS,
     CMSTestCase,
 )
+from cms.utils.permissions import current_user
 
 
 class Mock_PageSelectFormField(PageSelectFormField):

--- a/cms/tests/test_forms.py
+++ b/cms/tests/test_forms.py
@@ -24,6 +24,7 @@ from cms.forms.utils import (
 )
 from cms.forms.widgets import ApplicationConfigSelect
 from cms.models import ACCESS_PAGE, ACCESS_PAGE_AND_CHILDREN
+from cms.utils.permissions import current_user
 from cms.test_utils.testcases import (
     URL_CMS_PAGE_ADVANCED_CHANGE,
     URL_CMS_PAGE_PERMISSIONS,
@@ -377,7 +378,7 @@ class PermissionFormTestCase(CMSTestCase):
             response = self.client.get(URL_CMS_PAGE_PERMISSIONS % page.pk)
             self.assertEqual(response.status_code, 200)
 
-        with self.settings(CMS_RAW_ID_USERS=True):
+        with self.settings(CMS_RAW_ID_USERS=True), current_user(self.get_superuser()):
             data = {
                 "page": page.pk,
                 "grant_on": "hello",

--- a/cms/tests/test_forms.py
+++ b/cms/tests/test_forms.py
@@ -8,6 +8,7 @@ from django.utils.translation import override as force_language
 
 from cms.admin import forms
 from cms.admin.forms import (
+    AddPageForm,
     DuplicatePageForm,
     GlobalPagePermissionAdminForm,
     PagePermissionInlineAdminForm,
@@ -551,6 +552,52 @@ class DuplicatePageFormSecurityTestCase(CMSTestCase):
             # ``source`` must not be the reason the form is (in)valid.
             form.is_valid()
             self.assertNotIn("source", form.errors)
+
+
+class AddPageFormSecurityTestCase(CMSTestCase):
+    def _build_form(self, user, page, site):
+        request = self.get_request("/en/")
+        request.user = user
+        form_cls = type(
+            "TestAddPageForm",
+            (AddPageForm,),
+            # Admin form construction can omit ``source``, causing
+            # AddPageForm.__init__ to return before narrowing cms_page.
+            {
+                "source": None,
+                "_site": site,
+                "_request": request,
+                "Meta": type("Meta", (AddPageForm.Meta,), {"fields": []}),
+            },
+        )
+        return form_cls(data={"cms_page": page.pk, "title": "French", "slug": "french"})
+
+    def test_rejects_cms_page_from_another_site(self):
+        owner = self.get_superuser()
+        site = Site.objects.get_current()
+        other_site = Site.objects.create(domain="other.example.com", name="other.example.com")
+        allowed_page = create_page("allowed", "nav_playground.html", "en", site=site, created_by=owner)
+        page = create_page("secret", "nav_playground.html", "de", site=other_site, created_by=owner)
+        attacker = self._create_user("attacker", is_staff=True, add_default_permissions=True)
+        assign_user_to_page(allowed_page, attacker, can_change=True)
+
+        with self.settings(CMS_PERMISSION=True):
+            form = self._build_form(attacker, page, site)
+            self.assertFalse(form.is_valid())
+            self.assertIn("cms_page", form.errors)
+
+    def test_rejects_cms_page_user_cannot_change(self):
+        owner = self.get_superuser()
+        site = Site.objects.get_current()
+        allowed_page = create_page("allowed", "nav_playground.html", "en", site=site, created_by=owner)
+        page = create_page("secret", "nav_playground.html", "en", site=site, created_by=owner)
+        attacker = self._create_user("attacker", is_staff=True, add_default_permissions=True)
+        assign_user_to_page(allowed_page, attacker, can_change=True)
+
+        with self.settings(CMS_PERMISSION=True):
+            form = self._build_form(attacker, page, site)
+            self.assertFalse(form.is_valid())
+            self.assertIn("cms_page", form.errors)
 
 
 class ValidateUrlTestCase(CMSTestCase):

--- a/cms/tests/test_forms.py
+++ b/cms/tests/test_forms.py
@@ -3,14 +3,17 @@ from html import unescape
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.core.cache import cache
+from django.core.exceptions import ValidationError
 from django.utils.translation import override as force_language
 
 from cms.admin import forms
 from cms.admin.forms import (
+    DuplicatePageForm,
     GlobalPagePermissionAdminForm,
     PagePermissionInlineAdminForm,
     PageUserGroupForm,
     ViewRestrictionInlineAdminForm,
+    get_permission_accessor,
 )
 from cms.api import assign_user_to_page, create_page, create_page_content
 from cms.forms.fields import PageSelectFormField
@@ -460,3 +463,149 @@ class PermissionFormTestCase(CMSTestCase):
         form._current_user = user
         self.assertTrue(form.is_valid(), form.errors)
         form.save()
+
+    def test_page_user_group_form_drops_unauthorized_permissions(self):
+        """A delegated manager must not be able to grant a group permissions
+        they do not hold themselves, even by POSTing the hidden ``can_*``
+        fields that ``get_fieldsets`` never rendered for them (CWE-269).
+        """
+        # Manager holds change_page but NOT any pagepermission/pageuser perms.
+        manager = self._create_user("manager", is_staff=True, permissions=["change_page"])
+        self.assertTrue(manager.has_perm("cms.change_page"))
+        self.assertFalse(manager.has_perm("cms.change_pagepermission"))
+
+        data = {
+            "name": "evil_group",
+            "can_change_page": True,           # held by the manager -> must be kept
+            "can_change_pagepermission": True,  # NOT held -> must be dropped
+            "can_add_pagepermission": True,     # NOT held -> must be dropped
+            "can_change_pageuser": True,        # NOT held -> must be dropped
+        }
+        form = PageUserGroupForm(data=data, files=None)
+        form._current_user = manager
+        self.assertTrue(form.is_valid(), form.errors)
+        group = form.save()
+
+        granted = set(get_permission_accessor(group).values_list("codename", flat=True))
+        self.assertIn("change_page", granted)
+        self.assertNotIn("change_pagepermission", granted)
+        self.assertNotIn("add_pagepermission", granted)
+        self.assertNotIn("change_pageuser", granted)
+
+    def test_page_user_group_form_superuser_can_grant_anything(self):
+        """A superuser holds every permission, so nothing is dropped."""
+        superuser = self.get_superuser()
+        data = {
+            "name": "trusted_group",
+            "can_change_page": True,
+            "can_change_pagepermission": True,
+        }
+        form = PageUserGroupForm(data=data, files=None)
+        form._current_user = superuser
+        self.assertTrue(form.is_valid(), form.errors)
+        group = form.save()
+
+        granted = set(get_permission_accessor(group).values_list("codename", flat=True))
+        self.assertIn("change_page", granted)
+        self.assertIn("change_pagepermission", granted)
+
+
+class DuplicatePageFormSecurityTestCase(CMSTestCase):
+    def _build_form(self, user, source):
+        request = self.get_request("/en/")
+        request.user = user
+        # The admin sets ``_site``/``_request`` as class attributes via
+        # ``get_form`` before instantiation (they are read in ``__init__``).
+        form_cls = type(
+            "TestDuplicatePageForm",
+            (DuplicatePageForm,),
+            {"_site": Site.objects.get_current(), "_request": request},
+        )
+        return form_cls(data={"source": source.pk, "title": "x", "slug": "x"})
+
+    def test_duplicate_rejects_source_user_cannot_view(self):
+        """A staff user with only 'add page' rights must not be able to copy a
+        page they are not allowed to view (CWE-639 / CWE-862). ``source`` is a
+        hidden, client-controlled field whose queryset spans every page.
+        """
+        superuser = self.get_superuser()
+        secret = create_page("secret", "nav_playground.html", "en", created_by=superuser)
+        # Add a view restriction so the page is only viewable by the superuser.
+        self.add_page_permission(superuser, secret, can_view=True)
+
+        attacker = self._create_user("attacker", is_staff=True, add_default_permissions=True)
+
+        with self.settings(CMS_PERMISSION=True):
+            form = self._build_form(attacker, secret)
+            self.assertFalse(form.is_valid())
+            self.assertIn("source", form.errors)
+
+    def test_duplicate_allows_source_user_can_view(self):
+        """Copying a page the user is allowed to view keeps working."""
+        superuser = self.get_superuser()
+        source = create_page("source", "nav_playground.html", "en", created_by=superuser)
+
+        with self.settings(CMS_PERMISSION=True):
+            form = self._build_form(superuser, source)
+            # ``source`` must not be the reason the form is (in)valid.
+            form.is_valid()
+            self.assertNotIn("source", form.errors)
+
+
+class ValidateUrlTestCase(CMSTestCase):
+    """Regression tests for the dangerous-scheme bypass in ``validate_url``.
+
+    ``relative_url_regex`` matches any value whose first segment contains no
+    ``/<>``; a scheme such as ``javascript:`` was therefore accepted as a
+    "relative URL" and never reached ``URLValidator``. Such schemes execute
+    script when the value is later rendered into an ``href`` (CWE-79).
+    """
+
+    # Script-executing schemes -- these are the actual XSS vector.
+    DANGEROUS = [
+        "javascript:alert(1)/x",
+        "JavaScript:alert(document.domain)/a",
+        "data:text/html,<script>alert(1)</script>",
+        "vbscript:msgbox(1)/x",
+    ]
+
+    VALID_RELATIVE = [
+        "/foo/bar",
+        "/foo/bar/",
+        "foo/bar",
+        "../page/",
+        "./page/",
+        "/en/some-slug/",
+    ]
+
+    VALID_ABSOLUTE = [
+        "http://example.com/x",
+        "https://example.com/x?y=1",
+        # Protocol-relative / off-site targets navigate (not execute script)
+        # and are an intended capability of this field; they must be accepted
+        # just like an explicit ``https://`` URL.
+        "//example.com",
+        "//example.com/path",
+    ]
+
+    def test_dangerous_schemes_are_rejected(self):
+        from cms.forms.validators import validate_url
+
+        for value in self.DANGEROUS:
+            with self.subTest(value=value):
+                with self.assertRaises(ValidationError):
+                    validate_url(value)
+
+    def test_valid_relative_urls_are_accepted(self):
+        from cms.forms.validators import validate_url
+
+        for value in self.VALID_RELATIVE:
+            with self.subTest(value=value):
+                validate_url(value)  # must not raise
+
+    def test_valid_absolute_urls_are_accepted(self):
+        from cms.forms.validators import validate_url
+
+        for value in self.VALID_ABSOLUTE:
+            with self.subTest(value=value):
+                validate_url(value)  # must not raise

--- a/cms/tests/test_page.py
+++ b/cms/tests/test_page.py
@@ -878,6 +878,47 @@ class PagesTestCase(TransactionCMSTestCase):
             resp = self.client.get(page.get_absolute_url("en"))
             self.assertEqual(resp.get("X-Frame-Options"), None)
 
+    def test_xframe_options_inherit_with_cms_page_cache_and_clickjacking_middleware(self):
+        # A cached "Inherit" page must still receive the clickjacking
+        # middleware's X-Frame-Options header. Regression: the cached copy used
+        # to be served with xframe_options_exempt=True, which suppressed the
+        # middleware and dropped the header, leaving cached inherit pages
+        # framable while the uncached copy was protected.
+        if getattr(settings, "MIDDLEWARE", None):
+            override = {
+                "MIDDLEWARE": settings.MIDDLEWARE
+                + [
+                    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+                ]
+            }
+        else:
+            override = {
+                "MIDDLEWARE_CLASSES": settings.MIDDLEWARE_CLASSES
+                + [
+                    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+                ]
+            }
+
+        override["CMS_PAGE_CACHE"] = True
+        override["X_FRAME_OPTIONS"] = "SAMEORIGIN"
+
+        with self.settings(**override):
+            page = create_page(
+                "inherit page",
+                "nav_playground.html",
+                "en",
+                xframe_options=constants.X_FRAME_OPTIONS_INHERIT,
+            )
+
+            # Fresh response from render_page: the middleware adds the site
+            # default because the page defers to it (inherit).
+            resp = self.client.get(page.get_absolute_url("en"))
+            self.assertEqual(resp.get("X-Frame-Options"), "SAMEORIGIN")
+
+            # Response from page cache must carry the same protection.
+            resp = self.client.get(page.get_absolute_url("en"))
+            self.assertEqual(resp.get("X-Frame-Options"), "SAMEORIGIN")
+
     def test_page_cache_basic(self):
         """
         Test that the page cache works in its basic form
@@ -893,7 +934,7 @@ class PagesTestCase(TransactionCMSTestCase):
         self.assertIsNotNone(cached_data)
 
         # Verify cache contents
-        cached_content, cached_headers, expires = cached_data
+        cached_content, cached_headers, expires, xframe_options_exempt = cached_data
         self.assertEqual(cached_content, response.content)
 
     def test_page_cache_language_handling(self):

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -21,7 +21,12 @@ from django.utils.html import escape
 from django.utils.translation import get_language, gettext_lazy as _, override
 
 from cms.admin.forms import RequestToolbarForm
-from cms.api import add_plugin, create_page, create_page_content
+from cms.api import (
+    add_plugin,
+    assign_user_to_page,
+    create_page,
+    create_page_content,
+)
 from cms.cms_toolbars import (
     ADMIN_MENU_IDENTIFIER,
     ADMINISTRATION_BREAK,
@@ -347,6 +352,38 @@ class ToolbarTests(ToolbarTestBase):
                 data={"obj_id": cms_page.pk, "obj_type": "cms.somemodel", "cms_path": cms_page.get_absolute_url("en")},
             )
             self.assertEqual(response.status_code, 400)
+
+    @override_settings(CMS_PERMISSION=True)
+    def test_toolbar_request_endpoint_enforces_object_view_permission(self):
+        # The obj_id/obj_type come straight from the client, so the endpoint
+        # must enforce an object-level view check before rendering a toolbar
+        # (which discloses the object's title/breadcrumb/edit URLs). A staff
+        # user who cannot view a restricted page must be denied.
+        endpoint = self.get_admin_url(UserSettings, "get_toolbar")
+        cms_page = create_page("secret-page", "col_two.html", "en")
+        page_content = self.get_pagecontent_obj(cms_page)
+
+        # Grant view to one user only -> the page is now view-restricted.
+        assign_user_to_page(cms_page, self.get_standard_user(), can_view=True)
+
+        data = {
+            "obj_id": page_content.pk,
+            "obj_type": "cms.pagecontent",
+            "cms_path": get_object_edit_url(page_content),
+        }
+
+        # A staff user without view permission is denied with the same generic
+        # response as an unknown object (no existence oracle).
+        with self.login_user_context(self.get_staff_user_with_no_permissions()):
+            response = self.client.get(endpoint, data=data)
+        self.assertEqual(response.status_code, 400)
+        self.assertNotContains(response, "Clipboard", status_code=400)
+
+        # A superuser can still render the toolbar.
+        with self.login_user_context(self.get_superuser()):
+            response = self.client.get(endpoint, data=data)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Clipboard")
 
     def test_toolbar_request_form(self):
         cms_page = create_page("toolbar-page", "col_two.html", "en")

--- a/cms/utils/permissions.py
+++ b/cms/utils/permissions.py
@@ -22,8 +22,19 @@ def set_current_user(user):
     """
     Assigns current user from request to context variable, used by
     CurrentUserMiddleware.
+
+    Returns the ``contextvars.Token`` for the change, so callers can restore
+    the previous value with :func:`reset_current_user`.
     """
-    _current_user.set(user)
+    return _current_user.set(user)
+
+
+def reset_current_user(token):
+    """
+    Restores the current user context variable to the value it held before the
+    ``set_current_user`` call that produced ``token``.
+    """
+    _current_user.reset(token)
 
 
 def get_current_user():

--- a/cms/views.py
+++ b/cms/views.py
@@ -82,9 +82,16 @@ def details(request, slug):
     ):
         cache_content = get_page_cache(request)
         if cache_content is not None:
-            content, headers, expires_datetime = cache_content
+            # ``xframe_options_exempt`` is absent on cache entries written before
+            # this field was added; default to True to preserve their behaviour
+            # until they expire.
+            content, headers, expires_datetime, *rest = cache_content
+            xframe_options_exempt = rest[0] if rest else True
             response = HttpResponse(content)
-            response.xframe_options_exempt = True
+            # Replay the page's clickjacking decision. For "Inherit" pages this
+            # is False, so Django's XFrameOptionsMiddleware still adds the site
+            # default X-Frame-Options header to the cached response.
+            response.xframe_options_exempt = xframe_options_exempt
             response.headers = headers
             # Recalculate the max-age header for this cached response
             max_age = int(


### PR DESCRIPTION
## Summary by Sourcery

Harden security around page duplication, permission management, URL validation, and current-user tracking, and ensure clickjacking protections are preserved for cached pages.

Bug Fixes:
- Ensure create_page and create_page_content correctly set and restore the current user context without leaking between operations or requests.
- Prevent delegated managers from granting page, page permission, or page user permissions they do not hold themselves, including via crafted POSTs.
- Disallow duplicating pages a user cannot view, and enforce object-level view checks for toolbar rendering endpoints to avoid information disclosure.
- Tighten URL validation to reject dangerous script-executing schemes while still accepting valid relative and absolute URLs.
- Preserve X-Frame-Options behaviour for cached pages, including pages inheriting site defaults, so cached responses remain protected by clickjacking middleware.

Enhancements:
- Refine permission helper constants and utilities to centralize CMS permission model/action mappings and expose a model-aware permission codename helper.
- Extend CurrentUserMiddleware to reset the current user context at the end of each request, avoiding cross-request leakage of user identity.

Tests:
- Add regression tests for permission form hardening, page duplication permissions, URL validator behaviour, current-user restoration in page APIs, toolbar endpoint access control, and X-Frame-Options handling with page cache.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.