### PR TITLE
fix: EmptyToolbar missed clipboard and toolbar_language properties

### DIFF
--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -36,7 +36,12 @@ from cms.models.pluginmodel import CMSPlugin
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 from cms.signals import post_placeholder_operation, pre_placeholder_operation
-from cms.toolbar.utils import create_child_plugin_references, get_plugin_content, get_plugin_tree
+from cms.toolbar.utils import (
+    create_child_plugin_references,
+    get_clipboard_from_request,
+    get_plugin_content,
+    get_plugin_tree,
+)
 from cms.utils import get_current_site
 from cms.utils.conf import get_cms_setting
 from cms.utils.i18n import get_language_code, get_language_list
@@ -332,7 +337,10 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
 
     def has_copy_plugins_permission(self, request, plugins):
         # Plugins can only be copied to the clipboard
-        placeholder = request.toolbar.clipboard
+        placeholder = get_clipboard_from_request(request)
+        if placeholder is None:
+            # No toolbar, no clipboard to copy into.
+            return False
         return placeholder.has_add_plugins_permission(request.user, plugins)
 
     def has_copy_from_clipboard_permission(self, request, placeholder, plugins):
@@ -480,7 +488,8 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
         if not target_language or target_language not in get_language_list(site_id=get_current_site(request).pk):
             return HttpResponseBadRequest(_("Language must be set to a supported language!"))
 
-        copy_to_clipboard = target_placeholder.pk == request.toolbar.clipboard.pk
+        clipboard = get_clipboard_from_request(request)
+        copy_to_clipboard = clipboard is not None and target_placeholder.pk == clipboard.pk
         source_plugin_id = request.POST.get('source_plugin_id', None)
 
         if copy_to_clipboard and source_plugin_id:
@@ -751,7 +760,9 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
         move_a_copy = (
             move_a_copy and move_a_copy != "0" and move_a_copy.lower() != "false"
         )
-        move_to_clipboard = placeholder == request.toolbar.clipboard
+        clipboard = get_clipboard_from_request(request)
+        # Both may be None, which must not be read as "moving to the clipboard".
+        move_to_clipboard = clipboard is not None and placeholder == clipboard
         source_placeholder = plugin.placeholder
 
         if placeholder and placeholder != source_placeholder:
@@ -1192,7 +1203,9 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
         placeholder = get_object_or_404(Placeholder, pk=placeholder_id)
         language = request.GET.get('language')
 
-        if placeholder.pk == request.toolbar.clipboard.pk:
+        clipboard = get_clipboard_from_request(request)
+
+        if clipboard is not None and placeholder.pk == clipboard.pk:
             # User is clearing the clipboard, no need for permission
             # checks here as the clipboard is unique per user.
             # There could be a case where a plugin has relationship to

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -38,9 +38,9 @@ from cms.plugin_pool import plugin_pool
 from cms.signals import post_placeholder_operation, pre_placeholder_operation
 from cms.toolbar.utils import (
     create_child_plugin_references,
-    get_clipboard_from_request,
     get_plugin_content,
     get_plugin_tree,
+    get_toolbar_from_request,
 )
 from cms.utils import get_current_site
 from cms.utils.conf import get_cms_setting
@@ -337,7 +337,7 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
 
     def has_copy_plugins_permission(self, request, plugins):
         # Plugins can only be copied to the clipboard
-        placeholder = get_clipboard_from_request(request)
+        placeholder = get_toolbar_from_request(request).clipboard
         if placeholder is None:
             # No toolbar, no clipboard to copy into.
             return False
@@ -488,7 +488,7 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
         if not target_language or target_language not in get_language_list(site_id=get_current_site(request).pk):
             return HttpResponseBadRequest(_("Language must be set to a supported language!"))
 
-        clipboard = get_clipboard_from_request(request)
+        clipboard = get_toolbar_from_request(request).clipboard
         copy_to_clipboard = clipboard is not None and target_placeholder.pk == clipboard.pk
         source_plugin_id = request.POST.get('source_plugin_id', None)
 
@@ -760,7 +760,7 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
         move_a_copy = (
             move_a_copy and move_a_copy != "0" and move_a_copy.lower() != "false"
         )
-        clipboard = get_clipboard_from_request(request)
+        clipboard = get_toolbar_from_request(request).clipboard
         # Both may be None, which must not be read as "moving to the clipboard".
         move_to_clipboard = clipboard is not None and placeholder == clipboard
         source_placeholder = plugin.placeholder
@@ -1203,7 +1203,7 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
         placeholder = get_object_or_404(Placeholder, pk=placeholder_id)
         language = request.GET.get('language')
 
-        clipboard = get_clipboard_from_request(request)
+        clipboard = get_toolbar_from_request(request).clipboard
 
         if clipboard is not None and placeholder.pk == clipboard.pk:
             # User is clearing the clipboard, no need for permission

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import iptools
 from django.conf import settings
 from django.contrib import admin
+from django.contrib.admin import site
 from django.contrib.auth.models import AnonymousUser, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
@@ -18,6 +19,7 @@ from django.urls import reverse
 from django.utils.encoding import force_str
 from django.utils.functional import lazy
 from django.utils.html import escape
+from django.utils.http import urlencode
 from django.utils.translation import get_language, gettext_lazy as _, override
 
 from cms.admin.forms import RequestToolbarForm
@@ -37,7 +39,7 @@ from cms.cms_toolbars import (
     PageToolbar,
     get_user_model,
 )
-from cms.models import PagePermission, UserSettings
+from cms.models import PagePermission, Placeholder, UserSettings
 from cms.test_utils.project.placeholderapp.models import CharPksExample, Example1
 from cms.test_utils.project.placeholderapp.views import ClassDetail, detail_view
 from cms.test_utils.testcases import URL_CMS_USERSETTINGS, CMSTestCase
@@ -51,14 +53,16 @@ from cms.toolbar.items import (
     SubMenu,
     ToolbarAPIMixin,
 )
-from cms.toolbar.toolbar import CMSToolbar
+from cms.toolbar.toolbar import CMSToolbar, EmptyToolbar
 from cms.toolbar.utils import (
     add_live_url_querystring_param,
+    get_clipboard_from_request,
     get_object_edit_url,
     get_object_for_language,
     get_object_live_url,
     get_object_preview_url,
     get_object_structure_url,
+    get_plugin_tree,
 )
 from cms.toolbar_pool import toolbar_pool
 from cms.utils.conf import get_cms_setting
@@ -227,6 +231,70 @@ class ToolbarMiddlewareTest(ToolbarTestBase):
         with self.settings(CMS_INTERNAL_IPS=iptools.IpRangeList(("128.0.0.0", "128.0.0.255"))):
             request = self.get_page_request(None, self.get_staff(), "/en/example/")
             self.assertFalse(hasattr(request, "toolbar"))
+
+
+class MissingToolbarTest(CMSTestCase):
+    """
+    The plugin endpoints must degrade instead of crashing when the toolbar is
+    absent, e.g. because CMS_INTERNAL_IPS excludes the client or because
+    ToolbarMiddleware is not installed. They enforce their own permissions and
+    must not depend on the middleware having run.
+    """
+
+    def get_request_without_toolbar(self):
+        request = RequestFactory().post("/")
+        request.user = self.get_superuser()
+        self.assertFalse(hasattr(request, "toolbar"))
+        return request
+
+    def test_empty_toolbar_has_a_clipboard_attribute(self):
+        toolbar = EmptyToolbar(RequestFactory().get("/"))
+        self.assertIsNone(toolbar.clipboard)
+
+    def test_get_clipboard_from_request_without_toolbar(self):
+        self.assertIsNone(get_clipboard_from_request(self.get_request_without_toolbar()))
+
+    def test_get_plugin_tree_without_toolbar(self):
+        page = create_page("home", "nav_playground.html", "en")
+        placeholder = page.get_placeholders("en")[0]
+        plugin = add_plugin(placeholder, "LinkPlugin", "en", name="link", external_link="http://example.com")
+
+        tree = get_plugin_tree(self.get_request_without_toolbar(), [plugin])
+
+        self.assertIn("html", tree)
+        self.assertEqual(len(tree["plugins"]), 1)
+
+    def test_copy_plugins_permission_denied_without_clipboard(self):
+        """Without a clipboard there is nothing to copy into, so deny rather than crash."""
+        page = create_page("home", "nav_playground.html", "en")
+        placeholder = page.get_placeholders("en")[0]
+        plugin = add_plugin(placeholder, "LinkPlugin", "en", name="link", external_link="http://example.com")
+        admin_instance = site._registry[Placeholder]
+
+        self.assertFalse(admin_instance.has_copy_plugins_permission(self.get_request_without_toolbar(), [plugin]))
+
+    def test_add_plugin_endpoint_does_not_crash_without_toolbar(self):
+        """Regression: rendering the close frame used to raise AttributeError."""
+        page = create_page("home", "nav_playground.html", "en")
+        placeholder = page.get_placeholders("en")[0]
+        data = {
+            "plugin_type": "LinkPlugin",
+            "placeholder_id": placeholder.pk,
+            "plugin_language": "en",
+            "plugin_position": 1,
+            "cms_path": "/en/",
+        }
+        url = admin_reverse("cms_placeholder_add_plugin") + "?" + urlencode(data)
+
+        # CMS_INTERNAL_IPS excludes the test client, so no toolbar is attached.
+        with self.settings(CMS_INTERNAL_IPS=["203.0.113.10"]):
+            with self.login_user_context(self.get_superuser()):
+                response = self.client.post(
+                    url, {"name": "link", "external_link": "http://example.com"}
+                )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(placeholder.get_plugins("en").count(), 1)
 
 
 @override_settings(CMS_PERMISSION=False)

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -56,13 +56,13 @@ from cms.toolbar.items import (
 from cms.toolbar.toolbar import CMSToolbar, EmptyToolbar
 from cms.toolbar.utils import (
     add_live_url_querystring_param,
-    get_toolbar_from_request,
     get_object_edit_url,
     get_object_for_language,
     get_object_live_url,
     get_object_preview_url,
     get_object_structure_url,
     get_plugin_tree,
+    get_toolbar_from_request,
 )
 from cms.toolbar_pool import toolbar_pool
 from cms.utils.conf import get_cms_setting

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -56,7 +56,7 @@ from cms.toolbar.items import (
 from cms.toolbar.toolbar import CMSToolbar, EmptyToolbar
 from cms.toolbar.utils import (
     add_live_url_querystring_param,
-    get_clipboard_from_request,
+    get_toolbar_from_request,
     get_object_edit_url,
     get_object_for_language,
     get_object_live_url,
@@ -252,7 +252,7 @@ class MissingToolbarTest(CMSTestCase):
         self.assertIsNone(toolbar.clipboard)
 
     def test_get_clipboard_from_request_without_toolbar(self):
-        self.assertIsNone(get_clipboard_from_request(self.get_request_without_toolbar()))
+        self.assertIsNone(get_toolbar_from_request(self.get_request_without_toolbar()).clipboard)
 
     def test_get_plugin_tree_without_toolbar(self):
         page = create_page("home", "nav_playground.html", "en")

--- a/cms/toolbar/toolbar.py
+++ b/cms/toolbar/toolbar.py
@@ -625,9 +625,24 @@ class EmptyToolbar(BaseToolbar):
 
     _cache_disabled = True
 
+    #: No toolbar means no user settings, hence no clipboard. Mirrors the initial
+    #: value on ``CMSToolbarBase`` so that callers can rely on the attribute
+    #: existing and only have to handle ``None``.
+    clipboard = None
+
     def __init__(self, request):
         self.request = request
         super().__init__()
+
+    @cached_property
+    def toolbar_language(self):
+        # There are no user settings to take a preferred language from, so the
+        # request language is the best available answer.
+        return self.request_language
+
+    @cached_property
+    def toolbar_language_bidi(self):
+        return self.toolbar_language in settings.LANGUAGES_BIDI
 
     def get_object(self):
         return None

--- a/cms/toolbar/utils.py
+++ b/cms/toolbar/utils.py
@@ -122,7 +122,7 @@ def get_plugin_tree(
     template = toolbar.templates.drag_item_template
     get_plugin_info = get_plugin_toolbar_info
     placeholder = plugins[0].placeholder
-    copy_to_clipboard = placeholder.pk == toolbar.clipboard.pk
+    copy_to_clipboard = toolbar.clipboard and placeholder.pk == toolbar.clipboard.pk
     plugins = list(downcast_plugins(plugins, select_placeholder=True))
     root_plugins = create_child_plugin_references(plugins)
 


### PR DESCRIPTION
## Summary by Sourcery

Ensure plugin admin operations and toolbar utilities behave safely when no CMS toolbar or clipboard is available on the request.

Bug Fixes:
- Prevent plugin add/copy/move/clear endpoints from crashing when the toolbar or clipboard is missing by guarding access via a request-aware clipboard helper.
- Fix permission checks that previously assumed the presence of a toolbar clipboard, denying operations cleanly when no clipboard is available.

Enhancements:
- Extend EmptyToolbar with clipboard and language-related properties so callers can rely on consistent attributes even when the toolbar middleware is not active.

Tests:
- Add regression tests covering clipboard retrieval, plugin tree rendering, copy permission checks, and add-plugin endpoint behavior when the toolbar is absent.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.