### PR TITLE
fix: Upon edit localized text within plugins were rendered in the wrong language

### DIFF
--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -2129,6 +2129,22 @@ class EditModelTemplateTagTest(ToolbarTestBase):
 
 
 class ToolbarUtilsTestCase(ToolbarTestBase):
+    def test_get_plugin_content_uses_plugin_language(self):
+        page = create_page("test page", "col_two.html", "de")
+        placeholder = page.get_placeholders("de").get(slot="col_left")
+        plugin = add_plugin(placeholder, "TextPlugin", "de", body="test")
+        request = self.get_page_request(page, self.get_superuser(), "/de/")
+
+        with patch.object(
+            request.toolbar.content_renderer,
+            "render_plugin",
+            side_effect=lambda *args, **kwargs: get_language(),
+        ), override("en"):
+            content = utils.get_plugin_content(request, plugin)
+
+            self.assertEqual(content[0]["html"], "de")
+            self.assertEqual(get_language(), "en")
+
     @override_settings(CMS_ENDPOINT_LIVE_URL_QUERYSTRING_PARAM_ENABLED=True)
     @override_settings(CMS_ENDPOINT_LIVE_URL_QUERYSTRING_PARAM="test-live-link")
     def test_add_live_url_querystring_param_no_querystring(self):

--- a/cms/toolbar/utils.py
+++ b/cms/toolbar/utils.py
@@ -174,7 +174,7 @@ def get_plugin_tree(
     return {'html': '\n'.join(tree_structure), 'plugins': tree_data, **content}
 
 
-def get_plugin_content(request: HttpRequest, plugin: CMSPlugin | list[CMSPlugin], context: dict = None) -> dict[str, Any]:
+def get_plugin_content(request: HttpRequest, plugin: CMSPlugin | list[CMSPlugin], context: dict|None = None) -> list[dict[str, Any]]:
     if context is None:
         context = {}
     plugin_list = plugin if isinstance(plugin, list) else [plugin]
@@ -185,17 +185,17 @@ def get_plugin_content(request: HttpRequest, plugin: CMSPlugin | list[CMSPlugin]
     renderer._placeholders_are_editable = True
     context = SekizaiContext({'request': request, **context})
     try:
-        return [{
-            "html": renderer.render_plugin(plugin, context, placeholder=plugin.placeholder, editable=True),
-            "js": "".join(context[get_varname()].get("js", [])),
-            "css": "".join(context[get_varname()].get("css", [])),
-            "position": plugin.position,
-            "placeholder_id": plugin.placeholder_id,
-            "pluginIds": get_plugin_tree_ids(plugin),
-        } for plugin in plugin_list]
+        with force_language(plugin_list[0].language):
+            return [{
+                "html": renderer.render_plugin(plugin, context, placeholder=plugin.placeholder, editable=True),
+                "js": "".join(context[get_varname()].get("js", [])),
+                "css": "".join(context[get_varname()].get("css", [])),
+                "position": plugin.position,
+                "placeholder_id": plugin.placeholder_id,
+                "pluginIds": get_plugin_tree_ids(plugin),
+            } for plugin in plugin_list]
     except Exception:
         return []  # do not deliver content if rendering fails
-
 
 
 def get_plugin_tree_ids(plugin: CMSPlugin) -> list[int]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ extend-ignore = [
   "PLR0912",  # Too many branches
   "PLR0913",  # Too many arguments to function call
   "PLR0915",  # Too many statements
+  "PLR0917",  # Too many positional arguments
 
   # TODO fix separately
   "B006",

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -6,7 +6,7 @@ django-app-helper  # required to run the server for integration tests
 django-classy-tags>=0.7.2
 django-formtools
 django-sekizai>=0.7
-django-treebeard>=4.3
+django-treebeard>=4.3,<6  # 6.0 deprecates the Page.get_ancestors() etc. node API still used here
 djangocms-admin-style>=1.5
 djangocms-text-ckeditor
 iptools


### PR DESCRIPTION
## Summary by Sourcery

Ensure plugin content rendering respects the plugin’s own language when editing in the toolbar.

Bug Fixes:
- Fix plugin content being rendered in the wrong language during edit mode by forcing the plugin language for rendering.

Tests:
- Add a toolbar utility test verifying that get_plugin_content renders using the plugin language while preserving the active request language.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* back port of #8739
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.