### PR TITLE
fix: Upon edit localized text within plugins were rendered in the wrong language

### DIFF
--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -2291,6 +2291,22 @@ class EditModelTemplateTagTest(ToolbarTestBase):
 
 
 class ToolbarUtilsTestCase(ToolbarTestBase):
+    def test_get_plugin_content_uses_plugin_language(self):
+        page = create_page("test page", "col_two.html", "de")
+        placeholder = page.get_placeholders("de").get(slot="col_left")
+        plugin = add_plugin(placeholder, "TextPlugin", "de", body="test")
+        request = self.get_page_request(page, self.get_superuser(), "/de/")
+
+        with patch.object(
+            request.toolbar.content_renderer,
+            "render_plugin",
+            side_effect=lambda *args, **kwargs: get_language(),
+        ), override("en"):
+            content = utils.get_plugin_content(request, plugin)
+
+            self.assertEqual(content[0]["html"], "de")
+            self.assertEqual(get_language(), "en")
+
     @override_settings(CMS_ENDPOINT_LIVE_URL_QUERYSTRING_PARAM_ENABLED=True)
     @override_settings(CMS_ENDPOINT_LIVE_URL_QUERYSTRING_PARAM="test-live-link")
     def test_add_live_url_querystring_param_no_querystring(self):

--- a/cms/toolbar/utils.py
+++ b/cms/toolbar/utils.py
@@ -183,14 +183,15 @@ def get_plugin_content(request: HttpRequest, plugin: CMSPlugin | list[CMSPlugin]
     renderer._placeholders_are_editable = True
     sekizai_context = SekizaiContext({'request': request, **context})
     try:
-        return [{
-            "html": renderer.render_plugin(plugin, sekizai_context, placeholder=plugin.placeholder, editable=True),
-            "js": "".join(sekizai_context[get_varname()].get("js", [])),
-            "css": "".join(sekizai_context[get_varname()].get("css", [])),
-            "position": plugin.position,
-            "placeholder_id": plugin.placeholder_id,
-            "pluginIds": get_plugin_tree_ids(plugin),
-        } for plugin in plugin_list]
+        with force_language(plugin_list[0].language):
+            return [{
+                "html": renderer.render_plugin(plugin, sekizai_context, placeholder=plugin.placeholder, editable=True),
+                "js": "".join(sekizai_context[get_varname()].get("js", [])),
+                "css": "".join(sekizai_context[get_varname()].get("css", [])),
+                "position": plugin.position,
+                "placeholder_id": plugin.placeholder_id,
+                "pluginIds": get_plugin_tree_ids(plugin),
+            } for plugin in plugin_list]
     except Exception:
         return []  # do not deliver content if rendering fails
 


### PR DESCRIPTION
## Summary by Sourcery

Ensure toolbar plugin content is rendered in the plugin’s own language when editing localized text.

Bug Fixes:
- Fix plugin content rendering so localized plugins are displayed in the correct language during editing.

Tests:
- Add a toolbar utility test verifying get_plugin_content respects the plugin language while preserving the request language context.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* fixes #8738 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.