### PR TITLE
fix: Paste-a-copy IDOR discloses unauthorized plugin content

### DIFF
--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -338,6 +338,21 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
     def has_copy_from_clipboard_permission(self, request, placeholder, plugins):
         return placeholder.has_add_plugins_permission(request.user, plugins)
 
+    def has_paste_from_source_permission(self, request, source_placeholder, plugins):
+        # Pasting reads the plugins from the placeholder they are pasted from,
+        # so a user without access to that placeholder must not be able to
+        # exfiltrate its content into a placeholder they do control.
+        clipboard = request.toolbar.clipboard
+
+        if clipboard and source_placeholder.pk == clipboard.pk:
+            # Pasting from the user's own clipboard, which is what this
+            # operation is for. A user may always read their own clipboard.
+            return True
+
+        if not source_placeholder.has_add_plugins_permission(request.user, plugins):
+            return False
+        return source_placeholder.check_source(request.user)
+
     def has_copy_from_placeholder_permission(self, request, source_placeholder, target_placeholder, plugins):
         if not source_placeholder.has_add_plugins_permission(request.user, plugins):
             return False
@@ -872,6 +887,13 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
                       target_placeholder, target_position, target_parent=None):
         plugins = [plugin] + list(plugin.get_descendants())
 
+        # Check the source side as well: the plugin is identified by a
+        # client-supplied id, so it is not necessarily one the user is allowed
+        # to read.
+        if not self.has_paste_from_source_permission(request, plugin.placeholder, plugins):
+            message = _("You have no permission to paste this plugin")
+            raise PermissionDenied(message)
+
         if not self.has_copy_from_clipboard_permission(request, target_placeholder, plugins):
             message = _("You have no permission to paste this plugin")
             raise PermissionDenied(message)
@@ -931,6 +953,15 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
     def _paste_placeholder(self, request, plugin, target_language,
                            target_placeholder, target_position):
         plugins = plugin.placeholder_ref.get_plugins_list()
+
+        # Check the source side as well: the plugin is identified by a
+        # client-supplied id, so it is not necessarily one the user is allowed
+        # to read. The plugins live in the reference placeholder, but that one
+        # is only reachable through the placeholder holding the reference
+        # plugin itself (normally the user's own clipboard).
+        if not self.has_paste_from_source_permission(request, plugin.placeholder, plugins):
+            message = _("You have no permission to paste this placeholder")
+            raise PermissionDenied(message)
 
         if not self.has_copy_from_clipboard_permission(request, target_placeholder, plugins):
             message = _("You have no permission to paste this placeholder")

--- a/cms/models/settingmodels.py
+++ b/cms/models/settingmodels.py
@@ -5,9 +5,13 @@ from django.utils.translation import gettext_lazy as _
 
 
 class PlaceholderForeignKey(models.ForeignKey):
-    def run_checks(self, *args, **kwargs):
-        # User always has permission to change their own clipboard
-        return True
+    def run_checks(self, placeholder, user):
+        # A clipboard is private to its owner: only they have permission to
+        # change it. Other users must not be able to read from or write to it.
+        try:
+            return placeholder.source.has_placeholder_change_permission(user)
+        except AttributeError:
+            return False
 
 
 class UserSettings(models.Model):
@@ -36,5 +40,7 @@ class UserSettings(models.Model):
         return force_str(self.user)
 
     def has_placeholder_change_permission(self, user):
-        # User always has permission to change their own clipboard
-        return True
+        # User always has permission to change their own clipboard, but only
+        # their own: a clipboard may contain content other users are not
+        # allowed to see.
+        return self.user_id == user.pk or user.is_superuser

--- a/cms/tests/test_placeholder_admin.py
+++ b/cms/tests/test_placeholder_admin.py
@@ -7,6 +7,7 @@ from django.test.utils import CaptureQueriesContext, override_settings
 
 from cms.api import add_plugin, create_page
 from cms.models import CMSPlugin, Placeholder, UserSettings
+from cms.test_utils.project.placeholderapp.models import Example1
 from cms.test_utils.testcases import CMSTestCase
 from cms.utils.urlutils import admin_reverse
 
@@ -785,3 +786,130 @@ class PlaceholderAdminSecurityTestCase(CMSTestCase):
 
         self.assertEqual(response.status_code, 403)
         self.assertFalse(user_settings.clipboard.get_plugins("en").exists())
+
+    def _get_clipboard(self, user, with_source=True):
+        user_settings = UserSettings.objects.create(
+            language="en",
+            user=user,
+            clipboard=Placeholder.objects.create(slot="clipboard"),
+        )
+        if with_source:
+            user_settings.clipboard.source = user_settings
+            user_settings.clipboard.save()
+        return user_settings.clipboard
+
+    def test_paste_plugin_requires_source_permission(self):
+        """Pasting a plugin must check permission on the placeholder it is
+        pasted *from*.
+
+        The plugin to paste is identified by a client-supplied id, so a staff
+        user could otherwise name any plugin in the installation and have its
+        content copied into a placeholder they do control -- their own
+        clipboard, for instance.
+        """
+        attacker = self._create_user(
+            "attacker", is_staff=True, is_superuser=False, permissions=["add_link"]
+        )
+        clipboard = self._get_clipboard(attacker)
+
+        # A placeholder the attacker has no permission on.
+        victim_placeholder = Placeholder.objects.create(slot="secret")
+        victim_plugin = add_plugin(
+            victim_placeholder,
+            "LinkPlugin",
+            "en",
+            name="VictimSecretLink",
+            external_link="https://secret.example.com",
+        )
+        endpoint = self.get_move_plugin_uri(victim_plugin)
+        with self.login_user_context(attacker):
+            data = {
+                "plugin_id": victim_plugin.pk,
+                "placeholder_id": clipboard.pk,
+                "move_a_copy": "true",
+                "target_language": "en",
+                "target_position": 1,
+            }
+            response = self.client.post(endpoint, data)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertFalse(clipboard.get_plugins("en").exists())
+
+    def test_paste_placeholder_requires_source_permission(self):
+        """Pasting a placeholder reference must check permission on the
+        placeholder holding it.
+
+        A clipboard belongs to a single user, so its contents must not be
+        pasteable by anybody else.
+        """
+        attacker = self._create_user(
+            "attacker", is_staff=True, is_superuser=False, permissions=["add_link"]
+        )
+        victim = self._create_user(
+            "victim", is_staff=True, is_superuser=False, permissions=["add_link"]
+        )
+        attacker_clipboard = self._get_clipboard(attacker)
+        victim_clipboard = self._get_clipboard(victim)
+
+        # The victim copied a whole placeholder into their clipboard.
+        reference = add_plugin(
+            victim_clipboard, "PlaceholderPlugin", "en", name="Victim clipboard"
+        )
+        add_plugin(
+            reference.placeholder_ref,
+            "LinkPlugin",
+            "en",
+            name="VictimSecretLink",
+            external_link="https://secret.example.com",
+        )
+
+        endpoint = self.get_move_plugin_uri(reference)
+        with self.login_user_context(attacker):
+            data = {
+                "plugin_id": reference.pk,
+                "placeholder_id": attacker_clipboard.pk,
+                "move_a_copy": "true",
+                "target_language": "en",
+                "target_position": 1,
+            }
+            response = self.client.post(endpoint, data)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertFalse(attacker_clipboard.get_plugins("en").exists())
+
+    def test_paste_plugin_from_own_clipboard_without_source(self):
+        """A user may always paste from their own clipboard.
+
+        Clipboards created before they got a source object still have none by
+        the time the plugin to paste is fetched, so the source-side check must
+        not rely on the clipboard's source alone.
+        """
+        user = self.get_staff_user_with_no_permissions()
+        self.add_permission(user, "change_example1")
+        self.add_permission(user, "add_link")
+        clipboard = self._get_clipboard(user, with_source=False)
+
+        target = Example1.objects.create(
+            char_1="one", char_2="two", char_3="tree", char_4="four"
+        ).placeholder
+        plugin = add_plugin(
+            clipboard,
+            "LinkPlugin",
+            "en",
+            name="A Link",
+            external_link="https://www.django-cms.org",
+        )
+
+        endpoint = self.get_move_plugin_uri(plugin)
+        with self.login_user_context(user):
+            data = {
+                "plugin_id": plugin.pk,
+                "placeholder_id": target.pk,
+                "move_a_copy": "true",
+                "target_language": "en",
+                "target_position": 1,
+            }
+            response = self.client.post(endpoint, data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(target.get_plugins("en").count(), 1)

--- a/cms/tests/test_placeholder_checks.py
+++ b/cms/tests/test_placeholder_checks.py
@@ -71,6 +71,43 @@ class ChecksPlaceholderInterfaceTestCase(CMSTestCase):
         check.assert_not_called()
 
 
+class ClipboardPermissionTestCase(CMSTestCase):
+    """A clipboard is private: only its owner may work with it."""
+
+    def _get_clipboard(self, user):
+        user_settings = UserSettings.objects.create(
+            language='en',
+            user=user,
+            clipboard=Placeholder.objects.create(slot='clipboard'),
+        )
+        user_settings.clipboard.source = user_settings
+        user_settings.clipboard.save()
+        return user_settings.clipboard
+
+    def test_owner_has_permission(self):
+        user = self.get_staff_user_with_no_permissions()
+        clipboard = self._get_clipboard(user)
+
+        self.assertTrue(clipboard.has_change_permission(user))
+        self.assertTrue(clipboard.check_source(user))
+
+    def test_other_user_has_no_permission(self):
+        owner = self.get_staff_user_with_no_permissions()
+        other = self._create_user('other', is_staff=True, is_superuser=False)
+        clipboard = self._get_clipboard(owner)
+
+        self.assertFalse(clipboard.has_change_permission(other))
+        self.assertFalse(clipboard.check_source(other))
+
+    def test_superuser_has_permission(self):
+        owner = self.get_staff_user_with_no_permissions()
+        superuser = self.get_superuser()
+        clipboard = self._get_clipboard(owner)
+
+        self.assertTrue(clipboard.has_change_permission(superuser))
+        self.assertTrue(clipboard.check_source(superuser))
+
+
 class ChecksUsedInAdminEndpointsTestCase(CMSTestCase):
 
     def setUp(self):


### PR DESCRIPTION
## Summary by Sourcery

Strengthen clipboard and placeholder paste permissions to prevent unauthorized access to plugin content when pasting by ID or from another user’s clipboard.

Bug Fixes:
- Ensure pasting a plugin or placeholder checks permissions on the source placeholder to prevent exfiltration of unauthorized content.
- Restrict clipboard change access so only the owner or a superuser can read from or write to a user’s clipboard.

Enhancements:
- Add a dedicated permission check for paste operations that validates both source and target placeholder access before copying content.

Tests:
- Add tests covering paste-from-source permission enforcement for plugins and placeholder references, including attempts to paste from another user’s clipboard and legacy clipboards without a source.
- Add clipboard permission tests verifying owner, non-owner, and superuser access behavior.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.