### PR TITLE
fix: Squashed migration with custom user model

### DIFF
--- a/cms/migrations/0001_initial_squashed_0022_auto_20180620_1551.py
+++ b/cms/migrations/0001_initial_squashed_0022_auto_20180620_1551.py
@@ -4,14 +4,11 @@ import django.contrib.auth.models
 import django.db.models.deletion
 import django.utils.timezone
 from django.conf import settings
-from django.contrib.auth import get_user_model
 from django.db import migrations, models
 
 # Handle custom AUTH_USER_MODEL as in 0002_auto_20140816_1918.py
-User = get_user_model()
-
-user_model_label = '{}.{}'.format(User._meta.app_label, User._meta.model_name)
-user_ptr_name = '%s_ptr' % User._meta.object_name.lower()
+user_model_label = settings.AUTH_USER_MODEL.lower()
+user_ptr_name = f"{settings.AUTH_USER_MODEL.rsplit('.', 1)[1].lower()}_ptr"
 
 
 class Migration(migrations.Migration):

--- a/cms/migrations/0001_initial_squashed_0022_auto_20180620_1551.py
+++ b/cms/migrations/0001_initial_squashed_0022_auto_20180620_1551.py
@@ -4,7 +4,14 @@ import django.contrib.auth.models
 import django.db.models.deletion
 import django.utils.timezone
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.db import migrations, models
+
+# Handle custom AUTH_USER_MODEL as in 0002_auto_20140816_1918.py
+User = get_user_model()
+
+user_model_label = '{}.{}'.format(User._meta.app_label, User._meta.model_name)
+user_ptr_name = '%s_ptr' % User._meta.object_name.lower()
 
 
 class Migration(migrations.Migration):
@@ -370,7 +377,7 @@ class Migration(migrations.Migration):
             name="PageUser",
             fields=[
                 (
-                    "user_ptr",
+                    user_ptr_name,
                     models.OneToOneField(
                         auto_created=True,
                         on_delete=django.db.models.deletion.CASCADE,
@@ -393,7 +400,7 @@ class Migration(migrations.Migration):
                 "verbose_name": "User (page)",
                 "verbose_name_plural": "Users (page)",
             },
-            bases=("auth.user",),
+            bases=(user_model_label,),
         ),
         migrations.CreateModel(
             name="AliasPluginModel",


### PR DESCRIPTION
## Description

In the squashed migration `0001_initial_squashed_0022_auto_20180620_1551` (introduced in #8484),  the `PageUser` model hardcodes:

- parent link field: `user_ptr`
- bases: `("auth.user",)`

This causes an issue with a custom user model defined in `settings.AUTH_USER_MODEL` : 

```
django.core.exceptions.FieldError: Auto-generated field 'user_ptr' in class 'PageUser' for parent_link to base class 'User' clashes with declared field of the same name.
```
The following commit dynamically computes these two values, as was already done in https://github.com/django-cms/django-cms/blob/main/cms/migrations/0002_auto_20140816_1918.py

## Summary by Sourcery

Bug Fixes:
- Resolve migration failures when using a custom user model by avoiding hardcoded references to auth.User in the PageUser model definition.