### PR TITLE
fix: Avoid save_model errors for list_editable admin forms

### DIFF
--- a/cms/admin/utils.py
+++ b/cms/admin/utils.py
@@ -723,6 +723,9 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
     def save_model(self, request: HttpRequest, obj: models.Model, form: forms.Form, change: bool) -> None:
         """Save/create both grouper and content object"""
         super().save_model(request, obj or form.instance, form, change)
+        if not hasattr(form, "_content_fields"):
+            # list_editable fields
+            return
         content_dict = {
             field: form.cleaned_data[CONTENT_PREFIX + field]
             for field in form._content_fields


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent errors in admin save_model when forms do not define _content_fields, such as list_editable configurations.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* fixes #8669 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Prevent save_model from raising errors when admin forms lack _content_fields, such as in list_editable setups.