### PR TITLE
fix: Replace left-over inline JS/CSS that might be blocked by CSP (#8690)

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -85,7 +85,7 @@ from cms.utils.i18n import (
 )
 from cms.utils.permissions import clear_permission_lru_caches
 from cms.utils.plugins import copy_plugins_to_placeholder
-from cms.utils.urlutils import admin_reverse
+from cms.utils.urlutils import admin_reverse, static_with_version
 
 require_POST = method_decorator(require_POST)
 
@@ -768,6 +768,9 @@ class PageContentAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
     change_list_template = "admin/cms/page/tree/base.html"
     actions_menu_template = "admin/cms/page/tree/actions_dropdown.html"
     page_tree_row_template = "admin/cms/page/tree/menu.html"
+
+    class Media:
+        css = {"all": (static_with_version("cms/css/cms.admin.css"),)}
 
     form = AddPageForm
     add_form = form

--- a/cms/admin/utils.py
+++ b/cms/admin/utils.py
@@ -165,6 +165,8 @@ CONTENT_PREFIX = "content__"
 class GrouperChangeListBase(ChangeList):
     """Subclass ChangeList to disregard grouping fields get parameter as filter"""
 
+    current_language: str = None
+    available_languages: tuple[tuple[str, str], ...] = ()
     _extra_grouping_fields = []
 
     def get_filters_params(self, params: dict | None = None):
@@ -448,7 +450,11 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
     def get_changelist_instance(self, request: HttpRequest) -> GrouperChangeListBase:
         """Update grouping field properties and get changelist instance"""
         self.get_grouping_from_request(request)
-        return super().get_changelist_instance(request)
+        cl = super().get_changelist_instance(request)
+        cl.current_language = self.get_language()
+        if "language" in self.extra_grouping_fields:
+            cl.available_languages = self.get_language_tuple()
+        return cl
 
     def changeform_view(
         self,

--- a/cms/extensions/admin.py
+++ b/cms/extensions/admin.py
@@ -6,11 +6,15 @@ from django.urls import reverse
 
 from cms.models import Page, PageContent
 from cms.utils.page_permissions import user_can_change_page
+from cms.utils.urlutils import static_with_version
 
 
 class ExtensionAdmin(admin.ModelAdmin):
     change_form_template = "admin/cms/extensions/change_form.html"
     add_form_template = "admin/cms/extensions/change_form.html"
+
+    class Media:
+        css = {"all": (static_with_version("cms/css/cms.admin.css"),)}
 
 
 class PageExtensionAdmin(ExtensionAdmin):

--- a/cms/static/cms/js/admin/usersettings.js
+++ b/cms/static/cms/js/admin/usersettings.js
@@ -4,7 +4,7 @@
 // "?reload_window" marker. This script detects that marker and tells the parent
 // window's CMS instance to store the corrected sideframe URL and reload the whole
 // page, so the new settings take effect in the toolbar and surrounding UI.
-window.onload = function () {
+window.addEventListener('load', function () {
     // we have to setTimeout here because the cms.sideframe load event
     // fires after this one :(
     setTimeout(function () {
@@ -19,4 +19,4 @@ window.onload = function () {
             CMS.API.Helpers.reloadBrowser();
         }
     }, 0);
-};
+});

--- a/cms/static/cms/js/admin/usersettings.js
+++ b/cms/static/cms/js/admin/usersettings.js
@@ -1,0 +1,22 @@
+// Loaded by templates/admin/cms/usersettings/change_form.html, which renders
+// inside the CMS sideframe iframe. After the user changes their settings (e.g.
+// the admin language), the server redirects this iframe to its new URL with a
+// "?reload_window" marker. This script detects that marker and tells the parent
+// window's CMS instance to store the corrected sideframe URL and reload the whole
+// page, so the new settings take effect in the toolbar and surrounding UI.
+window.onload = function () {
+    // we have to setTimeout here because the cms.sideframe load event
+    // fires after this one :(
+    setTimeout(function () {
+        var CMS = window.parent.CMS;
+        // we need to reload the parent window once "?reload_window" is defined and
+        // set the new url for the sideframe with the correct language specification
+        if (location.href.indexOf('reload_window') > -1 && CMS) {
+            // save url in settings
+            CMS.settings.sideframe.url = window.location.href.replace(/[?&]reload_window/, '');
+            CMS.settings = CMS.API.Helpers.setSettings(CMS.settings);
+            // reload everything
+            CMS.API.Helpers.reloadBrowser();
+        }
+    }, 0);
+};

--- a/cms/static/cms/js/welcome.js
+++ b/cms/static/cms/js/welcome.js
@@ -1,7 +1,15 @@
 // CSP-safe replacement for the previously inline script in templates/cms/welcome.html
 // Reads its configuration from the #cms-welcome-config element's data-* attributes
 // so that no inline JavaScript (and no template interpolation into JS) is required.
+
 (function () {
+    /**
+     * Reads configuration from #cms-welcome-config and either redirects anonymous
+     * users to the login page or wires up the wizard modal for authenticated users.
+     *
+     * @function init
+     * @returns {void}
+     */
     function init() {
         var config = document.getElementById('cms-welcome-config');
 

--- a/cms/static/cms/js/welcome.js
+++ b/cms/static/cms/js/welcome.js
@@ -24,19 +24,17 @@
             return;
         }
 
-        var btn = document.querySelector('.js-welcome-add');
+        var buttons = document.querySelectorAll('.js-welcome-add');
 
-        if (!btn) {
-            return;
-        }
+        buttons.forEach(function (btn) {
+            btn.addEventListener('click', function (e) {
+                e.preventDefault();
+                var modal = new CMS.Modal();
 
-        btn.addEventListener('click', function (e) {
-            e.preventDefault();
-            var modal = new CMS.Modal();
-
-            modal.open({
-                url: config.dataset.addUrl,
-                title: config.dataset.addTitle
+                modal.open({
+                    url: config.dataset.addUrl,
+                    title: config.dataset.addTitle
+                });
             });
         });
     }

--- a/cms/static/cms/js/welcome.js
+++ b/cms/static/cms/js/welcome.js
@@ -33,9 +33,10 @@
         }
 
         var buttons = document.querySelectorAll('.js-welcome-add');
+        var i;
 
-        buttons.forEach(function (btn) {
-            btn.addEventListener('click', function (e) {
+        for (i = 0; i < buttons.length; i++) {
+            buttons[i].addEventListener('click', function (e) {
                 e.preventDefault();
                 var modal = new CMS.Modal();
 
@@ -44,7 +45,7 @@
                     title: config.dataset.addTitle
                 });
             });
-        });
+        }
     }
 
     if (document.readyState === 'loading') {

--- a/cms/static/cms/js/welcome.js
+++ b/cms/static/cms/js/welcome.js
@@ -1,0 +1,49 @@
+// CSP-safe replacement for the previously inline script in templates/cms/welcome.html
+// Reads its configuration from the #cms-welcome-config element's data-* attributes
+// so that no inline JavaScript (and no template interpolation into JS) is required.
+(function () {
+    function init() {
+        var config = document.getElementById('cms-welcome-config');
+
+        if (!config) {
+            return;
+        }
+
+        // Anonymous users get redirected to the login page.
+        var loginUrl = config.dataset.loginUrl;
+
+        if (loginUrl) {
+            window.location.href = loginUrl;
+            return;
+        }
+
+        // Authenticated users get the wizard modal wired up to the "add" button.
+        var CMS = window.CMS;
+
+        if (!CMS) {
+            return;
+        }
+
+        var btn = document.querySelector('.js-welcome-add');
+
+        if (!btn) {
+            return;
+        }
+
+        btn.addEventListener('click', function (e) {
+            e.preventDefault();
+            var modal = new CMS.Modal();
+
+            modal.open({
+                url: config.dataset.addUrl,
+                title: config.dataset.addTitle
+            });
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/cms/static/cms/sass/cms.admin.scss
+++ b/cms/static/cms/sass/cms.admin.scss
@@ -210,6 +210,23 @@ a.cms-actions-dropdown-menu-item-anchor.inactive {
 }
 
 
+// Language selector on grouper change lists (replaces former inline styles).
+.language-selector {
+    display: inline;
+    width: fit-content;
+    margin-bottom: 1em;
+}
+
+select.language-selector {
+    min-width: 180px;
+}
+
+// Submit row in admin popups needs to clear its floated buttons
+// (replaces a former inline style on the page/extension change forms).
+.submit-row.cms-submit-row-popup {
+    overflow: auto;
+}
+
 body:not(.djangocms-admin-style) #page_form_lang_tabs input[type="button"].selected {
     background-color: var(--button-bg);
     color: var(--button-fg)

--- a/cms/static/cms/sass/components/_dropdown.scss
+++ b/cms/static/cms/sass/components/_dropdown.scss
@@ -18,6 +18,13 @@
     }
 }
 
+// The toggle is an <a> without href (CSP-safe, no "javascript:" URI), so the
+// pointer cursor has to be set explicitly. Disabled toggles keep "not-allowed"
+// via the higher-specificity .cms-btn.cms-btn-disabled rule.
+.cms-dropdown-toggle {
+    cursor: pointer;
+}
+
 // Prevent the focus on the dropdown toggle when closing dropdowns
 .cms-dropdown-toggle:focus {
     outline: 0;

--- a/cms/templates/admin/cms/extensions/change_form.html
+++ b/cms/templates/admin/cms/extensions/change_form.html
@@ -1,7 +1,7 @@
 {% extends "admin/change_form.html" %}{% load i18n admin_urls %}
 
 {% block submit_buttons_bottom %}
-<div class="submit-row"{% if is_popup %} style="overflow: auto;"{% endif %}>
+<div class="submit-row{% if is_popup %} cms-submit-row-popup{% endif %}">
     <input type="submit" name="_save" class="default" value="{% trans 'Save' %}"/>
     {% if not add %}
         <p class="deletelink-box">

--- a/cms/templates/admin/cms/grouper/change_list.html
+++ b/cms/templates/admin/cms/grouper/change_list.html
@@ -1,11 +1,14 @@
 {% extends "admin/change_list.html" %}{% load i18n %}
 {% block search %}
-  <div class="language-selector" style="display: inline; width: fit-content; margin-bottom: 1em;">
-    <label>{% trans "Language" %}:&nbsp;</label>
-    <select class="language-selector js-language-selector" style="min-width: 180px;">
-      {% for code, lang in cl.model_admin.get_language_tuple %}
-        <option value="{{ code }}"{% if cl.model_admin.language == code %} selected{% endif %}>{{ lang }}</option>
-      {% endfor %}
-    </select>
-  </div>{{ block.super }}
+  {% if cl.available_languages %}
+    <div class="language-selector">
+      <label>{% trans "Language" %}:&nbsp;</label>
+      <select class="language-selector js-language-selector">
+        {% for code, lang in cl.available_languages %}
+          <option value="{{ code }}"{% if cl.current_language == code %} selected{% endif %}>{{ lang }}</option>
+        {% endfor %}
+      </select>
+    </div>
+  {% endif %}
+  {{ block.super }}
 {% endblock %}

--- a/cms/templates/admin/cms/page/change_form.html
+++ b/cms/templates/admin/cms/page/change_form.html
@@ -84,7 +84,7 @@
 {% block after_related_objects %}{% endblock %}
 
 {% if add %}
-    <div class="submit-row"{% if is_popup %} style="overflow: auto;"{% endif %}>
+    <div class="submit-row{% if is_popup %} cms-submit-row-popup{% endif %}">
         <input type="submit" name="_save" class="default" value="{% trans 'Save' %}" {{ onclick_attrib }}/>
         <input type="submit" name="_continue" value="{% trans 'Save and continue editing' %}" {{ onclick_attrib }}/>
     </div>

--- a/cms/templates/admin/cms/page/submit_row.html
+++ b/cms/templates/admin/cms/page/submit_row.html
@@ -1,6 +1,6 @@
 {% load i18n cms_tags admin_urls %}
 
-<div class="submit-row" {% if is_popup %}style="overflow: auto;"{% endif %}>
+<div class="submit-row{% if is_popup %} cms-submit-row-popup{% endif %}">
     {% if show_save %}<input type="submit" value="{% trans 'Save' %}" class="default" name="_save" />{% endif %}
 
     <p class="deletelink-box">

--- a/cms/templates/admin/cms/usersettings/change_form.html
+++ b/cms/templates/admin/cms/usersettings/change_form.html
@@ -1,28 +1,8 @@
-{% extends "admin/change_form.html" %}{% load i18n cms_tags %}
+{% extends "admin/change_form.html" %}{% load i18n static cms_tags %}
 
 {% block extrahead %}
 {{ block.super }}
-<script>
-    // we have to wait till the window is loaded, otherwise
-    // the sideframe code will override the url, because every time
-    // the iframe is loaded, it's current url is saved in the settings
-    window.onload = function () {
-        // we have to setTimeout here because the cms.sideframe load event
-        // fires after this one :(
-        setTimeout(function () {
-            var CMS = window.parent.CMS;
-            // we need to reload the parent window once "?reload_window" is defined and
-            // set the new url for the sideframe with the correct language specification
-            if (location.href.indexOf('reload_window') > -1 && CMS) {
-                // save url in settings
-                CMS.settings.sideframe.url = window.location.href.replace(/[?&]reload_window/, '');
-                CMS.settings = CMS.API.Helpers.setSettings(CMS.settings);
-                // reload everything
-                CMS.API.Helpers.reloadBrowser();
-            }
-        }, 0);
-    }
-</script>
+<script src="{% static "cms/js/admin/usersettings.js" %}"></script>
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/cms/templates/cms/toolbar/items/dropdown.html
+++ b/cms/templates/cms/toolbar/items/dropdown.html
@@ -4,7 +4,7 @@
     {% else %}
         <div class="cms-btn-group">
             {{ primary_button.render }}
-            <a href="javascript: void 0" class="cms-btn cms-dropdown-toggle {{ primary_button.extra_classes|join:' ' }} cms-dropdown-toggle-thin">
+            <a role="button" tabindex="0" class="cms-btn cms-dropdown-toggle {{ primary_button.extra_classes|join:' ' }} cms-dropdown-toggle-thin">
                 <span class="cms-dropdown-caret"></span>
             </a>
         </div>

--- a/cms/templates/cms/toolbar/items/dropdown_button.html
+++ b/cms/templates/cms/toolbar/items/dropdown_button.html
@@ -1,4 +1,4 @@
-<a href="javascript: void 0" class="cms-btn cms-dropdown-toggle {% if active %} cms-btn-active{% endif %}{% if disabled %} cms-btn-disabled{% endif %} {{ extra_classes|join:' ' }}">
+<a role="button" tabindex="0" class="cms-btn cms-dropdown-toggle {% if active %} cms-btn-active{% endif %}{% if disabled %} cms-btn-disabled{% endif %} {{ extra_classes|join:' ' }}">
     {{ name }}
     <span class="cms-dropdown-caret"></span>
 </a>

--- a/cms/templates/cms/welcome.html
+++ b/cms/templates/cms/welcome.html
@@ -108,23 +108,15 @@
     {% render_block "js" %}
 
     {% language request.toolbar.toolbar_language %}
-    <script>
-        {% if user.is_authenticated %}
-            CMS.$(function () {
-                var btn = CMS.$('.js-welcome-add');
-                btn.on('click', function (e) {
-                    e.preventDefault();
-                    var modal = new CMS.Modal();
-                    modal.open({
-                        url: '{% url "admin:cms_wizard_create" %}?language={{ LANGUAGE_CODE }}',
-                        title: '{% trans "Welcome to django CMS" %}'
-                    });
-                });
-            });
-        {% else %}
-            window.location.href = '{% url "admin:login" %}?next={{ next_url }}';
-        {% endif %}
-    </script>
+    {% if user.is_authenticated %}
+        <div id="cms-welcome-config"
+             data-add-url="{% url "admin:cms_wizard_create" %}?language={{ LANGUAGE_CODE }}"
+             data-add-title="{% trans "Welcome to django CMS" %}"></div>
+    {% else %}
+        <div id="cms-welcome-config"
+             data-login-url="{% url "admin:login" %}?next={{ next_url }}"></div>
+    {% endif %}
     {% endlanguage %}
+    <script src="{% static_with_version "cms/js/welcome.js" %}"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5142,9 +5142,9 @@
       "dev": true
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001695",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
-      "integrity": "sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==",
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
       "dev": true,
       "funding": [
         {
@@ -26085,9 +26085,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001695",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
-      "integrity": "sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==",
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
       "dev": true
     },
     "capital-case": {


### PR DESCRIPTION
## Summary by Sourcery

Replace remaining inline JavaScript and CSS with external, CSP-safe assets and adjust admin/toolbar UI to work with these changes.

Bug Fixes:
- Ensure the admin language selector on grouper change lists uses the correct language sources and avoids inline styling.
- Prevent toolbar dropdown buttons from relying on "javascript:" URLs, improving CSP compatibility and keyboard accessibility.

Enhancements:
- Move the welcome screen logic from inline script to a dedicated welcome.js that reads configuration from data attributes.
- Extract the user settings sideframe reload logic into an external usersettings.js script loaded via Django static files.
- Replace inline styles for admin language selector and popup submit rows with shared rules in cms.admin.scss and load this stylesheet for page and extension admin forms.
- Update toolbar dropdown templates to use button semantics (role and tabindex) and style-only anchors for CSP-safe interaction.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.