### PR TITLE
feat: Support django 6.1+ breadcrumb styles (#8689)

### DIFF
--- a/cms/static/cms/js/modules/cms.sideframe.js
+++ b/cms/static/cms/js/modules/cms.sideframe.js
@@ -217,7 +217,7 @@ var Sideframe = new Class({
 
             // the sideframe provides its own toolbar, so hide the admin page
             // header regardless of which admin styles the loaded page ships
-            body.find('header#header').hide();
+            body.find('#header').hide();
 
             // remove loader
             that.ui.frame.removeClass('cms-loader');

--- a/cms/static/cms/js/modules/cms.sideframe.js
+++ b/cms/static/cms/js/modules/cms.sideframe.js
@@ -215,6 +215,10 @@ var Sideframe = new Class({
             // inject css class
             body.addClass('cms-admin cms-admin-sideframe');
 
+            // the sideframe provides its own toolbar, so hide the admin page
+            // header regardless of which admin styles the loaded page ships
+            body.find('header#header').hide();
+
             // remove loader
             that.ui.frame.removeClass('cms-loader');
             // than show

--- a/cms/static/cms/sass/components/_sideframe.scss
+++ b/cms/static/cms/sass/components/_sideframe.scss
@@ -3,16 +3,15 @@
 
 @use "sass:math";
 
-// "Pages" frame on the left
+// Admin / "Pages" frame on the left
 .cms-sideframe {
     display: none;
     position: fixed;
     top: 0;
-    inline-start: 0;
+    inset-inline-start: 0;
     width: 0;
     bottom: 0;
     z-index: z(sideframe, base);
-
     @media (max-width: $screen-tablet) {
         width: 100% !important;
     }
@@ -20,8 +19,9 @@
 
 .cms-sideframe-frame {
     position: absolute;
-    left: 0;
+    inset-inline-start: 0;
     top: 0;
+    padding-top: $toolbar-height;  // Covered by toolbar
     -webkit-overflow-scrolling: touch;
     overflow-y: auto;
     z-index: z(sideframe, frame);

--- a/cms/static/cms/sass/settings/_cms.scss
+++ b/cms/static/cms/sass/settings/_cms.scss
@@ -371,7 +371,7 @@ $login-form-submit-padding-horizontal: 15px;
 // Sideframe
 $sideframe-buttons-position-top: $toolbar-height;
 $sideframe-buttons-position-right: 20px;
-$sideframe-buttons-offset: 5px;
+$sideframe-buttons-offset: 2px;
 $sideframe-button-area-size: 32px;
 $sideframe-button-icon-size: 12px;
 $sideframe-button-space: 2px;

--- a/cms/templates/admin/cms/page/change_form.html
+++ b/cms/templates/admin/cms/page/change_form.html
@@ -4,12 +4,22 @@
 {% block title %}{% if add %}{% trans 'Add a page' %}{% else %}{% trans "Change a page" %}{% endif %}{% endblock %}
 
 {% block breadcrumbs %}
+{% django_version_gte 6 1 as new_breadcrumbs %}
+{% if new_breadcrumbs %}
+<ol class="breadcrumbs">
+    <li><a href="{% url 'admin:index' %}">{% trans 'Home' %}</a></li>
+    <li><a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a></li>
+    <li>{% if has_change_permission %}<a href="{% url 'admin:cms_pagecontent_changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %}</li>
+    <li aria-current="page">{% if add %}{% trans 'Add' %} {{ opts.verbose_name }}{% else %}{{ original|truncatewords:"18" }}{% endif %}</li>
+</ol>
+{% else %}
 <div class="breadcrumbs">
     <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
     &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
     &rsaquo; {% if has_change_permission %}<a href="{% url 'admin:cms_pagecontent_changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %}
     &rsaquo; {% if add %}{% trans 'Add' %} {{ opts.verbose_name }}{% else %}{{ original|truncatewords:"18" }}{% endif %}
 </div>
+{% endif %}
 {% endblock %}
 
 {% block extrahead %}

--- a/cms/templates/admin/cms/page/tree/base.html
+++ b/cms/templates/admin/cms/page/tree/base.html
@@ -26,7 +26,7 @@
             <li><a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a></li>
             {# TODO might remove this or add reset #}
             {% if request.GET.q or request.POST.q %}
-            <li>Pages</li>
+            <li>{% trans "Pages" %}</li>
             <li aria-current="page">{% trans "Search" %}</li>
             {% else %}
             <li aria-current="page">Pages</li>

--- a/cms/templates/admin/cms/page/tree/base.html
+++ b/cms/templates/admin/cms/page/tree/base.html
@@ -19,6 +19,20 @@
 
 {% if not is_popup %}
     {% block breadcrumbs %}
+        {% django_version_gte 6 1 as new_breadcrumbs %}
+        {% if new_breadcrumbs %}
+        <ol class="breadcrumbs cms-pagetree-breadcrumbs">
+            <li><a href="{% url 'admin:index' %}">{% trans "Home" %}</a></li>
+            <li><a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a></li>
+            {# TODO might remove this or add reset #}
+            {% if request.GET.q or request.POST.q %}
+            <li>Pages</li>
+            <li aria-current="page">{% trans "Search" %}</li>
+            {% else %}
+            <li aria-current="page">Pages</li>
+            {% endif %}
+        </ol>
+        {% else %}
         <div class="breadcrumbs cms-pagetree-breadcrumbs">
             <a href="{% url 'admin:index' %}">{% trans "Home" %}</a> &rsaquo;
             <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a> &rsaquo;
@@ -28,6 +42,7 @@
             &rsaquo; {% trans "Search" %}
             {% endif %}
         </div>
+        {% endif %}
     {% endblock %}
 {% endif %}
 {% block content_title %}{% endblock %}

--- a/cms/templates/admin/cms/usersettings/change_form.html
+++ b/cms/templates/admin/cms/usersettings/change_form.html
@@ -1,4 +1,4 @@
-{% extends "admin/change_form.html" %}{% load i18n cms_tags %}
+{% extends "admin/change_form.html" %}{% load i18n cms_tags cms_admin %}
 
 {% block extrahead %}
 {{ block.super }}
@@ -26,12 +26,22 @@
 {% endblock %}
 
 {% block breadcrumbs %}
+{% django_version_gte 6 1 as new_breadcrumbs %}
+{% if new_breadcrumbs %}
+<ol class="breadcrumbs">
+    <li><a href="{% cms_admin_url 'index' %}">{% trans 'Home' %}</a></li>
+    <li><a href="{% cms_admin_url 'app_list' app_label=opts.app_label %}">{{ app_label|capfirst|escape }}</a></li>
+    <li>{{ opts.verbose_name_plural|capfirst }}</li>
+    <li aria-current="page">{% if add %}{% trans 'Add' %} {{ opts.verbose_name }}{% else %}{{ original|truncatewords:"18" }}{% endif %}</li>
+</ol>
+{% else %}
 <div class="breadcrumbs">
     <a href="{% cms_admin_url 'index' %}">{% trans 'Home' %}</a>
     &rsaquo; <a href="{% cms_admin_url 'app_list' app_label=opts.app_label %}">{{ app_label|capfirst|escape }}</a>
     &rsaquo; {{ opts.verbose_name_plural|capfirst }}
     &rsaquo; {% if add %}{% trans 'Add' %} {{ opts.verbose_name }}{% else %}{{ original|truncatewords:"18" }}{% endif %}
 </div>
+{% endif %}
 {% endblock %}
 
 {% block object-tools %}{% endblock %}

--- a/cms/templatetags/cms_admin.py
+++ b/cms/templatetags/cms_admin.py
@@ -1,3 +1,4 @@
+import django
 from classytags.arguments import Argument
 from classytags.core import Options, Tag
 from classytags.helpers import AsTag, InclusionTag
@@ -22,6 +23,18 @@ from cms.utils.urlutils import admin_reverse
 register = template.Library()
 
 CMS_ADMIN_ICON_BASE = f"{settings.STATIC_URL}admin/img/"
+
+
+@register.simple_tag
+def django_version_gte(major, minor=0):
+    """Return ``True`` if the running Django version is at least ``(major, minor)``.
+
+    Used in admin templates to switch between the legacy
+    ``<div class="breadcrumbs">`` markup (Django < 6.1) and the
+    ``<ol class="breadcrumbs">`` markup introduced in Django 6.1, whose CSS
+    is element-qualified (``ol.breadcrumbs``) and no longer styles a ``<div>``.
+    """
+    return django.VERSION[:2] >= (major, minor)
 
 
 @register.simple_tag

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -28,7 +28,7 @@ from cms.models import (
     PageContent,
     Placeholder,
 )
-from cms.templatetags.cms_admin import get_page_display_name
+from cms.templatetags.cms_admin import django_version_gte, get_page_display_name
 from cms.templatetags.cms_js_tags import json_filter
 from cms.templatetags.cms_tags import (
     _get_page_by_untyped_arg,
@@ -844,3 +844,66 @@ class CmsTagTemplateTagTests(CMSTestCase):
             self.fail("NoReverseMatch should not be raised.")
 
         self.assertEqual(rendered.strip(), "")
+
+
+class AdminBreadcrumbMarkupTests(CMSTestCase):
+    """Django 6.1 changed the admin breadcrumbs markup from
+    ``<div class="breadcrumbs">`` (with ``&rsaquo;`` separators) to a semantic
+    ``<ol class="breadcrumbs">`` whose CSS is element-qualified
+    (``ol.breadcrumbs``) and no longer styles a ``<div>``. The cms admin
+    overrides switch markup on the running Django version via the
+    ``{% django_version_gte %}`` tag, so they render correctly on both the
+    legacy (4.2-6.0) and the new (6.1+) admin.
+    """
+
+    # Plausible version tuples mirroring ``django.VERSION`` for both branches.
+    DJANGO_5_2 = (5, 2, 0, "final", 0)
+    DJANGO_6_1 = (6, 1, 0, "final", 0)
+
+    def test_django_version_gte_tag(self):
+        with patch("cms.templatetags.cms_admin.django.VERSION", self.DJANGO_5_2):
+            self.assertFalse(django_version_gte(6, 1))
+            self.assertTrue(django_version_gte(5, 2))
+            self.assertTrue(django_version_gte(4, 2))
+        with patch("cms.templatetags.cms_admin.django.VERSION", self.DJANGO_6_1):
+            self.assertTrue(django_version_gte(6, 1))
+            self.assertTrue(django_version_gte(6))
+            self.assertFalse(django_version_gte(7))
+
+    def _get_admin_html(self, uri):
+        with self.login_user_context(self.get_superuser()):
+            response = self.client.get(uri)
+        self.assertEqual(response.status_code, 200)
+        return response.content.decode("utf-8")
+
+    # -- page tree changelist: admin/cms/page/tree/base.html --
+
+    def test_pagetree_breadcrumbs_legacy_div_below_6_1(self):
+        with patch("cms.templatetags.cms_admin.django.VERSION", self.DJANGO_5_2):
+            html = self._get_admin_html(self.get_pages_admin_list_uri("en"))
+        self.assertIn('<div class="breadcrumbs cms-pagetree-breadcrumbs">', html)
+        self.assertNotIn('<ol class="breadcrumbs cms-pagetree-breadcrumbs">', html)
+
+    def test_pagetree_breadcrumbs_ol_on_6_1(self):
+        with patch("cms.templatetags.cms_admin.django.VERSION", self.DJANGO_6_1):
+            html = self._get_admin_html(self.get_pages_admin_list_uri("en"))
+        self.assertIn('<ol class="breadcrumbs cms-pagetree-breadcrumbs">', html)
+        self.assertIn('<li aria-current="page">Pages</li>', html)
+        self.assertNotIn('<div class="breadcrumbs cms-pagetree-breadcrumbs">', html)
+
+    # -- page change form: admin/cms/page/change_form.html --
+
+    def test_page_change_form_breadcrumbs_legacy_div_below_6_1(self):
+        page = create_page("Home", "nav_playground.html", "en")
+        with patch("cms.templatetags.cms_admin.django.VERSION", self.DJANGO_5_2):
+            html = self._get_admin_html(self.get_page_change_uri("en", page))
+        self.assertIn('<div class="breadcrumbs">', html)
+        self.assertNotIn('<ol class="breadcrumbs">', html)
+
+    def test_page_change_form_breadcrumbs_ol_on_6_1(self):
+        page = create_page("Home", "nav_playground.html", "en")
+        with patch("cms.templatetags.cms_admin.django.VERSION", self.DJANGO_6_1):
+            html = self._get_admin_html(self.get_page_change_uri("en", page))
+        self.assertIn('<ol class="breadcrumbs">', html)
+        self.assertIn('aria-current="page"', html)
+        self.assertNotIn('<div class="breadcrumbs">', html)


### PR DESCRIPTION
## Summary by Sourcery

Add Django-version-aware admin breadcrumb markup to support the new Django 6.1+ breadcrumb styles while keeping compatibility with older versions.

New Features:
- Introduce a django_version_gte template tag to conditionally switch admin templates based on the running Django version.
- Add ordered-list-based breadcrumb markup for page tree, page change form, and user settings admin views when running on Django 6.1+.
- Hide the Django admin page header inside the CMS sideframe to align with the embedded admin toolbar experience.

Enhancements:
- Adjust sideframe layout styles and button offsets to better accommodate the admin toolbar and new breadcrumb header area.

Tests:
- Add admin breadcrumb markup tests that verify legacy div-based and new ol-based breadcrumbs are rendered appropriately for different Django versions.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.