### PR TITLE
feat: Add list_editable support to GrouperAdmin

### DIFF
--- a/cms/admin/utils.py
+++ b/cms/admin/utils.py
@@ -1,6 +1,7 @@
 import re
 import typing
 from copy import copy
+from functools import partial
 from urllib.parse import parse_qsl
 
 from django import forms
@@ -10,17 +11,18 @@ from django.contrib.admin.utils import label_for_field
 from django.contrib.admin.views.main import ChangeList
 from django.contrib.auth import get_permission_codename
 from django.contrib.sites.models import Site
+from django.core import checks
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db import models
 from django.db.models import DateField, OuterRef, Subquery, functions
 from django.db.models.functions import Cast
-from django.forms import modelform_factory
+from django.forms import modelform_factory, modelformset_factory
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import render_to_string
 from django.urls import NoReverseMatch, path
 from django.utils.decorators import method_decorator
-from django.utils.html import format_html_join
+from django.utils.html import format_html, format_html_join
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 from django.utils.translation import get_language, gettext_lazy as _
@@ -179,6 +181,35 @@ class GrouperChangeListBase(ChangeList):
 
 
 class GrouperModelAdminChecks(ModelAdminChecks):
+    def _check_list_editable_item(self, obj, field_name, label):
+        """Check content model fields against the content model."""
+        if field_name.startswith(CONTENT_PREFIX) and obj.content_model:
+            content_field_name = field_name[len(CONTENT_PREFIX) :]
+            if content_field_name == obj.grouper_field_name or content_field_name in obj.extra_grouping_fields:
+                return [
+                    checks.Error(
+                        f"The value of '{label}' refers to '{field_name}', which cannot be edited "
+                        "from the changelist.",
+                        obj=obj.__class__,
+                        id="admin.E125",
+                    )
+                ]
+            content_obj = copy(obj)
+            content_obj.model = obj.content_model
+            content_obj.list_display = tuple(
+                item[len(CONTENT_PREFIX) :] if isinstance(item, str) and item.startswith(CONTENT_PREFIX) else item
+                for item in obj.list_display
+            )
+            if obj.list_display_links:
+                content_obj.list_display_links = tuple(
+                    item[len(CONTENT_PREFIX) :]
+                    if isinstance(item, str) and item.startswith(CONTENT_PREFIX)
+                    else item
+                    for item in obj.list_display_links
+                )
+            return super()._check_list_editable_item(content_obj, content_field_name, label)
+        return super()._check_list_editable_item(obj, field_name, label)
+
     def _check_prepopulated_fields_value_item(self, obj, field_name, label):
         """For `prepopulated_fields` equal to {"slug": ("content__title",)},
         `field_name` is "content__title"."""
@@ -674,6 +705,50 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
                     )
         return form_class
 
+    def get_changelist_form(self, request: HttpRequest, **kwargs) -> type:
+        """Return a grouper form capable of editing grouper and content fields."""
+        self.get_grouping_from_request(request)
+        content_id_field = forms.ModelChoiceField(
+            queryset=self.content_model.admin_manager.all(),
+            required=False,
+            widget=forms.HiddenInput(),
+        )
+        editable_content_fields = {
+            field for field in self.list_editable if field.startswith(CONTENT_PREFIX)
+        }
+        form_attributes = {
+            "_admin": self,
+            "_request": request,
+            "_content_object_id": content_id_field,
+        }
+        form_attributes.update(
+            {
+                CONTENT_PREFIX + field: None
+                for field in self.form._content_fields
+                if CONTENT_PREFIX + field not in editable_content_fields
+            }
+        )
+        form_class = type(self.form)(
+            self.form.__name__,
+            (self.form,),
+            form_attributes,
+        )
+        return super().get_changelist_form(request, form=form_class, **kwargs)
+
+    def get_changelist_formset(self, request: HttpRequest, **kwargs) -> type:
+        """Include the hidden content identity in the changelist formset."""
+        defaults = {
+            "formfield_callback": partial(self.formfield_for_dbfield, request=request),
+            **kwargs,
+        }
+        return modelformset_factory(
+            self.model,
+            self.get_changelist_form(request),
+            extra=0,
+            fields=(*self.list_editable, "_content_object_id"),
+            **defaults,
+        )
+
     # Admin list actions defined below:
     # * View button that takes the user to the preview endpoint of the content model
     # * Settings button that lets the user change the grouper AND the content model
@@ -846,13 +921,18 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
     def save_model(self, request: HttpRequest, obj: models.Model, form: forms.Form, change: bool) -> None:
         """Save/create both grouper and content object"""
         super().save_model(request, obj or form.instance, form, change)
+        if not hasattr(form, "_content_fields"):
+            return
         content_dict = {
             field: form.cleaned_data[CONTENT_PREFIX + field]
             for field in form._content_fields
             if CONTENT_PREFIX + field in form.cleaned_data
         }
+        if not content_dict:
+            return
         if form._content_instance is None or form._content_instance.pk is None:
             content_dict[self.grouper_field_name] = form.instance
+            content_dict.update(self.current_content_filters)
             if hasattr(form._content_model.objects, "with_user"):
                 # Create new using with_user syntax if available ...
                 form._content_model.objects.with_user(request.user).create(**content_dict)
@@ -912,6 +992,39 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
         return search_result_from_content, False
 
 
+class _ContentIdentityWidget(forms.Widget):
+    """Render a content field together with its changelist content identity."""
+
+    def __init__(self, widget, content_field_name):
+        super().__init__(attrs=widget.attrs)
+        self.widget = widget
+        self.content_field_name = content_field_name
+        self.content_object_id = None
+
+    @property
+    def media(self):
+        return self.widget.media
+
+    def id_for_label(self, id_):
+        return self.widget.id_for_label(id_)
+
+    def value_from_datadict(self, data, files, name):
+        return self.widget.value_from_datadict(data, files, name)
+
+    def value_omitted_from_data(self, data, files, name):
+        return self.widget.value_omitted_from_data(data, files, name)
+
+    def render(self, name, value, attrs=None, renderer=None):
+        field = self.widget.render(name, value, attrs=attrs, renderer=renderer)
+        prefix = name[: -len(self.content_field_name)]
+        identity = forms.HiddenInput().render(
+            f"{prefix}_content_object_id",
+            self.content_object_id,
+            renderer=renderer,
+        )
+        return format_html("{}{}", field, identity)
+
+
 class _GrouperAdminFormMixin:
     _content_fields: list = []
 
@@ -935,6 +1048,8 @@ class _GrouperAdminFormMixin:
                     },
                     **kwargs.get("initial", {}),
                 }
+                if "_content_object_id" in self.base_fields:
+                    kwargs["initial"]["_content_object_id"] = self._content_instance
         else:
             self._content_instance = None
 
@@ -947,10 +1062,21 @@ class _GrouperAdminFormMixin:
         # The actual init
         super().__init__(*args, **kwargs)
 
+        editable_content_fields = [
+            field for field in self.fields if field.startswith(CONTENT_PREFIX)
+        ]
+        if "_content_object_id" in self.fields and editable_content_fields:
+            field_name = editable_content_fields[0]
+            widget = _ContentIdentityWidget(self.fields[field_name].widget, field_name)
+            widget.content_object_id = self._content_instance.pk if self._content_instance else None
+            self.fields[field_name].widget = widget
+
         # Hide grouper foreign key
-        self.fields[CONTENT_PREFIX + self._admin.grouper_field_name].widget = forms.HiddenInput()
-        # Will be set on admin model save
-        self.fields[CONTENT_PREFIX + self._admin.grouper_field_name].required = False
+        grouper_field_name = CONTENT_PREFIX + self._admin.grouper_field_name
+        if grouper_field_name in self.fields:
+            self.fields[grouper_field_name].widget = forms.HiddenInput()
+            # Will be set on admin model save
+            self.fields[grouper_field_name].required = False
         self.update_labels(self._content_fields)
 
     def update_labels(self, fields: list[str]) -> None:
@@ -982,7 +1108,23 @@ class _GrouperAdminFormMixin:
                 params=dict(value=self.cleaned_data.get("language", _("<unspecified>"))),
                 code="invalid-language",
             )
-        return super().clean()
+        cleaned_data = super().clean()
+        if "_content_object_id" in cleaned_data:
+            content_obj = cleaned_data["_content_object_id"]
+            if content_obj is not None:
+                grouper_id = getattr(content_obj, f"{self._admin.grouper_field_name}_id")
+                grouping_matches = all(
+                    getattr(content_obj, field) == value
+                    for field, value in self._admin.current_content_filters.items()
+                )
+                if grouper_id != self.instance.pk or not grouping_matches:
+                    raise ValidationError(_("The selected content does not match this object and grouping."))
+                self._content_instance = content_obj
+            if any(field.startswith(CONTENT_PREFIX) for field in self.changed_data) and not self._admin.can_change_content(
+                self._request, content_obj
+            ):
+                raise ValidationError(_("You do not have permission to change this content."))
+        return cleaned_data
 
 
 class GrouperAdminFormMixin:

--- a/cms/tests/test_grouper_admin.py
+++ b/cms/tests/test_grouper_admin.py
@@ -153,6 +153,121 @@ class ChangeListActionsTestCase(SetupMixin, SimpleChangeListActionsTestCase):
 
 
 class GrouperModelAdminTestCase(SetupMixin, CMSTestCase):
+    def get_list_editable_post_data(self, response, **values):
+        formset = response.context["cl"].formset
+        data = {
+            "form-TOTAL_FORMS": formset.total_form_count(),
+            "form-INITIAL_FORMS": formset.initial_form_count(),
+            "form-MIN_NUM_FORMS": formset.min_num,
+            "form-MAX_NUM_FORMS": formset.max_num,
+            "_save": "Save",
+        }
+        for index, form in enumerate(formset.forms):
+            data[f"form-{index}-id"] = form.instance.pk
+            for field_name in self.admin.list_editable:
+                data[f"form-{index}-{field_name}"] = values.get(field_name, form[field_name].value())
+            data[f"form-{index}-_content_object_id"] = form["_content_object_id"].value() or ""
+        return data
+
+    def test_list_editable_saves_grouper_field(self):
+        with (
+            patch.object(self.admin, "list_display", ("category_name",)),
+            patch.object(self.admin, "list_display_links", None),
+            patch.object(self.admin, "list_editable", ("category_name",)),
+            self.login_user_context(self.admin_user),
+        ):
+            response = self.client.get(f"{self.changelist_url}?language=en")
+            data = self.get_list_editable_post_data(response, category_name="Changed grouper")
+            response = self.client.post(f"{self.changelist_url}?language=en", data)
+
+        self.assertEqual(response.status_code, 302)
+        self.grouper_instance.refresh_from_db()
+        self.assertEqual(self.grouper_instance.category_name, "Changed grouper")
+
+    def test_list_editable_saves_content_field_for_current_grouping(self):
+        english_content = self.createContentInstance("en")
+        german_content = self.createContentInstance("de")
+        with (
+            patch.object(self.admin, "list_display", ("category_name", "content__secret_greeting")),
+            patch.object(self.admin, "list_editable", ("content__secret_greeting",)),
+            self.login_user_context(self.admin_user),
+        ):
+            response = self.client.get(f"{self.changelist_url}?language=de")
+            self.assertContains(response, 'name="form-0-_content_object_id"')
+            data = self.get_list_editable_post_data(response, content__secret_greeting="Guten Tag")
+            response = self.client.post(f"{self.changelist_url}?language=de", data)
+
+        self.assertEqual(response.status_code, 302)
+        english_content.refresh_from_db()
+        german_content.refresh_from_db()
+        self.assertNotEqual(english_content.secret_greeting, "Guten Tag")
+        self.assertEqual(german_content.secret_greeting, "Guten Tag")
+
+    def test_list_editable_saves_grouper_and_content_fields(self):
+        content = self.createContentInstance("en")
+        with (
+            patch.object(self.admin, "list_display", ("category_name", "content__secret_greeting")),
+            patch.object(self.admin, "list_display_links", None),
+            patch.object(self.admin, "list_editable", ("category_name", "content__secret_greeting")),
+            self.login_user_context(self.admin_user),
+        ):
+            response = self.client.get(f"{self.changelist_url}?language=en")
+            data = self.get_list_editable_post_data(
+                response,
+                category_name="Changed grouper",
+                content__secret_greeting="Changed content",
+            )
+            response = self.client.post(f"{self.changelist_url}?language=en", data)
+
+        self.assertEqual(response.status_code, 302)
+        self.grouper_instance.refresh_from_db()
+        content.refresh_from_db()
+        self.assertEqual(self.grouper_instance.category_name, "Changed grouper")
+        self.assertEqual(content.secret_greeting, "Changed content")
+
+    def test_list_editable_creates_content_for_current_grouping(self):
+        with (
+            patch.object(self.admin, "list_display", ("category_name", "content__secret_greeting")),
+            patch.object(self.admin, "list_editable", ("content__secret_greeting",)),
+            self.login_user_context(self.admin_user),
+        ):
+            response = self.client.get(f"{self.changelist_url}?language=de")
+            data = self.get_list_editable_post_data(response, content__secret_greeting="Guten Tag")
+            response = self.client.post(f"{self.changelist_url}?language=de", data)
+
+        self.assertEqual(response.status_code, 302)
+        content = GrouperModelContent.objects.get(grouper_model=self.grouper_instance)
+        self.assertEqual(content.language, "de")
+        self.assertEqual(content.secret_greeting, "Guten Tag")
+
+    def test_list_editable_rejects_content_from_another_grouper(self):
+        self.createContentInstance("en")
+        other_grouper = GrouperModel.objects.create(category_name="Other")
+        other_content = GrouperModelContent.objects.create(
+            grouper_model=other_grouper,
+            language="en",
+            secret_greeting="Other greeting",
+        )
+        with (
+            patch.object(self.admin, "list_display", ("category_name", "content__secret_greeting")),
+            patch.object(self.admin, "list_editable", ("content__secret_greeting",)),
+            self.login_user_context(self.admin_user),
+        ):
+            response = self.client.get(f"{self.changelist_url}?language=en")
+            data = self.get_list_editable_post_data(response, content__secret_greeting="Tampered")
+            form_index = next(
+                index
+                for index, form in enumerate(response.context["cl"].formset.forms)
+                if form.instance.pk == self.grouper_instance.pk
+            )
+            data[f"form-{form_index}-_content_object_id"] = other_content.pk
+            response = self.client.post(f"{self.changelist_url}?language=en", data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "The selected content does not match this object and grouping.")
+        other_content.refresh_from_db()
+        self.assertEqual(other_content.secret_greeting, "Other greeting")
+
     def test_form_class_created(self):
         """The form class has automatically been enhanced with the GrouperAdminFormMixin for
         the appropriate content model (actually its parent class _GrouperAdminFormMixin)"""
@@ -162,6 +277,22 @@ class GrouperModelAdminTestCase(SetupMixin, CMSTestCase):
         # Assert
         self.assertTrue(issubclass(self.admin.form, _GrouperAdminFormMixin))
         self.assertEqual(self.admin.form._content_model, GrouperModelContent)
+
+    def test_content_field_is_valid_in_list_editable(self):
+        admin = copy.copy(self.admin)
+        admin.list_display = ("category_name", "content__secret_greeting")
+        admin.list_editable = ("content__secret_greeting",)
+
+        self.assertEqual(admin.check(), [])
+
+    def test_grouping_field_is_invalid_in_list_editable(self):
+        admin = copy.copy(self.admin)
+        admin.list_display = ("category_name", "content__language")
+        admin.list_editable = ("content__language",)
+
+        errors = admin.check()
+
+        self.assertIn("admin.E125", [error.id for error in errors])
 
     def test_form_class_content_fields(self):
         """The content fields appear in the admin form with a prefix"""


### PR DESCRIPTION
## Summary by Sourcery

Add list_editable support to GrouperAdmin changelists and ensure safe editing of related content objects.

New Features:
- Enable list_editable editing of grouper and content fields in GrouperAdmin changelists.
- Allow inline creation of new content objects for the current language/grouping from the changelist.

Bug Fixes:
- Prevent list_editable configuration from allowing editing of grouping or forbidden content fields in the changelist.
- Validate that selected content in list_editable rows belongs to the correct grouper and current grouping and enforce content change permissions.

Enhancements:
- Extend GrouperAdmin forms and widgets to carry hidden content identity through changelist edits so changes apply to the correct content instances.

Tests:
- Add comprehensive tests for list_editable behavior in GrouperAdmin, including saving grouper fields, saving content fields per language, simultaneous grouper/content edits, content creation, and validation errors for mismatched content.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8669
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.