### PR TITLE
chore: Fix bootstrap icon  license notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -91,6 +91,14 @@ Note: Used for accessibility - traps focus within modals
 
 ================================================================================
 
+Package: Bootstrap Icons
+License: MIT License
+License URL: https://github.com/twbs/icons/blob/main/LICENSE
+Copyright (c) 2019-2024 The Bootstrap Authors
+Website: https://icons.getbootstrap.com
+
+================================================================================
+
 Package: local-storage
 Version: 2.0.0
 License: MIT

--- a/README.rst
+++ b/README.rst
@@ -122,14 +122,10 @@ If your business depends on django CMS, consider supporting its long-term health
 Credits
 =======
 
-* Includes icons and adapted icons from `Bootstrap <https://icons.getbootstrap.com>`_.
-* Includes icons from `FamFamFam <http://www.famfamfam.com>`_.
-* Python tree engine powered by
-  `django-treebeard <https://tabo.pe/projects/django-treebeard/>`_.
-* JavaScript tree in admin uses `jsTree <https://www.jstree.com>`_.
-* Many thanks to
-  `all the contributors <https://github.com/django-cms/django-cms/graphs/contributors>`_
-  to django CMS!
+Many thanks to `all the contributors <https://github.com/django-cms/django-cms/graphs/contributors>`_
+to django CMS!
+
+See `LICENSE <LICENSE>`_ for credits to third-party contributions.
 
 .. |PyPiVersion| image:: https://img.shields.io/pypi/v/django-cms.svg
     :target: https://pypi.python.org/pypi/django-cms/

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -96,6 +96,14 @@ Note: Used for accessibility - traps focus within modals
 
 ${'='.repeat(80)}
 
+Package: Bootstrap Icons
+License: MIT License
+License URL: https://github.com/twbs/icons/blob/main/LICENSE
+Copyright (c) 2019-2024 The Bootstrap Authors
+Website: https://icons.getbootstrap.com
+
+${'='.repeat(80)}
+
 `;
 
 


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Document Bootstrap Icons package license details in the webpack configuration banner used for distributed builds.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* fixes #8735 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.