### PR TITLE
fix: Page tree had a n+1 regression fetching urls

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -65,6 +65,7 @@ from cms.models import (
     PageUrl,
     Placeholder,
 )
+from cms.models.pagemodel import AdminCacheDict
 from cms.models.permissionmodels import PermissionTuple
 from cms.operations.helpers import (
     send_post_page_operation,
@@ -375,12 +376,17 @@ class PageAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
             query_term = request.GET.get("q", "").strip("/")
 
             language_code = request.GET.get("language_code", settings.LANGUAGE_CODE)
-            matching_published_pages = self.model.objects.on_site(site).filter(
-                Q(pagecontent_set__title__icontains=query_term, pagecontent_set__language=language_code)
-                | Q(urls__path__icontains=query_term, pagecontent_set__language=language_code)
-                | Q(pagecontent_set__menu_title__icontains=query_term, pagecontent_set__language=language_code)
-                | Q(pagecontent_set__page_title__icontains=query_term, pagecontent_set__language=language_code)
-            ).distinct()
+            matching_published_pages = (
+                self.model.objects.on_site(site)
+                .filter(
+                    Q(pagecontent_set__title__icontains=query_term, pagecontent_set__language=language_code)
+                    | Q(urls__path__icontains=query_term, pagecontent_set__language=language_code)
+                    | Q(pagecontent_set__menu_title__icontains=query_term, pagecontent_set__language=language_code)
+                    | Q(pagecontent_set__page_title__icontains=query_term, pagecontent_set__language=language_code)
+                )
+                .prefetch_related("urls", "pagecontent_set")
+                .distinct()
+            )
 
             results = []
             for page in matching_published_pages:
@@ -1274,7 +1280,7 @@ class PageContentAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
             "language": force_str(get_language_object(obj.language, site_id=obj.page.site_id)["name"])
         }
         messages.success(request, message)
-        if obj.language in obj.page.admin_content_cache:
+        if obj.page.admin_content_cache and obj.language in obj.page.admin_content_cache:
             del obj.page.admin_content_cache[obj.language]
         if obj.language in obj.page.page_content_cache:
             del obj.page.page_content_cache[obj.language]
@@ -1372,7 +1378,9 @@ class PageContentAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
         user_can_change_permissions = page_permissions.user_can_change_page_permissions
 
         def render_page_row(page):
-            page.admin_content_cache = {trans.language: trans for trans in page.filtered_translations}
+            page.admin_content_cache = AdminCacheDict(
+                (trans.language, trans) for trans in page.filtered_translations
+            )
             has_move_page_permission = page_permissions.user_can_move_page(request.user, page, site=site)
 
             if permissions_on and not has_move_page_permission:

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -1140,6 +1140,7 @@ class PageContentAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
                 to_attr="filtered_translations",
                 queryset=page_contents,
             ),
+            "urls",  # rendering a tree row resolves the page's URLs
         )
 
         if changelist_form.is_filtered():
@@ -1342,6 +1343,7 @@ class PageContentAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
                 to_attr="filtered_translations",
                 queryset=PageContent.admin_manager.get_queryset().latest_content(),
             ),
+            "urls",  # rendering a tree row resolves the page's URLs
         )
         rows = self.get_tree_rows(
             request,

--- a/cms/cms_menus.py
+++ b/cms/cms_menus.py
@@ -291,6 +291,7 @@ class CMSMenu(Menu):
                 "redirect",
                 "page__site_id",
                 "page__parent_id",
+                "page__path",  # needed by the view-restriction check in get_visible_page_contents
                 "page__is_home",
                 "page__login_required",
                 "page__reverse_id",

--- a/cms/cms_toolbars.py
+++ b/cms/cms_toolbars.py
@@ -728,7 +728,7 @@ class PageToolbar(CMSToolbar):
             # delete
             delete_url = admin_reverse("cms_page_delete", args=(self.page.pk,))
             delete_disabled = not edit_mode or not user_can_delete_page(self.request.user, page=self.page)
-            on_delete_redirect_url = self.get_on_delete_redirect_url()
+            on_delete_redirect_url = self.get_on_delete_redirect_url() if not delete_disabled else None
             current_page_menu.add_modal_item(
                 _("Delete page"), url=delete_url, on_close=on_delete_redirect_url, disabled=delete_disabled
             )

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -151,7 +151,7 @@ class Page(MP_Node):
         #: Internal cache for page urls
         self.page_content_cache = {}
         #: Internal cache for page content objects visible publicly
-        self.admin_content_cache = AdminCacheDict()
+        self.admin_content_cache = None
         #: Internal cache for page content objects visible in the admin (i.e. to staff users.)
         #: Might be larger than the page_content_cache
 
@@ -211,7 +211,7 @@ class Page(MP_Node):
     def _clear_internal_cache(self):
         self.urls_cache = {}
         self.page_content_cache = {}
-        self.admin_content_cache = AdminCacheDict()
+        self.admin_content_cache = None
 
         if hasattr(self, "_prefetched_objects_cache"):
             del self._prefetched_objects_cache
@@ -703,7 +703,7 @@ class Page(MP_Node):
     def get_languages(self, admin_manager=True):
         """Returns available languages for the page. This is potentially costly."""
         if admin_manager:
-            if not self.admin_content_cache:
+            if self.admin_content_cache is None:
                 self.set_admin_content_cache()
             return list(self.admin_content_cache.keys())
         if not self.page_content_cache:
@@ -750,7 +750,7 @@ class Page(MP_Node):
     def get_admin_content(self, language, fallback=False):
         from cms.models.contentmodels import EmptyPageContent
 
-        if not self.admin_content_cache:
+        if self.admin_content_cache is None:
             self.set_admin_content_cache()
         page_content = self.admin_content_cache.get(language, EmptyPageContent(language=language, page=self))
         if not page_content and fallback:

--- a/cms/models/permissionmodels.py
+++ b/cms/models/permissionmodels.py
@@ -145,7 +145,7 @@ class AbstractPagePermission(models.Model):
     def save(self, *args, **kwargs):
         if not self.user and not self.group:
             # don't allow `empty` objects
-            return
+            raise TypeError(_('Please select user or group.'))
         return super().save(*args, **kwargs)
 
     def get_configured_actions(self):

--- a/cms/tests/test_forms.py
+++ b/cms/tests/test_forms.py
@@ -26,6 +26,7 @@ from cms.test_utils.testcases import (
     URL_CMS_PAGE_PERMISSIONS,
     CMSTestCase,
 )
+from cms.utils.permissions import current_user
 
 
 class Mock_PageSelectFormField(PageSelectFormField):
@@ -374,7 +375,7 @@ class PermissionFormTestCase(CMSTestCase):
             response = self.client.get(URL_CMS_PAGE_PERMISSIONS % page.pk)
             self.assertEqual(response.status_code, 200)
 
-        with self.settings(CMS_RAW_ID_USERS=True):
+        with self.settings(CMS_RAW_ID_USERS=True), current_user(self.get_superuser()):
             data = {
                 "page": page.pk,
                 "grant_on": "hello",

--- a/cms/tests/test_menu.py
+++ b/cms/tests/test_menu.py
@@ -3,14 +3,15 @@ import copy
 from django.contrib.auth.models import AnonymousUser, Group, Permission
 from django.contrib.sites.models import Site
 from django.core.cache import caches
+from django.db import connection
 from django.template import Template, TemplateSyntaxError
 from django.template.context import Context
-from django.test.utils import override_settings
+from django.test.utils import CaptureQueriesContext, override_settings
 from django.utils.translation import activate, override as force_language
 
 from cms.api import create_page, create_page_content
 from cms.apphook_pool import apphook_pool
-from cms.cms_menus import get_visible_page_contents
+from cms.cms_menus import CMSMenu, get_visible_page_contents
 from cms.models import ACCESS_PAGE_AND_DESCENDANTS, Page, PageContent
 from cms.models.permissionmodels import GlobalPagePermission, PagePermission
 from cms.test_utils.fixtures.menus import (
@@ -1915,6 +1916,52 @@ class PublicViewPermissionMenuTests(CMSTestCase):
         page_contents = get_visible_page_contents(self.request, page_contents, self.site)
         titles = [page_content.title for page_content in page_contents]
         self.assertSequenceEqual(sorted(titles), ["a", "b1", "c1", "c2"])
+
+
+@override_settings(
+    CMS_PERMISSION=True,
+    CMS_PUBLIC_FOR="all",
+)
+class ViewPermissionMenuQueryTests(CMSTestCase):
+    """
+    Regression tests: building the menu must not run one query per page.
+
+    ``CMSMenu.get_nodes`` restricts the loaded fields with ``only()``. Every
+    field accessed by the view-restriction check in
+    ``get_visible_page_contents`` (such as ``page.path``) has to be part of
+    that ``only()`` call, otherwise each page triggers an extra query to
+    load the deferred field.
+    """
+
+    template = "nav_playground.html"
+
+    def _get_menu_query_count(self):
+        request = self.get_request("/")
+        renderer = menu_pool.get_renderer(request)
+        menu = CMSMenu(renderer)
+        with CaptureQueriesContext(connection) as queries:
+            menu.get_nodes(request)
+        return len(queries.captured_queries)
+
+    def test_number_of_queries_does_not_scale_with_page_count(self):
+        create_page("home", self.template, "en", in_navigation=True)
+        restricted = create_page("restricted", self.template, "en", in_navigation=True)
+        PagePermission.objects.create(
+            page=restricted,
+            user=self.get_standard_user(),
+            can_view=True,
+            grant_on=ACCESS_PAGE_AND_DESCENDANTS,
+        )
+        for index in range(3):
+            create_page(f"page-{index}", self.template, "en", in_navigation=True)
+
+        self._get_menu_query_count()  # warm up caches (site, content types, ...)
+        query_count = self._get_menu_query_count()
+
+        for index in range(5):
+            create_page(f"extra-{index}", self.template, "en", in_navigation=True)
+
+        self.assertEqual(self._get_menu_query_count(), query_count)
 
 
 @override_settings(CMS_PERMISSION=False)

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -10,8 +10,8 @@ from django.conf import settings
 from django.contrib import admin
 from django.contrib.sites.models import Site
 from django.core.cache import cache
-from django.forms.models import model_to_dict
 from django.db import connection
+from django.forms.models import model_to_dict
 from django.http import HttpRequest, HttpResponse
 from django.test.html import HTMLParseError, Parser
 from django.test.utils import CaptureQueriesContext, override_settings

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -11,9 +11,10 @@ from django.contrib import admin
 from django.contrib.sites.models import Site
 from django.core.cache import cache
 from django.forms.models import model_to_dict
+from django.db import connection
 from django.http import HttpRequest, HttpResponse
 from django.test.html import HTMLParseError, Parser
-from django.test.utils import override_settings
+from django.test.utils import CaptureQueriesContext, override_settings
 from django.urls import clear_url_caches
 from django.utils.encoding import force_str
 from django.utils.timezone import now as tz_now
@@ -1623,6 +1624,40 @@ class PageTest(PageTestBase):
             parsed = self._parse_page_tree(response, parser_class=PageTreeLiParser)
             content = force_str(parsed)
             self.assertIn(tree, content)
+
+    def test_page_tree_prefetches_page_urls(self):
+        """
+        Regression test: the page tree endpoints must fetch the ``PageUrl``
+        objects of all pages in bulk instead of issuing one query per page
+        row (triggered by ``Page.get_url_obj`` filling ``urls_cache`` from
+        ``self.urls.all()`` for every rendered row).
+        """
+        superuser = self.get_superuser()
+
+        create_page("Home", "nav_playground.html", "en")
+        for index in range(4):
+            create_page(f"Page {index}", "nav_playground.html", "en")
+
+        endpoints = (
+            self.get_admin_url(PageContent, "get_tree"),
+            self.get_admin_url(PageContent, "changelist"),
+        )
+
+        with self.login_user_context(superuser):
+            for endpoint in endpoints:
+                with self.subTest(endpoint=endpoint):
+                    with CaptureQueriesContext(connection) as queries:
+                        response = self.client.get(endpoint)
+                    self.assertEqual(response.status_code, 200)
+                    page_url_queries = [
+                        query["sql"] for query in queries.captured_queries if '"cms_pageurl"' in query["sql"]
+                    ]
+                    self.assertLessEqual(
+                        len(page_url_queries),
+                        1,
+                        "The page tree issued one PageUrl query per page instead "
+                        "of prefetching them:\n" + "\n".join(page_url_queries),
+                    )
 
     def test_page_tree_redirect_icon_display(self):
         """Test that redirect icon is displayed in page tree when page has redirect"""

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -1659,6 +1659,41 @@ class PageTest(PageTestBase):
                         "of prefetching them:\n" + "\n".join(page_url_queries),
                     )
 
+    def test_page_tree_does_not_requery_content_less_pages(self):
+        """
+        Regression test: pages without any (filtered) translations must not
+        trigger a fresh ``set_admin_content_cache`` query per row. An empty
+        admin content cache used to be indistinguishable from an unpopulated
+        one, so ``get_admin_content`` / ``get_languages`` re-queried the
+        database for every content-less page in the tree.
+        """
+        superuser = self.get_superuser()
+        endpoint = self.get_admin_url(PageContent, "get_tree")
+
+        def add_content_less_pages(count, prefix):
+            for index in range(count):
+                page = create_page(f"{prefix}-{index}", "nav_playground.html", "en")
+                PageContent.admin_manager.filter(page=page).delete()
+
+        create_page("Home", "nav_playground.html", "en")
+        add_content_less_pages(2, "empty-a")
+
+        with self.login_user_context(superuser):
+            self.client.get(endpoint)  # warm up caches (content types, permissions, ...)
+            with CaptureQueriesContext(connection) as first:
+                self.assertEqual(self.client.get(endpoint).status_code, 200)
+
+            add_content_less_pages(3, "empty-b")
+            with CaptureQueriesContext(connection) as second:
+                self.assertEqual(self.client.get(endpoint).status_code, 200)
+
+        self.assertEqual(
+            len(second.captured_queries),
+            len(first.captured_queries),
+            "The page tree issued extra queries for content-less pages:\n"
+            + "\n".join(query["sql"] for query in second.captured_queries),
+        )
+
     def test_page_tree_redirect_icon_display(self):
         """Test that redirect icon is displayed in page tree when page has redirect"""
         superuser = self.get_superuser()
@@ -1962,6 +1997,44 @@ class PageActionsTestCase(PageTestBase):
         titles = {result["title"] for result in results}
         self.assertIn("Bravo Site 1", titles)
         self.assertNotIn("Bravo Site 2", titles)
+
+    def test_get_list_prefetches_page_urls(self):
+        """
+        Regression test: the smart-link autocomplete endpoint resolves the
+        path/title/URL of every matching page. It must prefetch ``urls`` (and
+        ``pagecontent_set``) in bulk instead of issuing one ``PageUrl`` query
+        per matched page.
+        """
+        for index in range(4):
+            create_page(
+                f"Bravo {index}",
+                "nav_playground.html",
+                "en",
+                site=self.site,
+                slug=f"bravo-{index}",
+                created_by=self.admin,
+            )
+
+        endpoint = admin_reverse("cms_page_get_list")
+        with self.login_user_context(self.admin):
+            with CaptureQueriesContext(connection) as queries:
+                response = self.client.get(
+                    endpoint,
+                    data={"site": self.site.pk, "q": "Bravo", "language_code": "en"},
+                    HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+                )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(json.loads(response.content.decode("utf-8"))), 4)
+        page_url_queries = [
+            query["sql"] for query in queries.captured_queries if 'FROM "cms_pageurl"' in query["sql"]
+        ]
+        self.assertLessEqual(
+            len(page_url_queries),
+            1,
+            "The smart-link endpoint issued one PageUrl query per matched page:\n"
+            + "\n".join(page_url_queries),
+        )
 
     def test_actions_menu_superuser(self):
         """Test actions_menu view returns correct context for superuser"""

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -28,6 +28,8 @@ from cms.cms_toolbars import (
     DEFAULT_HELP_MENU_ITEMS,
     HELP_MENU_IDENTIFIER,
     LANGUAGE_MENU_IDENTIFIER,
+    PAGE_MENU_IDENTIFIER,
+    PageToolbar,
     get_user_model,
 )
 from cms.models import PagePermission, UserSettings
@@ -682,6 +684,45 @@ class ToolbarTests(ToolbarTestBase):
         self.assertEqual(copy_german.name.lower(), "from german")
         self.assertEqual(
             copy_german_context["action"], admin_reverse("cms_pagecontent_copy_language", args=(german_content.pk,))
+        )
+
+    def _get_delete_page_item(self, toolbar):
+        page_menu = toolbar.get_menu(PAGE_MENU_IDENTIFIER)
+        for item in page_menu.items:
+            if force_str(getattr(item, "name", "")).startswith("Delete page"):
+                return item
+        return None
+
+    def test_delete_redirect_not_computed_when_delete_disabled(self):
+        """
+        Regression test: the on-delete redirect URL was computed on every
+        toolbar render of a page with a parent, issuing two parent-page
+        queries even when the delete item is disabled (e.g. outside edit
+        mode). It must only be computed when the delete action is available.
+        """
+        parent = create_page("parent", "nav_playground.html", "en")
+        child = create_page("child", "nav_playground.html", "en", parent=parent)
+
+        with patch.object(PageToolbar, "get_on_delete_redirect_url", autospec=True) as mocked:
+            # View mode: the delete item is disabled, so no redirect is needed.
+            self.get_page_request(child, self.get_superuser(), child.get_absolute_url())
+
+        mocked.assert_not_called()
+
+    def test_delete_redirect_computed_when_delete_enabled(self):
+        """The redirect URL is still resolved (to the parent) when deletion is possible."""
+        parent = create_page("parent", "nav_playground.html", "en")
+        child = create_page("child", "nav_playground.html", "en", parent=parent)
+        edit_url = get_object_edit_url(child.get_content_obj("en"))
+
+        request = self.get_page_request(child, self.get_superuser(), edit_url)
+
+        delete_item = self._get_delete_page_item(request.toolbar)
+        self.assertIsNotNone(delete_item)
+        self.assertFalse(delete_item.disabled)
+        self.assertEqual(
+            delete_item.on_close,
+            get_object_preview_url(parent.get_admin_content("en")),
         )
 
     def test_show_toolbar_staff(self):

--- a/cms/wizards/wizard_pool.py
+++ b/cms/wizards/wizard_pool.py
@@ -2,8 +2,7 @@ from django.apps import apps
 from django.utils.translation import gettext as _
 
 from cms.utils.compat.warnings import RemovedInDjangoCMS60Warning
-from cms.wizards.helpers import get_entries, get_entry  # noqa: F401
-from cms.wizards.wizard_base import Wizard, entry_choices  # noqa: F401
+from cms.wizards.wizard_base import Wizard, entry_choices, get_entries, get_entry  # noqa: F401
 
 
 class AlreadyRegisteredException(Exception):


### PR DESCRIPTION
## Summary by Sourcery

Prevent N+1 query regressions when building navigation menus and rendering the admin page tree by ensuring related URLs and page paths are loaded efficiently and covered by regression tests.

Bug Fixes:
- Ensure CMS menu node fetching includes the page path field to avoid per-page queries during view-permission checks.
- Ensure the admin page tree and changelist endpoints prefetch PageUrl objects in bulk instead of issuing one query per page row.
- Fix permission form tests by providing a current user context when using raw ID user settings.

Tests:
- Add regression tests asserting that menu query counts do not increase with the number of pages when view permissions are enabled.
- Add regression tests asserting that page tree and changelist endpoints issue at most a single query for PageUrl objects.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.