### PR TITLE
feat: json config for djangocms command

### DIFF
--- a/cms/management/commands/djangocms_install_rules.json
+++ b/cms/management/commands/djangocms_install_rules.json
@@ -1,5 +1,45 @@
 {
-    "comment": "Rules used by `djangocms .` to add django CMS to an existing project. Fetched from the cms-template repository (branch matching the installed django CMS major.minor), with this file as the bundled fallback. Top-level keys starting with `$` (such as `$schema`) and this comment are ignored. Each `when` condition may contain a `flag` (truthy command option) and/or a `mode` (list of matching --mode values). For installed_apps and middleware a rule may also carry a `before` or `after` anchor (an existing entry) for positional insertion; otherwise items are appended. A url rule may carry `\"i18n\": true` to route its pattern through `i18n_patterns()` (so the CMS catch-all keeps its language prefix) when the project's urls.py already uses i18n_patterns; otherwise the pattern is added to the plain urlpatterns list. The `warnings` list holds `{message, when}` entries; each message whose condition matches is printed to the screen (for example, should djangocms-stories be discontinued, add {\"message\": \"The --stories option no longer has any effect: djangocms-stories has been discontinued.\", \"when\": {\"flag\": \"stories\"}}).",
+    "comment": "Rules used by `djangocms .` to add django CMS to an existing project. Fetched from the cms-template repository (branch matching the installed django CMS major.minor), with this file as the bundled fallback. Top-level keys starting with `$` (such as `$schema`) and this comment are ignored. The `options` object describes template-owned command options. Each `when` condition may contain a `flag` (truthy command option) and/or a `mode` (list of matching --mode values). For installed_apps and middleware a rule may also carry a `before` or `after` anchor (an existing entry) for positional insertion; otherwise items are appended. A url rule may carry `\"i18n\": true` to route its pattern through `i18n_patterns()` (so the CMS catch-all keeps its language prefix) when the project's urls.py already uses i18n_patterns; otherwise the pattern is added to the plain urlpatterns list. The `warnings` list holds `{message, when}` entries; each message whose condition matches is printed to the screen (for example, should djangocms-stories be discontinued, add {\"message\": \"The --stories option no longer has any effect: djangocms-stories has been discontinued.\", \"when\": {\"flag\": \"stories\"}}).",
+    "options": {
+        "mode": {
+            "type": "choice",
+            "default": "traditional",
+            "choices": ["traditional", "headless", "hybrid"],
+            "label": "CMS mode",
+            "help": "Selects the CMS mode: traditional, headless or hybrid (default: traditional)."
+        },
+        "versioning": {
+            "type": "boolean",
+            "default": true,
+            "label": "Enable content versioning",
+            "help": "Adds content versioning (djangocms-versioning) to the project (default: on)."
+        },
+        "moderation": {
+            "type": "boolean",
+            "default": false,
+            "label": "Enable content moderation",
+            "requires": {"versioning": true},
+            "help": "Adds content moderation (djangocms-moderation) to the project (default: off)."
+        },
+        "alias": {
+            "type": "boolean",
+            "default": true,
+            "label": "Add reusable aliases",
+            "help": "Adds reusable aliases (djangocms-alias) to the project (default: on)."
+        },
+        "stories": {
+            "type": "boolean",
+            "default": false,
+            "label": "Add the stories component library",
+            "help": "Adds the stories component library (djangocms-stories) to the project (default: off)."
+        },
+        "history": {
+            "type": "boolean",
+            "default": false,
+            "label": "Add undo/redo history",
+            "help": "Adds djangocms-history to the project (default: off)."
+        }
+    },
     "installed_apps": [
         {"items": ["djangocms_simple_admin_style"], "before": "django.contrib.admin"},
         {
@@ -35,6 +75,7 @@
         {"items": ["djangocms_moderation"], "when": {"flag": "moderation"}},
         {"items": ["djangocms_alias"], "when": {"flag": "alias"}},
         {"items": ["djangocms_stories", "taggit"], "when": {"flag": "stories"}},
+        {"items": ["djangocms_history"], "when": {"flag": "history"}},
         {"items": ["rest_framework", "djangocms_rest"], "when": {"mode": ["headless", "hybrid"]}}
     ],
     "middleware": [
@@ -74,6 +115,7 @@
     ],
     "packages": {
         "filer": "django-filer",
+        "djangocms_history": "djangocms-history>=3",
         "rest_framework": "djangorestframework",
         "taggit": "django-taggit"
     },

--- a/cms/management/commands/startcmsproject.py
+++ b/cms/management/commands/startcmsproject.py
@@ -46,20 +46,14 @@ class ShellMixin:  # pragma: no cover
 class PromptMixin:  # pragma: no cover
     """Interactive prompting for the project name and the project options."""
 
-    # Effective defaults for the project options. The arguments themselves
-    # default to ``None`` so that ``--interactive`` can tell apart an option
-    # that was given on the command line from one that needs to be asked for.
-    OPTION_DEFAULTS = {
-        "mode": "traditional",
-        "versioning": True,
-        "moderation": False,
-        "alias": True,
-        "stories": False,
-    }
-
     def ask(self, label, default=None):
         suffix = f" [{default}]" if default not in (None, "") else ""
-        return input(f"{label}{suffix}: ").strip() or default
+        try:
+            return input(f"{label}{suffix}: ").strip() or default
+        except EOFError as exc:
+            raise CommandError(
+                "Input is not available. Provide a project name, or use --noinput to disable prompts."
+            ) from exc
 
     def ask_choice(self, label, choices, default):
         while True:
@@ -85,24 +79,19 @@ class PromptMixin:  # pragma: no cover
                 name = self.ask("Project name")
                 if not name:
                     self.stderr.write(self.style.ERROR("A project name is required."))
-        if options.get("mode") is None:
-            options["mode"] = self.ask_choice(
-                "CMS mode", ("traditional", "headless", "hybrid"), self.OPTION_DEFAULTS["mode"]
-            )
-        if options.get("versioning") is None:
-            options["versioning"] = self.ask_bool("Enable content versioning", self.OPTION_DEFAULTS["versioning"])
-        if options.get("moderation") is None:
-            # Moderation builds on top of versioning, so only offer it when
-            # versioning is enabled; otherwise it stays off.
-            options["moderation"] = (
-                self.ask_bool("Enable content moderation", self.OPTION_DEFAULTS["moderation"])
-                if options["versioning"]
-                else False
-            )
-        if options.get("alias") is None:
-            options["alias"] = self.ask_bool("Add reusable aliases", self.OPTION_DEFAULTS["alias"])
-        if options.get("stories") is None:
-            options["stories"] = self.ask_bool("Add the stories component library", self.OPTION_DEFAULTS["stories"])
+        for option_name, definition in self.get_template_options().items():
+            if options.get(option_name) is not None:
+                continue
+            if not self._requirements_met(definition.get("requires"), options):
+                options[option_name] = False if definition["type"] == "boolean" else definition["default"]
+                continue
+            label = definition.get("label", option_name.replace("_", " ").title())
+            if definition["type"] == "choice":
+                options[option_name] = self.ask_choice(label, tuple(definition["choices"]), definition["default"])
+            elif definition["type"] == "boolean":
+                options[option_name] = self.ask_bool(label, definition["default"])
+            else:
+                raise CommandError(f"Unsupported option type for --{option_name}: {definition['type']}")
         return name
 
 
@@ -497,8 +486,10 @@ class ExistingProjectMixin:
     # bundled next to this command serving as the offline fallback.
     INSTALL_RULES_FILENAME = "djangocms_install_rules.json"
 
-    # Package names may only contain letters, digits, underscores and minus signs.
-    SAFE_PACKAGE_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+    # Package specs are intentionally narrow: a package name plus an optional
+    # lower-bound version pin from trusted install rules.
+    SAFE_PACKAGE_RE = re.compile(r"^[A-Za-z0-9_-]+(>=[0-9][A-Za-z0-9_.-]*)?$")
+    BUNDLED_RULES_OPTION = "--use-bundled-install-rules"
 
     def get_install_rules_url(self):
         return (
@@ -646,20 +637,133 @@ class ExistingProjectMixin:
 
     def load_install_rules(self):
         """Fetch the install rules from GitHub, falling back to the bundled file."""
-        url = self.get_install_rules_url()
-        try:
-            with urllib.request.urlopen(url, timeout=15) as response:  # noqa: S310 (https URL)
-                rules = json.loads(response.read().decode("utf-8"))
-        except (urllib.error.URLError, OSError, ValueError) as exc:
-            self.stderr.write(
-                self.style.WARNING(f"Could not fetch installation rules from {url} ({exc}); using bundled defaults.")
-            )
-            bundled = os.path.join(os.path.dirname(__file__), self.INSTALL_RULES_FILENAME)
-            rules = json.loads(self._read(bundled))
+        cached = getattr(self, "_install_rules", None)
+        if cached is not None:
+            return cached
+        if getattr(self, "_use_bundled_install_rules", False):
+            rules = self.load_bundled_install_rules()
+        else:
+            url = self.get_install_rules_url()
+            try:
+                with urllib.request.urlopen(url, timeout=15) as response:  # noqa: S310 (https URL)
+                    rules = json.loads(response.read().decode("utf-8"))
+            except (urllib.error.URLError, OSError, ValueError) as exc:
+                self.stderr.write(
+                    self.style.WARNING(
+                        f"Could not fetch installation rules from {url} ({exc}); using bundled defaults."
+                    )
+                )
+                rules = self.load_bundled_install_rules()
         if not isinstance(rules, dict):
             raise CommandError("Invalid installation rules: expected a JSON object.")
         # Metadata keys such as "$schema" or "comment" carry no rules.
-        return {key: value for key, value in rules.items() if not key.startswith("$")}
+        rules = {key: value for key, value in rules.items() if not key.startswith("$")}
+        if "options" not in rules:
+            bundled_rules = {
+                key: value for key, value in self.load_bundled_install_rules().items() if not key.startswith("$")
+            }
+            rules["options"] = bundled_rules["options"]
+        self._validate_install_rules(rules)
+        self._install_rules = rules
+        return rules
+
+    def load_bundled_install_rules(self):
+        """Read the bundled install rules without fetching from cms-template."""
+        bundled = os.path.join(os.path.dirname(__file__), self.INSTALL_RULES_FILENAME)
+        return json.loads(self._read(bundled))
+
+    def get_template_options(self):
+        """Return the template-owned command options from the install rules."""
+        return self.load_install_rules()["options"]
+
+    def get_template_option_defaults(self):
+        """Effective defaults for template-owned options."""
+        return {name: definition["default"] for name, definition in self.get_template_options().items()}
+
+    def apply_template_option_defaults(self, options):
+        """Fill unset template-owned options from the JSON metadata."""
+        for key, value in self.get_template_option_defaults().items():
+            if options.get(key) is None:
+                options[key] = value
+
+    def validate_template_option_requirements(self, options):
+        """Validate simple option dependencies from the JSON metadata."""
+        for option_name, definition in self.get_template_options().items():
+            required = definition.get("requires")
+            if options.get(option_name) and not self._requirements_met(required, options):
+                requirements = ", ".join(name if value is True else f"{name}={value}" for name, value in required.items())
+                raise CommandError(f"--{option_name} requires {requirements}.")
+
+    @classmethod
+    def _validate_install_rules(cls, rules):
+        """Validate the parts of the install rules that the command executes."""
+        options = rules.get("options")
+        if not isinstance(options, dict) or not options:
+            raise CommandError("Invalid installation rules: expected a non-empty 'options' object.")
+        for option_name, definition in options.items():
+            if not re.match(r"^[A-Za-z][A-Za-z0-9_]*$", option_name):
+                raise CommandError(f"Invalid installation rules: invalid option name '{option_name}'.")
+            if not isinstance(definition, dict):
+                raise CommandError(f"Invalid installation rules: option '{option_name}' must be an object.")
+            option_type = definition.get("type")
+            if option_type not in ("boolean", "choice"):
+                raise CommandError(
+                    f"Invalid installation rules: option '{option_name}' has unsupported type '{option_type}'."
+                )
+            if "default" not in definition:
+                raise CommandError(f"Invalid installation rules: option '{option_name}' needs a default.")
+            if option_type == "boolean" and not isinstance(definition["default"], bool):
+                raise CommandError(f"Invalid installation rules: option '{option_name}' default must be boolean.")
+            if option_type == "choice":
+                choices = definition.get("choices")
+                if not isinstance(choices, list) or not choices:
+                    raise CommandError(f"Invalid installation rules: option '{option_name}' needs choices.")
+                if definition["default"] not in choices:
+                    raise CommandError(
+                        f"Invalid installation rules: option '{option_name}' default must be one of its choices."
+                    )
+            requires = definition.get("requires", {})
+            if not isinstance(requires, dict):
+                raise CommandError(f"Invalid installation rules: option '{option_name}' requires must be an object.")
+            for required_name in requires:
+                if required_name not in options:
+                    raise CommandError(
+                        f"Invalid installation rules: option '{option_name}' requires unknown option "
+                        f"'{required_name}'."
+                    )
+
+        declared_options = set(options)
+        for when in cls._iter_when_conditions(rules):
+            flag = when.get("flag")
+            if flag and flag not in declared_options:
+                raise CommandError(f"Invalid installation rules: unknown option flag '{flag}'.")
+            modes = when.get("mode")
+            if modes is not None:
+                mode_definition = options.get("mode")
+                if not mode_definition or mode_definition["type"] != "choice":
+                    raise CommandError("Invalid installation rules: 'mode' conditions require a choice option.")
+                unknown_modes = set(modes) - set(mode_definition["choices"])
+                if unknown_modes:
+                    raise CommandError(
+                        "Invalid installation rules: unknown mode value(s) " + ", ".join(sorted(unknown_modes))
+                    )
+
+    @classmethod
+    def _iter_when_conditions(cls, rules):
+        for section in ("installed_apps", "middleware", "context_processors", "settings", "urls", "warnings"):
+            for rule in rules.get(section, []):
+                when = rule.get("when") if isinstance(rule, dict) else None
+                if when:
+                    yield when
+        template_dir = rules.get("template_dir")
+        if isinstance(template_dir, dict) and template_dir.get("when"):
+            yield template_dir["when"]
+
+    @staticmethod
+    def _requirements_met(requirements, options):
+        if not requirements:
+            return True
+        return all(options.get(name) == value for name, value in requirements.items())
 
     @staticmethod
     def _rule_applies(when, options):
@@ -957,6 +1061,7 @@ class Command(PromptMixin, NewProjectMixin, ExistingProjectMixin, SourceEditorMi
 
     def add_arguments(self, parser):  # pragma: no cover -- argparse wiring; tests call handle() directly
         super().add_arguments(parser)
+        self._use_bundled_install_rules = self.BUNDLED_RULES_OPTION in sys.argv
         # Make the project name optional so it can be asked for in interactive
         # mode; a missing name is reported by handle() otherwise.
         for action in parser._actions:
@@ -994,35 +1099,25 @@ class Command(PromptMixin, NewProjectMixin, ExistingProjectMixin, SourceEditorMi
             help="Specifies the email for the superuser to be created (only when creating a new project).",
         )
         parser.add_argument(
-            "--stories",
-            action=argparse.BooleanOptionalAction,
-            default=None,
-            help="Adds the stories component library (djangocms-stories) to the project (default: off)",
+            self.BUNDLED_RULES_OPTION,
+            action="store_true",
+            dest="use_bundled_install_rules",
+            default=False,
+            help=(
+                "Use the install rules bundled with this django CMS package instead of fetching "
+                "them from cms-template."
+            ),
         )
-        parser.add_argument(
-            "--mode",
-            choices=("traditional", "headless", "hybrid"),
-            default=None,
-            help="Selects the CMS mode: traditional, headless or hybrid (default: traditional).",
-        )
-        parser.add_argument(
-            "--versioning",
-            action=argparse.BooleanOptionalAction,
-            default=None,
-            help="Adds content versioning (djangocms-versioning) to the project (default: on).",
-        )
-        parser.add_argument(
-            "--moderation",
-            action=argparse.BooleanOptionalAction,
-            default=None,
-            help="Adds content moderation (djangocms-moderation) to the project (default: off).",
-        )
-        parser.add_argument(
-            "--alias",
-            action=argparse.BooleanOptionalAction,
-            default=None,
-            help="Adds reusable aliases (djangocms-alias) to the project (default: on).",
-        )
+        for option_name, definition in self.get_template_options().items():
+            argument = "--" + option_name.replace("_", "-")
+            kwargs = {"default": None, "dest": option_name, "help": definition.get("help", argparse.SUPPRESS)}
+            if definition["type"] == "boolean":
+                kwargs["action"] = argparse.BooleanOptionalAction
+            elif definition["type"] == "choice":
+                kwargs["choices"] = tuple(definition["choices"])
+            else:
+                raise CommandError(f"Unsupported option type for {argument}: {definition['type']}")
+            parser.add_argument(argument, **kwargs)
         parser.add_argument(
             "--dry-run",
             action="store_true",
@@ -1038,6 +1133,12 @@ class Command(PromptMixin, NewProjectMixin, ExistingProjectMixin, SourceEditorMi
         # Capture target and name for postprocessing
         name = options.pop("name", None)
         directory = options.pop("directory", None)
+        use_bundled_install_rules = options.pop("use_bundled_install_rules", False)
+        if use_bundled_install_rules and not getattr(self, "_use_bundled_install_rules", False):
+            self._install_rules = None
+        self._use_bundled_install_rules = use_bundled_install_rules or getattr(
+            self, "_use_bundled_install_rules", False
+        )
 
         # Interactively ask for the project name and any option not provided.
         # Prompting is enabled explicitly via --interactive, or implicitly when
@@ -1046,18 +1147,14 @@ class Command(PromptMixin, NewProjectMixin, ExistingProjectMixin, SourceEditorMi
         if prompt:
             name = self.prompt_for_options(name, options)
 
-        # Fill in the effective defaults for any option not given (and not
-        # asked for interactively).
-        for key, value in self.OPTION_DEFAULTS.items():
-            if options.get(key) is None:
-                options[key] = value
+        # Fill in the effective defaults for any template-owned option not given
+        # (and not asked for interactively).
+        self.apply_template_option_defaults(options)
 
         if not name:
             raise CommandError(self.missing_args_message)
 
-        # Content moderation builds on top of content versioning.
-        if options["moderation"] and not options["versioning"]:
-            raise CommandError("--moderation requires versioning; remove --no-versioning or drop --moderation.")
+        self.validate_template_option_requirements(options)
 
         # A project name of "." means: add django CMS to the existing project in
         # the current directory instead of cloning the project template.

--- a/cms/tests/test_startcmsproject.py
+++ b/cms/tests/test_startcmsproject.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 import tempfile
 import urllib.error
 from io import StringIO
@@ -128,6 +129,7 @@ DEFAULT_OPTIONS = {
     "moderation": False,
     "alias": True,
     "stories": False,
+    "history": False,
 }
 
 
@@ -164,6 +166,26 @@ class LoadInstallRulesTests(SimpleTestCase):
         self.assertIn("installed_apps", rules)
         self.assertIn("using bundled defaults", command.stderr.getvalue())
 
+    def test_can_force_bundled_rules(self):
+        command = make_command()
+        command._use_bundled_install_rules = True
+        with mock.patch("urllib.request.urlopen") as urlopen:
+            rules = command.load_install_rules()
+        self.assertIn("installed_apps", rules)
+        urlopen.assert_not_called()
+
+    def test_fetched_rules_without_options_use_bundled_options(self):
+        rules = bundled_rules()
+        rules.pop("options")
+        rules["installed_apps"] = [{"items": ["remote_app"]}]
+        response = mock.MagicMock()
+        response.__enter__.return_value.read.return_value = json.dumps(rules).encode()
+        command = make_command()
+        with mock.patch("urllib.request.urlopen", return_value=response):
+            loaded = command.load_install_rules()
+        self.assertIn("options", loaded)
+        self.assertEqual(loaded["installed_apps"], [{"items": ["remote_app"]}])
+
     def test_non_object_rules_raise(self):
         response = mock.MagicMock()
         response.__enter__.return_value.read.return_value = b'["not", "a", "dict"]'
@@ -171,6 +193,38 @@ class LoadInstallRulesTests(SimpleTestCase):
         with mock.patch("urllib.request.urlopen", return_value=response):
             with self.assertRaises(CommandError):
                 command.load_install_rules()
+
+    def test_unknown_option_flag_raises(self):
+        rules = bundled_rules(installed_apps=[{"items": ["cms"], "when": {"flag": "unknown"}}])
+        response = mock.MagicMock()
+        response.__enter__.return_value.read.return_value = json.dumps(rules).encode()
+        command = make_command()
+        with mock.patch("urllib.request.urlopen", return_value=response):
+            with self.assertRaises(CommandError) as raised:
+                command.load_install_rules()
+        self.assertIn("unknown option flag", str(raised.exception))
+
+
+class ParserOptionTests(SimpleTestCase):
+    def test_template_options_are_added_from_rules(self):
+        command = make_command()
+        command.load_install_rules = mock.Mock(return_value=bundled_rules())
+        parser = command.create_parser("djangocms", "")
+        parsed = parser.parse_args(["mysite", "--mode", "headless", "--no-versioning", "--stories", "--history"])
+        self.assertEqual(parsed.mode, "headless")
+        self.assertFalse(parsed.versioning)
+        self.assertTrue(parsed.stories)
+        self.assertTrue(parsed.history)
+
+    def test_use_bundled_rules_option_skips_fetch_while_building_parser(self):
+        command = make_command()
+        with mock.patch.object(sys, "argv", ["djangocms", "--use-bundled-install-rules"]), mock.patch(
+            "urllib.request.urlopen"
+        ) as urlopen:
+            parser = command.create_parser("djangocms", "")
+        parsed = parser.parse_args(["mysite", "--use-bundled-install-rules"])
+        self.assertTrue(parsed.use_bundled_install_rules)
+        urlopen.assert_not_called()
 
 
 class EditingHelperTests(SimpleTestCase):
@@ -285,13 +339,25 @@ class PackageDerivationTests(SimpleTestCase):
             "djangocms_frontend.contrib.image",
             "rest_framework",
             "djangocms_rest",
+            "djangocms_history",
         ]
-        packages_map = {"filer": "django-filer", "rest_framework": "djangorestframework"}
+        packages_map = {
+            "filer": "django-filer",
+            "djangocms_history": "djangocms-history>=3",
+            "rest_framework": "djangorestframework",
+        }
         command._finish_existing_project(apps, packages_map, {"interactive": False})
         packages = command.install_packages.call_args.args[0]
         self.assertEqual(
             packages,
-            ["django-cms", "django-filer", "djangocms-frontend", "djangorestframework", "djangocms-rest"],
+            [
+                "django-cms",
+                "django-filer",
+                "djangocms-frontend",
+                "djangorestframework",
+                "djangocms-rest",
+                "djangocms-history>=3",
+            ],
         )
 
     def test_install_packages_rejects_unexpected_characters(self):
@@ -299,6 +365,13 @@ class PackageDerivationTests(SimpleTestCase):
         for bad in ["django-cms; rm -rf /", "pkg==1.0", "foo bar", "evil$(whoami)", "a/b"]:
             with self.assertRaises(CommandError):
                 command.install_packages([bad])
+
+    def test_install_packages_accepts_lower_bound_specs(self):
+        command = make_command()
+        with mock.patch.object(command, "running_in_venv", return_value=True), mock.patch("subprocess.run") as run:
+            run.return_value.returncode = 0
+            command.install_packages(["djangocms-history>=3"])
+        run.assert_called_once()
 
     def test_install_packages_refuses_outside_venv(self):
         # Outside a virtual environment (and without the opt-out env var) the
@@ -384,6 +457,7 @@ class AddToExistingProjectTests(SimpleTestCase):
             self.assertIn(app, settings_text)
         self.assertNotIn("djangocms_moderation", settings_text)
         self.assertNotIn("djangocms_stories", settings_text)
+        self.assertNotIn("djangocms_history", settings_text)
         self.assertNotIn("djangocms_rest", settings_text)
 
         # Positional inserts
@@ -410,6 +484,17 @@ class AddToExistingProjectTests(SimpleTestCase):
         # The dotted frontend apps must reach the package resolution step.
         apps = command._finish_existing_project.call_args.args[0]
         self.assertIn("djangocms_frontend.contrib.grid", apps)
+
+    def test_history_option(self):
+        command = self.run_command(history=True)
+
+        settings_text = self._read("mysite/settings.py")
+        self.assertIn('"djangocms_history",', settings_text)
+
+        apps = command._finish_existing_project.call_args.args[0]
+        packages_map = command._finish_existing_project.call_args.args[1]
+        self.assertIn("djangocms_history", apps)
+        self.assertEqual(packages_map["djangocms_history"], "djangocms-history>=3")
 
     def test_headless_mode(self):
         self.run_command(mode="headless")
@@ -591,6 +676,7 @@ class AddToExistingProjectTests(SimpleTestCase):
 class HandleValidationTests(SimpleTestCase):
     def test_moderation_requires_versioning(self):
         command = make_command()
+        command.load_install_rules = mock.Mock(return_value=bundled_rules())
         options = {
             "name": "mysite",
             "directory": None,
@@ -609,6 +695,7 @@ class HandleValidationTests(SimpleTestCase):
 
     def test_dry_run_rejected_for_new_project(self):
         command = make_command()
+        command.load_install_rules = mock.Mock(return_value=bundled_rules())
         options = {
             "name": "mysite",
             "directory": None,
@@ -628,6 +715,7 @@ class HandleValidationTests(SimpleTestCase):
 
     def test_missing_name_with_noinput(self):
         command = make_command()
+        command.load_install_rules = mock.Mock(return_value=bundled_rules())
         options = {
             "name": None,
             "directory": None,
@@ -643,3 +731,23 @@ class HandleValidationTests(SimpleTestCase):
         with self.assertRaises(CommandError) as raised:
             command.handle(**options)
         self.assertEqual(str(raised.exception), Command.missing_args_message)
+
+    def test_missing_name_without_input_fails_cleanly(self):
+        command = make_command()
+        command.load_install_rules = mock.Mock(return_value=bundled_rules())
+        options = {
+            "name": None,
+            "directory": None,
+            "interactive": True,
+            "prompt": False,
+            "template": None,
+            "mode": None,
+            "versioning": None,
+            "moderation": None,
+            "alias": None,
+            "stories": None,
+            "history": None,
+        }
+        with mock.patch("builtins.input", side_effect=EOFError), self.assertRaises(CommandError) as raised:
+            command.handle(**options)
+        self.assertIn("Input is not available", str(raised.exception))

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -64,10 +64,15 @@ It accepts the following options:
 * ``--stories`` / ``--no-stories``: add the stories component library
   (`djangocms-stories <https://github.com/django-cms/djangocms-stories>`_) to
   the project. Off by default.
+* ``--history`` / ``--no-history``: add content history
+  (``djangocms-history>=3``) to the project. Off by default.
+* ``--use-bundled-install-rules``: use the installation rules JSON bundled
+  with the installed django CMS package instead of fetching it from the
+  matching ``cms-template`` branch. Guarantees reproducibility.
 
 Example::
 
-    djangocms my_project --mode headless --no-versioning --stories
+    djangocms my_project --mode headless --no-versioning --stories --history
 
 To be guided through the available options interactively, run the command
 without a project name (or pass ``--interactive``)::
@@ -134,8 +139,9 @@ bundled with django CMS is used as an offline fallback.
 
 .. note::
 
-    The ``--stories``, ``--mode``, ``--versioning``, ``--moderation`` and
-    ``--alias`` options are evaluated by the project template. They require
+    The ``--stories``, ``--history``, ``--mode``, ``--versioning``,
+    ``--moderation`` and ``--alias`` options are evaluated by the project
+    template. They require
     version 5.1 or later of the `cms-template
     <https://github.com/django-cms/cms-template>`_ to support them.
 


### PR DESCRIPTION
## Summary by Sourcery

Drive the djangocms project creation command’s feature flags and options from validated JSON install rules, while adding support for a history option and safer, more flexible installation behavior.

New Features:
- Load template-owned command options and their defaults from JSON install rules instead of hardcoding them in the command.
- Expose template-defined options as CLI flags dynamically, including a new history option that installs and enables djangocms-history.
- Add a --use-bundled-install-rules flag to force using the bundled install rules without fetching from cms-template.

Enhancements:
- Validate and cache JSON install rules, including option schemas, dependencies, and conditional sections, and fall back to bundled options when remote rules omit them.
- Relax package validation to allow trusted lower-bound version pins while still rejecting unsafe specs.
- Improve interactive prompting to fail cleanly with a clear error when stdin is unavailable.

Documentation:
- Update CLI reference documentation to describe the JSON-driven options and new install-rules-related flags.

Tests:
- Extend tests to cover bundled-rule forcing, option schema validation and dependency checking, dynamic CLI option wiring, acceptance of lower-bound package specs, the new history option behavior, and graceful handling of missing stdin during prompting.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.