### PR TITLE
fix: disallow superusers as subordinate users

### DIFF
--- a/cms/admin/useradmin.py
+++ b/cms/admin/useradmin.py
@@ -2,8 +2,10 @@ from copy import deepcopy
 
 from django.contrib import admin
 from django.contrib.admin import ModelAdmin, site
+from django.contrib.admin.utils import unquote
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
+from django.core.exceptions import PermissionDenied
 from django.utils.translation import gettext
 
 from cms.admin.forms import PageUserChangeForm, PageUserGroupForm
@@ -97,6 +99,27 @@ class PageUserAdmin(GenericCmsPermissionAdmin, admin_class):
             # their subordinates.
             fields = list(fields) + ['is_superuser']
         return fields
+
+    def has_change_permission(self, request, obj=None):
+        if obj is not None and obj.is_superuser and not request.user.is_superuser:
+            # Superusers are nobody's subordinate. get_queryset() already hides
+            # them, this guards the views that resolve an object by other means.
+            return False
+        return super().has_change_permission(request, obj)
+
+    def has_delete_permission(self, request, obj=None):
+        if obj is not None and obj.is_superuser and not request.user.is_superuser:
+            return False
+        return super().has_delete_permission(request, obj)
+
+    def user_change_password(self, request, id, form_url=''):
+        # Django's password view only checks has_change_permission(), so a
+        # subordinate check has to happen before anything else.
+        user = self.get_object(request, unquote(id))
+
+        if user is not None and user.is_superuser and not request.user.is_superuser:
+            raise PermissionDenied
+        return super().user_change_password(request, id, form_url)
 
     def save_model(self, request, obj, form, change):
         if not change:

--- a/cms/tests/test_page_user_admin.py
+++ b/cms/tests/test_page_user_admin.py
@@ -1,10 +1,16 @@
+from unittest.mock import patch
+
+from django.contrib import admin
 from django.contrib.auth import get_permission_codename, get_user_model
 from django.contrib.messages.storage.cookie import CookieStorage
+from django.contrib.sites.models import Site
+from django.core.exceptions import PermissionDenied
 from django.forms.models import model_to_dict
 from django.test.utils import override_settings
 
 from cms.models.permissionmodels import PageUser
 from cms.test_utils.testcases import CMSTestCase
+from cms.utils.permissions import get_subordinate_users
 from cms.utils.urlutils import admin_reverse
 
 
@@ -542,3 +548,138 @@ class PermissionsOnPageTest(PermissionsOnTestCase):
             self.assertTrue(msgs[0], PageUser._meta.verbose_name)
             self.assertTrue(msgs[0], 'ID "%s"' % staff_user_2.pk)
             self.assertTrue(self._user_exists(username))
+
+
+@override_settings(CMS_PERMISSION=True)
+class SuperuserProtectionTest(PermissionsOnTestCase):
+    """
+    A superuser is nobody's subordinate. A staff user holding the cms user
+    permissions plus can_change_permissions must not be able to manage - and
+    thereby take over - a superuser account.
+    """
+
+    def _get_superuser_page_user(self):
+        parent_link_field = list(PageUser._meta.parents.values())[0]
+        user = self._create_user('perms-superuser', is_staff=True, is_superuser=True)
+        data = model_to_dict(user, exclude=['groups', 'user_permissions'])
+        data[parent_link_field.name] = user
+        data['created_by'] = user
+        page_user = PageUser.objects.create(**data)
+        page_user.set_password('original-password')
+        page_user.save()
+        return page_user
+
+    def _get_delegated_admin(self):
+        staff_user = self.get_staff_user_with_no_permissions()
+        self.add_permission(staff_user, 'change_pageuser')
+        self.add_permission(staff_user, 'delete_pageuser')
+        self.add_permission(staff_user, self._get_delete_perm())
+        self.add_global_permission(staff_user, can_change_permissions=True)
+        return staff_user
+
+    def test_superuser_not_subordinate_to_delegated_admin(self):
+        site = Site.objects.get_current()
+        superuser = self._get_superuser_page_user()
+        staff_user = self._get_delegated_admin()
+
+        subordinates = get_subordinate_users(staff_user, site)
+        self.assertNotIn(superuser.pk, subordinates.values_list('pk', flat=True))
+
+    def test_superuser_sees_superuser_as_subordinate(self):
+        site = Site.objects.get_current()
+        superuser = self._get_superuser_page_user()
+
+        subordinates = get_subordinate_users(self.get_superuser(), site)
+        self.assertIn(superuser.pk, subordinates.values_list('pk', flat=True))
+
+    def test_superuser_hidden_from_changelist(self):
+        superuser = self._get_superuser_page_user()
+        staff_user = self._get_delegated_admin()
+        endpoint = self.get_admin_url(PageUser, 'changelist')
+
+        with self.login_user_context(staff_user):
+            response = self.client.get(endpoint)
+            self.assertEqual(response.status_code, 200)
+            self.assertNotContains(
+                response,
+                getattr(superuser, superuser.USERNAME_FIELD),
+            )
+
+    def test_delegated_admin_cant_open_superuser_change_view(self):
+        superuser = self._get_superuser_page_user()
+        staff_user = self._get_delegated_admin()
+        endpoint = self.get_admin_url(PageUser, 'change', superuser.pk)
+
+        with self.login_user_context(staff_user):
+            response = self.client.get(endpoint)
+            self.assertEqual(response.status_code, 302)
+
+    def test_delegated_admin_cant_change_superuser_password(self):
+        superuser = self._get_superuser_page_user()
+        staff_user = self._get_delegated_admin()
+        endpoint = self.get_admin_url(PageUser, 'change', superuser.pk)
+        endpoint = endpoint.replace('/change/', '/password/')
+
+        data = {
+            'password1': 'hijacked-password',
+            'password2': 'hijacked-password',
+            'usable_password': 'true',
+        }
+
+        with self.login_user_context(staff_user):
+            # 404 rather than 403: the superuser is not in the admin's
+            # queryset at all, so it does not even leak its existence.
+            self.assertEqual(self.client.get(endpoint).status_code, 404)
+            self.assertEqual(self.client.post(endpoint, data).status_code, 404)
+
+        superuser.refresh_from_db()
+        self.assertFalse(superuser.check_password('hijacked-password'))
+        self.assertTrue(superuser.check_password('original-password'))
+
+    def test_admin_denies_change_permission_on_superuser(self):
+        """
+        Second line of defence, for the case where the admin's queryset is
+        widened again: the object level checks refuse a superuser outright.
+        """
+        superuser = self._get_superuser_page_user()
+        staff_user = self._get_delegated_admin()
+        model_admin = admin.site._registry[PageUser]
+        request = self.get_request()
+        request.user = staff_user
+
+        self.assertFalse(model_admin.has_change_permission(request, superuser))
+        self.assertFalse(model_admin.has_view_permission(request, superuser))
+        self.assertFalse(model_admin.has_delete_permission(request, superuser))
+
+        with self.assertRaises(PermissionDenied):
+            with patch.object(model_admin, 'get_object', return_value=superuser):
+                model_admin.user_change_password(request, str(superuser.pk))
+
+    def test_superuser_can_change_superuser_password(self):
+        superuser = self._get_superuser_page_user()
+        endpoint = self.get_admin_url(PageUser, 'change', superuser.pk)
+        endpoint = endpoint.replace('/change/', '/password/')
+
+        data = {
+            'password1': 'a-new-password',
+            'password2': 'a-new-password',
+            'usable_password': 'true',
+        }
+
+        with self.login_user_context(self.get_superuser()):
+            self.assertEqual(self.client.get(endpoint).status_code, 200)
+            self.assertEqual(self.client.post(endpoint, data).status_code, 302)
+
+        superuser.refresh_from_db()
+        self.assertTrue(superuser.check_password('a-new-password'))
+
+    def test_delegated_admin_cant_delete_superuser(self):
+        superuser = self._get_superuser_page_user()
+        staff_user = self._get_delegated_admin()
+        endpoint = self.get_admin_url(PageUser, 'delete', superuser.pk)
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint, {'post': 'yes'})
+            self.assertEqual(response.status_code, 302)
+
+        self.assertTrue(PageUser.objects.filter(pk=superuser.pk).exists())

--- a/cms/utils/permissions.py
+++ b/cms/utils/permissions.py
@@ -273,6 +273,10 @@ def get_subordinate_users(user, site):
     If user haves global permissions or is a superuser, then he can see all the
     users.
 
+    Superusers are never subordinate to a non-superuser, no matter how many
+    permissions the latter holds. Otherwise a delegated administrator could
+    manage - and take over - a superuser account.
+
     This function is currently used in PagePermissionInlineAdminForm for limit
     users in permission combobox.
 
@@ -291,6 +295,13 @@ def get_subordinate_users(user, site):
     """
     from cms.utils.page_permissions import get_change_permissions_perm_tuples
 
+    def without_superusers(qs):
+        # A non-superuser must never be handed a superuser as a subordinate:
+        # being able to manage the account means being able to take it over.
+        if user.is_superuser:
+            return qs
+        return qs.exclude(is_superuser=True)
+
     try:
         user_level = get_user_permission_level(user, site)
     except NoPermissionsException:
@@ -301,10 +312,10 @@ def get_subordinate_users(user, site):
             Q(is_staff=True) & Q(pageuser__created_by=user) & Q(pagepermission__page=None)
         )
         qs = qs.exclude(pk=user.pk).exclude(groups__user__pk=user.pk)
-        return qs
+        return without_superusers(qs)
 
     if user_level == ROOT_USER_LEVEL:
-        return get_user_model().objects.all()
+        return without_superusers(get_user_model().objects.all())
 
     from cms.models import PermissionTuple
     allow_list = Q()
@@ -320,7 +331,7 @@ def get_subordinate_users(user, site):
         )
     )
     qs = qs.exclude(pk=user.pk).exclude(groups__user__pk=user.pk)
-    return qs
+    return without_superusers(qs)
 
 
 def get_subordinate_groups(user, site):

--- a/docs/explanation/permissions.rst
+++ b/docs/explanation/permissions.rst
@@ -205,9 +205,19 @@ authority.
 The mental model is deliberate: **a page-user manager is a superuser
 for their subordinate users only.** A user is "subordinate" when the
 manager created them, or when they sit at the same or a lower level in
-the page tree the manager controls. Within that subordinate set, the
-manager can do almost everything a superuser could do to those
-accounts:
+the page tree the manager controls.
+
+The size of that set depends on where the manager's own authority comes
+from. A manager whose ``can_change_permissions`` right is granted by a
+:class:`~cms.models.permissionmodels.PagePermission` on part of the tree
+has only the users at or below that point. A manager granted the right
+by a :class:`~cms.models.permissionmodels.GlobalPagePermission` sits at
+the top of the hierarchy, and every non-superuser account on the site is
+subordinate to them — not merely the ones they created. Grant global
+permissions with that in mind.
+
+Within the subordinate set, the manager can do almost everything a
+superuser could do to those accounts:
 
 * create new staff users (new page-users are made staff automatically);
 * grant and revoke any permission or group the manager *themselves*
@@ -216,9 +226,24 @@ accounts:
   capability) and ``is_active`` (whether the account may log in at
   all).
 
-The single boundary a manager cannot cross is **superuser status**:
-``is_superuser`` is read-only for non-superusers, so a manager can
-never promote a subordinate (or themselves) to full superuser.
+The single boundary a manager cannot cross is **superuser status**,
+and it holds in both directions:
+
+* A manager can never *grant* superuser status. ``is_superuser`` is
+  read-only for non-superusers, so neither a subordinate nor the
+  manager themselves can be promoted.
+* A manager can never *manage an account that already has it*.
+  Superusers are never subordinate to a non-superuser, however many
+  permissions the manager holds. A superuser account is therefore
+  absent from the manager's user list entirely — they cannot edit it,
+  delete it, or change its password.
+
+The second half matters as much as the first. Being able to set an
+account's password is equivalent to being that account, so a manager
+who could reach a superuser's password would hold superuser rights in
+all but name. Both halves are enforced by the same rule — the
+subordinate set excludes superusers — rather than by the read-only
+field alone.
 
 **A manager can reverse a setting a superuser made.** This follows
 directly from the model and is worth stating plainly. If a superuser


### PR DESCRIPTION
## Summary by Sourcery

Prevent delegated administrators from managing or taking over superuser accounts in the CMS user admin by excluding superusers from non‑superuser subordinate queries and enforcing stricter admin permission checks.

Bug Fixes:
- Exclude superusers from the subordinate user queryset for non‑superusers to avoid delegated admins gaining control over superuser accounts.
- Block non‑superusers from changing, deleting, or changing passwords for superuser PageUser accounts at the admin permission level.

Tests:
- Add regression tests ensuring superusers are not treated as subordinates of non‑superusers and cannot be managed via the PageUser admin by delegated admins while remaining manageable by superusers.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.