### PR TITLE
feat: Persistent url fields for page contents

### DIFF
--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -546,26 +546,6 @@ class DuplicatePageForm(AddPageForm):
         return source
 
 
-def url_is_locked(page_content: PageContent) -> bool:
-    """Return whether ``page_content``'s URL is shared with a published
-    (publicly visible) version of the same page and language.
-
-    With a versioning package installed the slug and path live on the
-    (unversioned) :class:`~cms.models.pagemodel.PageUrl` and are therefore
-    shared across all versions of a page. Editing the slug of a draft would
-    silently change the URL of the already published version. Without versioning
-    the content being edited *is* the public version, so the URL is never
-    locked.
-    """
-    if page_content is None or page_content.pk is None:
-        return False
-    return (
-        PageContent.objects.filter(page=page_content.page_id, language=page_content.language)
-        .values_list("pk", flat=True)
-        .exclude(pk=page_content.pk).exists()
-    )
-
-
 class ChangePageForm(BasePageContentForm):
     overwrite_url = forms.CharField(
         label=_("Overwrite URL"),
@@ -640,26 +620,12 @@ class ChangePageForm(BasePageContentForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.url_obj = self.instance.page.get_url(self._language)
-        self.fields["slug"].initial = self.url_obj.slug
+        self.fields["slug"].initial = self.instance.slug
         self.fields["redirect"].widget.language = self._language
         self.fields["redirect"].initial = self.instance.redirect
 
-        if not self.url_obj.managed:
-            self.fields["overwrite_url"].initial = self.url_obj.path
-
-        if self._url_is_locked:
-            # The URL is shared with a published version of this page (only
-            # possible with a versioning package installed). Changing the slug
-            # or overwrite URL would silently change the live URL, so drop those
-            # fields from the editable form. PageContentAdmin renders them as
-            # read-only instead (see PageContentAdmin.get_readonly_fields()).
-            self.fields.pop("slug", None)
-            self.fields.pop("overwrite_url", None)
-
-    @cached_property
-    def _url_is_locked(self):
-        return url_is_locked(self.instance)
+        if self.instance.overwrite_url:
+            self.fields["overwrite_url"].initial = self.instance.overwrite_url
 
     @cached_property
     def _language(self):
@@ -674,10 +640,6 @@ class ChangePageForm(BasePageContentForm):
             return data
 
         page = self.instance.page
-
-        if self._url_is_locked:
-            # The slug and overwrite URL are read-only; the URL must not change.
-            return data
 
         if page.is_home:
             data["path"] = ""
@@ -738,30 +700,24 @@ class ChangePageForm(BasePageContentForm):
 
         data = self.cleaned_data.copy()
         page = self.instance.page
-        page_slug = data.pop("slug", None)
-        page_path = data.pop("path", None)
-        page_overwrite_url = data.pop("overwrite_url", None)
+        data.pop("path", None)  # the PageUrl path is derived from the content, never stored on it
+        data["overwrite_url"] = (data.get("overwrite_url") or "").strip("/") or None
         page_content = super().save(commit=False)
         page_content.update(
             changed_by=get_clean_username(self._request.user),
             changed_date=timezone.now(),
             **data,
         )
-        if not self._url_is_locked:
-            # When the URL is shared with a published version the slug/path must
-            # not change, so the (read-only) URL fields are ignored on save.
-            page.update_urls(
-                self._language,
-                path=page_path,
-                slug=page_slug,
-                managed=not bool(page_overwrite_url),
-            )
-            page._update_url_path_recursive(self._language)
-        page.clear_cache(menu=True)
+        if page_content.is_public():
+            # This content is what visitors see (nothing like a versioning
+            # package hides it), so the page URL follows the change right away.
+            # Otherwise the URL is only updated once this content is published.
+            page.update_urls_from_content(self._language)
 
-        if not self._url_is_locked and page.application_urls and "slug" in self.changed_data:
-            # Connects the apphook restart handler to the request finished signal
-            set_restart_trigger()
+            if page.application_urls and "slug" in self.changed_data:
+                # Connects the apphook restart handler to the request finished signal
+                set_restart_trigger()
+        page.clear_cache(menu=True)
         send_post_page_operation(
             request=self._request,
             operation=CHANGE_PAGE_TRANSLATION,

--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -642,7 +642,7 @@ class ChangePageForm(BasePageContentForm):
         page = self.instance.page
 
         if page.is_home:
-            data["path"] = ""
+            # the home page always lives at the root path
             return data
 
         slug = data["slug"]
@@ -650,18 +650,9 @@ class ChangePageForm(BasePageContentForm):
 
         if path_override:
             path = path_override.strip("/")
-        elif page.parent:
-            if page.parent.is_home:
-                path = slug
-            else:
-                base_path = page.parent.get_path(self._language)
-                path = f"{base_path}/{slug}" if base_path else None
         else:
-            path = slug
-
-        if path is None:
-            data["path"] = None
-            return data
+            # the same derivation Page.update_urls_from_content applies on save
+            path = page.get_path_for_slug(slug, self._language)
 
         user_language = get_site_language_from_request(self._request, site_id=self._site.pk)
 
@@ -677,8 +668,6 @@ class ChangePageForm(BasePageContentForm):
         except ValidationError as error:
             field = "overwrite_url" if path_override else "slug"
             self.add_error(field, error)
-        else:
-            data["path"] = path
         return data
 
     def clean_xframe_options(self):
@@ -700,7 +689,6 @@ class ChangePageForm(BasePageContentForm):
 
         data = self.cleaned_data.copy()
         page = self.instance.page
-        data.pop("path", None)  # the PageUrl path is derived from the content, never stored on it
         data["overwrite_url"] = (data.get("overwrite_url") or "").strip("/") or None
         page_content = super().save(commit=False)
         page_content.update(

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -34,11 +34,9 @@ from django.template.response import SimpleTemplateResponse, TemplateResponse
 from django.urls import re_path
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_str
-from django.utils.functional import lazy
-from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
-from django.utils.translation import gettext as _, gettext_lazy
+from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 
 from cms import operations
@@ -51,7 +49,6 @@ from cms.admin.forms import (
     CopyPermissionForm,
     DuplicatePageForm,
     MovePageForm,
-    url_is_locked,
 )
 from cms.admin.permissionadmin import PERMISSION_ADMIN_INLINES
 from cms.cache.permissions import clear_permission_cache
@@ -88,10 +85,6 @@ from cms.utils.plugins import copy_plugins_to_placeholder
 from cms.utils.urlutils import admin_reverse, static_with_version
 
 require_POST = method_decorator(require_POST)
-
-# Lazily-evaluated format_html so translatable admin labels containing markup are
-# resolved at render time (and in the active language), not at import time.
-format_html_lazy = lazy(format_html, str)
 
 
 class PageDeleteMessageMixin:
@@ -854,44 +847,6 @@ class PageContentAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
         form._site = get_site_from_request(request)
         form._request = request
         return form
-
-    def get_readonly_fields(self, request, obj=None):
-        readonly_fields = super().get_readonly_fields(request, obj)
-        if obj is not None and url_is_locked(obj):
-            # The page's URL is shared with a published version (only possible
-            # with a versioning package installed). Editing the slug here would
-            # silently change the live URL, so render the slug and overwrite URL
-            # read-only. The values are supplied by the matching display methods.
-            readonly_fields = (*readonly_fields, "slug", "overwrite_url")
-        return readonly_fields
-
-    @admin.display(
-        description=format_html_lazy(
-            '{} <small class="help">{}</small>',
-            gettext_lazy("Slug"),
-            gettext_lazy("(to change it, first unpublish the currently published version of this page)"),
-        )
-    )
-    def slug(self, obj):
-        # For read-only views: Get slug from the page content object
-        if not hasattr(obj, "_url_obj"):
-            obj._url_obj = obj.page.get_url(obj.language)
-        return obj._url_obj.slug
-
-    @admin.display(
-        description=format_html_lazy(
-            '{} <small class="help">{}</small>',
-            gettext_lazy("Overwrite URL"),
-            gettext_lazy("(to change it, first unpublish the currently published version of this page)"),
-        )
-    )
-    def overwrite_url(self, obj):
-        # For read-only views: Get the overwrite URL from the page content object
-        if not hasattr(obj, "_url_obj"):
-            obj._url_obj = obj.page.get_url(obj.language)
-        if obj._url_obj.managed:
-            return ""
-        return obj._url_obj.path
 
     def duplicate(self, request, object_id):
         """

--- a/cms/api.py
+++ b/cms/api.py
@@ -375,16 +375,6 @@ def create_page_content(
         except ValidationError as e:
             raise IntegrityError(e)
 
-        page.urls.update_or_create(
-            page=page,
-            language=language,
-            defaults=dict(
-                slug=slug,
-                path=path,
-                managed=not bool(overwrite_url),
-            ),
-        )
-
         # E.g., djangocms-versioning needs an User object to be passed when creating a versioned Object
         user = _current_user.get(None)
         page_content = PageContent.objects.with_user(user).create(
@@ -402,8 +392,24 @@ def create_page_content(
             template=template,
             limit_visibility_in_menu=limit_visibility_in_menu,
             xframe_options=xframe_options,
+            slug=slug,
+            overwrite_url=overwrite_url.strip("/") if overwrite_url else None,
         )
         page_content.rescan_placeholders()
+
+        if page_content.is_public():
+            # The page URL is derived from public content only. With a versioning
+            # package installed the new content is created as a draft and gets
+            # its URL on first publish.
+            page.urls.update_or_create(
+                page=page,
+                language=language,
+                defaults=dict(
+                    slug=slug,
+                    path=path,
+                    managed=not bool(overwrite_url),
+                ),
+            )
         page._clear_internal_cache()
 
         return page_content

--- a/cms/management/commands/subcommands/copy.py
+++ b/cms/management/commands/subcommands/copy.py
@@ -5,7 +5,7 @@ from django.db import transaction
 
 from cms.api import copy_plugins_to_language
 from cms.management.commands.subcommands.base import SubcommandsCommand
-from cms.models import EmptyPageContent, Page, PageContent, PageUrl
+from cms.models import EmptyPageContent, Page, PageContent
 from cms.utils import get_language_list
 from cms.utils.page import get_available_slug
 
@@ -87,30 +87,29 @@ class CopyLangCommand(SubcommandsCommand):
                     new_title.pop("id", None)  # No PK
                     new_title["language"] = to_lang
                     new_title["page"] = page
-                    PageContent.objects.with_user(user).create(**new_title)
+
+                    # inspired from pagemodels.Page.copy() - possibly refactorable
+                    parent_page = page.parent
+                    if parent_page:
+                        base = parent_page.get_path(to_lang)
+                        path = f'{base}/{title.slug}' if base else title.slug
+                    else:
+                        base = ''
+                        path = title.slug
+
+                    new_title["slug"] = get_available_slug(site, path, to_lang)
+                    if title.overwrite_url:
+                        new_title["overwrite_url"] = '{}/{}'.format(base, new_title["slug"]) if base \
+                            else new_title["slug"]
+                    new_content = PageContent.objects.with_user(user).create(**new_title)
 
                     if to_lang not in page.get_languages():
                         page.update_languages(page.get_languages() + [to_lang])
 
-                    # copy PageUrls - inspired from pagemodels.Page.copy() - possibly refactorable
-                    page_url = page.urls.get(language=from_lang)
-                    parent_page = page.parent
-
-                    new_url = model_to_dict(page_url)
-                    new_url.pop("id", None)  # No PK
-                    new_url["page"] = page
-                    new_url["language"] = to_lang
-
-                    if parent_page:
-                        base = parent_page.get_path(to_lang)
-                        path = f'{base}/{page_url.slug}' if base else page_url.slug
-                    else:
-                        base = ''
-                        path = page_url.slug
-
-                    new_url["slug"] = get_available_slug(site, path, to_lang)
-                    new_url["path"] = '{}/{}'.format(base, new_url["slug"]) if base else new_url["slug"]
-                    PageUrl.objects.with_user(user).create(**new_url)
+                    if new_content.is_public():
+                        # The page URL is derived from public content only; drafts
+                        # created by a versioning package get theirs on publish.
+                        page.update_urls_from_content(to_lang)
 
                 if copy_content:
                     # copy plugins using API

--- a/cms/migrations/0044_pagecontent_slug_overwrite_url.py
+++ b/cms/migrations/0044_pagecontent_slug_overwrite_url.py
@@ -1,0 +1,67 @@
+from django.db import migrations, models
+
+
+def _copy_urls_to_content(apps, schema_editor):
+    """Copy the authored URL values from the (unversioned) PageUrl objects onto
+    every PageContent object of the same page and language.
+
+    All versions of a page content implicitly shared one URL before this
+    migration, so every version receives the currently effective slug and
+    overwrite URL.
+    """
+    PageContent = apps.get_model("cms", "PageContent")
+    PageUrl = apps.get_model("cms", "PageUrl")
+
+    urls = {(url.page_id, url.language): url for url in PageUrl.objects.all().iterator()}
+
+    batch = []
+    for content in PageContent.objects.all().iterator(chunk_size=1000):
+        url = urls.get((content.page_id, content.language))
+        if url is None:
+            continue
+        content.slug = url.slug
+        content.overwrite_url = None if url.managed else url.path
+        batch.append(content)
+        if len(batch) >= 1000:
+            PageContent.objects.bulk_update(batch, ["slug", "overwrite_url"])
+            batch = []
+    if batch:
+        PageContent.objects.bulk_update(batch, ["slug", "overwrite_url"])
+
+
+def _noop(apps, schema_editor):
+    # The PageUrl objects still hold the published values; removing the fields
+    # loses only draft-specific edits made after migrating forward.
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("cms", "0043_alter_globalpagepermission_can_view_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="pagecontent",
+            name="slug",
+            field=models.SlugField(
+                default="",
+                help_text="The part of the title that is used in the URL",
+                max_length=255,
+                verbose_name="slug",
+            ),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name="pagecontent",
+            name="overwrite_url",
+            field=models.CharField(
+                blank=True,
+                help_text="Keep this field empty if standard path should be used.",
+                max_length=255,
+                null=True,
+                verbose_name="overwrite URL",
+            ),
+        ),
+        migrations.RunPython(_copy_urls_to_content, _noop, elidable=False),
+    ]

--- a/cms/migrations/0044_pagecontent_slug_overwrite_url.py
+++ b/cms/migrations/0044_pagecontent_slug_overwrite_url.py
@@ -1,4 +1,5 @@
 from django.db import migrations, models
+from django.db.models import Case, Exists, F, OuterRef, Subquery, Value, When
 
 
 def _copy_urls_to_content(apps, schema_editor):
@@ -12,21 +13,19 @@ def _copy_urls_to_content(apps, schema_editor):
     PageContent = apps.get_model("cms", "PageContent")
     PageUrl = apps.get_model("cms", "PageUrl")
 
-    urls = {(url.page_id, url.language): url for url in PageUrl.objects.all().iterator()}
-
-    batch = []
-    for content in PageContent.objects.all().iterator(chunk_size=1000):
-        url = urls.get((content.page_id, content.language))
-        if url is None:
-            continue
-        content.slug = url.slug
-        content.overwrite_url = None if url.managed else url.path
-        batch.append(content)
-        if len(batch) >= 1000:
-            PageContent.objects.bulk_update(batch, ["slug", "overwrite_url"])
-            batch = []
-    if batch:
-        PageContent.objects.bulk_update(batch, ["slug", "overwrite_url"])
+    url_qs = PageUrl.objects.filter(page_id=OuterRef("page_id"), language=OuterRef("language"))
+    PageContent.objects.filter(Exists(url_qs)).update(
+        slug=Subquery(url_qs.values("slug")[:1]),
+        overwrite_url=Subquery(
+            url_qs.annotate(
+                overwrite=Case(
+                    When(managed=True, then=Value(None)),
+                    default=F("path"),
+                    output_field=models.CharField(),
+                )
+            ).values("overwrite")[:1]
+        ),
+    )
 
 
 def _noop(apps, schema_editor):

--- a/cms/models/contentmodels.py
+++ b/cms/models/contentmodels.py
@@ -35,6 +35,8 @@ class PageContent(models.Model):
     # a PageContent object to know if it has changed.
     editable_fields = [
         "title",
+        "slug",
+        "overwrite_url",
         "redirect",
         "page_title",
         "menu_title",
@@ -73,6 +75,22 @@ class PageContent(models.Model):
         blank=True,
         null=True,
         help_text=_("Redirects to this URL."),
+    )
+    #: The slug and overwrite URL are authored per page content object. The routable
+    #: :class:`~cms.models.pagemodel.PageUrl` objects are derived from the publicly
+    #: visible page content only (see :meth:`cms.models.pagemodel.Page.update_urls_from_content`),
+    #: so changing the slug of a draft version does not affect the published URL.
+    slug = models.SlugField(
+        verbose_name=_("slug"),
+        max_length=255,
+        help_text=_("The part of the title that is used in the URL"),
+    )
+    overwrite_url = models.CharField(
+        verbose_name=_("overwrite URL"),
+        max_length=255,
+        blank=True,
+        null=True,
+        help_text=_("Keep this field empty if standard path should be used."),
     )
     page = models.ForeignKey(Page, on_delete=models.CASCADE, verbose_name=_("page"), related_name="pagecontent_set")
     creation_date = models.DateTimeField(verbose_name=_("creation date"), editable=False, default=timezone.now)
@@ -306,6 +324,19 @@ class PageContent(models.Model):
         """
         return True
 
+    def is_public(self):
+        """Return whether this content object is visible to the public, i.e. whether
+        the default manager returns it. Without a versioning package every saved
+        page content is public; with a versioning package installed only published
+        versions are. The page's URL is only derived from public content
+        (see :meth:`cms.models.pagemodel.Page.update_urls_from_content`).
+
+        :rtype: ``bool``
+        """
+        if self.pk is None:
+            return False
+        return self.__class__.objects.filter(pk=self.pk).exists()
+
     def content_indicator(self):
         """returns the content indicator status. Without additional packages like
         djangocms-versioning page content always is public.
@@ -346,6 +377,8 @@ class EmptyPageContent:
     """
 
     title = ""
+    slug = ""
+    overwrite_url = None
     meta_description = ""
     redirect = ""
     application_urls = ""

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -484,39 +484,35 @@ class Page(MP_Node):
         new_page._clear_internal_cache()
 
         if language and translations:
-            page_urls = self.urls.filter(language=language)
             translations = self.pagecontent_set(manager="admin_manager").filter(language=language)
         elif translations:
-            page_urls = self.urls.all()
             translations = self.pagecontent_set(manager="admin_manager")
         else:
-            page_urls = self.urls.none()
             translations = self.pagecontent_set(manager="admin_manager").none()
         translations = translations.prefetch_related("placeholders")
-
-        for page_url in page_urls:
-            new_url = model_to_dict(page_url)
-            new_url.pop("id", None)  # No PK
-            new_url.pop("site", None)  # Let the save method handle this
-            new_url["page"] = new_page
-
-            if parent_page:
-                base = parent_page.get_path(page_url.language)
-                path = f"{base}/{page_url.slug}" if base else page_url.slug
-            else:
-                base = ""
-                path = page_url.slug
-
-            new_url["slug"] = get_available_slug(site, path, page_url.language)
-            new_url["path"] = "{}/{}".format(base, new_url["slug"]) if base else new_url["slug"]
-            PageUrl.objects.with_user(user).create(**new_url)
 
         # copy titles of this page
         for title in translations.current_content():
             new_title = model_to_dict(title)
             new_title.pop("id", None)  # No PK
             new_title["page"] = new_page
+
+            if parent_page:
+                base = parent_page.get_path(title.language)
+                path = f"{base}/{title.slug}" if base else title.slug
+            else:
+                base = ""
+                path = title.slug
+
+            new_title["slug"] = get_available_slug(site, path, title.language)
+            if title.overwrite_url:
+                new_title["overwrite_url"] = "{}/{}".format(base, new_title["slug"]) if base else new_title["slug"]
             new_title = PageContent.objects.with_user(user).create(**new_title)
+            if new_title.is_public():
+                # The page URL is derived from public content only. With a
+                # versioning package installed the copy is created as a draft
+                # and gets its URL on first publish.
+                new_page.update_urls_from_content(new_title.language)
 
             for placeholder in title.placeholders.all():
                 # copy the placeholders (and plugins on those placeholders!)
@@ -820,6 +816,57 @@ class Page(MP_Node):
 
         # If no collision detected, proceed with the update
         return page_urls_qs.update(**data)
+
+    def update_urls_from_content(self, language):
+        """Derive this page's :class:`~cms.models.pagemodel.PageUrl` for ``language``
+        from the publicly visible :class:`~cms.models.contentmodels.PageContent`
+        object, then update the paths of all descendant pages.
+
+        The slug and overwrite URL are authored on the page content object.
+        ``PageUrl`` is a routing table that must only ever reflect published
+        content: without a versioning package every saved content is public and
+        this runs on every save; with a versioning package installed it must be
+        called when a version is published or unpublished.
+
+        When no public content exists, the URL's path is set to ``None`` so the
+        page stops resolving while the slug stays reserved for the page.
+
+        Raises ``IntegrityError`` if the derived path collides with the URL of
+        another page on the same site.
+        """
+        from cms.models import PageContent
+
+        content = PageContent.objects.filter(page=self, language=language).first()
+
+        if content is None:
+            self.urls.filter(language=language).update(path=None)
+        else:
+            if content.overwrite_url and not self.is_home:
+                path = content.overwrite_url.strip("/")
+            else:
+                # the home page always lives at the root path
+                path = self.get_path_for_slug(content.slug, language)
+            data = {
+                "slug": content.slug,
+                "path": path,
+                "managed": not bool(content.overwrite_url),
+            }
+            if self.urls.filter(language=language).exists():
+                self.update_urls(language, **data)  # includes the path collision check
+            else:
+                collision = (
+                    path is not None
+                    and PageUrl.objects.filter(language=language, path=path, page__site=self.site_id).exists()
+                )
+                if collision:
+                    raise IntegrityError(
+                        f"Cannot create URL. A page URL with path='{path}' and "
+                        f"language='{language}' already exists for another page on the same site."
+                    )
+                self.urls.create(page=self, language=language, **data)
+
+        self.urls_cache = {}
+        self._update_url_path_recursive(language)
 
     def get_fallbacks(self, language):
         return i18n.get_fallback_languages(language, site_id=self.site_id)

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -837,8 +837,11 @@ class Page(MP_Node):
         from cms.models import PageContent
 
         content = PageContent.objects.filter(page=self, language=language).first()
+        url = self.urls.filter(language=language).first()
 
         if content is None:
+            if url is None or url.path is None:
+                return
             self.urls.filter(language=language).update(path=None)
         else:
             if content.overwrite_url and not self.is_home:
@@ -851,7 +854,11 @@ class Page(MP_Node):
                 "path": path,
                 "managed": not bool(content.overwrite_url),
             }
-            if self.urls.filter(language=language).exists():
+            if url is not None:
+                if (url.slug, url.path, url.managed) == (data["slug"], data["path"], data["managed"]):
+                    # the URL already reflects the content; descendant paths derive
+                    # from this page's path, so they are up to date as well
+                    return
                 self.update_urls(language, **data)  # includes the path collision check
             else:
                 collision = (

--- a/cms/tests/test_migrations.py
+++ b/cms/tests/test_migrations.py
@@ -1,7 +1,13 @@
+import importlib
 from io import StringIO
 
+from django.apps import apps
 from django.core.management import call_command
 from django.test import TestCase, override_settings
+
+from cms.api import create_page, create_page_content
+from cms.models import PageContent
+from cms.test_utils.testcases import CMSTestCase
 
 
 class MigrationTestCase(TestCase):
@@ -26,3 +32,52 @@ class MigrationTestCase(TestCase):
 
         if status_code == '1':
             self.fail(f'There are missing migrations:\n {output.getvalue()}')  # TODO: reactivate this line
+
+
+class CopyUrlsToContentMigrationTestCase(CMSTestCase):
+    """Exercises the data migration of 0044 against the current model state.
+
+    The forward function only touches fields that exist unchanged in the
+    current schema, so it can run against the live app registry.
+    """
+
+    def _run_migration(self):
+        migration = importlib.import_module("cms.migrations.0044_pagecontent_slug_overwrite_url")
+        migration._copy_urls_to_content(apps, None)
+
+    def test_copies_urls_onto_contents(self):
+        managed = create_page("Managed", "nav_playground.html", "en", slug="managed")
+        overwritten = create_page("Overwritten", "nav_playground.html", "en", slug="overwritten")
+        overwritten.urls.filter(language="en").update(managed=False, path="custom/path")
+        orphan = create_page("Orphan", "nav_playground.html", "en", slug="orphan")
+        orphan.urls.all().delete()
+
+        # Simulate the pre-migration state where the content rows do not yet
+        # carry the authored URL values.
+        PageContent.objects.update(slug="stale", overwrite_url="stale")
+
+        self._run_migration()
+
+        managed_content = PageContent.objects.get(page=managed, language="en")
+        self.assertEqual(managed_content.slug, "managed")
+        self.assertIsNone(managed_content.overwrite_url)
+
+        overwritten_content = PageContent.objects.get(page=overwritten, language="en")
+        self.assertEqual(overwritten_content.slug, "overwritten")
+        self.assertEqual(overwritten_content.overwrite_url, "custom/path")
+
+        # Contents without a matching PageUrl keep their values
+        orphan_content = PageContent.objects.get(page=orphan, language="en")
+        self.assertEqual(orphan_content.slug, "stale")
+        self.assertEqual(orphan_content.overwrite_url, "stale")
+
+    def test_copies_urls_per_language(self):
+        page = create_page("English", "nav_playground.html", "en", slug="english")
+        create_page_content("de", "Deutsch", page, slug="deutsch")
+
+        PageContent.objects.update(slug="stale", overwrite_url="stale")
+
+        self._run_migration()
+
+        self.assertEqual(PageContent.objects.get(page=page, language="en").slug, "english")
+        self.assertEqual(PageContent.objects.get(page=page, language="de").slug, "deutsch")

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -2,7 +2,6 @@ import datetime
 import json
 import re
 import sys
-from contextlib import contextmanager
 from unittest import skipUnless
 from unittest.mock import patch
 
@@ -21,7 +20,6 @@ from django.utils.timezone import now as tz_now
 from django.utils.translation import override as force_language
 
 from cms import constants
-from cms.admin.forms import ChangePageForm
 from cms.admin.pageadmin import PageContentAdmin
 from cms.api import add_plugin, create_page, create_page_content
 from cms.appresolver import clear_app_resolvers
@@ -1221,51 +1219,37 @@ class PageTest(PageTestBase):
             self.assertContains(response, expected, html=True)
 
     @override_settings(CMS_PERMISSION=False)
-    def test_slug_readonly_when_url_locked(self):
-        # When the page URL is shared with a published version (only possible
-        # with a versioning package installed), the slug and overwrite URL are
-        # rendered read-only: they are dropped from the editable form and shown
-        # as static text by PageContentAdmin instead.
+    def test_slug_stored_on_page_content(self):
+        # The slug and overwrite URL are authored on the PageContent object;
+        # the PageUrl is derived from it.
         superuser = self.get_superuser()
         cms_page = create_page("page", "nav_playground.html", "en")
+        translation = cms_page.get_content_obj("en", fallback=False)
+        changelist = self.get_pages_admin_list_uri()
         endpoint = self.get_page_change_uri("en", cms_page)
 
-        with self.login_user_context(superuser), self._url_locked():
-            response = self.client.get(endpoint)
-
-            self.assertEqual(response.status_code, 200)
-            adminform = response.context["adminform"]
-            # Rendered read-only by the admin (so no editable form field) ...
-            self.assertIn("slug", adminform.readonly_fields)
-            self.assertIn("overwrite_url", adminform.readonly_fields)
-            self.assertNotIn("slug", adminform.form.fields)
-            self.assertNotIn("overwrite_url", adminform.form.fields)
-            # ... while still displaying the current value ...
-            self.assertContains(response, "page")
-            # ... and explaining in the label how to make it editable.
-            self.assertContains(response, "first unpublish the currently published version")
-
-    @override_settings(CMS_PERMISSION=False)
-    def test_slug_editable_when_url_not_locked(self):
-        # Without a published version sharing the URL (the default in core
-        # django-CMS) the slug stays editable.
-        superuser = self.get_superuser()
-        cms_page = create_page("page", "nav_playground.html", "en")
-        endpoint = self.get_page_change_uri("en", cms_page)
+        self.assertEqual(translation.slug, "page")
 
         with self.login_user_context(superuser):
-            response = self.client.get(endpoint)
+            page_data = {
+                "title": translation.title,
+                "slug": "new-slug",
+                "overwrite_url": "",
+                "template": translation.template,
+            }
+            response = self.client.post(endpoint, page_data)
+            self.assertRedirects(response, changelist)
 
-            self.assertEqual(response.status_code, 200)
-            adminform = response.context["adminform"]
-            self.assertNotIn("slug", adminform.readonly_fields)
-            self.assertIn("slug", adminform.form.fields)
-            self.assertIn("overwrite_url", adminform.form.fields)
+        translation.refresh_from_db()
+        self.assertEqual(translation.slug, "new-slug")
+        # The content is public (no versioning package), so the URL follows.
+        self.assertEqual(cms_page.reload().get_slug("en"), "new-slug")
 
     @override_settings(CMS_PERMISSION=False)
-    def test_locked_url_unchanged_on_save(self):
-        # A locked URL must not change even if a different slug is posted, but
-        # other (non-URL) page content fields are still saved.
+    def test_url_not_synced_for_non_public_content(self):
+        # When the edited content is not publicly visible (as with a draft
+        # version created by a versioning package), saving a new slug is stored
+        # on the content but must not touch the page's published URL.
         superuser = self.get_superuser()
         cms_page = create_page("page", "nav_playground.html", "en")
         translation = cms_page.get_content_obj("en", fallback=False)
@@ -1279,28 +1263,52 @@ class PageTest(PageTestBase):
                 "overwrite_url": "",
                 "template": translation.template,
             }
-            with self._url_locked():
+            with patch.object(PageContent, "is_public", return_value=False):
                 response = self.client.post(endpoint, page_data)
             self.assertRedirects(response, changelist)
 
-        # The slug/path are untouched ...
+        # The published URL is untouched ...
         self.assertEqual(cms_page.get_slug("en"), "page")
         self.assertFalse(cms_page.urls.filter(slug="a-changed-slug").exists())
-        # ... while other content fields were saved.
+        # ... while the content carries the new slug and other saved fields.
         translation.refresh_from_db()
+        self.assertEqual(translation.slug, "a-changed-slug")
         self.assertEqual(translation.title, "A new title")
 
-    @staticmethod
-    @contextmanager
-    def _url_locked():
-        # Simulate a shared, published page URL (as a versioning package would
-        # produce) without versioning installed. The helper is imported into
-        # both the forms and the pageadmin namespaces, so both must be patched.
-        with (
-            patch("cms.admin.forms.url_is_locked", return_value=True),
-            patch("cms.admin.pageadmin.url_is_locked", return_value=True),
-        ):
-            yield
+    @override_settings(CMS_PERMISSION=False)
+    def test_update_urls_from_content(self):
+        # The publish-time hook of versioning packages: derives the PageUrl
+        # from the publicly visible content and updates descendant paths.
+        cms_page = create_page("page", "nav_playground.html", "en", slug="page")
+        child = create_page("child", "nav_playground.html", "en", parent=cms_page, slug="child")
+        translation = cms_page.get_content_obj("en", fallback=False)
+
+        translation.update(slug="renamed")
+        cms_page.update_urls_from_content("en")
+
+        self.assertEqual(cms_page.reload().get_slug("en"), "renamed")
+        self.assertEqual(child.reload().get_path("en"), "renamed/child")
+
+        # An overwrite URL on the content wins over the derived path.
+        translation.update(overwrite_url="somewhere/else")
+        cms_page.update_urls_from_content("en")
+
+        url = cms_page.reload().get_url("en")
+        self.assertEqual(url.path, "somewhere/else")
+        self.assertFalse(url.managed)
+
+    @override_settings(CMS_PERMISSION=False)
+    def test_update_urls_from_content_without_public_content(self):
+        # Without publicly visible content the path is invalidated so the page
+        # stops resolving, but the slug stays reserved.
+        cms_page = create_page("page", "nav_playground.html", "en", slug="page")
+
+        with patch.object(PageContent.objects, "filter", return_value=PageContent.objects.none()):
+            cms_page.update_urls_from_content("en")
+
+        url = cms_page.urls.get(language="en")
+        self.assertIsNone(url.path)
+        self.assertEqual(url.slug, "page")
 
     @override_settings(CMS_PERMISSION=False)
     def test_advanced_settings_form_apphook(self):
@@ -1480,32 +1488,17 @@ class PageTest(PageTestBase):
             self.assertTrue("form_url" in response.context_data)
             self.assertEqual(response.context_data["form_url"], form_url)
 
-    def test_pagecontent_change_view_uses_cached_url_obj(self):
-        superuser = self.get_superuser()
-        with self.login_user_context(superuser):
-            content_admin = PageContentAdmin(PageContent, admin.site)
-            page1 = self.get_page()
-            content1 = self.get_pagecontent_obj(page1, "en")
-            content1.page = page1
-            page2 = self.get_page()
-            content2 = self.get_pagecontent_obj(page2, "en")
+    def test_pagecontent_slug_needs_no_extra_queries(self):
+        # slug and overwrite_url live on the PageContent object itself, so
+        # read-only admin rendering needs no PageUrl lookups.
+        page1 = self.get_page()
+        content1 = self.get_pagecontent_obj(page1, "en")
+        page2 = self.get_page()
+        content2 = self.get_pagecontent_obj(page2, "en")
 
-            content_admin.slug(content1)
-            content_admin.overwrite_url(content1)
-
-            with self.assertNumQueries(0):
-                # Slugs and overwrite urls are cached
-                slug = content_admin.slug(content1)
-                content_admin.overwrite_url(content1)
-
-            self.assertNotEqual(slug, content_admin.slug(content2))
-
-            with self.assertNumQueries(0):
-                # Both still cached
-                content_admin.overwrite_url(content1)
-                content_admin.slug(content1)
-                content_admin.slug(content2)
-                content_admin.overwrite_url(content2)
+        with self.assertNumQueries(0):
+            self.assertNotEqual(content1.slug, content2.slug)
+            self.assertIsNone(content1.overwrite_url)
 
     def test_change_view_shows_language_tabs_for_latest_content(self):
         """The page content change view offers the language selector for the latest content."""


### PR DESCRIPTION
## Summary by Sourcery

Persist page slug and overwrite URL on PageContent objects and derive PageUrl entries only from publicly visible content, updating URL handling, copying, and admin behavior accordingly.

New Features:
- Store slug and overwrite URL directly on PageContent and expose them as editable fields.
- Add Page.update_urls_from_content to generate and update PageUrl records from public content, including descendant paths, with collision protection.

Bug Fixes:
- Ensure non-public (draft) content slug changes do not affect the published page URL.
- Prevent pages without public content from resolving while keeping their slug reserved.

Enhancements:
- Refactor page and language copy operations to derive slugs and overwrite URLs from PageContent instead of PageUrl.
- Simplify ChangePageForm and PageContentAdmin by removing URL-locking logic and relying on PageContent for slug and overwrite URL.
- Optimize admin usage of slug and overwrite_url by avoiding extra PageUrl queries and using PageContent fields directly.

Tests:
- Update and extend admin and URL behavior tests to cover slug storage on PageContent, URL syncing rules for public vs non-public content, and update_urls_from_content edge cases.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #8578 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.