### PR TITLE
feat: Add allowed_slots property to plugins

### DIFF
--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -1500,6 +1500,12 @@ class PluginAddValidationForm(forms.Form):
         page = placeholder.page
         template = page.get_template() if page else None
 
+        plugin_class = plugin_pool.get_plugin(data["plugin_type"])
+        if not plugin_class.is_allowed_in_slot(placeholder.slot):
+            message = gettext("Plugin %(plugin)s is not allowed in placeholder '%(slot)s'.")
+            self.add_error(None, message % {"plugin": plugin_class.__name__, "slot": placeholder.slot})
+            return self.cleaned_data
+
         try:
             has_reached_plugin_limit(placeholder, data["plugin_type"], language, template=template)
         except PluginLimitReached as error:

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -42,6 +42,7 @@ from cms.utils.i18n import get_language_code, get_language_list
 from cms.utils.plugins import (
     copy_plugins_to_placeholder,
     downcast_plugins,
+    get_plugin_disallowed_in_slot,
     has_reached_plugin_limit,
 )
 from cms.views import (
@@ -490,6 +491,16 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
             )
             new_plugins = [new_plugin]
         else:
+            source_language = request.POST['source_language']
+            source_plugins = source_placeholder.get_plugins_list(language=source_language)
+            disallowed = get_plugin_disallowed_in_slot(
+                (plugin.plugin_type for plugin in source_plugins),
+                target_placeholder.slot,
+            )
+            if disallowed:
+                return HttpResponseBadRequest(
+                    f"Plugin {disallowed} is not allowed in placeholder '{target_placeholder.slot}'."
+                )
             new_plugins = self._add_plugins_from_placeholder(
                 request,
                 source_placeholder,
@@ -735,10 +746,13 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
 
         if placeholder and placeholder != source_placeholder:
             if not move_to_clipboard:
-                plugin_class = plugin_pool.get_plugin(plugin.plugin_type)
-                if not plugin_class.is_allowed_in_slot(placeholder.slot):
+                # The whole subtree moves with the plugin, so every descendant must
+                # also be allowed in the target slot, not just the moved plugin itself.
+                moved_types = [plugin.plugin_type, *plugin.get_descendants().values_list("plugin_type", flat=True)]
+                disallowed = get_plugin_disallowed_in_slot(moved_types, placeholder.slot)
+                if disallowed:
                     return HttpResponseBadRequest(
-                        f"Plugin {plugin.plugin_type} is not allowed in placeholder '{placeholder.slot}'."
+                        f"Plugin {disallowed} is not allowed in placeholder '{placeholder.slot}'."
                     )
             try:
                 template = self.get_placeholder_template(request, placeholder)

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -734,6 +734,12 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
         source_placeholder = plugin.placeholder
 
         if placeholder and placeholder != source_placeholder:
+            if not move_to_clipboard:
+                plugin_class = plugin_pool.get_plugin(plugin.plugin_type)
+                if not plugin_class.is_allowed_in_slot(placeholder.slot):
+                    return HttpResponseBadRequest(
+                        f"Plugin {plugin.plugin_type} is not allowed in placeholder '{placeholder.slot}'."
+                    )
             try:
                 template = self.get_placeholder_template(request, placeholder)
                 has_reached_plugin_limit(placeholder, plugin.plugin_type,

--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -1,3 +1,4 @@
+import fnmatch
 import json
 import re
 from collections.abc import Callable
@@ -207,6 +208,22 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
     See also: Model's ``allowed_plugins`` attribute for model-level restrictions.
     """
 
+    allowed_slots = None
+    """Plugin-level restriction: A list of placeholder slot names where this plugin can be added.
+
+    Each entry may be an exact slot name or a glob pattern (e.g. ``"content"`` or ``"footer_*"``),
+    matched against the placeholder's ``slot``.
+
+    - If ``None`` (default): The plugin can be added to any slot.
+    - If a list/tuple is provided: The plugin can only be added to slots matching one of the entries.
+    - If an empty list ``[]``: The plugin cannot be added to any slot.
+
+    This is the plugin-side counterpart to the ``plugins``/``excluded_plugins`` keys of
+    ``CMS_PLACEHOLDER_CONF``. Both filters must pass for the plugin to be available in a slot.
+
+    See also: :attr:`allowed_models`, ``CMS_PLACEHOLDER_CONF``.
+    """
+
     allow_children = False
     """Allows this plugin to have child plugins - other plugins placed inside it?
 
@@ -374,6 +391,17 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
         context["instance"] = instance
         context["placeholder"] = placeholder
         return context
+
+    @classmethod
+    def is_allowed_in_slot(cls, slot: str | None) -> bool:
+        """Return whether this plugin may be added to a placeholder with the given ``slot``.
+
+        Honours the :attr:`allowed_slots` plugin-level restriction. A ``slot`` of ``None``
+        (an unbound query, e.g. the global plugin listing) is always allowed.
+        """
+        if cls.allowed_slots is None or slot is None:
+            return True
+        return any(fnmatch.fnmatchcase(slot, pattern) for pattern in cls.allowed_slots)
 
     @classmethod
     def requires_parent_plugin(cls, slot, page):

--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -401,7 +401,10 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
         """
         if cls.allowed_slots is None or slot is None:
             return True
-        return any(fnmatch.fnmatchcase(slot, pattern) for pattern in cls.allowed_slots)
+        # Tolerate a bare string (e.g. ``allowed_slots = "content"``) instead of
+        # iterating over its characters, which would silently misbehave.
+        patterns = [cls.allowed_slots] if isinstance(cls.allowed_slots, str) else cls.allowed_slots
+        return any(fnmatch.fnmatchcase(slot, pattern) for pattern in patterns)
 
     @classmethod
     def requires_parent_plugin(cls, slot, page):

--- a/cms/plugin_pool.py
+++ b/cms/plugin_pool.py
@@ -270,6 +270,11 @@ class PluginPool:
             # Check that plugins are not in the list of the excluded ones
             plugins = (plugin for plugin in plugins if plugin.__name__ not in excluded_plugins)
 
+        if placeholder is not None:
+            # Honour each plugin's allowed_slots restriction (plugin-side counterpart to the
+            # placeholder's plugins/excluded_plugins config).
+            plugins = (plugin for plugin in plugins if plugin.is_allowed_in_slot(placeholder))
+
         if root_plugin:
             # Filters out any plugin that requires a parent or has set parent classes
             plugins = (plugin for plugin in plugins if not plugin.requires_parent_plugin(placeholder, page))

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -1,4 +1,5 @@
 import warnings
+from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -1284,6 +1285,37 @@ class PlaceholderConfTests(TestCase):
             plugins = list(plugin_pool.get_all_plugins(placeholder.slot, placeholder.source, root_plugin=True))
             self.assertEqual(len(plugins), 1, plugins)
             self.assertEqual(plugins[0], LinkPlugin)
+
+    def test_is_allowed_in_slot(self):
+        LinkPlugin = plugin_pool.get_plugin("LinkPlugin")
+
+        # No restriction (default): allowed everywhere, including unbound (None) queries.
+        self.assertTrue(LinkPlugin.is_allowed_in_slot("content"))
+        self.assertTrue(LinkPlugin.is_allowed_in_slot(None))
+
+        with patch.object(LinkPlugin, "allowed_slots", ["content", "footer_*"]):
+            # Exact match and glob match are allowed; an unlisted slot is not.
+            self.assertTrue(LinkPlugin.is_allowed_in_slot("content"))
+            self.assertTrue(LinkPlugin.is_allowed_in_slot("footer_left"))
+            self.assertFalse(LinkPlugin.is_allowed_in_slot("sidebar"))
+            # An unbound query is always allowed, even with a restriction set.
+            self.assertTrue(LinkPlugin.is_allowed_in_slot(None))
+
+        with patch.object(LinkPlugin, "allowed_slots", []):
+            # An empty list forbids every slot.
+            self.assertFalse(LinkPlugin.is_allowed_in_slot("content"))
+
+    def test_get_all_plugins_respects_allowed_slots(self):
+        page = create_page("page", "col_two.html", "en")
+        placeholder = page.get_placeholders("en").get(slot="col_left")
+        LinkPlugin = plugin_pool.get_plugin("LinkPlugin")
+
+        with patch.object(LinkPlugin, "allowed_slots", ["col_right"]):
+            available = list(plugin_pool.get_all_plugins(placeholder.slot, placeholder.source))
+            self.assertNotIn(LinkPlugin, available)
+            # The plugin is available in a slot it allows.
+            allowed = list(plugin_pool.get_all_plugins("col_right", placeholder.source))
+            self.assertIn(LinkPlugin, allowed)
 
 
 class PlaceholderPluginTestsBase(CMSTestCase):

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -1305,6 +1305,12 @@ class PlaceholderConfTests(TestCase):
             # An empty list forbids every slot.
             self.assertFalse(LinkPlugin.is_allowed_in_slot("content"))
 
+        with patch.object(LinkPlugin, "allowed_slots", "content"):
+            # A bare string is treated as a single pattern, not iterated per character.
+            self.assertTrue(LinkPlugin.is_allowed_in_slot("content"))
+            self.assertFalse(LinkPlugin.is_allowed_in_slot("sidebar"))
+            self.assertFalse(LinkPlugin.is_allowed_in_slot("c"))
+
     def test_get_all_plugins_respects_allowed_slots(self):
         page = create_page("page", "col_two.html", "en")
         placeholder = page.get_placeholders("en").get(slot="col_left")
@@ -1316,6 +1322,23 @@ class PlaceholderConfTests(TestCase):
             # The plugin is available in a slot it allows.
             allowed = list(plugin_pool.get_all_plugins("col_right", placeholder.source))
             self.assertIn(LinkPlugin, allowed)
+
+    def test_get_plugin_disallowed_in_slot(self):
+        from cms.utils.plugins import get_plugin_disallowed_in_slot
+
+        LinkPlugin = plugin_pool.get_plugin("LinkPlugin")
+
+        with patch.object(LinkPlugin, "allowed_slots", ["content"]):
+            # The offending plugin type is returned for a disallowed slot.
+            self.assertEqual(
+                get_plugin_disallowed_in_slot(["LinkPlugin"], "sidebar"), "LinkPlugin"
+            )
+            # Every plugin is allowed -> nothing is reported.
+            self.assertIsNone(get_plugin_disallowed_in_slot(["LinkPlugin"], "content"))
+            # Unregistered plugin types are skipped (treated as allowed).
+            self.assertIsNone(
+                get_plugin_disallowed_in_slot(["DoesNotExistPlugin"], "sidebar")
+            )
 
 
 class PlaceholderPluginTestsBase(CMSTestCase):

--- a/cms/tests/test_placeholder_admin.py
+++ b/cms/tests/test_placeholder_admin.py
@@ -113,6 +113,31 @@ class PlaceholderAdminTestCase(CMSTestCase):
         self.assertTrue(source_placeholder.get_plugins("en").filter(pk=source_plugin.pk).exists())
         self.assertTrue(target_placeholder.get_plugins("en").filter(plugin_type=source_plugin.plugin_type).exists())
 
+    def test_copy_plugins_rejected_into_disallowed_slot(self):
+        """A plugin with allowed_slots cannot be copied into a slot it does not allow."""
+        from cms.plugin_pool import plugin_pool
+
+        superuser = self.get_superuser()
+        source_placeholder = Placeholder.objects.create(slot="content")
+        target_placeholder = Placeholder.objects.create(slot="sidebar")
+        source_plugin = self._add_plugin_to_placeholder(source_placeholder)
+        endpoint = self.get_copy_plugin_uri(source_plugin)
+
+        LinkPlugin = plugin_pool.get_plugin("LinkPlugin")
+        with patch.object(LinkPlugin, "allowed_slots", ["content"]):
+            with self.login_user_context(superuser):
+                data = {
+                    "source_language": "en",
+                    "source_placeholder_id": source_placeholder.pk,
+                    "target_language": "en",
+                    "target_placeholder_id": target_placeholder.pk,
+                }
+                response = self.client.post(endpoint, data)
+
+        self.assertEqual(response.status_code, 400)
+        # Nothing was copied into the disallowed target slot.
+        self.assertFalse(target_placeholder.get_plugins("en").exists())
+
     def test_copy_plugins_to_clipboard(self):
         """
         User can copy plugins from a placeholder to the clipboard
@@ -506,6 +531,34 @@ class PlaceholderAdminSecurityTestCase(CMSTestCase):
         plugin.refresh_from_db()
         # The plugin stays in its original placeholder.
         self.assertEqual(plugin.placeholder_id, source.pk)
+
+    def test_move_plugin_rejected_when_descendant_disallowed_in_slot(self):
+        """Moving a subtree is rejected if any descendant is disallowed in the target slot."""
+        from cms.plugin_pool import plugin_pool
+
+        superuser = self.get_superuser()
+        source = Placeholder.objects.create(slot="content")
+        target = Placeholder.objects.create(slot="sidebar")
+        # The moved (root) plugin is allowed in every slot, but its child is restricted.
+        parent = add_plugin(source, "StylePlugin", "en", label="wrap")
+        add_plugin(source, "LinkPlugin", "en", name="link", external_link="https://example.com", target=parent)
+
+        LinkPlugin = plugin_pool.get_plugin("LinkPlugin")
+        endpoint = self.get_move_plugin_uri(parent)
+        with patch.object(LinkPlugin, "allowed_slots", ["content"]):
+            with self.login_user_context(superuser):
+                data = {
+                    "plugin_id": parent.pk,
+                    "placeholder_id": target.pk,
+                    "target_language": "en",
+                    "target_position": 1,
+                }
+                response = self.client.post(endpoint, data)
+
+        self.assertEqual(response.status_code, 400)
+        parent.refresh_from_db()
+        # The subtree stays in its original placeholder.
+        self.assertEqual(parent.placeholder_id, source.pk)
 
     def test_copy_plugin_to_clipboard_requires_source_permission(self):
         """Copying a plugin to the clipboard must check source-side permission.

--- a/cms/tests/test_placeholder_admin.py
+++ b/cms/tests/test_placeholder_admin.py
@@ -31,6 +31,48 @@ class PlaceholderAdminTestCase(CMSTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(plugins.count(), 1)
 
+    def test_add_plugin_rejected_in_disallowed_slot(self):
+        """A plugin with allowed_slots cannot be added to a slot it does not allow."""
+        from cms.plugin_pool import plugin_pool
+
+        superuser = self.get_superuser()
+        placeholder = Placeholder.objects.create(slot="sidebar")
+        plugins = placeholder.get_plugins("en").filter(plugin_type="LinkPlugin")
+        uri = self.get_add_plugin_uri(
+            placeholder=placeholder,
+            plugin_type="LinkPlugin",
+            language="en",
+        )
+        LinkPlugin = plugin_pool.get_plugin("LinkPlugin")
+        with patch.object(LinkPlugin, "allowed_slots", ["content"]):
+            with self.login_user_context(superuser):
+                data = {"name": "A Link", "external_link": "https://www.django-cms.org"}
+                response = self.client.post(uri, data)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(plugins.count(), 0)
+
+    def test_add_plugin_allowed_in_listed_slot(self):
+        """A plugin with allowed_slots can be added to a slot it allows."""
+        from cms.plugin_pool import plugin_pool
+
+        superuser = self.get_superuser()
+        placeholder = Placeholder.objects.create(slot="content")
+        plugins = placeholder.get_plugins("en").filter(plugin_type="LinkPlugin")
+        uri = self.get_add_plugin_uri(
+            placeholder=placeholder,
+            plugin_type="LinkPlugin",
+            language="en",
+        )
+        LinkPlugin = plugin_pool.get_plugin("LinkPlugin")
+        with patch.object(LinkPlugin, "allowed_slots", ["content"]):
+            with self.login_user_context(superuser):
+                data = {"name": "A Link", "external_link": "https://www.django-cms.org"}
+                response = self.client.post(uri, data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(plugins.count(), 1)
+
     def test_add_plugin_with_ghost(self):
         """Adding a text plugin works. Text plugins create a ghost plugin."""
         superuser = self.get_superuser()
@@ -438,6 +480,32 @@ class PlaceholderAdminSecurityTestCase(CMSTestCase):
         # No cycle: parent stays at the root, child stays under parent.
         self.assertIsNone(parent.parent_id)
         self.assertEqual(child.parent_id, parent.pk)
+
+    def test_move_plugin_rejected_into_disallowed_slot(self):
+        """A plugin with allowed_slots cannot be moved into a slot it does not allow."""
+        from cms.plugin_pool import plugin_pool
+
+        superuser = self.get_superuser()
+        source = Placeholder.objects.create(slot="content")
+        target = Placeholder.objects.create(slot="sidebar")
+        plugin = add_plugin(source, "LinkPlugin", "en", name="link", external_link="https://example.com")
+
+        LinkPlugin = plugin_pool.get_plugin("LinkPlugin")
+        endpoint = self.get_move_plugin_uri(plugin)
+        with patch.object(LinkPlugin, "allowed_slots", ["content"]):
+            with self.login_user_context(superuser):
+                data = {
+                    "plugin_id": plugin.pk,
+                    "placeholder_id": target.pk,
+                    "target_language": "en",
+                    "target_position": 1,
+                }
+                response = self.client.post(endpoint, data)
+
+        self.assertEqual(response.status_code, 400)
+        plugin.refresh_from_db()
+        # The plugin stays in its original placeholder.
+        self.assertEqual(plugin.placeholder_id, source.pk)
 
     def test_copy_plugin_to_clipboard_requires_source_permission(self):
         """Copying a plugin to the clipboard must check source-side permission.

--- a/cms/tests/test_placeholder_admin.py
+++ b/cms/tests/test_placeholder_admin.py
@@ -138,6 +138,32 @@ class PlaceholderAdminTestCase(CMSTestCase):
         # Nothing was copied into the disallowed target slot.
         self.assertFalse(target_placeholder.get_plugins("en").exists())
 
+    def test_copy_plugins_allowed_into_listed_slot(self):
+        """A plugin with allowed_slots can be copied into a slot it allows."""
+        from cms.plugin_pool import plugin_pool
+
+        superuser = self.get_superuser()
+        source_placeholder = Placeholder.objects.create(slot="content")
+        target_placeholder = Placeholder.objects.create(slot="sidebar")
+        source_plugin = self._add_plugin_to_placeholder(source_placeholder)
+        endpoint = self.get_copy_plugin_uri(source_plugin)
+
+        LinkPlugin = plugin_pool.get_plugin("LinkPlugin")
+        with patch.object(LinkPlugin, "allowed_slots", ["content", "sidebar"]):
+            with self.login_user_context(superuser):
+                data = {
+                    "source_language": "en",
+                    "source_placeholder_id": source_placeholder.pk,
+                    "target_language": "en",
+                    "target_placeholder_id": target_placeholder.pk,
+                }
+                response = self.client.post(endpoint, data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            target_placeholder.get_plugins("en").filter(plugin_type="LinkPlugin").exists()
+        )
+
     def test_copy_plugins_to_clipboard(self):
         """
         User can copy plugins from a placeholder to the clipboard
@@ -559,6 +585,32 @@ class PlaceholderAdminSecurityTestCase(CMSTestCase):
         parent.refresh_from_db()
         # The subtree stays in its original placeholder.
         self.assertEqual(parent.placeholder_id, source.pk)
+
+    def test_move_plugin_allowed_into_listed_slot(self):
+        """A plugin with allowed_slots can be moved into a slot it allows."""
+        from cms.plugin_pool import plugin_pool
+
+        superuser = self.get_superuser()
+        source = Placeholder.objects.create(slot="content")
+        target = Placeholder.objects.create(slot="sidebar")
+        plugin = add_plugin(source, "LinkPlugin", "en", name="link", external_link="https://example.com")
+
+        LinkPlugin = plugin_pool.get_plugin("LinkPlugin")
+        endpoint = self.get_move_plugin_uri(plugin)
+        with patch.object(LinkPlugin, "allowed_slots", ["content", "sidebar"]):
+            with self.login_user_context(superuser):
+                data = {
+                    "plugin_id": plugin.pk,
+                    "placeholder_id": target.pk,
+                    "target_language": "en",
+                    "target_position": 1,
+                }
+                response = self.client.post(endpoint, data)
+
+        self.assertEqual(response.status_code, 200)
+        plugin.refresh_from_db()
+        # The plugin moved into the allowed target placeholder.
+        self.assertEqual(plugin.placeholder_id, target.pk)
 
     def test_copy_plugin_to_clipboard_requires_source_permission(self):
         """Copying a plugin to the clipboard must check source-side permission.

--- a/cms/toolbar/utils.py
+++ b/cms/toolbar/utils.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import json
 from collections import defaultdict, deque
-from typing import Any, Optional
+from collections.abc import Sequence
+from typing import Any
 
 from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
@@ -90,7 +91,7 @@ def create_child_plugin_references(plugins: list[CMSPlugin]) -> deque[CMSPlugin]
 
 def get_plugin_tree(
     request: HttpRequest,
-    plugins: list[CMSPlugin],
+    plugins: Sequence[CMSPlugin],
     restrictions: dict | None = None,
     target_plugin: CMSPlugin | None = None,
 ) -> dict[str, Any]:

--- a/cms/utils/plugins.py
+++ b/cms/utils/plugins.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 from collections import OrderedDict, defaultdict, deque
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from copy import deepcopy
 from itertools import starmap
 from operator import itemgetter
@@ -27,7 +27,7 @@ def get_plugin_class(plugin_type: str) -> type[CMSPluginBase]:
     return plugin_pool.get_plugin(plugin_type)
 
 
-def get_plugin_model(plugin_type: str) -> CMSPlugin:
+def get_plugin_model(plugin_type: str) -> type[CMSPlugin]:
     """Returns the plugin model class for a given plugin_type (str)"""
     return get_plugin_class(plugin_type).model
 
@@ -407,7 +407,7 @@ def get_bound_plugins(plugins):
 
 def downcast_plugins(
     plugins: Iterable[CMSPlugin],
-    placeholders: list | None = None,
+    placeholders: Sequence | None = None,
     select_placeholder: bool = False,
     request: HttpRequest | None = None,
 ) -> Iterable[CMSPlugin]:
@@ -531,3 +531,21 @@ def has_reached_plugin_limit(placeholder, plugin_type, language, template=None):
             )
             % {"limit": type_limit, "plugin_name": plugin_name}
         )
+
+
+def get_plugin_disallowed_in_slot(plugin_types: Iterable[str], slot: str | None) -> str | None:
+    """Return the first plugin type whose ``allowed_slots`` restriction forbids ``slot``.
+
+    ``plugin_types`` is an iterable of plugin type names (e.g. the plugin being moved or
+    copied together with all of its descendants). Returns the offending plugin type name,
+    or ``None`` if every plugin may be added to ``slot``. Unregistered plugin types are
+    skipped (treated as allowed), mirroring the rest of the move/copy handling.
+    """
+    for plugin_type in dict.fromkeys(plugin_types):
+        try:
+            plugin_class = plugin_pool.get_plugin(plugin_type)
+        except KeyError:
+            continue
+        if not plugin_class.is_allowed_in_slot(slot):
+            return plugin_type
+    return None

--- a/docs/reference/plugins.rst
+++ b/docs/reference/plugins.rst
@@ -33,6 +33,18 @@ Plugins
 
         See :ref:`plugin-model-restrictions` for details.
 
+  .. attribute:: allowed_slots
+        :noindex:
+
+        A list of placeholder slot names that restricts where this plugin can be
+        added. Entries may be exact slot names or glob patterns (e.g. ``"content"``
+        or ``"footer_*"``). If ``None`` (default), the plugin is available in every
+        slot; an empty list ``[]`` forbids every slot.
+
+        This is the plugin-side counterpart to the ``plugins``/``excluded_plugins``
+        keys of :setting:`CMS_PLACEHOLDER_CONF`. Both filters must pass for the
+        plugin to be available in a slot.
+
 
 .. autoclass:: cms.plugin_base.PluginMenuItem
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce plugin-level slot restrictions and enforce them across plugin add, copy, move, and listing operations, alongside adding security advisory documentation for known vulnerabilities.

New Features:
- Add an allowed_slots configuration to plugins to restrict which placeholder slots they can be used in.
- Expose a CMSPluginBase.is_allowed_in_slot helper and enforce plugin-side slot restrictions when listing available plugins for a placeholder.

Enhancements:
- Update admin forms and placeholder admin endpoints to reject adding, copying, or moving plugins (including subtrees) into disallowed slots.
- Refine plugin utilities and type hints (e.g., downcast_plugins and get_plugin_tree signatures) for better type safety and reuse.
- Add helper logic to detect plugin types disallowed in a given slot when processing bulk operations.

Documentation:
- Add three security advisory documents covering stored XSS in redirect URLs, broken access control in page duplication, and privilege escalation via Page User Group permissions.

Tests:
- Add tests ensuring add, copy, and move plugin endpoints respect the allowed_slots restriction, including subtree moves with restricted descendants.
- Add tests validating is_allowed_in_slot behavior and that get_all_plugins respects plugin allowed_slots when determining availability.

This completes the extension of the plugin configurations

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8395
* #8675

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.