### PR TITLE
fix: Harden page duplication, group permissions and URL validator (#8704)

### DIFF
--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -51,7 +51,7 @@ from cms.utils.compat.warnings import RemovedInDjangoCMS51Warning
 from cms.utils.conf import get_cms_setting
 from cms.utils.i18n import get_language_list, get_site_language_from_request
 from cms.utils.page import get_clean_username
-from cms.utils.page_permissions import user_can_view_page
+from cms.utils.page_permissions import user_can_change_page, user_can_view_page
 from cms.utils.permissions import (
     get_current_user,
     get_model_permission_codename,
@@ -278,15 +278,14 @@ class AddPageForm(BasePageContentForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        page_field = self.fields.get("cms_page")
+        if page_field:
+            page_field.queryset = page_field.queryset.filter(site=self._site)
+
         source_field = self.fields.get("source")
 
         if not source_field or source_field.widget.is_hidden:
             return
-
-        page_field = self.fields.get("cms_page")
-
-        if page_field:
-            page_field.queryset = page_field.queryset.filter(site=self._site)
 
         root_page = PageType.get_root_page(site=self._site)
 
@@ -338,6 +337,12 @@ class AddPageForm(BasePageContentForm):
         if parent_page and parent_page.site_id != self._site.pk:
             raise ValidationError("Site doesn't match the parent's page site")
         return parent_page
+
+    def clean_cms_page(self):
+        page = self.cleaned_data.get("cms_page")
+        if page and not user_can_change_page(self._user, page, site=page.site):
+            raise ValidationError(_("You do not have permission to change this page."))
+        return page
 
     def create_translation(self, page, main_language_page_content_template=None):
         data = self.cleaned_data

--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -51,8 +51,10 @@ from cms.utils.compat.warnings import RemovedInDjangoCMS51Warning
 from cms.utils.conf import get_cms_setting
 from cms.utils.i18n import get_language_list, get_site_language_from_request
 from cms.utils.page import get_clean_username
+from cms.utils.page_permissions import user_can_view_page
 from cms.utils.permissions import (
     get_current_user,
+    get_model_permission_codename,
     get_subordinate_groups,
     get_subordinate_users,
     get_user_permission_level,
@@ -517,6 +519,22 @@ class DuplicatePageForm(AddPageForm):
         required=True,
         widget=forms.HiddenInput(),
     )
+
+    def clean_source(self):
+        source = self.cleaned_data.get("source")
+        # ``source`` is a hidden field whose value is fully controlled by the
+        # client on POST and whose queryset spans every page on every site.
+        # ``has_add_permission`` only checks that the user may create *a* page,
+        # not that they may read ``source``. Without an explicit object-level
+        # check, a staff user with only "add page" rights could duplicate (and
+        # thereby read the plugin content of) any page -- bypassing per-page
+        # view restrictions and multi-site isolation (CWE-639 / CWE-862).
+        # ``copy(..., permissions=False)`` even strips the source's view
+        # restrictions, leaving the copy fully readable. Require that the user
+        # is actually allowed to view the page they are copying.
+        if source and not user_can_view_page(self._user, source):
+            raise ValidationError(_("You do not have permission to copy this page."))
+        return source
 
 
 def url_is_locked(page_content: PageContent) -> bool:
@@ -1296,6 +1314,11 @@ class GenericCmsPermissionForm(forms.ModelForm):
     can_change_pagepermission = forms.BooleanField(label=_("Change"), required=False)
     can_delete_pagepermission = forms.BooleanField(label=_("Delete"), required=False)
 
+    # Maps the ``can_<action>_<name>`` permission fields to the model whose
+    # permission they grant. Mirrors ``save_permissions`` and the fieldsets
+    # rendered by ``PageUserGroupAdmin``/``PageUserAdmin``.
+    _permission_models = ((Page, "page"), (PageUser, "pageuser"), (PagePermission, "pagepermission"))
+
     def __init__(self, *args, **kwargs):
         instance = kwargs.get("instance")
         initial = kwargs.get("initial") or {}
@@ -1352,6 +1375,33 @@ class GenericCmsPermissionForm(forms.ModelForm):
                     "to change permissions. Edit permissions required."
                 )
                 raise ValidationError(message)
+
+        # Enforce "nobody can grant more than they have" at the data layer.
+        self._drop_unauthorized_permissions(data)
+        return data
+
+    def _drop_unauthorized_permissions(self, data):
+        """Remove ``can_*`` entries the current manager is not allowed to manage.
+
+        ``PageUserGroupAdmin.get_fieldsets`` only *renders* the permission
+        checkboxes the manager actually holds, but the ``can_*`` fields are
+        declared on this form and therefore stay in ``base_fields`` regardless
+        of the admin's ``fields=`` restriction. A crafted POST can set the
+        hidden ones, and ``save_permissions`` would then grant them -- letting a
+        delegated manager escalate a group beyond their own rights (CWE-269).
+        Dropping the unauthorized entries here means they are neither granted
+        nor revoked, so any existing value the manager may not touch is left
+        untouched as well.
+        """
+        user = self._current_user
+        for model, name in self._permission_models:
+            for action in ("add", "change", "delete"):
+                field = f"can_{action}_{name}"
+                if field not in self.fields:
+                    continue
+                if user is None or not user.has_perm(get_model_permission_codename(model, action)):
+                    data.pop(field, None)
+        return data
 
     def populate_initials(self, obj):
         """Read out permissions from permission system."""

--- a/cms/forms/validators.py
+++ b/cms/forms/validators.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
 
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator, URLValidator
@@ -26,6 +27,21 @@ def validate_url(value):
     except ValidationError:
         # Fallback to absolute urls
         URLValidator()(value)
+    else:
+        # ``relative_url_regex`` only constrains the *characters* of a relative
+        # path, not the part before the first slash. Values such as
+        # ``javascript:alert(1)/x``, ``data:text/html,...`` or ``vbscript:.../x``
+        # therefore match the relative branch while still carrying a scheme that
+        # executes script when the value is later rendered into an ``href``
+        # (CWE-79). A genuine relative URL has no scheme, so reject any value
+        # that does. (Off-site targets such as ``https://example.com`` or
+        # ``//example.com`` are intentionally permitted -- this field allows
+        # absolute redirects -- and navigate rather than execute script.)
+        if urlsplit(value).scheme:
+            raise ValidationError(
+                gettext("Enter a valid relative or absolute URL."),
+                code="invalid",
+            )
 
 
 def validate_url_uniqueness(

--- a/cms/tests/test_forms.py
+++ b/cms/tests/test_forms.py
@@ -8,6 +8,7 @@ from django.utils.translation import override as force_language
 
 from cms.admin import forms
 from cms.admin.forms import (
+    AddPageForm,
     DuplicatePageForm,
     GlobalPagePermissionAdminForm,
     MovePageForm,
@@ -560,6 +561,52 @@ class DuplicatePageFormSecurityTestCase(CMSTestCase):
             # ``source`` must not be the reason the form is (in)valid.
             form.is_valid()
             self.assertNotIn("source", form.errors)
+
+
+class AddPageFormSecurityTestCase(CMSTestCase):
+    def _build_form(self, user, page, site):
+        request = self.get_request("/en/")
+        request.user = user
+        form_cls = type(
+            "TestAddPageForm",
+            (AddPageForm,),
+            # Admin form construction can omit ``source``, causing
+            # AddPageForm.__init__ to return before narrowing cms_page.
+            {
+                "source": None,
+                "_site": site,
+                "_request": request,
+                "Meta": type("Meta", (AddPageForm.Meta,), {"fields": []}),
+            },
+        )
+        return form_cls(data={"cms_page": page.pk, "title": "French", "slug": "french"})
+
+    def test_rejects_cms_page_from_another_site(self):
+        owner = self.get_superuser()
+        site = Site.objects.get_current()
+        other_site = Site.objects.create(domain="other.example.com", name="other.example.com")
+        allowed_page = create_page("allowed", "nav_playground.html", "en", site=site, created_by=owner)
+        page = create_page("secret", "nav_playground.html", "de", site=other_site, created_by=owner)
+        attacker = self._create_user("attacker", is_staff=True, add_default_permissions=True)
+        assign_user_to_page(allowed_page, attacker, can_change=True)
+
+        with self.settings(CMS_PERMISSION=True):
+            form = self._build_form(attacker, page, site)
+            self.assertFalse(form.is_valid())
+            self.assertIn("cms_page", form.errors)
+
+    def test_rejects_cms_page_user_cannot_change(self):
+        owner = self.get_superuser()
+        site = Site.objects.get_current()
+        allowed_page = create_page("allowed", "nav_playground.html", "en", site=site, created_by=owner)
+        page = create_page("secret", "nav_playground.html", "en", site=site, created_by=owner)
+        attacker = self._create_user("attacker", is_staff=True, add_default_permissions=True)
+        assign_user_to_page(allowed_page, attacker, can_change=True)
+
+        with self.settings(CMS_PERMISSION=True):
+            form = self._build_form(attacker, page, site)
+            self.assertFalse(form.is_valid())
+            self.assertIn("cms_page", form.errors)
 
 
 class ValidateUrlTestCase(CMSTestCase):

--- a/cms/tests/test_forms.py
+++ b/cms/tests/test_forms.py
@@ -3,15 +3,18 @@ from html import unescape
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.core.cache import cache
+from django.core.exceptions import ValidationError
 from django.utils.translation import override as force_language
 
 from cms.admin import forms
 from cms.admin.forms import (
+    DuplicatePageForm,
     GlobalPagePermissionAdminForm,
     MovePageForm,
     PagePermissionInlineAdminForm,
     PageUserGroupForm,
     ViewRestrictionInlineAdminForm,
+    get_permission_accessor,
 )
 from cms.api import assign_user_to_page, create_page, create_page_content
 from cms.forms.fields import PageSelectFormField
@@ -470,3 +473,149 @@ class PermissionFormTestCase(CMSTestCase):
         form._current_user = user
         self.assertTrue(form.is_valid(), form.errors)
         form.save()
+
+    def test_page_user_group_form_drops_unauthorized_permissions(self):
+        """A delegated manager must not be able to grant a group permissions
+        they do not hold themselves, even by POSTing the hidden ``can_*``
+        fields that ``get_fieldsets`` never rendered for them (CWE-269).
+        """
+        # Manager holds change_page but NOT any pagepermission/pageuser perms.
+        manager = self._create_user("manager", is_staff=True, permissions=["change_page"])
+        self.assertTrue(manager.has_perm("cms.change_page"))
+        self.assertFalse(manager.has_perm("cms.change_pagepermission"))
+
+        data = {
+            "name": "evil_group",
+            "can_change_page": True,           # held by the manager -> must be kept
+            "can_change_pagepermission": True,  # NOT held -> must be dropped
+            "can_add_pagepermission": True,     # NOT held -> must be dropped
+            "can_change_pageuser": True,        # NOT held -> must be dropped
+        }
+        form = PageUserGroupForm(data=data, files=None)
+        form._current_user = manager
+        self.assertTrue(form.is_valid(), form.errors)
+        group = form.save()
+
+        granted = set(get_permission_accessor(group).values_list("codename", flat=True))
+        self.assertIn("change_page", granted)
+        self.assertNotIn("change_pagepermission", granted)
+        self.assertNotIn("add_pagepermission", granted)
+        self.assertNotIn("change_pageuser", granted)
+
+    def test_page_user_group_form_superuser_can_grant_anything(self):
+        """A superuser holds every permission, so nothing is dropped."""
+        superuser = self.get_superuser()
+        data = {
+            "name": "trusted_group",
+            "can_change_page": True,
+            "can_change_pagepermission": True,
+        }
+        form = PageUserGroupForm(data=data, files=None)
+        form._current_user = superuser
+        self.assertTrue(form.is_valid(), form.errors)
+        group = form.save()
+
+        granted = set(get_permission_accessor(group).values_list("codename", flat=True))
+        self.assertIn("change_page", granted)
+        self.assertIn("change_pagepermission", granted)
+
+
+class DuplicatePageFormSecurityTestCase(CMSTestCase):
+    def _build_form(self, user, source):
+        request = self.get_request("/en/")
+        request.user = user
+        # The admin sets ``_site``/``_request`` as class attributes via
+        # ``get_form`` before instantiation (they are read in ``__init__``).
+        form_cls = type(
+            "TestDuplicatePageForm",
+            (DuplicatePageForm,),
+            {"_site": Site.objects.get_current(), "_request": request},
+        )
+        return form_cls(data={"source": source.pk, "title": "x", "slug": "x"})
+
+    def test_duplicate_rejects_source_user_cannot_view(self):
+        """A staff user with only 'add page' rights must not be able to copy a
+        page they are not allowed to view (CWE-639 / CWE-862). ``source`` is a
+        hidden, client-controlled field whose queryset spans every page.
+        """
+        superuser = self.get_superuser()
+        secret = create_page("secret", "nav_playground.html", "en", created_by=superuser)
+        # Add a view restriction so the page is only viewable by the superuser.
+        self.add_page_permission(superuser, secret, can_view=True)
+
+        attacker = self._create_user("attacker", is_staff=True, add_default_permissions=True)
+
+        with self.settings(CMS_PERMISSION=True):
+            form = self._build_form(attacker, secret)
+            self.assertFalse(form.is_valid())
+            self.assertIn("source", form.errors)
+
+    def test_duplicate_allows_source_user_can_view(self):
+        """Copying a page the user is allowed to view keeps working."""
+        superuser = self.get_superuser()
+        source = create_page("source", "nav_playground.html", "en", created_by=superuser)
+
+        with self.settings(CMS_PERMISSION=True):
+            form = self._build_form(superuser, source)
+            # ``source`` must not be the reason the form is (in)valid.
+            form.is_valid()
+            self.assertNotIn("source", form.errors)
+
+
+class ValidateUrlTestCase(CMSTestCase):
+    """Regression tests for the dangerous-scheme bypass in ``validate_url``.
+
+    ``relative_url_regex`` matches any value whose first segment contains no
+    ``/<>``; a scheme such as ``javascript:`` was therefore accepted as a
+    "relative URL" and never reached ``URLValidator``. Such schemes execute
+    script when the value is later rendered into an ``href`` (CWE-79).
+    """
+
+    # Script-executing schemes -- these are the actual XSS vector.
+    DANGEROUS = [
+        "javascript:alert(1)/x",
+        "JavaScript:alert(document.domain)/a",
+        "data:text/html,<script>alert(1)</script>",
+        "vbscript:msgbox(1)/x",
+    ]
+
+    VALID_RELATIVE = [
+        "/foo/bar",
+        "/foo/bar/",
+        "foo/bar",
+        "../page/",
+        "./page/",
+        "/en/some-slug/",
+    ]
+
+    VALID_ABSOLUTE = [
+        "http://example.com/x",
+        "https://example.com/x?y=1",
+        # Protocol-relative / off-site targets navigate (not execute script)
+        # and are an intended capability of this field; they must be accepted
+        # just like an explicit ``https://`` URL.
+        "//example.com",
+        "//example.com/path",
+    ]
+
+    def test_dangerous_schemes_are_rejected(self):
+        from cms.forms.validators import validate_url
+
+        for value in self.DANGEROUS:
+            with self.subTest(value=value):
+                with self.assertRaises(ValidationError):
+                    validate_url(value)
+
+    def test_valid_relative_urls_are_accepted(self):
+        from cms.forms.validators import validate_url
+
+        for value in self.VALID_RELATIVE:
+            with self.subTest(value=value):
+                validate_url(value)  # must not raise
+
+    def test_valid_absolute_urls_are_accepted(self):
+        from cms.forms.validators import validate_url
+
+        for value in self.VALID_ABSOLUTE:
+            with self.subTest(value=value):
+                validate_url(value)  # must not raise


### PR DESCRIPTION
## Summary by Sourcery

Harden page duplication, group permission delegation, and URL validation to prevent privilege escalation and XSS vectors.

Bug Fixes:
- Prevent staff users with only page creation rights from duplicating pages they are not allowed to view by enforcing object-level access checks on the source page in the duplicate page form.
- Ensure delegated managers cannot grant or revoke page, pagepermission, or pageuser permissions they do not themselves hold by dropping unauthorized permission flags at form clean time.
- Reject dangerous script-executing URL schemes that previously bypassed validation through the relative URL path branch while preserving support for valid relative, absolute, and protocol-relative URLs.

Tests:
- Add regression tests covering permission stripping in the page user group form, access control enforcement when duplicating pages, and validation of dangerous versus valid URL schemes.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.