### PR TITLE
fix: Remove stray data from wheel

### DIFF
--- a/.github/workflows/publish-to-live-pypi.yml
+++ b/.github/workflows/publish-to-live-pypi.yml
@@ -38,20 +38,37 @@ jobs:
 
     - name: Check wheel contents
       run: |
-        python -m pip install check-wheel-contents --user
-        check-wheel-contents dist/*.whl
+        python -m pip install check-wheel-contents
+        python -m check_wheel_contents dist/*.whl
         python - <<'EOF'
-        import glob, sys, zipfile
-        wheel = glob.glob("dist/*.whl")[0]
-        names = zipfile.ZipFile(wheel).namelist()
+        import glob, os, sys, zipfile
+        wheels = glob.glob("dist/*.whl")
+        if len(wheels) != 1:
+            sys.exit(f"Expected exactly one wheel in dist/, found: {wheels or 'none'}")
+        wheel = wheels[0]
+        z = zipfile.ZipFile(wheel)
+        names = z.namelist()
         allowed = ("cms/", "menus/")
         stray = sorted({n.split("/")[0] for n in names
                         if not n.startswith(allowed) and ".dist-info/" not in n})
-        tests = [n for n in names if n.startswith("cms/tests/")]
+        # Step 2 (#8733): uncomment to fail on cms.tests in the wheel, and drop the shim line:
+        # tests = [n for n in names if n.startswith("cms/tests/")]
+        tests = []
         if not any(n.startswith("cms/test_utils/") for n in names):
             sys.exit("cms.test_utils missing from wheel - it is public API for third-party test suites")
         if stray or tests:
             sys.exit(f"Unexpected wheel contents - stray top-level: {stray}, cms/tests files: {len(tests)}")
+        compressed = os.path.getsize(wheel) / 1024 / 1024
+        installed = sum(i.file_size for i in z.infolist()) / 1024 / 1024
+        summary = (
+            f"### Wheel check: `{os.path.basename(wheel)}`\n\n"
+            f"| | Size |\n|---|---|\n"
+            f"| Compressed | {compressed:.1f} MB |\n"
+            f"| Installed | {installed:.1f} MB |\n"
+        )
+        print(summary)
+        with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as fh:
+            fh.write(summary)
         EOF
 
     - name: Publish distribution 📦 to PyPI

--- a/.github/workflows/publish-to-live-pypi.yml
+++ b/.github/workflows/publish-to-live-pypi.yml
@@ -36,6 +36,24 @@ jobs:
         --outdir dist/
         .
 
+    - name: Check wheel contents
+      run: |
+        python -m pip install check-wheel-contents --user
+        check-wheel-contents dist/*.whl
+        python - <<'EOF'
+        import glob, sys, zipfile
+        wheel = glob.glob("dist/*.whl")[0]
+        names = zipfile.ZipFile(wheel).namelist()
+        allowed = ("cms/", "menus/")
+        stray = sorted({n.split("/")[0] for n in names
+                        if not n.startswith(allowed) and ".dist-info/" not in n})
+        tests = [n for n in names if n.startswith("cms/tests/")]
+        if not any(n.startswith("cms/test_utils/") for n in names):
+            sys.exit("cms.test_utils missing from wheel - it is public API for third-party test suites")
+        if stray or tests:
+            sys.exit(f"Unexpected wheel contents - stray top-level: {stray}, cms/tests files: {len(tests)}")
+        EOF
+
     - name: Publish distribution 📦 to PyPI
       if: "!contains(github.ref_name, 'dev')"
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish-to-live-pypi.yml
+++ b/.github/workflows/publish-to-live-pypi.yml
@@ -62,9 +62,10 @@ jobs:
         installed = sum(i.file_size for i in z.infolist()) / 1024 / 1024
         summary = (
             f"### Wheel check: `{os.path.basename(wheel)}`\n\n"
-            f"| | Size |\n|---|---|\n"
-            f"| Compressed | {compressed:.1f} MB |\n"
-            f"| Installed | {installed:.1f} MB |\n"
+            f"| Wheel      |       Size |\n"
+            f"|------------|------------|\n"
+            f"| Compressed | {compressed:7.1f} MB |\n"
+            f"| Installed  | {installed:7.1f} MB |\n"
         )
         print(summary)
         with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as fh:

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -40,20 +40,37 @@ jobs:
 
     - name: Check wheel contents
       run: |
-        python -m pip install check-wheel-contents --user
-        check-wheel-contents dist/*.whl
+        python -m pip install check-wheel-contents
+        python -m check_wheel_contents dist/*.whl
         python - <<'EOF'
-        import glob, sys, zipfile
-        wheel = glob.glob("dist/*.whl")[0]
-        names = zipfile.ZipFile(wheel).namelist()
+        import glob, os, sys, zipfile
+        wheels = glob.glob("dist/*.whl")
+        if len(wheels) != 1:
+            sys.exit(f"Expected exactly one wheel in dist/, found: {wheels or 'none'}")
+        wheel = wheels[0]
+        z = zipfile.ZipFile(wheel)
+        names = z.namelist()
         allowed = ("cms/", "menus/")
         stray = sorted({n.split("/")[0] for n in names
                         if not n.startswith(allowed) and ".dist-info/" not in n})
-        tests = [n for n in names if n.startswith("cms/tests/")]
+        # Step 2 (#8733): uncomment to fail on cms.tests in the wheel, and drop the shim line:
+        # tests = [n for n in names if n.startswith("cms/tests/")]
+        tests = []
         if not any(n.startswith("cms/test_utils/") for n in names):
             sys.exit("cms.test_utils missing from wheel - it is public API for third-party test suites")
         if stray or tests:
             sys.exit(f"Unexpected wheel contents - stray top-level: {stray}, cms/tests files: {len(tests)}")
+        compressed = os.path.getsize(wheel) / 1024 / 1024
+        installed = sum(i.file_size for i in z.infolist()) / 1024 / 1024
+        summary = (
+            f"### Wheel check: `{os.path.basename(wheel)}`\n\n"
+            f"| | Size |\n|---|---|\n"
+            f"| Compressed | {compressed:.1f} MB |\n"
+            f"| Installed | {installed:.1f} MB |\n"
+        )
+        print(summary)
+        with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as fh:
+            fh.write(summary)
         EOF
 
     - name: Publish distribution 📦 to Test PyPI

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -37,6 +37,24 @@ jobs:
         --outdir dist/
         .
 
+    - name: Check wheel contents
+      run: |
+        python -m pip install check-wheel-contents --user
+        check-wheel-contents dist/*.whl
+        python - <<'EOF'
+        import glob, sys, zipfile
+        wheel = glob.glob("dist/*.whl")[0]
+        names = zipfile.ZipFile(wheel).namelist()
+        allowed = ("cms/", "menus/")
+        stray = sorted({n.split("/")[0] for n in names
+                        if not n.startswith(allowed) and ".dist-info/" not in n})
+        tests = [n for n in names if n.startswith("cms/tests/")]
+        if not any(n.startswith("cms/test_utils/") for n in names):
+            sys.exit("cms.test_utils missing from wheel - it is public API for third-party test suites")
+        if stray or tests:
+            sys.exit(f"Unexpected wheel contents - stray top-level: {stray}, cms/tests files: {len(tests)}")
+        EOF
+
     - name: Publish distribution 📦 to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -64,9 +64,10 @@ jobs:
         installed = sum(i.file_size for i in z.infolist()) / 1024 / 1024
         summary = (
             f"### Wheel check: `{os.path.basename(wheel)}`\n\n"
-            f"| | Size |\n|---|---|\n"
-            f"| Compressed | {compressed:.1f} MB |\n"
-            f"| Installed | {installed:.1f} MB |\n"
+            f"| Wheel      |       Size |\n"
+            f"|------------|------------|\n"
+            f"| Compressed | {compressed:7.1f} MB |\n"
+            f"| Installed  | {installed:7.1f} MB |\n"
         )
         print(summary)
         with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as fh:

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'develop'
       - 'release/**'
+      - 'fix/**'
 
 jobs:
   build-n-publish:

--- a/docs/upgrade/5.1.0.rst
+++ b/docs/upgrade/5.1.0.rst
@@ -483,6 +483,20 @@ Wizard helpers
 * The ``cms.wizards.helpers`` module has been deprecated and will be removed in django CMS 6.0. Use
   ``cms.wizards.wizard_base.get_entries()`` and ``cms.wizards.wizard_pool.get_entry()`` instead.
 
+Packaging
+---------
+
+* Shipping the internal test suite (``cms.tests``) in binary distributions (wheels) is
+  deprecated; a future release will no longer include it (#8733). The suite remains part
+  of the source distribution and stays available via
+  ``pip install --no-binary django-cms django-cms`` or the release tarballs. The public
+  testing utilities in ``cms.test_utils``, including
+  ``cms.test_utils.testcases.CMSTestCase``, are not affected and remain in the wheel.
+  Projects importing from ``cms.tests`` should switch to ``cms.test_utils``.
+* The 5.1.0 wheel erroneously included the top-level directories ``docs``, ``scripts``,
+  and ``test_requirements``. These are not part of django CMS's Python API and will be
+  removed from wheels in the next patch release without a deprecation period.
+
 Removal of deprecated functionality
 ===================================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,17 @@ packages = { find = { include = [ "cms*", "menus*" ], exclude = [ "cms.tests*" ]
 [tool.setuptools.package-data]
 "cms.management.commands" = [ "*.json" ]
 
+# The find exclude above only removes cms.tests from the package list; with
+# include-package-data its files would still ship as data of the cms package.
+[tool.setuptools.exclude-package-data]
+cms = [ "tests/**" ]
+
+[tool.check-wheel-contents]
+# W002: intentional duplicates (test templates, icon variants)
+# W004: Django migration modules have non-identifier names (0001_...)
+# W009: cms and menus are both intentional top-level packages
+ignore = [ "W002", "W004", "W009" ]
+
 [tool.setuptools.dynamic]
 version = { attr = "cms.__version__" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,17 +64,20 @@ djangocms = "cms.management.djangocms:execute_from_command_line"
 [tool.setuptools]
 # Explicit allow-list: the empty find {} defaults to namespace-package discovery,
 # which sweeps any git-tracked top-level directory (docs, scripts, ...) into wheels.
-# cms.tests is excluded from wheels but remains in the sdist; cms.test_utils is
-# public API relied on by third-party packages and must stay included.
-packages = { find = { include = [ "cms*", "menus*" ], exclude = [ "cms.tests*" ] } }
+# cms.test_utils is public API relied on by third-party packages and must stay included.
+# Step 2 (#8733): drop cms.tests from wheels (it remains in the sdist) by replacing
+# the packages line with the commented one below:
+# packages = { find = { include = [ "cms*", "menus*" ], exclude = [ "cms.tests*" ] } }
+packages = { find = { include = [ "cms*", "menus*" ] } }
 
 [tool.setuptools.package-data]
 "cms.management.commands" = [ "*.json" ]
 
-# The find exclude above only removes cms.tests from the package list; with
-# include-package-data its files would still ship as data of the cms package.
-[tool.setuptools.exclude-package-data]
-cms = [ "tests/**" ]
+# Step 2 (#8733): uncomment together with the exclude above. The find exclude only
+# removes cms.tests from the package list; with include-package-data its files
+# would still ship as data of the cms package without this section.
+# [tool.setuptools.exclude-package-data]
+# cms = [ "tests/**" ]
 
 [tool.check-wheel-contents]
 # W002: intentional duplicates (test templates, icon variants)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,11 @@ admin-style = ["djangocms-simple-admin-style"]
 djangocms = "cms.management.djangocms:execute_from_command_line"
 
 [tool.setuptools]
-packages = { find = {} }
+# Explicit allow-list: the empty find {} defaults to namespace-package discovery,
+# which sweeps any git-tracked top-level directory (docs, scripts, ...) into wheels.
+# cms.tests is excluded from wheels but remains in the sdist; cms.test_utils is
+# public API relied on by third-party packages and must stay included.
+packages = { find = { include = [ "cms*", "menus*" ], exclude = [ "cms.tests*" ] } }
 
 [tool.setuptools.package-data]
 "cms.management.commands" = [ "*.json" ]


### PR DESCRIPTION
## Summary by Sourcery

Tighten Python package packaging to control wheel contents and prevent stray or test-only modules from being shipped.

Build:
- Restrict setuptools package discovery to only cms* and menus* packages while excluding cms.tests* from wheels, keeping cms.test_utils included.
- Add CI checks in both Test PyPI and live PyPI publish workflows to validate wheel contents and fail if unexpected top-level files or cms/tests modules are present. Show wheel sizes (compressed and uncompressed)

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* fixes #8733 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.