### PR TITLE
fix: Placeholder operation signals lacked plugin ordering context

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,7 @@ Backward incompatible changes:
 
 Bug Fixes:
 ----------
+* Correct inaccurate and stale keyword arguments sent with placeholder operation signals (#8668) -- Fabian Braun
 * Enforce authorization when rendering frontend object structures (#8692) -- Fabian Braun
 * Harden page duplication, group permission handling, and URL validation (#8704) -- Fabian Braun
 * Prevent page titles from being inserted unescaped into rendering errors and prevent clipboard clearing through GET

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -443,12 +443,17 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
         plugin = getattr(plugin_instance, 'saved_object', None)
 
         if plugin_instance._operation_token:
+            tree_order = plugin.placeholder.get_plugin_tree_order(
+                plugin.language,
+                plugin.parent_id,
+            )
             self._send_post_placeholder_operation(
                 request,
                 operation=operations.ADD_PLUGIN,
                 token=plugin_instance._operation_token,
                 plugin=plugin,
                 placeholder=plugin.placeholder,
+                tree_order=tree_order,
             )
         return response
 
@@ -647,6 +652,10 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
 
         new_plugins = CMSPlugin.objects.filter(pk__in=new_plugin_ids)
         new_plugins = list(new_plugins)
+        target_tree_order = target_placeholder.get_plugin_tree_order(
+            language=target_language,
+            parent_id=None,
+        )
 
         self._send_post_placeholder_operation(
             request,
@@ -979,6 +988,8 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
     def _move_plugin(self, request, plugin, target_position, target_placeholder=None, target_parent=None):
         language = plugin.language
         source_placeholder = plugin.placeholder
+        source_language = plugin.language
+        source_parent_id = plugin.parent_id
 
         if not self.has_move_plugin_permission(request, plugin, source_placeholder):
             message = _("You have no permission to move this plugin")
@@ -1005,9 +1016,9 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
             request,
             operation=operations.MOVE_PLUGIN,
             plugin=plugin,
-            source_language=plugin.language,
+            source_language=source_language,
             source_placeholder=source_placeholder,
-            source_parent_id=plugin.parent_id,
+            source_parent_id=source_parent_id,
             target_language=language,
             target_placeholder=(target_placeholder or source_placeholder),
             target_parent_id=target_parent_id,
@@ -1031,9 +1042,9 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
             operation=operations.MOVE_PLUGIN,
             plugin=updated_plugin.get_bound_plugin(),
             token=action_token,
-            source_language=language,
+            source_language=source_language,
             source_placeholder=source_placeholder,
-            source_parent_id=updated_plugin.parent_id,
+            source_parent_id=source_parent_id,
             target_language=language,
             target_placeholder=(target_placeholder or source_placeholder),
             target_parent_id=target_parent_id,
@@ -1042,6 +1053,8 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
 
     def _cut_plugin(self, request, plugin, target_language, target_placeholder):
         source_placeholder = plugin.placeholder
+        source_language = plugin.language
+        source_parent_id = plugin.parent_id
 
         if not self.has_move_plugin_permission(request, plugin, source_placeholder):
             message = _("You have no permission to cut this plugin")
@@ -1051,16 +1064,21 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
             message = _("You have no permission to cut this plugin")
             raise PermissionDenied(message)
 
+        source_order = source_placeholder.get_plugin_tree_order(
+            source_language,
+            source_parent_id,
+        )
+
         action_token = self._send_pre_placeholder_operation(
             request,
             operation=operations.CUT_PLUGIN,
             plugin=plugin,
             clipboard=target_placeholder,
             clipboard_language=target_language,
-            source_language=plugin.language,
+            source_language=source_language,
             source_placeholder=source_placeholder,
-            source_parent_id=plugin.parent_id,
-            source_order=[],
+            source_parent_id=source_parent_id,
+            source_order=source_order,
         )
 
         # Empty the clipboard
@@ -1073,6 +1091,10 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
         )
         source_placeholder.clear_cache(plugin.language)
         updated_plugin = plugin.reload()
+        source_order = source_placeholder.get_plugin_tree_order(
+            source_language,
+            source_parent_id,
+        )
 
         self._send_post_placeholder_operation(
             request,
@@ -1081,10 +1103,10 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
             plugin=updated_plugin.get_bound_plugin(),
             clipboard=target_placeholder,
             clipboard_language=target_language,
-            source_language=plugin.language,
+            source_language=source_language,
             source_placeholder=source_placeholder,
-            source_parent_id=plugin.parent_id,
-            source_order=[],
+            source_parent_id=source_parent_id,
+            source_order=source_order,
         )
         return updated_plugin
 
@@ -1125,6 +1147,7 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
             )
             placeholder.delete_plugin(plugin)
             placeholder.clear_cache(plugin.language)
+            plugin_tree_order = placeholder.get_plugin_tree_order(language=plugin.language)
 
             self.message_user(request, _('The %(name)s plugin "%(obj)s" was deleted successfully.') % {
                 'name': force_str(opts.verbose_name), 'obj': force_str(obj_display)})

--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -642,7 +642,7 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
             operation_kwargs["operation"] = operations.CHANGE_PLUGIN
         else:
             parent_id = obj.parent.pk if obj.parent else None
-            tree_order = obj.placeholder.get_plugin_tree_order(parent_id)
+            tree_order = obj.placeholder.get_plugin_tree_order(obj.language, parent_id)
             operation_kwargs["plugin"] = obj
             operation_kwargs["operation"] = operations.ADD_PLUGIN
             operation_kwargs["tree_order"] = tree_order

--- a/cms/tests/test_placeholder_operation_signals.py
+++ b/cms/tests/test_placeholder_operation_signals.py
@@ -32,11 +32,12 @@ class PagePlaceholderTestCase(CMSTestCase):
         )
         return plugin
 
-    def _get_add_plugin_uri(self, language='en'):
+    def _get_add_plugin_uri(self, language='en', parent=None):
         uri = self.get_add_plugin_uri(
             placeholder=self._placeholder_1,
             plugin_type='LinkPlugin',
             language=language,
+            parent=parent,
         )
         return uri
 
@@ -52,8 +53,19 @@ class PagePlaceholderTestCase(CMSTestCase):
         self._placeholder_2 = self._cms_page.get_placeholders("en").get(slot='right-column')
 
     def test_pre_add_plugin(self):
+        parent = self._add_plugin()
+        existing_plugin = add_plugin(
+            self._placeholder_1,
+            'LinkPlugin',
+            'en',
+            target=parent,
+            position='last-child',
+            name='A Link',
+            external_link='https://www.django-cms.org',
+        )
+
         with signal_tester(pre_placeholder_operation) as env:
-            endpoint = self._get_add_plugin_uri()
+            endpoint = self._get_add_plugin_uri(parent=parent)
             data = {'name': 'A Link', 'external_link': 'https://www.django-cms.org'}
 
             with self.login_user_context(self._admin_user):
@@ -71,10 +83,22 @@ class PagePlaceholderTestCase(CMSTestCase):
             self.assertEqual(call_kwargs['placeholder'], self._placeholder_1)
             self.assertEqual(call_kwargs['plugin'].name, data['name'])
             self.assertEqual(call_kwargs['plugin'].external_link, data['external_link'])
+            self.assertEqual(call_kwargs['tree_order'], [existing_plugin.pk])
 
     def test_post_add_plugin(self):
+        parent = self._add_plugin()
+        existing_plugin = add_plugin(
+            self._placeholder_1,
+            'LinkPlugin',
+            'en',
+            target=parent,
+            position='last-child',
+            name='A Link',
+            external_link='https://www.django-cms.org',
+        )
+
         with signal_tester(pre_placeholder_operation, post_placeholder_operation) as env:
-            endpoint = self._get_add_plugin_uri()
+            endpoint = self._get_add_plugin_uri(parent=parent)
             data = {'name': 'A Link', 'external_link': 'https://www.django-cms.org'}
 
             with self.login_user_context(self._admin_user):
@@ -96,6 +120,11 @@ class PagePlaceholderTestCase(CMSTestCase):
             self.assertTrue(post_call_kwargs['plugin'].pk)
             self.assertEqual(post_call_kwargs['plugin'].name, data['name'])
             self.assertEqual(post_call_kwargs['plugin'].external_link, data['external_link'])
+            self.assertEqual(pre_call_kwargs['tree_order'], [existing_plugin.pk])
+            self.assertEqual(
+                post_call_kwargs['tree_order'],
+                [existing_plugin.pk, post_call_kwargs['plugin'].pk],
+            )
 
     def test_pre_edit_plugin(self):
         plugin = self._add_plugin()
@@ -175,6 +204,7 @@ class PagePlaceholderTestCase(CMSTestCase):
 
     def test_post_delete_plugin(self):
         plugin = self._add_plugin()
+        remaining_plugin = self._add_plugin()
         endpoint = self.get_delete_plugin_uri(plugin)
 
         with signal_tester(pre_placeholder_operation, post_placeholder_operation) as env:
@@ -198,6 +228,8 @@ class PagePlaceholderTestCase(CMSTestCase):
             self.assertEqual(post_call_kwargs['placeholder'], self._placeholder_1)
             self.assertEqual(post_call_kwargs['plugin'].name, 'A Link')
             self.assertEqual(post_call_kwargs['plugin'].external_link, 'https://www.django-cms.org')
+            self.assertEqual(pre_call_kwargs['tree_order'], [plugin.pk, remaining_plugin.pk])
+            self.assertEqual(post_call_kwargs['tree_order'], [remaining_plugin.pk])
 
     def test_pre_move_plugin(self):
         plugin = self._add_plugin()
@@ -235,7 +267,16 @@ class PagePlaceholderTestCase(CMSTestCase):
             self.assertEqual(call_kwargs['target_parent_id'], None)
 
     def test_post_move_plugin(self):
-        plugin = self._add_plugin()
+        parent = self._add_plugin()
+        plugin = add_plugin(
+            self._placeholder_1,
+            'LinkPlugin',
+            'en',
+            target=parent,
+            position='last-child',
+            name='A Link',
+            external_link='https://www.django-cms.org',
+        )
         endpoint = self.get_move_plugin_uri(plugin)
         source_placeholder = plugin.placeholder
 
@@ -267,7 +308,7 @@ class PagePlaceholderTestCase(CMSTestCase):
             self.assertEqual(post_call_kwargs['plugin'].external_link, 'https://www.django-cms.org')
             self.assertEqual(post_call_kwargs['source_language'], 'en')
             self.assertEqual(post_call_kwargs['source_placeholder'], source_placeholder)
-            self.assertEqual(post_call_kwargs['source_parent_id'], plugin.parent_id)
+            self.assertEqual(post_call_kwargs['source_parent_id'], parent.pk)
             self.assertEqual(post_call_kwargs['target_language'], 'en')
             self.assertEqual(post_call_kwargs['target_placeholder'], self._placeholder_2)
             self.assertEqual(post_call_kwargs['target_parent_id'], None)
@@ -279,6 +320,7 @@ class PagePlaceholderTestCase(CMSTestCase):
             clipboard=Placeholder.objects.create(slot='clipboard'),
         )
         plugin = self._add_plugin()
+        remaining_plugin = self._add_plugin()
         endpoint = self.get_move_plugin_uri(plugin)
 
         data = {
@@ -308,6 +350,7 @@ class PagePlaceholderTestCase(CMSTestCase):
             self.assertEqual(call_kwargs['source_language'], 'en')
             self.assertEqual(call_kwargs['source_placeholder'], self._placeholder_1)
             self.assertEqual(call_kwargs['source_parent_id'], plugin.parent_id)
+            self.assertEqual(call_kwargs['source_order'], [plugin.pk, remaining_plugin.pk])
 
     def test_post_cut_plugin(self):
         user_settings = UserSettings.objects.create(
@@ -316,6 +359,7 @@ class PagePlaceholderTestCase(CMSTestCase):
             clipboard=Placeholder.objects.create(slot='clipboard'),
         )
         plugin = self._add_plugin()
+        remaining_plugin = self._add_plugin()
         endpoint = self.get_move_plugin_uri(plugin)
 
         data = {
@@ -348,6 +392,8 @@ class PagePlaceholderTestCase(CMSTestCase):
             self.assertEqual(post_call_kwargs['source_language'], 'en')
             self.assertEqual(post_call_kwargs['source_placeholder'], self._placeholder_1)
             self.assertEqual(post_call_kwargs['source_parent_id'], plugin.parent_id)
+            self.assertEqual(pre_call_kwargs['source_order'], [plugin.pk, remaining_plugin.pk])
+            self.assertEqual(post_call_kwargs['source_order'], [remaining_plugin.pk])
 
     def test_pre_paste_plugin(self):
         user_settings = UserSettings.objects.create(
@@ -554,6 +600,7 @@ class PagePlaceholderTestCase(CMSTestCase):
 
     def test_post_add_plugins_from_placeholder(self):
         plugin = self._add_plugin()
+        existing_target_plugin = self._add_plugin(placeholder=self._placeholder_2, language='de')
         endpoint = self.get_copy_plugin_uri(plugin)
         source_placeholder = plugin.placeholder
 
@@ -590,6 +637,11 @@ class PagePlaceholderTestCase(CMSTestCase):
             self.assertEqual(post_call_kwargs['source_placeholder'], source_placeholder)
             self.assertEqual(post_call_kwargs['target_language'], 'de')
             self.assertEqual(post_call_kwargs['target_placeholder'], self._placeholder_2)
+            self.assertEqual(pre_call_kwargs['target_order'], [existing_target_plugin.pk])
+            self.assertEqual(
+                post_call_kwargs['target_order'],
+                [existing_target_plugin.pk, new_plugin.pk],
+            )
 
     def test_pre_clear_placeholder(self):
         plugin = self._add_plugin()

--- a/docs/upgrade/5.1.0.rst
+++ b/docs/upgrade/5.1.0.rst
@@ -298,6 +298,7 @@ Minor features
 Bug Fixes
 =========
 
+* Correct inaccurate and stale keyword arguments sent with placeholder operation signals
 * Enforce authorization on structure rendering, plugin movement, and clipboard endpoints
 * Prevent inline editing from bypassing permissions
 * Prevent toolbar login from following an unverified redirect
@@ -332,6 +333,20 @@ Bug Fixes
 **************************************
 Backward incompatible changes in 5.1.0
 **************************************
+
+Placeholder operation signals
+=============================
+
+Placeholder operation signal keyword arguments now consistently describe the
+state at the time of the signal: pre-operation signals describe the state before
+the operation, post-operation signals describe the resulting state, and
+``source_*`` arguments retain their original source values. Consequently,
+``*_order`` and source-related arguments can differ from the previously empty,
+stale, or target-side values.
+
+The ``ADD_PLUGIN`` post-operation signal also now includes a ``tree_order``
+keyword argument. Custom signal receivers must accept ``**kwargs``, as recommended
+for Django signal receivers, and must not rely on the previous incorrect values.
 
 Dependencies, settings, and migrations
 ======================================


### PR DESCRIPTION
## Summary by Sourcery

Ensure placeholder operation signals include accurate plugin ordering and source/target context for add, move, cut, delete, and copy operations.

Bug Fixes:
- Correct plugin tree order calculation to include language when adding plugins.
- Provide accurate source language and parent context in move and cut plugin operations.
- Include plugin tree order and source/target order data in placeholder operation signals for add, cut, delete, and copy actions.

Enhancements:
- Expand placeholder operation signal tests to cover plugin ordering and parent-child relationships across add, move, cut, delete, and copy scenarios.

Tests:
- Strengthen placeholder operation signal tests to assert correct tree_order, source_order, and target_order values for relevant plugin operations.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* fixes #8668 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.