### PR TITLE
feat: Offer replacement for djangotree-beard dependency (#8744)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,6 +170,11 @@ jobs:
 
   django-main-sqlite:
     runs-on: ${{ matrix.os }}
+    # The django-main jobs run the suite on the materialized-path tree backend
+    # (all databases). cms.tests.test_mptree_backend only runs under it; every
+    # other job stays on treebeard.
+    env:
+      CMS_TREE_BACKEND: mptree
     strategy:
       fail-fast: false
       matrix:
@@ -202,6 +207,8 @@ jobs:
 
   django-main-postgres:
     runs-on: ${{ matrix.os }}
+    env:
+      CMS_TREE_BACKEND: mptree
     strategy:
       fail-fast: false
       matrix:
@@ -250,6 +257,8 @@ jobs:
 
   django-main-mysql:
     runs-on: ${{ matrix.os }}
+    env:
+      CMS_TREE_BACKEND: mptree
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ concurrency:
 jobs:
   postgres:
     runs-on: ${{ matrix.os }}
+    env:
+      CMS_TREE_BACKEND: mptree
     strategy:
       fail-fast: false
       matrix:

--- a/cms/models/managers.py
+++ b/cms/models/managers.py
@@ -6,7 +6,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 from django.db import models
 from django.db.models import Q
-from treebeard.mp_tree import MP_NodeManager
 
 from cms.constants import ROOT_USER_LEVEL
 from cms.exceptions import NoPermissionsException
@@ -14,7 +13,7 @@ from cms.models.query import PageQuerySet
 from cms.utils.i18n import get_fallback_languages
 
 
-class PageManager(MP_NodeManager):
+class PageManager(models.Manager):
 
     def get_queryset(self):
         """Change standard model queryset to our own.

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -4,8 +4,8 @@ from os.path import join
 
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
-from django.db import IntegrityError, connection, models
-from django.db.models import F, Prefetch, Q
+from django.db import IntegrityError, connection, models, router
+from django.db.models import Prefetch
 from django.db.models.base import ModelState
 from django.db.models.constraints import UniqueConstraint
 from django.db.models.functions import Concat
@@ -14,7 +14,6 @@ from django.urls import NoReverseMatch, reverse
 from django.utils.encoding import force_str
 from django.utils.timezone import now
 from django.utils.translation import get_language, gettext_lazy as _, override as force_language
-from treebeard.mp_tree import MP_Node
 
 from cms import constants
 from cms.models.managers import PageManager, PageUrlManager
@@ -22,6 +21,7 @@ from cms.utils import i18n
 from cms.utils.compat.warnings import RemovedInDjangoCMS60Warning
 from cms.utils.conf import get_cms_setting
 from cms.utils.i18n import get_current_language
+from cms.utils.mptree import get_tree_base
 from cms.utils.page import get_clean_username
 from menus.menu_pool import menu_pool
 
@@ -44,6 +44,8 @@ class AdminCacheDict(dict):
     def __setitem__(self, key, value):
         raise ValueError("Do not set individual items in the admin cache dict. Use the clear_cache method instead.")
 
+
+MP_Node = get_tree_base()
 
 class Page(MP_Node):
     """
@@ -603,10 +605,13 @@ class Page(MP_Node):
         return new_root_page
 
     def delete(self, *args, **kwargs):
-        Page.get_tree(self).delete_fast()
+        using = self._state.db or router.db_for_write(Page, instance=self)
+        Page.get_tree(self).using(using).delete_fast()
 
-        if self.parent:
-            Page.objects.filter(id=self.parent_id).update(numchild=models.F("numchild") - 1)
+        if self.parent_id:
+            Page.objects.using(using).filter(id=self.parent_id).update(
+                numchild=models.F("numchild") - 1
+            )
         self.clear_cache(menu=True)
 
     def delete_translations(self, language=None):
@@ -682,7 +687,9 @@ class Page(MP_Node):
         return self.get_descendants().order_by("path")
 
     def get_root(self):
-        return self.__class__.objects.get(path=self.path[0 : self.steplen])
+        return self.__class__.objects.using(self._state.db).get(
+            path=self.path[0 : self.steplen]
+        )
 
     def get_parent_page(self):
         warnings.warn(

--- a/cms/models/query.py
+++ b/cms/models/query.py
@@ -1,15 +1,55 @@
 import warnings
+from collections import Counter
 
-from treebeard.mp_tree import MP_NodeQuerySet
+from django.db import models
+from django.db.models import Case, F, When
 
 from cms.exceptions import NoHomeFound
 from cms.utils.compat.warnings import RemovedInDjangoCMS60Warning
+from cms.utils.mptree import get_queryset_base, get_tree_backend
+
+# Resolved once at import time (same as the model base in pagemodel.py). In
+# mptree mode the base is a plain QuerySet and treebeard is never imported.
+_USING_TREEBEARD = get_tree_backend() == "treebeard"
 
 
-class PageQuerySet(MP_NodeQuerySet):
+class PageQuerySet(get_queryset_base()):
 
     node_warning = ("As of django CMS 5.0 the Page model does not have a node property anymore. "
                     "Use the related fields directly.")
+
+    def delete(self, *args, **kwargs):
+        if _USING_TREEBEARD:
+            # treebeard's MP_NodeQuerySet.delete removes whole subtrees by path
+            # and fixes parent numchild.
+            return super().delete(*args, **kwargs)
+        # mptree backend: the parent FK's on_delete=CASCADE removes descendants
+        # (no orphans), but the surviving parents' numchild cache still needs
+        # decrementing -- mirror treebeard's behaviour using parent_id instead
+        # of path. (Instance .delete() is handled on the model mixin; this path
+        # covers bulk ``Page.objects.filter(...).delete()``.)
+        rows = list(self.values_list("pk", "parent_id"))
+        deleted = {pk for pk, _ in rows}
+        lost = Counter(
+            parent_id for _, parent_id in rows
+            if parent_id is not None and parent_id not in deleted
+        )
+        using = self.db
+        result = models.QuerySet.delete(self, *args, **kwargs)
+        for parent_id, num_lost in lost.items():
+            self.model._base_manager.using(using).filter(pk=parent_id).update(
+                # Floored at zero in case the cache was already stale. Not with
+                # Greatest(F("numchild") - n, 0): ``numchild`` is unsigned, so
+                # MySQL raises "value is out of range" on the subtraction before
+                # GREATEST ever sees it. CASE evaluates its branch lazily and so
+                # only subtracts where the result cannot underflow.
+                numchild=Case(
+                    When(numchild__gte=num_lost, then=F("numchild") - num_lost),
+                    default=0,
+                    output_field=models.PositiveIntegerField(),
+                )
+            )
+        return result
 
     def get_descendants(self, parent=None):
         if parent is None:
@@ -41,8 +81,8 @@ class PageQuerySet(MP_NodeQuerySet):
         return self.exclude(application_urls=None).exclude(application_urls='').exists()
 
     def delete_fast(self):
-        # calls django's delete instead of the one from treebeard
-        super(MP_NodeQuerySet, self).delete()
+        # plain Django delete, skipping any tree-fixup delete (both backends)
+        models.QuerySet.delete(self)
 
     def root_only(self):
         return self.filter(depth=1)

--- a/cms/test_utils/project/sampleapp/models.py
+++ b/cms/test_utils/project/sampleapp/models.py
@@ -2,10 +2,12 @@ from functools import cached_property
 
 from django.db import models
 from django.urls import reverse
-from treebeard.mp_tree import MP_Node
 
 from cms.models.fields import PlaceholderRelationField
+from cms.utils.mptree import get_tree_base
 from cms.utils.placeholder import get_placeholder_from_slot
+
+MP_Node = get_tree_base()
 
 
 class Category(MP_Node):

--- a/cms/tests/test_mptree_backend.py
+++ b/cms/tests/test_mptree_backend.py
@@ -1,0 +1,1055 @@
+"""
+Guardrail + functional tests for the swappable tree backend.
+
+* ``TreeFieldParityTests`` proves the swap is *migration-invisible*: Django
+  builds migrations purely from field deconstruction, so if
+  ``MaterializedPathMixin`` deconstructs its tree fields identically to
+  treebeard's ``MP_Node``, substituting one for the other produces no migration.
+
+* ``PageTreeBackendTests`` and ``PageQuerySetDeleteTests`` are ordinary
+  page-tree tests covering build, query, move and delete.
+
+The whole module only runs under the mptree backend::
+
+    CMS_TREE_BACKEND=mptree python manage.py test cms.tests.test_mptree_backend
+
+Under treebeard it is skipped: those code paths belong to treebeard, are covered
+by the rest of the suite, and holding treebeard to this module's expectations
+means asserting on upstream behaviour we cannot fix.
+"""
+import os
+import time
+from collections import defaultdict
+from unittest import skipIf
+
+from django.test import SimpleTestCase, TestCase, TransactionTestCase
+from treebeard.mp_tree import MP_Node
+
+from cms.api import create_page
+from cms.models import Page
+from cms.test_utils.project.sampleapp.models import Category
+from cms.test_utils.testcases import CMSTestCase
+from cms.utils.mptree import (
+    MaterializedPath,
+    MaterializedPathMixin,
+    TreePathOverflow,
+    get_tree_backend,
+    get_tree_base,
+)
+
+TEMPLATE = "nav_playground.html"
+
+mptree_only = skipIf(
+    get_tree_backend() == "treebeard",
+    "mptree backend only -- run with CMS_TREE_BACKEND=mptree",
+)
+
+
+@mptree_only
+class TreeFieldParityTests(SimpleTestCase):
+    """Field-level proof that the two backends are interchangeable without a
+    schema migration."""
+
+    TREE_FIELDS = {"path", "depth", "numchild"}
+
+    def _deconstructed(self, base):
+        # drop the field name (index 0); compare (import_path, args, kwargs)
+        return {
+            f.name: f.deconstruct()[1:]
+            for f in base._meta.get_fields()
+            if f.name in self.TREE_FIELDS
+        }
+
+    def test_fields_deconstruct_identically(self):
+        self.assertEqual(
+            self._deconstructed(MaterializedPathMixin),
+            self._deconstructed(MP_Node),
+        )
+
+    def test_same_concrete_field_set(self):
+        mp = {f.name for f in MaterializedPathMixin._meta.get_fields()}
+        tb = {f.name for f in MP_Node._meta.get_fields()}
+        self.assertEqual(mp, tb)
+        self.assertEqual(mp, self.TREE_FIELDS)
+
+    def test_selector_matches_active_backend(self):
+        self.assertIs(get_tree_base(), MaterializedPathMixin)
+
+    def test_queryset_is_treebeard_free_in_mptree_mode(self):
+        # The page queryset must not inherit from treebeard when the mptree
+        # backend is active -- otherwise treebeard would be imported.
+        from cms.models.query import PageQuerySet
+
+        mro_modules = {base.__module__ for base in PageQuerySet.__mro__}
+        self.assertNotIn("treebeard.mp_tree", mro_modules)
+        # The manager is backend-agnostic (never treebeard) in either mode.
+        from cms.models import Page
+
+        self.assertNotIn("treebeard", type(Page.objects).__module__)
+
+
+@mptree_only
+class PageTreeBackendTests(CMSTestCase):
+    """The page tree as built, queried and moved by the mptree backend."""
+
+    def test_build_and_query(self):
+        root = create_page("root", TEMPLATE, "en")
+        c1 = create_page("c1", TEMPLATE, "en", parent=root)
+        c2 = create_page("c2", TEMPLATE, "en", parent=root)
+        g1 = create_page("g1", TEMPLATE, "en", parent=c1)
+
+        root.refresh_from_db()
+        self.assertTrue(root.is_root())
+        self.assertEqual(
+            list(root.get_child_pages().values_list("pk", flat=True)),
+            [c1.pk, c2.pk],
+        )
+        self.assertEqual(root.get_descendant_pages().count(), 3)
+        self.assertEqual(
+            list(g1.get_ancestor_pages().values_list("pk", flat=True)),
+            [root.pk, c1.pk],
+        )
+        self.assertTrue(g1.is_leaf())
+        self.assertEqual(g1.get_root().pk, root.pk)
+        # paths stay correctly nested
+        for child in (c1, c2, g1):
+            child.refresh_from_db()
+        self.assertTrue(c1.path.startswith(root.path))
+        self.assertTrue(g1.path.startswith(c1.path))
+
+    def test_move_page_reparents_subtree(self):
+        root = create_page("root", TEMPLATE, "en")
+        a = create_page("a", TEMPLATE, "en", parent=root)
+        b = create_page("b", TEMPLATE, "en", parent=root)
+        a_child = create_page("a_child", TEMPLATE, "en", parent=a)
+
+        # Move `a` (with its subtree) under `b`.
+        a.refresh_from_db()
+        b.refresh_from_db()
+        a.move_page(b, "last-child")
+
+        a.refresh_from_db()
+        a_child.refresh_from_db()
+        b.refresh_from_db()
+
+        self.assertEqual(a.parent_id, b.pk)
+        self.assertEqual(a.depth, b.depth + 1)
+        self.assertEqual(a_child.depth, a.depth + 1)
+        self.assertTrue(a.path.startswith(b.path))
+        self.assertTrue(a_child.path.startswith(a.path))
+        self.assertIn(a.pk, b.get_descendant_pages().values_list("pk", flat=True))
+        self.assertIn(
+            a_child.pk, b.get_descendant_pages().values_list("pk", flat=True)
+        )
+
+    def test_move_left_orders_db_correctly(self):
+        # DB-truth check (the real-suite regression tests assert on stale
+        # in-memory objects + treebeard's exact bytes; here we verify ordering).
+        home = create_page("Home", TEMPLATE, "en")
+        alpha = create_page("Alpha", TEMPLATE, "en", parent=home)
+        beta = create_page("Beta", TEMPLATE, "en", parent=home)
+
+        beta.move_page(alpha, position="left")
+
+        alpha.refresh_from_db()
+        beta.refresh_from_db()
+        home.refresh_from_db()
+        self.assertEqual(
+            list(home.get_child_pages().values_list("pk", flat=True)),
+            [beta.pk, alpha.pk],
+        )
+        self.assertTrue(beta.path < alpha.path)
+
+    def test_move_page_out_to_the_left_of_its_own_parent(self):
+        # What the admin does for "move to root position N": the target sibling
+        # is the page's own parent, so the page has to climb out of a subtree
+        # that the same layout is shifting.
+        home = create_page("Home", TEMPLATE, "en")
+        gamma = create_page("Gamma", TEMPLATE, "en")
+        delta = create_page("Delta", TEMPLATE, "en", parent=gamma)
+
+        gamma.refresh_from_db()
+        delta.refresh_from_db()
+        delta.move_page(gamma, position="left")
+
+        gamma.refresh_from_db()
+        delta.refresh_from_db()
+        self.assertEqual(delta.parent_id, None)
+        self.assertEqual(delta.depth, 1)
+        self.assertEqual(gamma.numchild, 0)
+        self.assertEqual(gamma.get_descendant_pages().count(), 0)
+        self.assertEqual(
+            list(Page.get_root_nodes().values_list("pk", flat=True)),
+            [home.pk, delta.pk, gamma.pk],
+        )
+
+    def test_delete_updates_parent_numchild(self):
+        page1 = create_page("home", TEMPLATE, "en")
+        page2 = create_page("page2", TEMPLATE, "en", parent=page1)
+        self.assertEqual(page1.numchild, 1)  # in-memory, no refresh
+        page2.delete()
+        page1.refresh_from_db()
+        self.assertEqual(page1.numchild, 0)
+        self.assertTrue(page1.is_leaf())
+
+    def test_rebuild_preserves_sibling_order_not_pk_order(self):
+        # Reorder siblings away from creation (pk) order, then rebuild and
+        # confirm the editor-chosen order survives -- i.e. order comes from the
+        # path, so no separate `position` field is required.
+        root = create_page("root", TEMPLATE, "en")
+        a = create_page("a", TEMPLATE, "en", parent=root)  # pk order: a, b, c
+        b = create_page("b", TEMPLATE, "en", parent=root)
+        c = create_page("c", TEMPLATE, "en", parent=root)
+
+        c.refresh_from_db()
+        a.refresh_from_db()
+        c.move_page(a, position="left")  # path order now: c, a, b
+        root.refresh_from_db()
+        self.assertEqual(
+            list(root.get_child_pages().values_list("pk", flat=True)),
+            [c.pk, a.pk, b.pk],
+        )
+
+        Page.fix_tree()  # -> rebuild()
+        root.refresh_from_db()
+        self.assertEqual(
+            list(root.get_child_pages().values_list("pk", flat=True)),
+            [c.pk, a.pk, b.pk],  # preserved, NOT [a, b, c]
+        )
+
+    def test_bulk_queryset_delete_updates_numchild(self):
+        # Bulk Page.objects.filter(...).delete() must keep the surviving
+        # parent's numchild correct (treebeard does this; the mptree branch
+        # must too). Descendants are removed via parent FK CASCADE.
+        root = create_page("root", TEMPLATE, "en")
+        a = create_page("a", TEMPLATE, "en", parent=root)
+        create_page("b", TEMPLATE, "en", parent=root)
+        create_page("a_child", TEMPLATE, "en", parent=a)
+
+        root.refresh_from_db()
+        self.assertEqual(root.numchild, 2)
+
+        # delete `a` (and its subtree) via a bulk queryset delete
+        Page.objects.filter(pk=a.pk).delete()
+
+        root.refresh_from_db()
+        self.assertEqual(root.numchild, 1)
+        self.assertEqual(root.get_child_pages().count(), 1)
+        self.assertFalse(Page.objects.filter(pk=a.pk).exists())
+
+    def test_root_nodes_and_fix_tree(self):
+        r1 = create_page("r1", TEMPLATE, "en")
+        r2 = create_page("r2", TEMPLATE, "en")
+        create_page("child", TEMPLATE, "en", parent=r1)
+
+        roots = set(Page.get_root_nodes().values_list("pk", flat=True))
+        self.assertEqual(roots, {r1.pk, r2.pk})
+
+        # fix_tree / rebuild must leave a consistent, queryable tree.
+        Page.fix_tree()
+        r1.refresh_from_db()
+        self.assertEqual(r1.get_descendant_pages().count(), 1)
+        self.assertEqual(set(Page.get_root_nodes().values_list("pk", flat=True)), roots)
+
+
+@mptree_only
+class PageQuerySetDeleteTests(CMSTestCase):
+    """``PageQuerySet.delete`` is the one queryset method with a backend-specific
+    implementation: treebeard walks ``path`` prefixes to remove subtrees, while
+    the mptree branch leans on the ``parent`` FK cascade and fixes the surviving
+    parents' ``numchild`` cache itself. ``delete_fast`` is the escape hatch that
+    skips all of that."""
+
+    def _tree(self):
+        """``root -> (a -> (a1, a2), b)`` -- returns the pages top-down."""
+        root = create_page("root", TEMPLATE, "en")
+        a = create_page("a", TEMPLATE, "en", parent=root)
+        b = create_page("b", TEMPLATE, "en", parent=root)
+        a1 = create_page("a1", TEMPLATE, "en", parent=a)
+        a2 = create_page("a2", TEMPLATE, "en", parent=a)
+        return root, a, b, a1, a2
+
+    def test_delete_removes_the_whole_subtree(self):
+        # Deleting a branch must take its descendants with it -- no orphans
+        # pointing at a gone parent.
+        root, a, b, a1, a2 = self._tree()
+
+        Page.objects.filter(pk=a.pk).delete()
+
+        self.assertFalse(Page.objects.filter(pk__in=[a.pk, a1.pk, a2.pk]).exists())
+        self.assertEqual(
+            set(Page.objects.values_list("pk", flat=True)), {root.pk, b.pk}
+        )
+        root.refresh_from_db()
+        self.assertEqual(root.numchild, 1)
+
+    def test_delete_several_children_of_one_parent(self):
+        # Two children of the same parent in a single call -> numchild must drop
+        # by two, not by one.
+        root, a, b, a1, a2 = self._tree()
+
+        Page.objects.filter(pk__in=[a1.pk, a2.pk]).delete()
+
+        a.refresh_from_db()
+        self.assertEqual(a.numchild, 0)
+        self.assertTrue(a.is_leaf())
+        root.refresh_from_db()
+        self.assertEqual(root.numchild, 2)  # untouched
+
+    def test_delete_parent_and_child_in_one_queryset(self):
+        # `a1` is deleted twice over (explicitly, and as a descendant of `a`):
+        # only `root` may be decremented, and only once.
+        root, a, b, a1, a2 = self._tree()
+
+        Page.objects.filter(pk__in=[a.pk, a1.pk]).delete()
+
+        root.refresh_from_db()
+        self.assertEqual(root.numchild, 1)
+        self.assertEqual(
+            set(Page.objects.values_list("pk", flat=True)), {root.pk, b.pk}
+        )
+
+    def test_delete_root_pages(self):
+        # Roots have parent_id NULL -- there is nothing to decrement, and the
+        # NULL must not be mistaken for a parent to update.
+        r1 = create_page("r1", TEMPLATE, "en")
+        create_page("r1_child", TEMPLATE, "en", parent=r1)
+        create_page("r2", TEMPLATE, "en")
+
+        Page.objects.filter(depth=1).delete()
+
+        self.assertEqual(Page.objects.count(), 0)
+
+    def test_delete_never_makes_numchild_negative(self):
+        # A stale/corrupt numchild cache must not be driven below zero -- and
+        # must not blow up on MySQL's unsigned column either.
+        root, a, b, a1, a2 = self._tree()
+        Page.objects.filter(pk=root.pk).update(numchild=0)
+
+        Page.objects.filter(pk=a.pk).delete()
+
+        root.refresh_from_db()
+        self.assertEqual(root.numchild, 0)
+
+    def test_delete_on_empty_queryset_is_a_noop(self):
+        root, a, b, a1, a2 = self._tree()
+
+        Page.objects.filter(pk__in=[]).delete()
+
+        self.assertEqual(Page.objects.count(), 5)
+        root.refresh_from_db()
+        a.refresh_from_db()
+        self.assertEqual((root.numchild, a.numchild), (2, 2))
+
+    # --- delete_fast ----------------------------------------------------
+
+    def test_delete_fast_removes_rows_and_descendants(self):
+        # Plain Django delete: the rows go, and so do their descendants -- but
+        # via the parent FK cascade, in *both* backends (treebeard's path walk
+        # is bypassed entirely).
+        root, a, b, a1, a2 = self._tree()
+
+        Page.objects.filter(pk=a.pk).delete_fast()
+
+        self.assertEqual(
+            set(Page.objects.values_list("pk", flat=True)), {root.pk, b.pk}
+        )
+
+    def test_delete_fast_leaves_numchild_stale_on_purpose(self):
+        # The whole point of delete_fast: no tree bookkeeping. The caller is
+        # responsible for numchild -- compare with delete(), which fixes it.
+        root, a, b, a1, a2 = self._tree()
+
+        Page.objects.filter(pk=a.pk).delete_fast()
+
+        root.refresh_from_db()
+        self.assertEqual(root.numchild, 2)  # stale, not 1
+
+        # ...whereas the same removal through delete() does fix the cache.
+        Page.objects.filter(pk=b.pk).delete()
+        root.refresh_from_db()
+        self.assertEqual(root.numchild, 1)
+
+    def test_delete_fast_on_empty_queryset_is_a_noop(self):
+        root, a, b, a1, a2 = self._tree()
+
+        Page.objects.filter(pk__in=[]).delete_fast()
+
+        self.assertEqual(Page.objects.count(), 5)
+
+    def test_page_instance_delete_builds_on_delete_fast(self):
+        # Page.delete() is the real caller: it drops the subtree with
+        # delete_fast and then decrements the parent itself -- exactly once,
+        # no matter how large the subtree.
+        root, a, b, a1, a2 = self._tree()
+
+        a.refresh_from_db()
+        a.delete()
+
+        self.assertEqual(
+            set(Page.objects.values_list("pk", flat=True)), {root.pk, b.pk}
+        )
+        root.refresh_from_db()
+        self.assertEqual(root.numchild, 1)
+
+
+
+@mptree_only
+class MaterializedPathDriverTests(TestCase):
+    def setUp(self):
+        self.mp = MaterializedPath(Category)
+
+    def test_int2str(self):
+        test_matrix = (
+            (1, "1"),
+            (10, "A"),
+            (100, "2S"),
+            (1000, "RS"),
+            (10000, "7PS"),
+        )
+        for num, exp_str in test_matrix:
+            self.assertEqual(exp_str, self.mp._int2str(num))
+
+    def test_tree_root_of_and_empty_ancestors(self):
+        r = self.mp.add_root(name="r")
+        c = self.mp.add_child(r, name="c")
+        g = self.mp.add_child(c, name="g")
+
+        self.assertEqual(self.mp.tree().count(), 3)                       # parent=None
+        self.assertEqual(
+            set(self.mp.tree(r).values_list("name", flat=True)),         # parent given
+            {"r", "c", "g"},
+        )
+        self.assertEqual(self.mp.root_of(g).pk, r.pk)
+        self.assertEqual(list(self.mp.ancestors(r)), [])                 # root has none
+
+    def test_add_child_first_child(self):
+        r = self.mp.add_root(name="r")
+        self.mp.add_child(r, name="a")
+        self.mp.add_child(r, name="b")
+        self.mp.add_child(r, position="first-child", name="c")
+        self.assertEqual(
+            list(self.mp.children(r).values_list("name", flat=True)),
+            ["c", "a", "b"],
+        )
+
+    def test_add_sibling_all_positions(self):
+        r = self.mp.add_root(name="r")
+        a = self.mp.add_child(r, name="a")
+        b = self.mp.add_child(r, name="b")
+
+        # child siblings -> _place_relative (after True/False) + last/first
+        self.mp.add_sibling(a, name="s_last")                  # default last-sibling
+        self.mp.add_sibling(a, position="right", name="s_right")
+        self.mp.add_sibling(b, position="left", name="s_left")
+        self.mp.add_sibling(b, position="first-sibling", name="s_first")
+
+        # root siblings -> parent-None branch (last + left/no-op)
+        self.mp.add_sibling(r, name="r2")
+        self.mp.add_sibling(r, position="left", name="r3")
+
+        self.assertEqual(self.mp.roots().count(), 3)
+        self.assertEqual(Category.objects.count(), 9)
+        # every node still has a path correctly nested under its parent
+        for cat in Category.objects.all():
+            if cat.parent_id:
+                self.assertTrue(cat.path.startswith(cat.parent.path))
+
+    def test_move_left_and_right_into_middle(self):
+        r = self.mp.add_root(name="r")
+        a = self.mp.add_child(r, name="a")
+        self.mp.add_child(r, name="b")
+        c = self.mp.add_child(r, name="c")
+
+        self.mp.move(c, a, "left")   # left, lands mid-group -> _layout
+        self.assertEqual(
+            list(self.mp.children(r).values_list("name", flat=True)), ["c", "a", "b"]
+        )
+        self.mp.move(c, a, "right")  # right, lands mid-group -> _layout
+        self.assertEqual(
+            list(self.mp.children(r).values_list("name", flat=True)), ["a", "c", "b"]
+        )
+
+    def test_positional_move_landing_at_end(self):
+        r = self.mp.add_root(name="r")
+        a = self.mp.add_child(r, name="a")
+        b = self.mp.add_child(r, name="b")
+
+        # 'right' of the last sibling -> append branch (siblings non-empty)
+        self.mp.move(a, b, "right")
+        self.assertEqual(
+            list(self.mp.children(r).values_list("name", flat=True)), ["b", "a"]
+        )
+        # 'first-child' of a leaf -> append branch with empty siblings
+        self.mp.move(b, a, "first-child")
+        self.assertEqual(self.mp.children(a).first().name, "b")
+
+    def test_move_out_from_under_a_shifted_sibling(self):
+        # Regression: the node being moved lives *inside* a sibling that the
+        # layout has to shift. Rewriting that sibling's subtree first used to
+        # drag the node along, so its own rewrite then matched nothing and it
+        # stayed buried (admin "move to root position N" hit exactly this).
+        gamma = self.mp.add_root(name="gamma")
+        delta = self.mp.add_child(gamma, name="delta")
+
+        self.mp.move(delta, gamma, "left")  # left of its own parent
+
+        delta.refresh_from_db()
+        gamma.refresh_from_db()
+        self.assertEqual(
+            list(self.mp.roots().values_list("name", flat=True)), ["delta", "gamma"]
+        )
+        self.assertEqual((delta.depth, delta.parent_id), (1, None))
+        self.assertEqual(self.mp.descendants(gamma).count(), 0)
+        self.assertEqual(gamma.numchild, 0)
+
+    def test_move_out_from_under_an_uncle(self):
+        # Same nesting hazard one level over: `c` sits under `b`, and landing it
+        # first-child of `r` shifts both `a` and `b` down a slot.
+        r = self.mp.add_root(name="r")
+        self.mp.add_child(r, name="a")
+        b = self.mp.add_child(r, name="b")
+        c = self.mp.add_child(b, name="c")
+
+        self.mp.move(c, r, "first-child")
+
+        c.refresh_from_db()
+        b.refresh_from_db()
+        self.assertEqual(
+            list(self.mp.children(r).values_list("name", flat=True)), ["c", "a", "b"]
+        )
+        self.assertEqual((c.depth, c.parent_id), (2, r.pk))
+        self.assertEqual(b.numchild, 0)
+
+    def test_move_into_own_subtree_raises(self):
+        r = self.mp.add_root(name="r")
+        c = self.mp.add_child(r, name="c")
+        with self.assertRaises(ValueError):
+            self.mp.move(r, c, "last-child")
+
+    def test_scope_sets_fields(self):
+        # `scope` filters the forest and is stamped onto new nodes (both the
+        # field-kwargs path and the explicit instance path).
+        mp = MaterializedPath(Category, scope={"name": "scoped"})
+        mp.add_root()
+        stamped = mp.add_root(instance=Category(name="ignored"))
+        self.assertEqual(stamped.name, "scoped")
+        self.assertEqual(mp.roots().count(), 2)
+
+    def test_lock_disabled(self):
+        mp = MaterializedPath(Category, lock=False)
+        r = mp.add_root(name="r")
+        mp.add_child(r, name="c")
+        self.assertEqual(mp.children(r).count(), 1)
+
+
+@mptree_only
+class MaterializedPathOverflowTests(TestCase):
+    """
+    ``steplen`` and the ``path`` column's ``max_length`` cap how wide and how
+    deep the tree can go. Both ceilings are checked in Python before any
+    statement runs, so hitting one raises ``TreePathOverflow`` and leaves the
+    tree untouched, rather than silently truncating a path or failing halfway
+    through a multi-statement rewrite.
+    """
+
+    def setUp(self):
+        self.mp = MaterializedPath(Category)
+        self.max_depth = self.mp.path_max_length // self.mp.steplen
+
+    def _node_at_max_depth(self, name, depth=None):
+        # Written directly: reaching depth 63 through add_child would be 63
+        # round trips to set up a test about the 64th. Step 9 keeps this chain
+        # off the step-1 branch that `add_root` hands out, so it is nobody's
+        # ancestor by path prefix.
+        depth = depth if depth is not None else self.max_depth
+        return Category.objects.create(
+            name=name, path=self.mp.segment(9) * depth, depth=depth, numchild=0
+        )
+
+    def test_sibling_step_wider_than_one_segment_is_rejected(self):
+        widest = self.mp.radix**self.mp.steplen - 1
+        self.assertEqual(len(self.mp.segment(widest)), self.mp.steplen)
+        for step in (0, widest + 1):
+            with self.assertRaises(TreePathOverflow):
+                self.mp.segment(step)
+
+    def test_add_child_below_the_deepest_level_is_rejected(self):
+        deepest = self._node_at_max_depth("deepest")
+        with self.assertRaises(TreePathOverflow):
+            self.mp.add_child(deepest, name="one-too-deep")
+        self.assertEqual(Category.objects.filter(name="one-too-deep").count(), 0)
+
+    def test_move_checks_the_deepest_descendant_before_rewriting(self):
+        # The subtree root itself would still fit under `deep`; its grandchild
+        # is what overflows. Guarding only the new prefix would let the rewrite
+        # start and truncate the descendants.
+        deep = self._node_at_max_depth("deep", depth=self.max_depth - 1)
+        root = self.mp.add_root(name="r")
+        child = self.mp.add_child(root, name="c")
+        self.mp.add_child(child, name="g")
+        before = dict(Category.objects.values_list("name", "path"))
+
+        with self.assertRaises(TreePathOverflow):
+            self.mp.move(root, deep, "last-child")
+
+        self.assertEqual(dict(Category.objects.values_list("name", "path")), before)
+
+
+@mptree_only
+class MaterializedPathStaleInstanceTests(TestCase):
+    """
+    Callers hand the driver model instances they may have been holding since
+    before a concurrent write. Every mutation re-reads their tree columns under
+    its locks, because the layout it plans from ``path``/``depth``/``parent``
+    would otherwise rewrite the rows the node used to occupy.
+    """
+
+    def setUp(self):
+        self.mp = MaterializedPath(Category)
+
+    def test_add_child_plans_from_the_refreshed_parent(self):
+        r1 = self.mp.add_root(name="r1")
+        r2 = self.mp.add_root(name="r2")
+        parent = self.mp.add_child(r1, name="p")
+        stale = Category.objects.get(pk=parent.pk)  # caller's copy, under r1
+        self.mp.move(parent, r2, "last-child")  # someone else re-parents it
+
+        self.mp.add_child(stale, name="c")
+
+        parent.refresh_from_db()
+        child = Category.objects.get(name="c")
+        self.assertEqual(child.parent_id, parent.pk)
+        self.assertTrue(child.path.startswith(parent.path))
+        self.assertEqual(child.depth, parent.depth + 1)
+
+    def test_move_plans_from_the_refreshed_target(self):
+        r1 = self.mp.add_root(name="r1")
+        r2 = self.mp.add_root(name="r2")
+        target = self.mp.add_child(r1, name="t")
+        node = self.mp.add_child(r1, name="n")
+        stale_target = Category.objects.get(pk=target.pk)
+        self.mp.move(target, r2, "last-child")
+
+        self.mp.move(node, stale_target, "last-child")
+
+        target.refresh_from_db()
+        node.refresh_from_db()
+        self.assertEqual(node.parent_id, target.pk)
+        self.assertTrue(node.path.startswith(target.path))
+        self.assertEqual(node.depth, target.depth + 1)
+
+    def test_move_decrements_the_parent_the_node_actually_left(self):
+        r1 = self.mp.add_root(name="r1")
+        r2 = self.mp.add_root(name="r2")
+        r3 = self.mp.add_root(name="r3")
+        node = self.mp.add_child(r1, name="n")
+        stale = Category.objects.get(pk=node.pk)  # remembers r1 as its parent
+        self.mp.move(node, r2, "last-child")
+
+        self.mp.move(stale, r3, "last-child")
+
+        for root, expected in ((r1, 0), (r2, 0), (r3, 1)):
+            root.refresh_from_db()
+            self.assertEqual(root.numchild, expected, root.name)
+
+    def test_add_sibling_plans_from_the_refreshed_node(self):
+        r1 = self.mp.add_root(name="r1")
+        r2 = self.mp.add_root(name="r2")
+        node = self.mp.add_child(r1, name="n")
+        stale = Category.objects.get(pk=node.pk)
+        self.mp.move(node, r2, "last-child")
+
+        self.mp.add_sibling(stale, name="s")
+
+        sibling = Category.objects.get(name="s")
+        self.assertEqual(sibling.parent_id, r2.pk)
+
+    def test_refresh_keeps_unsaved_edits_to_other_fields(self):
+        # Only the tree columns are re-read, so a caller that set a field and
+        # then built structure does not silently lose the edit.
+        root = self.mp.add_root(name="r")
+        root.name = "renamed-but-unsaved"
+        self.mp.add_child(root, name="c")
+        self.assertEqual(root.name, "renamed-but-unsaved")
+
+
+@mptree_only
+class MaterializedPathDatabaseAliasTests(TransactionTestCase):
+    """
+    One operation must not straddle two connections. ``other`` is a test mirror
+    of ``default`` -- the same rows -- so what these assert is which *connection*
+    the driver used, not which database ended up holding the data.
+    """
+
+    databases = {"default", "other"}
+
+    def test_driver_defaults_to_the_routed_write_alias(self):
+        self.assertEqual(MaterializedPath(Category).db_alias, "default")
+
+    def test_explicit_alias_keeps_every_statement_off_default(self):
+        mp = MaterializedPath(Category, using="other")
+        with self.assertNumQueries(0, using="default"):
+            root = mp.add_root(name="r")
+            child = mp.add_child(root, name="c")
+            mp.add_child(root, position="first-child", name="c2")
+            mp.move(child, root, "first-child")
+            mp.rebuild()
+        self.assertEqual(root._state.db, "other")
+
+    def test_instance_api_stays_on_the_alias_it_was_loaded_from(self):
+        Category.add_root(instance=Category(name="r"))
+        root = Category.objects.using("other").get(name="r")
+        with self.assertNumQueries(0, using="default"):
+            child = root.add_child(instance=Category(name="c"))
+            list(root.get_children())
+            list(child.get_ancestors())
+            list(child.get_siblings())
+            child.get_root()
+            child.delete()
+        self.assertEqual(child._state.db, "other")
+
+    def test_class_api_accepts_an_explicit_alias(self):
+        with self.assertNumQueries(0, using="default"):
+            list(Category.get_root_nodes(using="other"))
+            list(Category.get_tree(using="other"))
+            Category.fix_tree(using="other")
+
+
+@mptree_only
+class MaterializedPathMixinCoverageTests(CMSTestCase):
+    def _page(self, name, parent=None, position="last-child"):
+        return create_page(name, TEMPLATE, "en", parent=parent, position=position)
+
+    def test_treebeard_compat_predicates(self):
+        root = self._page("root")
+        a = self._page("a", parent=root)
+        b = self._page("b", parent=a)
+        for page in (root, a, b):
+            page.refresh_from_db()
+
+        a2 = self._page("a2", parent=root)
+        a.refresh_from_db()
+        a2.refresh_from_db()
+
+        self.assertEqual(a.get_parent().pk, root.pk)
+        self.assertEqual(root.get_first_child().pk, a.pk)
+        self.assertTrue(a.is_sibling_of(a2))
+        self.assertFalse(a.is_sibling_of(b))
+        self.assertTrue(a.is_child_of(root))
+        self.assertFalse(b.is_child_of(root))
+        self.assertTrue(b.is_descendant_of(root))
+        self.assertFalse(root.is_descendant_of(b))
+        self.assertIn(root.pk, [s.pk for s in root.get_siblings()])   # root branch
+        self.assertIn(a.pk, [s.pk for s in a.get_siblings()])         # child branch
+
+        # get_root is overridden on Page -> exercise the mixin's directly
+        self.assertEqual(MaterializedPathMixin.get_root(b).pk, root.pk)
+
+    def test_add_sibling_via_position(self):
+        root = self._page("root")
+        a = self._page("a", parent=root)
+        # position "left" routes Page.add_to_tree -> Page.add_sibling -> mixin
+        self._page("left-of-a", parent=a, position="left")
+        root.refresh_from_db()
+        # first-child into a branch -> get_first_child().add_sibling(...)
+        self._page("first", parent=root, position="first-child")
+        self.assertGreaterEqual(root.get_child_pages().count(), 1)
+
+    def test_mixin_delete_decrements_numchild(self):
+        root = self._page("root")
+        leaf = self._page("leaf", parent=root)
+        leaf.refresh_from_db()
+        # Page overrides delete(); call the mixin implementation directly.
+        MaterializedPathMixin.delete(leaf)
+        root.refresh_from_db()
+        self.assertEqual(root.numchild, 0)
+
+
+def make_spec():
+    """A deterministic (name, parent_name) build order; parents precede children."""
+    spec = []
+    for r in range(3):  # roots
+        root = f"r{r}"
+        spec.append((root, None))
+        for c in range(4):  # children
+            child = f"{root}_c{c}"
+            spec.append((child, root))
+            for g in range(2):  # grandchildren
+                spec.append((f"{child}_g{g}", child))
+    return spec
+
+
+def snapshot():
+    return {
+        c.name: (c.path, c.depth, c.numchild)
+        for c in Category.objects.all()
+    }
+
+
+def build_with_treebeard(spec):
+    nodes = {}
+    for name, parent in spec:
+        if parent is None:
+            nodes[name] = Category.add_root(name=name)
+        else:
+            nodes[name] = nodes[parent].add_child(name=name)
+    return nodes
+
+
+def build_with_mptree(spec, mp):
+    nodes = {}
+    for name, parent in spec:
+        if parent is None:
+            nodes[name] = mp.add_root(name=name)
+        else:
+            nodes[name] = mp.add_child(nodes[parent], name=name)
+    return nodes
+
+
+def build_bulk(n, fanout=5):
+    """Fast-create a balanced ``fanout``-ary tree of ``n`` nodes (explicit pks)."""
+    mp = MaterializedPath(Category)
+    paths, depths = {}, {}
+    childcount = defaultdict(int)
+    for i in range(n):
+        parent = None if i == 0 else (i - 1) // fanout
+        childcount[parent] += 1
+        step = childcount[parent]
+        if parent is None:
+            paths[i], depths[i] = mp.segment(step), 1
+        else:
+            paths[i], depths[i] = paths[parent] + mp.segment(step), depths[parent] + 1
+    objs = [
+        Category(
+            pk=i + 1,
+            name=f"n{i}",
+            path=paths[i],
+            depth=depths[i],
+            numchild=childcount[i],
+            parent_id=None if i == 0 else ((i - 1) // fanout) + 1,
+        )
+        for i in range(n)
+    ]
+    Category.objects.bulk_create(objs, batch_size=1000)
+    return mp
+
+
+@mptree_only
+class MPTreeEquivalenceTests(TestCase):
+    """The prototype must match treebeard byte-for-byte where it claims to."""
+
+    def setUp(self):
+        self.mp = MaterializedPath(Category)
+        self.spec = make_spec()
+
+    def test_build_matches_treebeard(self):
+        build_with_treebeard(self.spec)
+        treebeard_snap = snapshot()
+
+        Category.objects.all().delete()
+
+        build_with_mptree(self.spec, self.mp)
+        mptree_snap = snapshot()
+
+        self.assertEqual(treebeard_snap, mptree_snap)
+        # spot-check the encoding itself
+        self.assertEqual(mptree_snap["r0"][0], "0001")
+        self.assertEqual(mptree_snap["r0_c0"][0], "00010001")
+        self.assertEqual(mptree_snap["r0_c0_g1"][0], "000100010002")
+
+    def test_move_last_child_matches_treebeard(self):
+        # treebeard reference: move a subtree to be the last child of another
+        # branch (same depth) and to a deeper target (depth changes).
+        nodes = build_with_treebeard(self.spec)
+        nodes["r0_c2"].move(Category.objects.get(name="r1"), "last-child")
+        nodes["r2_c0"].move(Category.objects.get(name="r1_c0"), "last-child")
+        treebeard_snap = snapshot()
+
+        Category.objects.all().delete()
+
+        nodes = build_with_mptree(self.spec, self.mp)
+        self.mp.move(nodes["r0_c2"], nodes["r1"], "last-child")
+        self.mp.move(nodes["r2_c0"], nodes["r1_c0"], "last-child")
+        mptree_snap = snapshot()
+
+        self.assertEqual(treebeard_snap, mptree_snap)
+
+    def test_descendants_children_ancestors(self):
+        nodes = build_with_mptree(self.spec, self.mp)
+        r0 = nodes["r0"]
+        self.assertEqual(
+            sorted(self.mp.children(r0).values_list("name", flat=True)),
+            ["r0_c0", "r0_c1", "r0_c2", "r0_c3"],
+        )
+        self.assertEqual(self.mp.descendants(r0).count(), 4 + 4 * 2)
+        g = nodes["r0_c2_g1"]
+        self.assertEqual(
+            list(self.mp.ancestors(g).values_list("name", flat=True)),
+            ["r0", "r0_c2"],
+        )
+
+
+@mptree_only
+class MPTreeInvariantTests(TestCase):
+    """Operations with no simple treebeard analogue are checked by invariants."""
+
+    def setUp(self):
+        self.mp = MaterializedPath(Category)
+
+    def assert_consistent_tree(self):
+        """Every node's path/depth must be a pure function of its parent chain,
+        paths must be unique, and ordering by path must be a valid DFS."""
+        by_pk = {c.pk: c for c in Category.objects.all()}
+        paths = [c.path for c in by_pk.values()]
+        self.assertEqual(len(paths), len(set(paths)), "paths must be unique")
+        for c in by_pk.values():
+            self.assertEqual(len(c.path), c.depth * self.mp.steplen)
+            if c.parent_id is None:
+                self.assertEqual(c.depth, 1)
+            else:
+                parent = by_pk[c.parent_id]
+                self.assertEqual(c.depth, parent.depth + 1)
+                self.assertTrue(
+                    c.path.startswith(parent.path),
+                    f"{c.name} path {c.path} not under parent {parent.path}",
+                )
+            # numchild cache matches reality
+            kids = sum(1 for o in by_pk.values() if o.parent_id == c.pk)
+            self.assertEqual(c.numchild, kids, f"numchild wrong on {c.name}")
+
+    def test_first_child_shift_keeps_tree_valid(self):
+        spec = make_spec()
+        nodes = build_with_mptree(spec, self.mp)
+        # r1 already has children c0..c3; insert r0_c2 (with its grandchildren)
+        # as the *first* child -> every existing child must shift up by one.
+        self.mp.move(nodes["r0_c2"], nodes["r1"], "first-child")
+        self.assert_consistent_tree()
+
+        r1 = Category.objects.get(name="r1")
+        first = self.mp.children(r1).first()
+        self.assertEqual(first.name, "r0_c2")
+        # the moved subtree came along
+        self.assertEqual(
+            sorted(self.mp.children(first).values_list("name", flat=True)),
+            ["r0_c2_g0", "r0_c2_g1"],
+        )
+        self.assertEqual(r1.numchild, 5)
+
+    def test_rebuild_from_parent_ids(self):
+        spec = make_spec()
+        nodes = build_with_mptree(spec, self.mp)
+
+        # Simulate the "parent_id is the source of truth" world: reparent purely
+        # by FK, leaving path/depth deliberately stale...
+        moved = nodes["r2_c0"]
+        Category.objects.filter(pk=moved.pk).update(parent=nodes["r0"])
+        Category.objects.filter(pk=moved.pk).update(path="ZZZZ", depth=99)  # garbage
+
+        # ...then rebuild reconstructs a fully consistent tree from parent_id.
+        self.mp.rebuild()
+        self.assert_consistent_tree()
+        self.assertEqual(
+            Category.objects.get(name="r2_c0").parent.name, "r0"
+        )
+
+
+@mptree_only
+@skipIf(
+    os.environ.get("GITHUB_ACTIONS") == "true",
+    "Benchmark is too slow for CI -- run locally instead.",
+)
+class MPTreeBenchmark(TransactionTestCase):
+    """Timing only -- prints results, asserts correctness of the big move."""
+
+    def test_benchmark_move_and_rebuild(self):
+        n = int(os.environ.get("MPTREE_BENCH_N", "10000"))
+        fanout = 5
+
+        # ----- subtree move on identical 10k trees -----------------------
+        mp = build_bulk(n, fanout)
+        node = Category.objects.get(pk=2)        # a root's first child
+        target = Category.objects.get(pk=6)      # a disjoint sibling branch
+        subtree_size = mp.descendants(node).count() + 1
+
+        t0 = time.perf_counter()
+        node.move(target, "last-child")          # treebeard
+        tb_move = time.perf_counter() - t0
+
+        Category.objects.all().delete()
+        mp = build_bulk(n, fanout)
+        node = Category.objects.get(pk=2)
+        target = Category.objects.get(pk=6)
+
+        t0 = time.perf_counter()
+        mp.move(node, target, "last-child")      # prototype (single UPDATE)
+        mp_move = time.perf_counter() - t0
+
+        # correctness of the prototype move at scale
+        node.refresh_from_db()
+        self.assertEqual(node.parent_id, target.pk)
+        self.assertEqual(Category.objects.count(), n)
+
+        # ----- full rebuild / fix_tree ----------------------------------
+        t0 = time.perf_counter()
+        Category.fix_tree()                      # treebeard
+        tb_fix = time.perf_counter() - t0
+
+        t0 = time.perf_counter()
+        mp.rebuild()                             # prototype
+        mp_rebuild = time.perf_counter() - t0
+
+        print(
+            f"\n[mptree benchmark] n={n}, moved subtree={subtree_size} nodes\n"
+            f"  move    treebeard={tb_move*1000:8.1f} ms   prototype={mp_move*1000:8.1f} ms\n"
+            f"  rebuild fix_tree ={tb_fix*1000:8.1f} ms   prototype={mp_rebuild*1000:8.1f} ms"
+        )
+
+    def test_benchmark_mid_insert(self):
+        # Worst case for _layout: a `first-child` move into a *wide* sibling
+        # group, which renumbers every existing sibling (unlike the last-child
+        # fast path, a single statement). Exercises the no-park shift.
+        width = int(os.environ.get("MPTREE_BENCH_WIDTH", "2000"))
+
+        def build():
+            Category.objects.all().delete()
+            mp = MaterializedPath(Category)
+            objs = [Category(pk=1, name="root", path=mp.segment(1), depth=1, numchild=width)]
+            pk = 2
+            for i in range(1, width + 1):
+                cpath = mp.segment(1) + mp.segment(i)
+                objs.append(Category(pk=pk, name=f"c{i}", path=cpath, depth=2, numchild=1, parent_id=1))
+                child_pk = pk
+                pk += 1
+                objs.append(Category(pk=pk, name=f"c{i}g", path=cpath + mp.segment(1), depth=3, parent_id=child_pk))
+                pk += 1
+            root2 = pk
+            objs.append(Category(pk=pk, name="root2", path=mp.segment(2), depth=1, numchild=1))
+            pk += 1
+            x = pk
+            objs.append(Category(pk=pk, name="X", path=mp.segment(2) + mp.segment(1), depth=2, parent_id=root2))
+            Category.objects.bulk_create(objs, batch_size=1000)
+            return mp, x
+
+        _, x_pk = build()
+        root = Category.objects.get(pk=1)
+        x = Category.objects.get(pk=x_pk)
+        t0 = time.perf_counter()
+        x.move(root, "first-child")              # treebeard
+        tb = time.perf_counter() - t0
+
+        mp, x_pk = build()
+        root = Category.objects.get(pk=1)
+        x = Category.objects.get(pk=x_pk)
+        t0 = time.perf_counter()
+        mp.move(x, root, "first-child")          # prototype (_layout, no-park shift)
+        mp_t = time.perf_counter() - t0
+
+        x.refresh_from_db()
+        self.assertEqual(x.parent_id, 1)
+        self.assertEqual(mp.children(root).first().pk, x_pk)  # X is now first child
+
+        print(
+            f"\n[mptree mid-insert] first-child move into width={width} sibling group\n"
+            f"  move    treebeard={tb*1000:8.1f} ms   prototype={mp_t*1000:8.1f} ms"
+        )

--- a/cms/utils/mptree.py
+++ b/cms/utils/mptree.py
@@ -337,7 +337,7 @@ class MaterializedPath:
             # sorted neighbours is enough to spot it.
             in_order = sorted(m[3] for m in movers)
             needs_park = any(
-                b.startswith(a) for a, b in zip(in_order, in_order[1:], strict=False)
+                b.startswith(a) for a, b in zip(in_order, in_order[1:])
             )
         if needs_park:
             # Deepest first: parking a nested subtree before its ancestor keeps

--- a/cms/utils/mptree.py
+++ b/cms/utils/mptree.py
@@ -1,0 +1,878 @@
+"""
+Dependency-free materialized-path tree backend
+
+This replaces the ``django-treebeard`` dependency for the page tree
+by treating ``parent_id`` as the single source of truth and maintaining
+``path``/``depth``/``numchild`` as a derived, set-based-recomputed cache.
+
+The module ships three things:
+
+* :class:`MaterializedPath` -- a low-level *driver* implementing the tree
+  algorithms against any model exposing the treebeard column layout
+  (``path``/``depth``/``numchild``/``parent``). Operates set-based, never pulls
+  a subtree into Python on the hot paths, uses only cross-database ORM
+  functions (``Concat``/``Substr``/``Length``/``F``), and locks at *parent-row*
+  granularity for concurrency.
+* :class:`MaterializedPathMixin` -- an abstract model exposing the subset of the
+  treebeard ``MP_Node`` API that django-cms uses, delegating to the driver. Its
+  fields are declared **identically to treebeard** so that swapping it in for
+  ``MP_Node`` produces *no* migration.
+* :func:`get_tree_base` -- selects the base class (treebeard or this) from the
+  ``CMS_TREE_BACKEND`` setting, so the backend can be swapped per-deployment
+  (setting + restart, same database, no migration).
+
+The path encoding is byte-for-byte compatible with treebeard's defaults
+(base-36 alphabet, ``steplen=4``, no separators), so existing ``path`` values
+remain valid in either direction.
+
+A future redesign that removes sibling renumbering and the depth/width ceilings
+("fractional ordering") is sketched in the **PHASE 2 DESIGN NOTE** at the bottom
+of this module. It is intentionally *not* implemented: it requires a one-time
+migration and ends treebeard byte-compatibility, so it is a deliberate later
+step, not part of this drop-in backend.
+"""
+
+from collections import defaultdict
+from functools import wraps
+
+from django.db import models, router, transaction
+from django.db.models import F, Value
+from django.db.models.functions import Concat, Length, Substr
+
+DEFAULT_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+DEFAULT_STEPLEN = 4
+
+# Columns the driver plans from. Re-read under lock before planning a mutation
+# so a concurrently moved/renumbered node is never laid out from stale values.
+TREE_FIELDS = ["path", "depth", "numchild", "parent"]
+
+
+class TreePathOverflow(ValueError):
+    """
+    Raised when a tree position cannot be represented: a sibling step too large
+    for one ``steplen``-wide segment, or a path too long for the ``path`` column.
+
+    Raised *before* any statement runs, so the transaction is left untouched
+    rather than failing mid-rewrite on a truncated or over-long value.
+    """
+
+
+def _atomic_on_alias(method):
+    """``transaction.atomic`` on the driver's own database, not ``default``."""
+
+    @wraps(method)
+    def wrapped(self, *args, **kwargs):
+        with transaction.atomic(using=self.db_alias):
+            return method(self, *args, **kwargs)
+
+    return wrapped
+
+
+class MaterializedPath:
+    """
+    Set-based materialized-path operations for a model with the treebeard
+    column layout: ``path`` (unique CharField), ``depth``, ``numchild`` and a
+    self-referential ``parent`` FK.
+
+    ``scope`` is an optional dict of field lookups that partitions the forest
+    (e.g. ``{"site_id": 3}``). It defaults to no scope, i.e. the whole table is
+    one forest -- matching treebeard's behaviour for the page tree.
+
+    ``using`` pins every read, write, lock and transaction to one database
+    alias. It defaults to the write database the router picks for ``model``, and
+    callers coming from a loaded instance pass that instance's alias so an
+    operation never straddles two connections.
+    """
+
+    def __init__(
+        self,
+        model,
+        *,
+        steplen=DEFAULT_STEPLEN,
+        alphabet=DEFAULT_ALPHABET,
+        scope=None,
+        lock=True,
+        using=None,
+    ):
+        self.model = model
+        self.steplen = steplen
+        self.alphabet = alphabet
+        self.radix = len(alphabet)
+        self.path_max_length = model._meta.get_field("path").max_length
+        self.scope = scope or {}
+        self.lock = lock
+        self.db_alias = using or router.db_for_write(model)
+
+    # -- encoding (treebeard-compatible) ---------------------------------
+
+    def _int2str(self, num):
+        ret = ""
+        num = int(num)
+        while True:
+            ret = self.alphabet[num % self.radix] + ret
+            if num < self.radix:
+                return ret
+            num //= self.radix
+
+    def _str2int(self, key):
+        num = 0
+        for char in key:
+            num = num * self.radix + self.alphabet.index(char)
+        return num
+
+    def segment(self, step):
+        """The fixed-width path segment for a 1-based sibling ``step``."""
+        step = int(step)
+        if step < 1 or step >= self.radix**self.steplen:
+            raise TreePathOverflow(
+                f"Sibling step {step} does not fit in a {self.steplen}-character "
+                f"base-{self.radix} path segment."
+            )
+        key = self._int2str(step)
+        return self.alphabet[0] * (self.steplen - len(key)) + key
+
+    def step_of(self, path):
+        """Decode the last (own) segment of ``path`` back to its integer step."""
+        return self._str2int(path[-self.steplen :])
+
+    # -- path length guards ----------------------------------------------
+
+    def _ensure_path_fits(self, path):
+        self._ensure_path_length_fits(len(path))
+
+    def _ensure_path_length_fits(self, required):
+        if self.path_max_length is not None and required > self.path_max_length:
+            raise TreePathOverflow(
+                f"Path requires {required} characters but "
+                f"{self.model._meta.label}.path allows {self.path_max_length}."
+            )
+
+    # -- read queries ----------------------------------------------------
+
+    def _scoped(self):
+        return self.model._default_manager.using(self.db_alias).filter(**self.scope)
+
+    def roots(self):
+        return self._scoped().filter(depth=1).order_by("path")
+
+    def children(self, node):
+        return self._scoped().filter(
+            path__startswith=node.path, depth=node.depth + 1
+        ).order_by("path")
+
+    def descendants(self, node):
+        # The materialized path *is* the precomputed recursion: an indexed
+        # prefix scan, no WITH RECURSIVE required.
+        return self._scoped().filter(
+            path__startswith=node.path, depth__gt=node.depth
+        ).order_by("path")
+
+    def ancestors(self, node):
+        paths = [
+            node.path[0:pos]
+            for pos in range(self.steplen, len(node.path), self.steplen)
+        ]
+        if not paths:
+            return self.model._default_manager.using(self.db_alias).none()
+        return self._scoped().filter(path__in=paths).order_by("path")
+
+    def tree(self, parent=None):
+        if parent is None:
+            return self._scoped().order_by("path")
+        return self._scoped().filter(
+            path__startswith=parent.path, depth__gte=parent.depth
+        ).order_by("path")
+
+    def root_of(self, node):
+        return self._scoped().get(path=node.path[0 : self.steplen])
+
+    def _children_rows(self, parent_path, parent_depth):
+        # Ordered direct children as lightweight (deferred) instances, fetched
+        # once and reused for index/append/layout to avoid repeat queries.
+        return list(
+            self._scoped()
+            .filter(path__startswith=parent_path, depth=parent_depth + 1)
+            .order_by("path")
+            .only("pk", "path", "depth")
+        )
+
+    def _ordered_child_pks(self, parent_path, parent_depth):
+        return [c.pk for c in self._children_rows(parent_path, parent_depth)]
+
+    def _last_child_step(self, parent_path, parent_depth, exclude_pk=None):
+        qs = self._scoped().filter(path__startswith=parent_path, depth=parent_depth + 1)
+        if exclude_pk is not None:
+            # When *moving* a node to the end of its own sibling group, its
+            # current slot must not count -- otherwise it would be bumped into a
+            # spurious gap instead of staying put.
+            qs = qs.exclude(pk=exclude_pk)
+        last = qs.order_by("path").values_list("path", flat=True).last()
+        return self.step_of(last) if last else 0
+
+    def _last_root_step(self):
+        last = self.roots().values_list("path", flat=True).last()
+        return self.step_of(last) if last else 0
+
+    # -- concurrency -----------------------------------------------------
+
+    def _lock_rows(self, *pks):
+        """
+        Take row-level write locks (in pk order, to avoid deadlocks) on the rows
+        whose sibling slot / numchild caches an operation will touch. Parent-row
+        granularity: writes under different parents do not serialise against each
+        other. No-op on backends without ``SELECT ... FOR UPDATE`` (SQLite).
+        """
+        if not self.lock:
+            return
+        pks = sorted({pk for pk in pks if pk is not None})
+        if pks:
+            list(
+                self.model._base_manager.using(self.db_alias)
+                .filter(pk__in=pks)
+                .order_by("pk")
+                .select_for_update()
+            )
+
+    def _refresh(self, *instances):
+        """
+        Re-read the tree columns of caller-supplied instances, after locking and
+        before planning. The caller may have held them across an earlier request
+        or a concurrent move, in which case their ``path``/``depth``/``parent``
+        no longer describe where the node actually is -- and a layout planned
+        from those values rewrites the wrong rows. Only the tree columns are
+        reloaded, so unsaved edits the caller made to other fields survive.
+        """
+        for instance in instances:
+            if instance is not None and instance.pk is not None:
+                instance.refresh_from_db(using=self.db_alias, fields=TREE_FIELDS)
+
+    # -- low-level subtree rewrite --------------------------------------
+
+    def _reprefix(self, *, old_prefix, new_prefix, depth_delta):
+        """
+        Rewrite an entire subtree's paths by prefix-swap in one statement::
+
+            new path = new_prefix || (old path with its old_prefix stripped)
+
+        Never pulls descendant rows into Python.
+        """
+        qs = self._scoped().filter(path__startswith=old_prefix)
+        self._ensure_path_fits(new_prefix)
+        prefix_growth = len(new_prefix) - len(old_prefix)
+        if prefix_growth > 0:
+            # The subtree moves deeper (or is being parked under a longer
+            # placeholder prefix): every descendant path grows by the same
+            # amount, so the deepest one decides whether the whole rewrite
+            # fits. One aggregate query, only on the branch that can overflow.
+            longest = (
+                qs.annotate(_mptree_path_length=Length("path"))
+                .order_by("-_mptree_path_length")
+                .values_list("_mptree_path_length", flat=True)
+                .first()
+            )
+            if longest is not None:
+                self._ensure_path_length_fits(longest + prefix_growth)
+        update = {"path": Concat(Value(new_prefix), Substr("path", len(old_prefix) + 1))}
+        if depth_delta:
+            update["depth"] = F("depth") + depth_delta
+        qs.update(**update)
+
+    def _layout(self, parent_path, parent_depth, ordered_pks, info=None):
+        """
+        Lay the given child subtrees out as contiguous steps ``1..n`` under the
+        parent, in the given order, fixing each subtree's prefix *and* depth.
+        ``info`` may carry already-fetched ``{pk: instance}`` rows (with
+        ``path``/``depth``) so the caller's prior query can be reused.
+
+        Two correctness-preserving shortcuts, both byte-identical to a naive
+        full relayout:
+
+        * **Skip already-placed children.** Target slots are a permutation of
+          ``1..n``, so a child already at its target slot is wanted by no other
+          child -- leaving it can never collide. Turns "insert near the end"
+          from O(n) rewrites into O(moved).
+        * **Skip the parking pass when nothing moves *down*.** Parking into the
+          disjoint ``~<pk>~`` namespace only exists to break collisions. If no
+          mover targets a lower slot than it currently holds (the usual
+          insert/shift-up / move-from-elsewhere case), writing movers
+          highest-slot-first always lands in a slot just vacated (or never
+          occupied), so a single pass suffices -- halving the statements.
+          A genuine down-move (e.g. moving a later sibling to an earlier slot)
+          falls back to the always-safe park-then-write.
+
+        Both shortcuts assume the movers are *disjoint* subtrees. One mover can
+        sit inside another -- moving a node to a slot relative to its own parent
+        or uncle -- and then rewriting the outer subtree first would drag the
+        inner one along and leave its recorded ``old_path`` matching nothing.
+        Those layouts always park, deepest path first, so that by the time an
+        ancestor is rewritten its nested mover is already out of the way.
+        """
+        known = dict(info or {})
+        missing = [pk for pk in ordered_pks if pk not in known]
+        if missing:
+            for obj in self._scoped().filter(pk__in=missing).only("pk", "path", "depth"):
+                known[obj.pk] = obj
+
+        target_depth = parent_depth + 1
+        prefix_len = len(parent_path)
+        movers = []  # (pk, target_step, target_prefix, old_path, depth_delta, old_slot)
+        for step, pk in enumerate(ordered_pks, start=1):
+            obj = known[pk]
+            target_prefix = parent_path + self.segment(step)
+            if obj.path == target_prefix and obj.depth == target_depth:
+                continue  # already in place; cannot collide (slots are unique)
+            is_child_here = (
+                obj.depth == target_depth
+                and obj.path.startswith(parent_path)
+                and len(obj.path) == prefix_len + self.steplen
+            )
+            old_slot = self.step_of(obj.path) if is_child_here else None
+            movers.append((pk, step, target_prefix, obj.path, target_depth - obj.depth, old_slot))
+
+        needs_park = any(slot is not None and step < slot for _, step, _, _, _, slot in movers)
+        if not needs_park:
+            # Nested movers (one mover's subtree contains another's) cannot be
+            # rewritten in place either. If a path is a proper prefix of another
+            # every path sorting between them shares that prefix, so comparing
+            # sorted neighbours is enough to spot it.
+            in_order = sorted(m[3] for m in movers)
+            needs_park = any(
+                b.startswith(a) for a, b in zip(in_order, in_order[1:], strict=False)
+            )
+        if needs_park:
+            # Deepest first: parking a nested subtree before its ancestor keeps
+            # the ancestor's rewrite from touching it.
+            for pk, _, _, old_path, _, _ in sorted(movers, key=lambda m: len(m[3]), reverse=True):
+                self._reprefix(old_prefix=old_path, new_prefix=f"~{pk}~", depth_delta=0)
+            for pk, _, target_prefix, _, depth_delta, _ in movers:
+                self._reprefix(old_prefix=f"~{pk}~", new_prefix=target_prefix, depth_delta=depth_delta)
+        else:
+            # highest target slot first -> destination is always free
+            for pk, _, target_prefix, old_path, depth_delta, _ in sorted(
+                movers, key=lambda m: m[1], reverse=True
+            ):
+                self._reprefix(old_prefix=old_path, new_prefix=target_prefix, depth_delta=depth_delta)
+
+    # -- node construction ----------------------------------------------
+
+    def _materialise(self, instance, attrs, *, path, depth, parent):
+        self._ensure_path_fits(path)
+        # `parent`/`parent_id` are determined by the tree operation, not by the
+        # caller's kwargs (treebeard's add_child/add_sibling accept them as
+        # redundant field values) -- drop them so they can't conflict.
+        attrs.pop("parent", None)
+        attrs.pop("parent_id", None)
+        if instance is None:
+            instance = self.model(**{**self.scope, **attrs})
+        instance.path = path
+        instance.depth = depth
+        instance.numchild = 0
+        instance.parent = parent
+        for field, value in self.scope.items():
+            setattr(instance, field, value)
+        instance.save(using=self.db_alias)
+        return instance
+
+    def _bump_numchild(self, pk, delta):
+        if pk is not None:
+            self.model._base_manager.using(self.db_alias).filter(pk=pk).update(
+                numchild=F("numchild") + delta
+            )
+
+    # -- build (append + positional insert) ------------------------------
+
+    @_atomic_on_alias
+    def add_root(self, instance=None, **attrs):
+        self._lock_rows(*self.roots().values_list("pk", flat=True))
+        step = self._last_root_step() + 1
+        return self._materialise(
+            instance, attrs, path=self.segment(step), depth=1, parent=None
+        )
+
+    @_atomic_on_alias
+    def add_child(self, parent, position="last-child", instance=None, **attrs):
+        self._lock_rows(parent.pk)
+        self._refresh(parent)
+        step = self._last_child_step(parent.path, parent.depth) + 1
+        node = self._materialise(
+            instance,
+            attrs,
+            path=parent.path + self.segment(step),
+            depth=parent.depth + 1,
+            parent=parent,
+        )
+        self._bump_numchild(parent.pk, +1)
+        parent.numchild = (parent.numchild or 0) + 1  # keep caller's instance honest
+        if position == "first-child":
+            existing = [pk for pk in self._ordered_child_pks(parent.path, parent.depth) if pk != node.pk]
+            self._layout(parent.path, parent.depth, [node.pk] + existing)
+            self._refresh(node)
+        return node
+
+    @_atomic_on_alias
+    def add_sibling(self, node, position="last-sibling", instance=None, **attrs):
+        self._lock_rows(node.pk)
+        self._refresh(node)
+        parent = node.parent
+        if parent is None:
+            new = self.add_root(instance=instance, **attrs)
+            if position in ("first-sibling", "left"):
+                # rare: reorder roots is not exercised by django-cms; left to
+                # rebuild() which canonicalises root order.
+                pass
+            return new
+        new = self.add_child(parent, instance=instance, **attrs)
+        if position in ("last-sibling", "right"):
+            # 'right' relative to an arbitrary sibling still lands at the end in
+            # this minimal implementation unless it must sit immediately after
+            # `node`; place precisely:
+            self._place_relative(new, node, after=(position == "right"))
+        elif position in ("first-sibling", "left"):
+            self._place_relative(new, node, after=False)
+        return new
+
+    def _place_relative(self, node, sibling, *, after):
+        parent = sibling.parent
+        parent_path = parent.path if parent else ""
+        parent_depth = parent.depth if parent else 0
+        order = [pk for pk in self._ordered_child_pks(parent_path, parent_depth) if pk != node.pk]
+        idx = order.index(sibling.pk) + (1 if after else 0)
+        order.insert(idx, node.pk)
+        self._layout(parent_path, parent_depth, order)
+        self._refresh(node)
+
+    # -- move (single statement for append; layout for insert) -----------
+
+    @_atomic_on_alias
+    def move(self, node, target, pos="last-child"):
+        """
+        Move ``node`` (and its whole subtree). Supported ``pos``:
+        ``last-child``/``first-child`` (relative to ``target``) and
+        ``left``/``right`` (relative to sibling ``target``).
+        """
+        # Read the parent ids first so every row this move touches can be taken
+        # in one pk-ordered `_lock_rows` -- concurrent moves then queue behind
+        # each other instead of deadlocking on opposite acquisition orders. The
+        # values are unverified at this point; the lock below is what makes them
+        # true, and the re-read after it is what proves they still are.
+        parent_ids = dict(
+            self.model._base_manager.using(self.db_alias)
+            .filter(pk__in={pk for pk in (node.pk, target.pk) if pk is not None})
+            .values_list("pk", "parent_id")
+        )
+        self._lock_rows(
+            node.pk, target.pk, parent_ids.get(node.pk), parent_ids.get(target.pk)
+        )
+        # Everything below -- which parent to lock, which slot to target, the
+        # move-into-own-subtree check -- is planned from these tree columns, so
+        # they have to be the committed ones, not whatever the caller has been
+        # holding since an earlier request.
+        self._refresh(node, target)
+        old_parent_id = node.parent_id
+
+        relative_to_sibling = pos in ("left", "right")
+        new_parent_id = target.parent_id if relative_to_sibling else target.pk
+        # No-op when the pre-read was accurate (re-locking a row this
+        # transaction already holds is free); only a concurrent re-parent
+        # between the read and the lock makes this acquire anything new.
+        self._lock_rows(old_parent_id, new_parent_id)
+
+        if not relative_to_sibling:
+            new_parent = target
+        elif new_parent_id is None:
+            new_parent = None
+        else:
+            # Re-fetched rather than followed through `target.parent`: the
+            # descriptor can hand back an object cached before the lock, i.e.
+            # exactly the stale state re-reading `target` was meant to escape.
+            new_parent = self.model._base_manager.using(self.db_alias).get(
+                pk=new_parent_id
+            )
+
+        if new_parent is not None and (
+            target.path == node.path or new_parent.path.startswith(node.path)
+        ):
+            raise ValueError("Cannot move a node into itself or its own subtree.")
+
+        parent_path = new_parent.path if new_parent else ""
+        parent_depth = new_parent.depth if new_parent else 0
+
+        if pos == "last-child":
+            # Fast path: a single set-based UPDATE, no sibling touched.
+            new_step = self._last_child_step(parent_path, parent_depth, exclude_pk=node.pk) + 1
+            new_prefix = parent_path + self.segment(new_step)
+            depth_delta = (parent_depth + 1) - node.depth
+            self._reprefix(old_prefix=node.path, new_prefix=new_prefix, depth_delta=depth_delta)
+        else:
+            # One child fetch, reused for index lookup, append step and layout.
+            siblings = [c for c in self._children_rows(parent_path, parent_depth) if c.pk != node.pk]
+            order = [c.pk for c in siblings]
+            if pos == "first-child":
+                idx = 0
+            elif pos == "left":
+                idx = order.index(target.pk)
+            else:  # right
+                idx = order.index(target.pk) + 1
+            if idx == len(order):
+                # Landing at the end is an append: one set-based UPDATE, leaving
+                # the vacated source slot as a gap (matching treebeard, and far
+                # cheaper than relaying out every sibling).
+                new_step = (self.step_of(siblings[-1].path) + 1) if siblings else 1
+                new_prefix = parent_path + self.segment(new_step)
+                depth_delta = (parent_depth + 1) - node.depth
+                self._reprefix(old_prefix=node.path, new_prefix=new_prefix, depth_delta=depth_delta)
+            else:
+                order.insert(idx, node.pk)
+                # node carries fresh path/depth; pass everything so _layout needs
+                # no further query.
+                info = {c.pk: c for c in siblings}
+                info[node.pk] = node
+                self._layout(parent_path, parent_depth, order, info=info)
+
+        new_parent_pk = new_parent.pk if new_parent else None
+        self.model._base_manager.using(self.db_alias).filter(pk=node.pk).update(
+            parent=new_parent
+        )
+        if old_parent_id != new_parent_pk:
+            self._bump_numchild(old_parent_id, -1)
+            self._bump_numchild(new_parent_pk, +1)
+        # Keep the caller's in-memory instances honest: `node` moved, and
+        # `target` may have been renumbered (left/right) or had its numchild
+        # change (first/last-child) -- treebeard updates these in place too.
+        self._refresh(node, target)
+
+    # -- rebuild (recompute everything from parent_id) -------------------
+
+    @_atomic_on_alias
+    def rebuild(self):
+        """
+        Recompute every ``path``/``depth``/``numchild`` in the scope from the
+        tree structure, compacting sibling steps to ``1..N`` while **preserving
+        the existing sibling order** (read from the current ``path``, exactly
+        like treebeard's ``fix_tree``). The dependency-free replacement for
+        ``fix_tree`` -- a rare maintenance operation, written back in two
+        collision-free passes (park in the disjoint ``~<pk>`` namespace, then
+        write final values).
+
+        Ordering by ``path`` means siblings keep the order an editor arranged,
+        not creation order -- so no separate ``position`` field is needed for
+        order to survive a rebuild.
+        """
+        rows = list(
+            self._scoped().order_by("path").values("pk", "parent_id")
+        )
+        present = {r["pk"] for r in rows}
+        children = defaultdict(list)
+        for r in rows:
+            # rows are in path order, so each parent's children list is built in
+            # sibling order
+            parent = r["parent_id"] if r["parent_id"] in present else None
+            children[parent].append(r["pk"])
+
+        computed = {}
+        stack = [(None, "", 1)]
+        while stack:
+            parent_pk, parent_path, depth = stack.pop()
+            for step, pk in enumerate(children.get(parent_pk, []), start=1):
+                path = parent_path + self.segment(step)
+                self._ensure_path_fits(path)
+                computed[pk] = [path, depth, len(children.get(pk, []))]
+                stack.append((pk, path, depth + 1))
+
+        self.model._base_manager.using(self.db_alias).bulk_update(
+            [self.model(pk=pk, path=f"~{pk}") for pk in computed],
+            ["path"],
+            batch_size=500,
+        )
+        self.model._base_manager.using(self.db_alias).bulk_update(
+            [
+                self.model(pk=pk, path=p, depth=d, numchild=n)
+                for pk, (p, d, n) in computed.items()
+            ],
+            ["path", "depth", "numchild"],
+            batch_size=500,
+        )
+        return len(computed)
+
+
+class MaterializedPathMixin(models.Model):
+    """
+    Drop-in replacement base for treebeard's ``MP_Node`` covering the API that
+    django-cms uses. Fields are declared **identically to treebeard** so that
+    substituting this for ``MP_Node`` generates no migration.
+    """
+
+    path = models.CharField(max_length=255, unique=True)
+    depth = models.PositiveIntegerField()
+    numchild = models.PositiveIntegerField(default=0)
+
+    steplen = DEFAULT_STEPLEN
+    alphabet = DEFAULT_ALPHABET
+    node_order_by = []
+
+    class Meta:
+        abstract = True
+
+    # -- driver ----------------------------------------------------------
+
+    @classmethod
+    def _tree(cls, using=None):
+        return MaterializedPath(
+            cls, steplen=cls.steplen, alphabet=cls.alphabet, using=using
+        )
+
+    def _instance_tree(self):
+        """
+        Driver pinned to the database this instance was loaded from, so a node
+        read from a replica or a secondary alias is never queried, locked or
+        rewritten against ``default``.
+        """
+        return type(self)._tree(using=self._state.db)
+
+    # -- treebeard-compatible API ---------------------------------------
+
+    @classmethod
+    def add_root(cls, instance=None, **attrs):
+        using = None
+        if instance is not None:
+            using = instance._state.db or router.db_for_write(cls, instance=instance)
+        return cls._tree(using=using).add_root(instance=instance, **attrs)
+
+    @classmethod
+    def get_root_nodes(cls, using=None):
+        return cls._tree(using=using).roots()
+
+    @classmethod
+    def get_tree(cls, parent=None, using=None):
+        if using is None and parent is not None:
+            using = parent._state.db
+        return cls._tree(using=using).tree(parent)
+
+    @classmethod
+    def fix_tree(cls, using=None, **kwargs):
+        return cls._tree(using=using).rebuild()
+
+    def add_child(self, instance=None, **attrs):
+        attrs.pop("parent", None)  # redundant: the parent is `self`
+        return self._instance_tree().add_child(self, instance=instance, **attrs)
+
+    def add_sibling(self, pos="last-sibling", instance=None, **attrs):
+        attrs.pop("parent", None)
+        attrs.pop("parent_id", None)
+        return self._instance_tree().add_sibling(
+            self, position=pos, instance=instance, **attrs
+        )
+
+    def move(self, target, pos="last-child"):
+        self._instance_tree().move(self, target, pos)
+
+    def get_children(self):
+        return self._instance_tree().children(self)
+
+    def get_descendants(self):
+        return self._instance_tree().descendants(self)
+
+    def get_ancestors(self):
+        return self._instance_tree().ancestors(self)
+
+    def get_root(self):
+        return self._instance_tree().root_of(self)
+
+    def get_parent(self, update=False):
+        return self.parent
+
+    def get_first_child(self):
+        return self._instance_tree().children(self).first()
+
+    def is_root(self):
+        return self.depth == 1
+
+    def is_leaf(self):
+        return self.numchild == 0
+
+    def is_sibling_of(self, other):
+        return self.depth == other.depth and self.parent_id == other.parent_id
+
+    def is_child_of(self, other):
+        return self.parent_id == other.pk
+
+    def is_descendant_of(self, other):
+        return self.depth > other.depth and self.path.startswith(other.path)
+
+    def get_siblings(self):
+        if self.parent_id is None:
+            return self._instance_tree().roots()
+        return self._instance_tree().children(self.parent)
+
+    def delete(self, *args, **kwargs):
+        # Deleting a node removes it from its parent's child set; keep the
+        # parent's numchild cache correct (treebeard does this via its
+        # queryset/model delete overrides). Descendants are removed by the
+        # parent FK's on_delete cascade and do not affect surviving nodes.
+        parent_id = self.parent_id
+        # Resolved before the delete: `Model.delete` accepts `using` positionally
+        # as well as by keyword, and clears the instance's state afterwards.
+        using = (
+            kwargs.get("using")
+            or (args[0] if args else None)
+            or self._state.db
+            or router.db_for_write(type(self), instance=self)
+        )
+        result = super().delete(*args, **kwargs)
+        if parent_id is not None:
+            type(self)._base_manager.using(using).filter(pk=parent_id).update(
+                numchild=models.F("numchild") - 1
+            )
+        return result
+
+
+def get_tree_backend() -> str:
+    """
+    The active page-tree backend: ``"treebeard"`` (default) or ``"mptree"``,
+    from the ``CMS_TREE_BACKEND`` setting. An env var of the same name overrides
+    the setting only when the setting is not explicitly defined, which keeps the
+    backends swappable in CI / subprocess tests without touching the settings
+    module. Resolved at import time, so a change requires a process restart --
+    but no migration, because both backends declare identical fields.
+
+    ``treebeard`` is imported lazily (only by the selectors below, only when this
+    returns ``"treebeard"``), so the ``mptree`` backend never imports it.
+    """
+    import os
+
+    from django.conf import settings
+
+    return getattr(settings, "CMS_TREE_BACKEND", None) or os.environ.get(
+        "CMS_TREE_BACKEND", "treebeard"
+    )
+
+
+def get_tree_base() -> type:
+    """Base model class for ``Page`` -- treebeard's ``MP_Node`` or our mixin."""
+    if get_tree_backend() == "mptree":
+        return MaterializedPathMixin
+
+    from treebeard.mp_tree import MP_Node
+
+    return MP_Node
+
+
+def get_queryset_base() -> type:
+    """
+    Base class for ``PageQuerySet``. Treebeard mode keeps ``MP_NodeQuerySet``
+    (its only contribution is a tree-fixup ``delete``); mptree mode uses a plain
+    Django ``QuerySet`` so treebeard is not imported at all.
+    """
+    if get_tree_backend() == "mptree":
+        return models.QuerySet
+
+    from treebeard.mp_tree import MP_NodeQuerySet
+
+    return MP_NodeQuerySet
+
+
+# ======================================================================
+# PHASE 2 DESIGN NOTE -- FRACTIONAL ORDERING
+# ======================================================================
+#
+# Status: NOT IMPLEMENTED. Deliberate future step. Requires a one-time data
+# migration and ends treebeard byte-compatibility (so it cannot be hot-swapped
+# back to treebeard). Documented for potential future dev
+#
+# ----------------------------------------------------------------------
+# Why
+# ----------------------------------------------------------------------
+# This backend stores sibling order as contiguous base-36 steps inside `path`.
+# Two consequences follow from that single choice:
+#
+#   * Inserting/reordering in the middle of a sibling group renumbers the
+#     following siblings -- `_layout()` rewrites O(width) subtrees. (Benchmarked:
+#     a first-child move into a 2000-wide group is ~840 ms, on par with
+#     treebeard, because both renumber.) The `last-child` fast path is a single
+#     statement; only mid-inserts pay this.
+#   * Fixed `steplen=4` + `path <= 255` caps the tree at ~63 levels deep and
+#     36^4 (~1.6M) siblings per node.
+#
+# Fractional ordering removes BOTH by separating "structure" from "order" into
+# two explicit source-of-truth columns and demoting `path` to a pure read cache.
+#
+# ----------------------------------------------------------------------
+# Model
+# ----------------------------------------------------------------------
+#   class FractionalTreeMixin(models.Model):
+#       # --- source of truth ---
+#       parent   = FK("self", null=True, on_delete=CASCADE, related_name="children")
+#       position = CharField(max_length=255)   # fractional / LexoRank key, e.g.
+#                                               # "a0", "a0V", "a1"; sibling-local
+#       # --- derived read cache (rebuildable from parent_id + position) ---
+#       path      = TextField()                 # SEP-joined ancestor position keys
+#       path_hash = CharField(max_length=40, unique=True)   # sha1(path); see below
+#       depth     = PositiveIntegerField()
+#       numchild  = PositiveIntegerField(default=0)
+#
+#       class Meta:
+#           constraints = [UniqueConstraint(fields=["parent", "position"])]
+#           indexes = [Index(fields=["path_hash"])]  # + a prefix index for LIKE
+#
+# `(parent_id, position)` is the complete, minimal source of truth. `path`,
+# `depth`, `numchild` are ALL recomputable from it; `path` exists only so reads
+# stay indexed prefix scans (`path__startswith`) instead of recursion.
+#
+# Fractional key invariant: for any two sibling keys A < B there is always a key
+# strictly between them (densely-ordered strings -- append a digit when A and B
+# are adjacent). So `key_between(A, B)` lets you place/insert/reorder a node by
+# touching ONLY that node.
+#
+# ----------------------------------------------------------------------
+# Operation semantics (the payoff)
+# ----------------------------------------------------------------------
+#   * Insert between A and B: position = key_between(A.position, B.position);
+#     path = parent.path + SEP + position. ONE row. Siblings untouched -- no
+#     renumber, no `_layout`, no parking. The O(width) mid-insert -> ~O(1).
+#   * Reorder within siblings: recompute only the moved node's position between
+#     its new neighbours, then one `_reprefix` of its own subtree.
+#   * Move to a new parent: parent_id + a new position among the new siblings +
+#     one set-based subtree `_reprefix` -- same single statement as today.
+#   * Reads: unchanged. `path__startswith(prefix + SEP)` for strict descendants
+#     (the separator makes prefix matching unambiguous), `order_by("path")` for
+#     DFS order. `position` must not contain SEP.
+#
+# ----------------------------------------------------------------------
+# Gains
+# ----------------------------------------------------------------------
+#   * No sibling renumbering, ever -> mid-insert/reorder are single-node; the
+#     per-sibling loop (and any CTE written to speed it) becomes unnecessary.
+#   * No ceilings: variable-length path removes the ~63-level depth cap and the
+#     siblings-per-node cap.
+#   * Concurrency: concurrent inserts at different spots compute different keys
+#     with no shared "max+1" counter and no sibling-row locks; same-spot inserts
+#     collide only on the (parent, position) unique constraint and retry. This is
+#     the real write-concurrency win over treebeard.
+#
+# ----------------------------------------------------------------------
+# Costs / things to get right
+# ----------------------------------------------------------------------
+#   * `path` is effectively unbounded (fractional keys grow under adversarial
+#     repeated-between inserts) -> TextField. MySQL cannot put a UNIQUE index on
+#     a long/text column (767/3072-byte limit), so uniqueness lives on a
+#     `path_hash` (sha1) column, with a prefix index on `path` for LIKE.
+#   * One-time migration + end of treebeard byte-compat: backfill `position` from
+#     each node's current sibling (path-step) order, then recompute every `path`
+#     in the SEP encoding. After this, hot-swapping BACK to treebeard is no
+#     longer possible.
+#   * Own `key_between(a, b)`: ~100 lines, pure Python, no dependency (base-N
+#     midpoint, append a digit when neighbours are adjacent). It is the
+#     correctness core -- test it hard (adjacent keys, empty bounds, long chains).
+#   * Occasional key renormalisation: if a hot spot grows keys long, a rare
+#     maintenance pass reassigns short keys to a parent's children (same class as
+#     `rebuild()`, off the hot path).
+#
+# ----------------------------------------------------------------------
+# Net
+# ----------------------------------------------------------------------
+# parent_id = structure, position = order, path = indexed read cache (with depth
+# /numchild), all caches rebuildable from the first two. Deletes the renumber
+# problem and the depth/width ceilings; strongest concurrency story. Cost: one
+# irreversible migration, a TextField path + hash for MySQL uniqueness, and
+# owning key generation. Reads are unchanged.
+# ======================================================================

--- a/cms/utils/setup.py
+++ b/cms/utils/setup.py
@@ -16,7 +16,11 @@ def validate_dependencies():
     """
     Check for installed apps, their versions and configuration options
     """
-    if not app_is_installed("treebeard"):
+    from cms.utils.mptree import get_tree_backend
+
+    # treebeard is only required for the (default) treebeard tree backend; the
+    # dependency-free mptree backend neither imports nor needs it.
+    if get_tree_backend() == "treebeard" and not app_is_installed("treebeard"):
         raise ImproperlyConfigured(
             'django CMS requires django-treebeard. Please install it and add "treebeard" to INSTALLED_APPS.'
         )

--- a/manage.py
+++ b/manage.py
@@ -151,6 +151,14 @@ if __name__ == "__main__":
         },
     }
 
+    # A second alias for the tree backend's multi-database tests. Declared as a test
+    # mirror, so no extra test database is created and only tests that opt in via
+    # ``databases = {"default", "other"}`` ever touch the connection.
+    dynamic_configs["DATABASES"]["other"] = {
+        **dynamic_configs["DATABASES"]["default"],
+        "TEST": {"MIRROR": "default"},
+    }
+
     if "test" in sys.argv:
         SESSION_ENGINE = "django.contrib.sessions.backends.cache"
     else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     Django >= 2.2
     django-classy-tags >=0.7.2
     django-formtools >=2.1
-    django-treebeard >=4.3
+    django-treebeard >=4.3,<6
     django-sekizai >=0.7
     djangocms-admin-style >=1.2
     packaging

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-
 setup()

--- a/testserver.py
+++ b/testserver.py
@@ -22,7 +22,7 @@ for arg in sys.argv:
 gettext = noop_gettext
 
 
-class DisableMigrations(object):
+class DisableMigrations:
 
     def __contains__(self, item):
         return True
@@ -152,8 +152,8 @@ HELPER_SETTINGS = dict(
 
 
 def _helper_patch(*args, **kwargs):
-    from django.core.management import call_command
     from app_helper import utils
+    from django.core.management import call_command
 
     call_command('migrate', run_syncdb=True)
     utils.create_user(
@@ -163,8 +163,7 @@ def _helper_patch(*args, **kwargs):
 
 
 def run():
-    from app_helper import runner
-    from app_helper import utils
+    from app_helper import runner, utils
 
     os.environ.setdefault('DATABASE_URL', 'sqlite://localhost/testdb.sqlite')
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce a configurable, dependency-free materialized-path tree backend for the CMS page tree, keeping treebeard as the default while enabling a swappable backend, and extend tests and CI to validate both backends.

New Features:
- Add a materialized-path tree backend implementation (MaterializedPath/MaterializedPathMixin) that can replace django-treebeard for page and Category trees.
- Make the Page and sample Category models select their tree base class at runtime via CMS_TREE_BACKEND, allowing deployments to opt into the new backend without schema changes.
- Add comprehensive tests for the materialized-path backend, including parity with treebeard, delete semantics, database-alias handling, and performance benchmarks.

Bug Fixes:
- Ensure Page deletion and bulk queryset deletion correctly maintain numchild caches and respect database routing across both tree backends.
- Fix Page.get_root and related tree operations to use the correct database alias in multi-database setups.
- Adjust testserver helper imports and class definitions for minor robustness and style fixes.

Enhancements:
- Refactor PageManager and PageQuerySet to work with either treebeard or the new materialized-path backend, avoiding importing treebeard when not needed.
- Relax the hard dependency check on django-treebeard so it is only required when the treebeard backend is selected.
- Extend test database configuration to support mirrored multi-database tests for the tree backend.

CI:
- Configure django-main CI jobs to run the test suite under the materialized-path backend via CMS_TREE_BACKEND=mptree.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.