### PR TITLE
Chore/django 61 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           ubuntu-latest,
         ]
         exclude:
-          # Python 3.10 and 3.11 only supported until Django 5.2
+          # Django 6.0 and 6.1 support Python 3.12+ only.
           - python-version: '3.10'
             requirements-file: django-6.0.txt
           - python-version: '3.11'
@@ -100,7 +100,7 @@ jobs:
           ubuntu-latest,
         ]
         exclude:
-          # Python 3.10 and 3.11 only supported until Django 5.2
+          # Django 6.0 and 6.1 support Python 3.12+ only.
           - python-version: '3.10'
             requirements-file: django-6.0.txt
           - python-version: '3.11'
@@ -166,7 +166,7 @@ jobs:
           ubuntu-latest,
         ]
         exclude:
-          # Python 3.10 and 3.11 only supported until Django 5.2
+          # Django 6.0 and 6.1 support Python 3.12+ only.
           - python-version: '3.10'
             requirements-file: django-6.0.txt
           - python-version: '3.11'

--- a/.github/workflows/test_startcmsproject.yml
+++ b/.github/workflows/test_startcmsproject.yml
@@ -20,11 +20,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        django-version: [
-          '4.2', '5.0', '5.1', '5.2',
-        ]
-        python-version: ['3.13']
-        requirements-file: ['requirements_base.txt']
         os: [
           ubuntu-latest,
         ]
@@ -34,23 +29,34 @@ jobs:
             flags: "--stories --versioning --moderation --alias"
           - name: all-off
             flags: "--no-stories --no-versioning --no-moderation --no-alias"
+        django:
+          - version: '5.2'
+            requirement: 'Django>=5.2,<6.0'
+            python: '3.13'
+          - version: '6.0'
+            requirement: 'Django>=6.0,<6.1'
+            python: '3.13'
+          - version: '6.1'
+            requirement: 'Django>=6.1,<6.2'
+            python: '3.13'
 
     steps:
     - uses: actions/checkout@v7
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.django.python }}
 
       uses: actions/setup-python@v7
       with:
-        python-version: ${{ matrix.python-version }}
-    - name: Create project from template (${{ matrix.mode }} / ${{ matrix.switches.name }})
+        python-version: ${{ matrix.django.python }}
+    - name: Create project with Django ${{ matrix.django.version }} (${{ matrix.mode }} / ${{ matrix.switches.name }})
       run: |
         sudo apt install gettext gcc -y
         python -m venv .venv
         source ./.venv/bin/activate
         python -m pip install --upgrade pip
-        pip install Django~=${{ matrix.django-version }}
-        pip install -e .
+        pip install -e . "${{ matrix.django.requirement }}"
+        python -c "import django; assert django.get_version().startswith('${{ matrix.django.version }}.')"
         djangocms mysite --noinput --mode ${{ matrix.mode }} ${{ matrix.switches.flags }}
+        python -c "import django; assert django.get_version().startswith('${{ matrix.django.version }}.')"
     - name: Verify requirements.in reflects the selected options
       env:
         MODE: ${{ matrix.mode }}

--- a/cms/signals/permissions.py
+++ b/cms/signals/permissions.py
@@ -75,7 +75,9 @@ def pre_delete_group(instance, **kwargs):
         clear_user_permission_cache(user)
 
 
-def user_m2m_changed(instance, action, reverse, pk_set, **kwargs):
+def user_m2m_changed(instance, action, reverse, pk_set, raw=False, **kwargs):
+    if raw:
+        return
     if action in (
         "pre_add",
         "pre_remove",

--- a/cms/signals/permissions.py
+++ b/cms/signals/permissions.py
@@ -76,6 +76,7 @@ def pre_delete_group(instance, **kwargs):
 
 
 def user_m2m_changed(instance, action, reverse, pk_set, raw=False, **kwargs):
+    # Fixture loading can emit this signal before related rows are safe to query.
     if raw:
         return
     if action in (

--- a/cms/templates/admin/cms/page/change_form.html
+++ b/cms/templates/admin/cms/page/change_form.html
@@ -42,7 +42,10 @@
 {% endblock %}
 {% block content %}
 <div id="content-main">
+{% django_version_gte 6 1 as object_tools_outside_content %}
+{% if not object_tools_outside_content %}
 {% block object-tools %}{% endblock %}
+{% endif %}
 
 <form {% if has_file_field %}enctype="multipart/form-data" {% endif %}action="?language={{ language }}{% if request.GET.site %}&amp;site={{ request.GET.site }}{% endif %}{% if request.GET.parent_page %}&amp;parent_page={{ request.GET.parent_page }}{% endif %}{%if request.GET.source %}&amp;source={{ request.GET.source }}{% endif %}" method="post" id="{{ opts.model_name }}_form">
 {% csrf_token %}

--- a/cms/templates/admin/cms/page/change_form.html
+++ b/cms/templates/admin/cms/page/change_form.html
@@ -42,6 +42,7 @@
 {% endblock %}
 {% block content %}
 <div id="content-main">
+{# Django 6.1 renders object-tools outside content; older parents need it here because this template replaces content. #}
 {% django_version_gte 6 1 as object_tools_outside_content %}
 {% if not object_tools_outside_content %}
 {% block object-tools %}{% endblock %}

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -95,7 +95,7 @@ def _get_page_by_untyped_arg(page_lookup, request, site_id):
             if "django.middleware.common.BrokenLinkEmailsMiddleware" in settings.MIDDLEWARE:
                 try:
                     mail_managers(subject, body)
-                except Exception:
+                except OSError:
                     # Reporting a missing page must not fail because its error email could not be sent.
                     pass
             return None

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -93,7 +93,11 @@ def _get_page_by_untyped_arg(page_lookup, request, site_id):
             raise Page.DoesNotExist(body)
         else:
             if "django.middleware.common.BrokenLinkEmailsMiddleware" in settings.MIDDLEWARE:
-                mail_managers(subject, body, fail_silently=True)
+                try:
+                    mail_managers(subject, body)
+                except Exception:
+                    # Reporting a missing page must not fail because its error email could not be sent.
+                    pass
             return None
 
 

--- a/cms/test_utils/email.py
+++ b/cms/test_utils/email.py
@@ -1,0 +1,16 @@
+from django.core import mail as django_mail
+
+LOCMEM_EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+
+
+def get_locmem_email_settings():
+    """Return locmem backend settings using the API supported by this Django version."""
+    if hasattr(django_mail, "mailers"):
+        return {
+            "MAILERS": {
+                "default": {
+                    "BACKEND": LOCMEM_EMAIL_BACKEND,
+                },
+            },
+        }
+    return {"EMAIL_BACKEND": LOCMEM_EMAIL_BACKEND}

--- a/cms/test_utils/project/emailuserapp/admin.py
+++ b/cms/test_utils/project/emailuserapp/admin.py
@@ -28,7 +28,6 @@ class UserAdmin(OriginalUserAdmin):
     add_fieldsets = (
         (
             None, {
-                'classes': ('wide',),
                 'fields': ('email', 'password1', 'password2')
             }
         ),

--- a/cms/test_utils/project/templates/admin/cms/page/object_tools_test.html
+++ b/cms/test_utils/project/templates/admin/cms/page/object_tools_test.html
@@ -1,0 +1,3 @@
+{% extends "admin/cms/page/change_form.html" %}
+
+{% block object-tools %}<div id="object-tools-test-marker"></div>{% endblock %}

--- a/cms/tests/settings.py
+++ b/cms/tests/settings.py
@@ -173,6 +173,8 @@ CMS_MEDIA_URL = "/cms-media/"
 MEDIA_URL = "/media/"
 STATIC_URL = "/static/"
 ADMIN_MEDIA_PREFIX = "/static/admin/"
+# MAILERS exists only on Django 6.1+, so feature detection keeps these shared
+# settings importable on every supported version.
 if hasattr(django_mail, "mailers"):
     MAILERS = {
         "default": {

--- a/cms/tests/settings.py
+++ b/cms/tests/settings.py
@@ -17,6 +17,7 @@ import os
 import tempfile
 
 import dj_database_url
+from django.core import mail as django_mail
 
 
 def gettext(s):
@@ -172,7 +173,14 @@ CMS_MEDIA_URL = "/cms-media/"
 MEDIA_URL = "/media/"
 STATIC_URL = "/static/"
 ADMIN_MEDIA_PREFIX = "/static/admin/"
-EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+if hasattr(django_mail, "mailers"):
+    MAILERS = {
+        "default": {
+            "BACKEND": "django.core.mail.backends.locmem.EmailBackend",
+        },
+    }
+else:
+    EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
 DEBUG_TOOLBAR_PATCH_SETTINGS = False
 INTERNAL_IPS = ["127.0.0.1"]
 AUTHENTICATION_BACKENDS = (

--- a/cms/tests/settings.py
+++ b/cms/tests/settings.py
@@ -17,7 +17,8 @@ import os
 import tempfile
 
 import dj_database_url
-from django.core import mail as django_mail
+
+from cms.test_utils.email import get_locmem_email_settings
 
 
 def gettext(s):
@@ -173,16 +174,7 @@ CMS_MEDIA_URL = "/cms-media/"
 MEDIA_URL = "/media/"
 STATIC_URL = "/static/"
 ADMIN_MEDIA_PREFIX = "/static/admin/"
-# MAILERS exists only on Django 6.1+, so feature detection keeps these shared
-# settings importable on every supported version.
-if hasattr(django_mail, "mailers"):
-    MAILERS = {
-        "default": {
-            "BACKEND": "django.core.mail.backends.locmem.EmailBackend",
-        },
-    }
-else:
-    EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+globals().update(get_locmem_email_settings())
 DEBUG_TOOLBAR_PATCH_SETTINGS = False
 INTERNAL_IPS = ["127.0.0.1"]
 AUTHENTICATION_BACKENDS = (

--- a/cms/tests/test_admin.py
+++ b/cms/tests/test_admin.py
@@ -613,6 +613,17 @@ class NoDBAdminTests(CMSTestCase):
         self.assertTrue(self.admin_class.lookup_allowed("site__exact", "1", request=request))
 
 
+class EmailUserAdminCompatibilityTests(CMSTestCase):
+    def test_add_fieldsets_do_not_use_removed_wide_class(self):
+        if settings.AUTH_USER_MODEL != "emailuserapp.EmailUser":
+            self.skipTest("This test requires the email-based custom user model")
+
+        from cms.test_utils.project.emailuserapp.admin import UserAdmin
+
+        fieldset_options = UserAdmin.add_fieldsets[0][1]
+        self.assertNotIn("wide", fieldset_options.get("classes", ()))
+
+
 class PluginPermissionTests(AdminTestsBase):
     def setUp(self):
         self._page = create_page("test page", "nav_playground.html", "en")

--- a/cms/tests/test_admin.py
+++ b/cms/tests/test_admin.py
@@ -615,6 +615,7 @@ class NoDBAdminTests(CMSTestCase):
 
 class EmailUserAdminCompatibilityTests(CMSTestCase):
     def test_add_fieldsets_do_not_use_removed_wide_class(self):
+        # Importing this admin under the default user model mutates the global app and admin registries.
         if settings.AUTH_USER_MODEL != "emailuserapp.EmailUser":
             self.skipTest("This test requires the email-based custom user model")
 

--- a/cms/tests/test_mail.py
+++ b/cms/tests/test_mail.py
@@ -1,9 +1,11 @@
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
 from django.core import mail
 
 from cms.api import create_page_user
 from cms.test_utils.testcases import CMSTestCase
-from cms.utils.mail import mail_page_user_change
+from cms.utils.mail import mail_page_user_change, send_mail
 
 
 class MailTestCase(CMSTestCase):
@@ -15,3 +17,21 @@ class MailTestCase(CMSTestCase):
         user = create_page_user(user, user, grant_all=True)
         mail_page_user_change(user)
         self.assertEqual(len(mail.outbox), 1)
+
+    @patch("cms.utils.mail.EmailMultiAlternatives.send", side_effect=OSError("mail unavailable"))
+    def test_send_mail_suppresses_backend_errors_by_default(self, send):
+        send_mail("Subject", "admin/cms/mail/page_user_change.txt", ["user@example.com"])
+
+        send.assert_called_once_with()
+
+    @patch("cms.utils.mail.EmailMultiAlternatives.send", side_effect=OSError("mail unavailable"))
+    def test_send_mail_can_propagate_backend_errors(self, send):
+        with self.assertRaisesRegex(OSError, "mail unavailable"):
+            send_mail(
+                "Subject",
+                "admin/cms/mail/page_user_change.txt",
+                ["user@example.com"],
+                fail_silently=False,
+            )
+
+        send.assert_called_once_with()

--- a/cms/tests/test_mail.py
+++ b/cms/tests/test_mail.py
@@ -1,9 +1,12 @@
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.core import mail
+from django.test import SimpleTestCase
 
 from cms.api import create_page_user
+from cms.test_utils.email import get_locmem_email_settings
 from cms.test_utils.testcases import CMSTestCase
 from cms.utils.mail import mail_page_user_change, send_mail
 
@@ -24,6 +27,23 @@ class MailTestCase(CMSTestCase):
 
         send.assert_called_once_with()
 
+    def test_send_mail_sends_text_and_html_message_on_success(self):
+        send_mail(
+            "Subject",
+            "admin/cms/mail/page_user_change.txt",
+            ["user@example.com"],
+            context={"user": SimpleNamespace(username="test-user"), "password": "test-password"},
+            html_template="admin/cms/mail/page_user_change.html",
+        )
+
+        self.assertEqual(len(mail.outbox), 1)
+        message = mail.outbox[0]
+        self.assertIn("test-user", message.body)
+        self.assertEqual(len(message.alternatives), 1)
+        html_body, mimetype = message.alternatives[0]
+        self.assertIn("test-user", html_body)
+        self.assertEqual(mimetype, "text/html")
+
     @patch("cms.utils.mail.EmailMultiAlternatives.send", side_effect=OSError("mail unavailable"))
     def test_send_mail_can_propagate_backend_errors(self, send):
         with self.assertRaisesRegex(OSError, "mail unavailable"):
@@ -35,3 +55,22 @@ class MailTestCase(CMSTestCase):
             )
 
         send.assert_called_once_with()
+
+    @patch("cms.utils.mail.EmailMultiAlternatives.send", side_effect=ValueError("invalid message"))
+    def test_send_mail_does_not_suppress_unexpected_errors(self, send):
+        with self.assertRaisesRegex(ValueError, "invalid message"):
+            send_mail("Subject", "admin/cms/mail/page_user_change.txt", ["user@example.com"])
+
+        send.assert_called_once_with()
+
+
+class LocmemEmailSettingsTests(SimpleTestCase):
+    def test_locmem_settings_use_the_supported_django_api(self):
+        backend = "django.core.mail.backends.locmem.EmailBackend"
+        expected = (
+            {"MAILERS": {"default": {"BACKEND": backend}}}
+            if hasattr(mail, "mailers")
+            else {"EMAIL_BACKEND": backend}
+        )
+
+        self.assertEqual(get_locmem_email_settings(), expected)

--- a/cms/tests/test_signals.py
+++ b/cms/tests/test_signals.py
@@ -1,6 +1,9 @@
 import warnings
 
 from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.db.models.signals import m2m_changed
 from django.test.utils import override_settings
 
 from cms.api import create_page
@@ -19,6 +22,22 @@ overrides = {
 
 @override_settings(**overrides)
 class SignalTests(CMSTestCase):
+    def test_raw_user_group_fixture_event_does_not_access_database(self):
+        user = get_user_model().objects.create_user("fixture-user")
+        group = Group.objects.create(name="fixture-group")
+
+        with self.assertNumQueries(0):
+            m2m_changed.send(
+                sender=get_user_model().groups.through,
+                instance=group,
+                action="pre_add",
+                reverse=True,
+                model=get_user_model(),
+                pk_set={user.pk},
+                using="default",
+                raw=True,
+            )
+
     def test_move_page_signal_warns_on_connect(self):
         def receiver(**kwargs):
             return None

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -377,6 +377,19 @@ class TemplatetagDatabaseTests(TwoPagesFixture, CMSTestCase):
         self.assertIsNone(page)
         mail_managers.assert_called_once()
 
+    @patch("cms.templatetags.cms_tags.mail_managers", side_effect=ValueError("invalid message"))
+    def test_get_page_by_untyped_arg_does_not_ignore_unexpected_mail_errors(self, mail_managers):
+        with self.settings(
+            MIDDLEWARE=settings.MIDDLEWARE + ["django.middleware.common.BrokenLinkEmailsMiddleware"],
+            DEBUG=False,
+            MANAGERS=TEST_MANAGERS,
+        ):
+            request = self.get_request("/")
+            with self.assertRaisesRegex(ValueError, "invalid message"):
+                _get_page_by_untyped_arg({"pk": 1003}, request, 1)
+
+        mail_managers.assert_called_once()
+
     def test_get_page_by_untyped_arg_dict_fail_nodebug_no_email(self):
         with self.settings(
             MIDDLEWARE=[

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -2,6 +2,7 @@ import os
 from copy import deepcopy
 from unittest.mock import patch
 
+import django
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.sessions.backends.base import SessionBase
@@ -10,6 +11,7 @@ from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse
 from django.template import Context, Template
+from django.template.loader import render_to_string
 from django.test import RequestFactory
 from django.test.utils import override_settings
 from django.urls import NoReverseMatch
@@ -43,6 +45,8 @@ from cms.toolbar.toolbar import CMSToolbar
 from cms.toolbar.utils import get_object_edit_url, get_object_preview_url
 from cms.utils.conf import get_cms_setting, get_site_id
 from cms.utils.placeholder import get_placeholders
+
+TEST_MANAGERS = ["tests@django-cms.org"] if django.VERSION >= (6, 0) else [("Jenkins", "tests@django-cms.org")]
 
 
 class TemplatetagTests(CMSTestCase):
@@ -352,12 +356,25 @@ class TemplatetagDatabaseTests(TwoPagesFixture, CMSTestCase):
         with self.settings(
             MIDDLEWARE=settings.MIDDLEWARE + ["django.middleware.common.BrokenLinkEmailsMiddleware"],
             DEBUG=False,
-            MANAGERS=[("Jenkins", "tests@django-cms.org")],
+            MANAGERS=TEST_MANAGERS,
         ):
             request = self.get_request("/")
             page = _get_page_by_untyped_arg({"pk": 1003}, request, 1)
             self.assertEqual(page, None)
             self.assertEqual(len(mail.outbox), 1)
+
+    @patch("cms.templatetags.cms_tags.mail_managers", side_effect=OSError("mail unavailable"))
+    def test_get_page_by_untyped_arg_ignores_mail_backend_errors(self, mail_managers):
+        with self.settings(
+            MIDDLEWARE=settings.MIDDLEWARE + ["django.middleware.common.BrokenLinkEmailsMiddleware"],
+            DEBUG=False,
+            MANAGERS=TEST_MANAGERS,
+        ):
+            request = self.get_request("/")
+            page = _get_page_by_untyped_arg({"pk": 1003}, request, 1)
+
+        self.assertIsNone(page)
+        mail_managers.assert_called_once()
 
     def test_get_page_by_untyped_arg_dict_fail_nodebug_no_email(self):
         with self.settings(
@@ -365,7 +382,7 @@ class TemplatetagDatabaseTests(TwoPagesFixture, CMSTestCase):
                 mw for mw in settings.MIDDLEWARE if mw != "django.middleware.common.BrokenLinkEmailsMiddleware"
             ],
             DEBUG=False,
-            MANAGERS=[("Jenkins", "tests@django-cms.org")],
+            MANAGERS=TEST_MANAGERS,
         ):
             request = self.get_request("/")
             page = _get_page_by_untyped_arg({"pk": 1003}, request, 1)
@@ -874,11 +891,14 @@ class AdminBreadcrumbMarkupTests(CMSTestCase):
             self.assertTrue(django_version_gte(6))
             self.assertFalse(django_version_gte(7))
 
-    def _get_admin_html(self, uri):
+    def _get_admin_response(self, uri):
         with self.login_user_context(self.get_superuser()):
             response = self.client.get(uri)
         self.assertEqual(response.status_code, 200)
-        return response.content.decode("utf-8")
+        return response
+
+    def _get_admin_html(self, uri):
+        return self._get_admin_response(uri).content.decode("utf-8")
 
     # -- page tree changelist: admin/cms/page/tree/base.html --
 
@@ -911,3 +931,19 @@ class AdminBreadcrumbMarkupTests(CMSTestCase):
         self.assertIn('<ol class="breadcrumbs">', html)
         self.assertIn('aria-current="page"', html)
         self.assertNotIn('<div class="breadcrumbs">', html)
+
+    def test_page_change_form_object_tools_follow_django_layout(self):
+        page = create_page("Home", "nav_playground.html", "en")
+        response = self._get_admin_response(self.get_page_change_uri("en", page))
+        html = render_to_string(
+            "admin/cms/page/object_tools_test.html",
+            response.context_data,
+            request=response.wsgi_request,
+        )
+
+        marker = '<div id="object-tools-test-marker"></div>'
+        self.assertEqual(html.count(marker), 1)
+        if django.VERSION >= (6, 1):
+            self.assertLess(html.index(marker), html.index('<div id="content-main">'))
+        else:
+            self.assertGreater(html.index(marker), html.index('<div id="content-main">'))

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -46,6 +46,7 @@ from cms.toolbar.utils import get_object_edit_url, get_object_preview_url
 from cms.utils.conf import get_cms_setting, get_site_id
 from cms.utils.placeholder import get_placeholders
 
+# Django 6.0 changed MANAGERS from name/address pairs to plain email addresses.
 TEST_MANAGERS = ["tests@django-cms.org"] if django.VERSION >= (6, 0) else [("Jenkins", "tests@django-cms.org")]
 
 

--- a/cms/utils/mail.py
+++ b/cms/utils/mail.py
@@ -25,6 +25,8 @@ def send_mail(subject, txt_template, to, context=None, html_template=None, fail_
     if html_template:
         body = render_to_string(html_template, context)
         message.attach_alternative(body, 'text/html')
+    # Preserve this helper's contract without forwarding Django 6.1's
+    # deprecated fail_silently argument.
     try:
         message.send()
     except Exception:

--- a/cms/utils/mail.py
+++ b/cms/utils/mail.py
@@ -29,7 +29,7 @@ def send_mail(subject, txt_template, to, context=None, html_template=None, fail_
     # deprecated fail_silently argument.
     try:
         message.send()
-    except Exception:
+    except OSError:
         if not fail_silently:
             raise
 

--- a/cms/utils/mail.py
+++ b/cms/utils/mail.py
@@ -25,7 +25,11 @@ def send_mail(subject, txt_template, to, context=None, html_template=None, fail_
     if html_template:
         body = render_to_string(html_template, context)
         message.attach_alternative(body, 'text/html')
-    message.send(fail_silently=fail_silently)
+    try:
+        message.send()
+    except Exception:
+        if not fail_silently:
+            raise
 
 
 def mail_page_user_change(user, created=False, password="", site=None):

--- a/docs/upgrade/5.1.0.rst
+++ b/docs/upgrade/5.1.0.rst
@@ -22,7 +22,10 @@ django CMS 5.1 supports **Django 5.2, 6.0, and 6.1**. Django 4.2, 5.0, and
 maintenance. We highly recommend and only support the latest release of each
 supported series.
 
-It supports **Python 3.10, 3.11, 3.12, 3.13, and 3.14**.
+Supported Python versions depend on the selected Django series:
+
+* Django 5.2 supports Python 3.10 through 3.14.
+* Django 6.0 and 6.1 support Python 3.12 through 3.14.
 
 ******************
 Release highlights
@@ -55,7 +58,7 @@ more precise plugin configuration, and a modernized editing interface.
   previous theme remains available as a migration aid.
 
 * **Deploy on all maintained platform versions.** django CMS 5.1 supports Django
-  5.2, 6.0, and 6.1 and Python 3.10 through 3.14.
+  5.2, 6.0, and 6.1 across each series' supported Python versions.
 
 * **Benefit from security and reliability improvements.** The release
   strengthens authorization around editing and clipboard operations, improves

--- a/docs/upgrade/django-6.1-compatibility-audit.md
+++ b/docs/upgrade/django-6.1-compatibility-audit.md
@@ -93,7 +93,7 @@ several error-handling arguments. The old APIs are deprecated in 6.1 and are
 scheduled for removal in 7.0. See the [mailers overview and migration guide](https://docs.djangoproject.com/en/6.1/howto/mailers-migration/).
 
 This is directly relevant and needs the changes described under
-[Required repository updates](#required-repository-updates).
+[Implemented repository updates](#implemented-repository-updates).
 
 ### Admin, forms, and CSP
 
@@ -199,14 +199,15 @@ No repository usage of these removed forms was found.
 The [official `fail_silently` guidance](https://docs.djangoproject.com/en/6.1/howto/mailers-migration/#replacing-fail-silently)
 recommends intent-specific exception handling rather than the boolean argument.
 
-- In the missing-page error path, `fail_silently` was omitted and `Exception`
-  is caught:
-  this is an error reporter where mail failure must not replace the original
-  response.
+- In the missing-page error path, `fail_silently` was omitted and transport
+  errors represented by `OSError` are caught. This is an error reporter where
+  mail failure must not replace the original response, while unexpected errors
+  still propagate.
 - `cms.utils.mail.send_mail()` preserves its public `fail_silently` argument
   for django CMS API compatibility but calls `message.send()` without the
-  deprecated Django argument. It catches broadly when suppression is requested
-  and re-raises otherwise; tests cover both branches.
+  deprecated Django argument. It suppresses `OSError` when requested and
+  re-raises it otherwise; other exceptions always propagate. Tests cover each
+  branch and successful multipart delivery.
 - On Django 6.1, the locmem backend is configured as:
 
   ```python
@@ -217,9 +218,10 @@ recommends intent-specific exception handling rather than the boolean argument.
   }
   ```
 
-  `EMAIL_BACKEND` is retained for Django <6.1 through feature detection. Django
-  explicitly recommends `hasattr(django.core.mail, "mailers")` or
-  `django.VERSION >= (6, 1)` for multi-version libraries.
+  `EMAIL_BACKEND` is retained for Django <6.1 through a shared feature-detection
+  helper used by the test settings and standalone test server. Django explicitly
+  recommends `hasattr(django.core.mail, "mailers")` or `django.VERSION >= (6, 1)`
+  for multi-version libraries.
 
 ### 2. Align the custom admin change form with the 6.1 block layout
 
@@ -257,7 +259,7 @@ work rather than fixing a signature crash.
 
 ## Validation evidence
 
-Clean Python 3.14 SQLite runs passed all 1,700 tests on Django 5.2.17, 6.0.8,
+Clean Python 3.14 SQLite runs passed all 1,704 tests on Django 5.2.17, 6.0.8,
 and 6.1, with 57 expected skips in each environment. The Django 6.0 and 6.1
 suites ran with Python warnings enabled; the 6.1 run emitted no deprecated
 `fail_silently` or legacy email-backend warnings. Focused custom-user runs

--- a/docs/upgrade/django-6.1-compatibility-audit.md
+++ b/docs/upgrade/django-6.1-compatibility-audit.md
@@ -1,0 +1,282 @@
+# Django 6.1 compatibility audit
+
+Audit date: 2026-08-06
+
+This note compares django CMS at `be0baa565` with Django 6.1, released on
+2026-08-05, and records the compatibility work completed from that baseline.
+It is an implementation audit, not a django CMS release note.
+
+Primary sources:
+
+- [Django 6.1 release notes](https://docs.djangoproject.com/en/6.1/releases/6.1/)
+- [Django 6.1 mailers migration guide](https://docs.djangoproject.com/en/6.1/howto/mailers-migration/)
+- [Django 6.1 fetch modes](https://docs.djangoproject.com/en/6.1/topics/db/fetch-modes/)
+- [Django fixture signal guidance](https://docs.djangoproject.com/en/6.1/topics/db/fixtures/#how-fixtures-are-saved-to-the-database)
+
+## Executive summary
+
+The repository already declared Django 6.1 support and had mostly correct CI
+coverage. No removed Django 6.1 API was used by production code. Four follow-up
+changes were identified and completed:
+
+1. Migrate django CMS's email calls away from deprecated `fail_silently`, and
+   configure the test email backend through `MAILERS` on Django 6.1 while
+   preserving Django 5.2/6.0 compatibility.
+2. Remove the obsolete admin `wide` fieldset class, move the `object-tools`
+   override in the custom page change form outside its `content` block, and
+   visually test every custom admin change form with 6.1.
+3. Make the permissions `m2m_changed` receiver explicitly accept and ignore
+   `raw=True` fixture events, then cover that behavior with a fixture test.
+4. Change the Django 6.1 test requirement from the prerelease floor
+   `Django>=6.1a1` to the final-release floor `Django>=6.1`, and repair the
+   generated-project matrix so it tests the three supported Django series.
+
+These are compatibility and deprecation-cleanup changes. No django CMS model
+migration is required by Django 6.1.
+
+## Runtime and database floors
+
+Django 6.1 supports Python 3.12, 3.13, and 3.14; PostgreSQL 15 or newer;
+MySQL 8.4 or newer; MariaDB 10.11 or newer; and SQLite 3.37.0 or newer. See
+[Python compatibility](https://docs.djangoproject.com/en/6.1/releases/6.1/#python-compatibility),
+[dropped database support](https://docs.djangoproject.com/en/6.1/releases/6.1/#dropped-support-for-postgresql-14),
+and [miscellaneous incompatibilities](https://docs.djangoproject.com/en/6.1/releases/6.1/#miscellaneous).
+
+| Requirement | Repository state | Action |
+| --- | --- | --- |
+| Python 3.12-3.14 for Django 6.1 | `.github/workflows/test.yml` excludes Python 3.10 and 3.11 from the 6.1 jobs. `requires-python >=3.10` remains valid because django CMS also supports Django 5.2. | Do not raise the package-wide Python floor solely for 6.1. Clarify the per-Django Python combinations in the compatibility documentation. |
+| PostgreSQL >=15 | CI uses PostgreSQL 16-18. | None. |
+| MySQL >=8.4 | CI uses MySQL 8.4 and 9.5. | None. |
+| MariaDB >=10.11 | MariaDB is documented as supported but has no dedicated CI service. | Document the 10.11 floor; add a MariaDB job if MariaDB compatibility is a release guarantee. |
+| SQLite >=3.37.0 | The GitHub-hosted Python 3.12-3.14 builds satisfy this in practice. | Optionally assert `sqlite3.sqlite_version_info >= (3, 37)` in the 6.1 job to make the assumption explicit. |
+| Final Django 6.1 | `test_requirements/django-6.1.txt` now says `Django>=6.1,<6.2`. | Complete; prereleases are no longer selected after the final release. |
+
+The normal PostgreSQL, MySQL, and SQLite matrices already exercise Django 6.1.
+At the audited baseline, `.github/workflows/test_startcmsproject.yml` listed
+Django 4.2 through 5.2 and could silently upgrade the selected Django version.
+It now installs django CMS and an explicit 5.2, 6.0, or 6.1 constraint together
+and asserts the resolved Django version before and after project generation.
+
+## New features relevant to django CMS
+
+### ORM fetch modes
+
+`QuerySet.fetch_mode()` can use `FETCH_ONE` (the old/default behavior),
+`FETCH_PEERS` (batch deferred fields across queryset peers), or `FETCH_RAISE`
+(reject accidental deferred-field queries). This can reduce N+1 queries or
+enforce query budgets. See the [fetch mode documentation](https://docs.djangoproject.com/en/6.1/topics/db/fetch-modes/).
+
+django CMS has deliberate `.only()` querysets in `cms/cms_menus.py`,
+`cms/forms/utils.py`, and the optional materialized-path tree backend. No
+change is required: their projected fields appear intentional. `FETCH_RAISE`
+would be useful in performance tests around menu rendering to detect future
+access to omitted fields; `FETCH_PEERS` should only be adopted after query-count
+benchmarks.
+
+### Database-level `on_delete`
+
+`ForeignKey.on_delete` now accepts `DB_CASCADE`, `DB_SET_NULL`, and
+`DB_SET_DEFAULT`. They avoid loading related objects in Python, but
+`DB_CASCADE` deliberately does not send `pre_delete` or `post_delete` signals.
+See [database-level delete options](https://docs.djangoproject.com/en/6.1/releases/6.1/#database-level-delete-options-for-foreignkey-on-delete).
+
+django CMS relies on deletion behavior, signals, tree maintenance, plugin
+cleanup, and cache invalidation. Do not mechanically replace existing
+`CASCADE` declarations. Treat any use of `DB_CASCADE` as a separate design and
+performance change with database-specific migration and signal tests.
+
+### Mailers
+
+`MAILERS`, `django.core.mail.mailers`, and the `using=` argument replace the
+legacy `EMAIL_*` settings, `get_connection()`, connection arguments, and
+several error-handling arguments. The old APIs are deprecated in 6.1 and are
+scheduled for removal in 7.0. See the [mailers overview and migration guide](https://docs.djangoproject.com/en/6.1/howto/mailers-migration/).
+
+This is directly relevant and needs the changes described under
+[Required repository updates](#required-repository-updates).
+
+### Admin, forms, and CSP
+
+Relevant additions and behavior changes include:
+
+- Admin actions can be exposed on the change form as well as the change list,
+  and can have separate singular/plural descriptions.
+- `ModelAdmin.list_select_related=False` now selects only foreign keys present
+  in `list_display`, rather than every foreign key.
+- Admin change-form fields, labels, help text, and errors have a new accessible
+  vertical layout.
+- `FilteredSelectMultiple` preserves grouped choices with `<optgroup>`.
+- The default blank-choice label is more accessible and translatable.
+- The new `csp_nonce_attr` tag can render nonce-bearing form assets, and Django
+  admin/built-in templates add nonce attributes when the CSP context processor
+  is enabled.
+
+These are listed under the [Django 6.1 minor features](https://docs.djangoproject.com/en/6.1/releases/6.1/#minor-features).
+The admin layout is the main immediate concern because django CMS overrides
+admin templates and bundles admin-specific CSS/JavaScript. The CSP feature is a
+useful future hardening option, not an upgrade requirement.
+
+### Signals, JSON, responses, and validation
+
+Potentially useful or observable additions are:
+
+- `m2m_changed` now receives `raw`, and `loaddata` sends it with `raw=True`.
+- `JSONNull` explicitly represents JSON scalar `null`.
+- `HttpResponseRedirect` and `redirect()` accept a configurable URL
+  `max_length`.
+- `BinaryField`, multipart uploads, and database-cache decoding now reject
+  invalid Base64 instead of accepting or ignoring it.
+- Signed cookies use an unambiguous salt derivation by default.
+
+See [model, request, and security features](https://docs.djangoproject.com/en/6.1/releases/6.1/#models)
+and the [strict Base64 and signed-cookie incompatibilities](https://docs.djangoproject.com/en/6.1/releases/6.1/#miscellaneous).
+django CMS has no `JSONField` or `BinaryField` model usage. Its permission
+receiver does use `m2m_changed`, so fixture behavior needs attention below.
+
+## Backwards-incompatible changes and repository exposure
+
+The complete upstream list is in [Backwards incompatible changes in 6.1](https://docs.djangoproject.com/en/6.1/releases/6.1/#backwards-incompatible-changes-in-6-1).
+
+| Django change | Baseline django CMS exposure | Assessment or response |
+| --- | --- | --- |
+| Admin removes the `wide` CSS class and hoists `object-tools` outside `content`. | `cms/test_utils/project/emailuserapp/admin.py` assigned `classes=("wide",)` to `add_fieldsets`. `cms/templates/admin/cms/page/change_form.html` declared `object-tools` inside `content`; `usersettings/change_form.html` already declared it at top level. | Removed `wide` and added a version-aware template fallback with rendered regression coverage. |
+| `m2m_changed` is emitted by `loaddata` with `raw=True`. | `cms/signals/permissions.py:user_m2m_changed()` accepted `**kwargs`, so it did not crash, but it could clear caches and query users during raw fixture loading. Django's fixture guidance says receivers that access related data should return for `raw=True`. | Added an explicit `raw=False` parameter, an early return, and a zero-query regression test. |
+| Supplying `fail_silently`, auth credentials, or a connection together has stricter errors; `EmailMessage` connection behavior changed. | No combined connection/auth usage was found, but deprecated `fail_silently` was used. | Migrated the calls to explicit exception handling. |
+| `first()`/`last()` no longer add primary-key ordering after ordering was explicitly cleared with `order_by()`. | The only production bare `.order_by()` found builds a distinct field list and does not call `first()`/`last()`. | None. |
+| ORM-generated aliases are consistently quoted; mixed-case `RawSQL` references may need quoting. | No `RawSQL` usage was found. | None. |
+| `check` supplies every database when none is named. | django CMS provides checks and invokes `cms check`, but no code was found that assumes the old `databases=None` behavior. Multi-database projects may observe additional connections. | Run the check suite with two configured databases; no production edit is currently indicated. |
+| PostgreSQL, MySQL, MariaDB, SQLite, GIS, and third-party database backend floors/APIs changed. | django CMS has no custom database backend or GIS code. Active PostgreSQL/MySQL CI meets the floors. | Documentation/CI changes only, as above. |
+| Vary-aware page and fragment cache keys changed. | django CMS tests Django's update/fetch cache middleware and has its own plugin cache keys. The upstream change only means a one-time cache miss for old Django-generated vary-aware keys. | No migration or purge is required; note the expected cold miss in upgrade notes. |
+| Signed-cookie salt fallback now defaults to false. | No direct signing API usage was found. Deployments using Django signed-cookie sessions or messages may invalidate legacy cookies at upgrade. | Document the possible logout/cookie invalidation. Use the transitional fallback only when continuity is essential. |
+| Base `File` is always truthy, while common subclasses retain name-based truthiness. | No boolean checks of base `File` instances were found. | None. |
+| `GenericForeignKey` now uses a private descriptor class. | django CMS uses public `GenericForeignKey` behavior but does not reference its private descriptor. | None. |
+| Custom ASGI `RemoteUserMiddleware` headers changed. | No `RemoteUserMiddleware` subclass exists in the repository. | None. |
+| Strict Base64 errors can surface from multipart input and corrupted database-cache values. | No custom multipart parser, `BinaryField`, or database-cache decoder exists. | No code change; malformed uploads/cache rows may now fail loudly by design. |
+
+## Deprecations introduced in 6.1
+
+The full list is in [Features deprecated in 6.1](https://docs.djangoproject.com/en/6.1/releases/6.1/#features-deprecated-in-6-1).
+The baseline repository scan found these direct hits:
+
+- `cms/utils/mail.py` passes `fail_silently` to
+  `EmailMultiAlternatives.send()`.
+- `cms/templatetags/cms_tags.py` calls
+  `mail_managers(..., fail_silently=True)` while handling a missing page.
+- `cms/tests/settings.py` and `testserver.py` configure `EMAIL_BACKEND`.
+
+No affected usage was found for:
+
+- argumentless `select_related()`;
+- `ModelAdmin.list_select_related=True` or a method returning `True`;
+- `values_list(flat=True)` without a field;
+- top-level `JSONField` null queries;
+- `BLANK_CHOICE_DASH` or either transitional setting;
+- `salted_hmac()`/`base64_hmac()` without an explicit algorithm;
+- `ModelAdmin.get_actions()` or `get_action_choices()` overrides;
+- `transaction.savepoint()`;
+- double-dot template lookups;
+- deprecated field/compiler placeholder hooks; or
+- PostgreSQL-specific bitwise aggregate imports.
+
+## APIs removed in 6.1
+
+Django 6.1 completes the 5.2 deprecation cycle. It removes:
+
+- `staticfiles.finders.find(all=...)` in favor of `find_all=`;
+- the `user=None` fallback in `login()`/`alogin()`;
+- `ordering=` on PostgreSQL `ArrayAgg`, `JSONBAgg`, and `StringAgg` in favor
+  of `order_by=`; and
+- support for a `RemoteUserMiddleware` subclass that overrides only the sync
+  `process_request()` method.
+
+See [Features removed in 6.1](https://docs.djangoproject.com/en/6.1/releases/6.1/#features-removed-in-6-1).
+No repository usage of these removed forms was found.
+
+## Implemented repository updates
+
+### 1. Migrate email behavior without dropping Django 5.2/6.0
+
+The [official `fail_silently` guidance](https://docs.djangoproject.com/en/6.1/howto/mailers-migration/#replacing-fail-silently)
+recommends intent-specific exception handling rather than the boolean argument.
+
+- In the missing-page error path, `fail_silently` was omitted and `Exception`
+  is caught:
+  this is an error reporter where mail failure must not replace the original
+  response.
+- `cms.utils.mail.send_mail()` preserves its public `fail_silently` argument
+  for django CMS API compatibility but calls `message.send()` without the
+  deprecated Django argument. It catches broadly when suppression is requested
+  and re-raises otherwise; tests cover both branches.
+- On Django 6.1, the locmem backend is configured as:
+
+  ```python
+  MAILERS = {
+      "default": {
+          "BACKEND": "django.core.mail.backends.locmem.EmailBackend",
+      },
+  }
+  ```
+
+  `EMAIL_BACKEND` is retained for Django <6.1 through feature detection. Django
+  explicitly recommends `hasattr(django.core.mail, "mailers")` or
+  `django.VERSION >= (6, 1)` for multi-version libraries.
+
+### 2. Align the custom admin change form with the 6.1 block layout
+
+The obsolete `classes=("wide",)` was removed from the test email user's
+`add_fieldsets`. The page change form now detects Django 6.1's hoisted
+`object-tools` block and renders the nested fallback only on older Django
+versions. Rendered regression tests verify that the tools appear exactly once
+and in the appropriate location on Django 5.2 and 6.1. The custom email-user
+admin configuration is also tested under its required custom-user setting.
+
+### 3. Handle raw M2M fixture events
+
+The permissions receiver now has the equivalent of:
+
+```python
+def user_m2m_changed(instance, action, reverse, pk_set, raw=False, **kwargs):
+    if raw:
+        return
+    # Existing cache invalidation follows.
+```
+
+A test sends an M2M fixture event with `raw=True` and asserts that
+permission-cache/user queries are skipped. This prevents unsafe fixture-time
+work rather than fixing a signature crash.
+
+### 4. Close release/test coverage gaps
+
+- `test_requirements/django-6.1.txt` now uses `Django>=6.1,<6.2`.
+- The unsupported 4.2/5.0/5.1 `test_startcmsproject` rows were replaced with
+  5.2, 6.0, and 6.1. The workflow installs the editable package and Django
+  constraint together and asserts `django.get_version()` before and after
+  generation.
+- The local Django 6.1 suite ran with deprecation warnings enabled, and the
+  generated-project smoke tests verified the constrained 5.2 and 6.1 series.
+
+## Validation evidence
+
+Clean Python 3.14 SQLite runs passed all 1,700 tests on Django 5.2.17, 6.0.8,
+and 6.1, with 57 expected skips in each environment. The Django 6.0 and 6.1
+suites ran with Python warnings enabled; the 6.1 run emitted no deprecated
+`fail_silently` or legacy email-backend warnings. Focused custom-user runs
+verified the admin fieldset change on Django 5.2 and 6.1. Generated-project
+smoke tests also completed on 5.2 and 6.1 without changing the constrained
+Django series.
+
+The remaining warnings are pre-existing django CMS deprecations, Python
+resource/import deprecations, and Treebeard manager warnings; they are outside
+the Django 6.1 compatibility work covered here.
+
+## Optional adoption, not upgrade work
+
+- Trial `FETCH_RAISE` in query-count tests and `FETCH_PEERS` only after
+  benchmarking menu/admin workloads.
+- Evaluate `csp_nonce_attr` and Django's CSP context processor as a separate
+  security-hardening change.
+- Consider `DB_CASCADE` only after identifying relations that do not depend on
+  Django delete signals or Python-side cascade behavior.
+- The new accessible blank-choice label may allow replacing the manual
+  `("", "----")` label in `cms/forms/utils.py`, but that is a UX change and is
+  not required for 6.1 compatibility.

--- a/docs/upgrade/version.rst.template
+++ b/docs/upgrade/version.rst.template
@@ -20,11 +20,13 @@ updating an existing project.
 Django and Python compatibility
 *******************************
 
-django CMS supports **Django 4.2, 5.0, 5.1, and 5.2**. We highly recommend and only
+django CMS supports **Django 5.2, 6.0, and 6.1**. We highly recommend and only
 support the latest release of each series.
 
-It supports **Python 3.11, 3.12, 3.13, and 3.14**. As for Django we highly recommend and only
-support the latest release of each series.
+Supported Python versions depend on the selected Django series:
+
+* Django 5.2 supports Python 3.10 through 3.14.
+* Django 6.0 and 6.1 support Python 3.12 through 3.14.
 
 ***********************
 How to upgrade to 5.X.X
@@ -69,4 +71,3 @@ Removal of deprecated functionality
 ===================================
 
 Empty sections are to be removed before release.
-

--- a/test_requirements/django-6.1.txt
+++ b/test_requirements/django-6.1.txt
@@ -1,2 +1,2 @@
 -r requirements_base.txt
-Django>=6.1a1,<6.2
+Django>=6.1,<6.2

--- a/testserver.py
+++ b/testserver.py
@@ -5,6 +5,7 @@ import tempfile
 import warnings
 
 import dj_database_url
+from django.core import mail as django_mail
 
 from cms.exceptions import DontUsePageAttributeWarning
 
@@ -145,6 +146,17 @@ if __name__ == "__main__":
 
     SESSION_ENGINE = "django.contrib.sessions.backends.db"
 
+    if hasattr(django_mail, "mailers"):
+        email_settings = {
+            "MAILERS": {
+                "default": {
+                    "BACKEND": "django.core.mail.backends.locmem.EmailBackend",
+                },
+            },
+        }
+    else:
+        email_settings = {"EMAIL_BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
+
     MIDDLEWARES = [
         "django.middleware.cache.UpdateCacheMiddleware",
         "django.middleware.http.ConditionalGetMiddleware",
@@ -186,7 +198,6 @@ if __name__ == "__main__":
             MEDIA_URL="/media/",
             STATIC_URL="/static/",
             ADMIN_MEDIA_PREFIX="/static/admin/",
-            EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
             PLUGIN_APPS=PLUGIN_APPS,
             DEBUG_TOOLBAR_PATCH_SETTINGS=False,
             INTERNAL_IPS=["127.0.0.1"],
@@ -311,4 +322,5 @@ if __name__ == "__main__":
             MIGRATION_MODULES=MIGRATION_MODULES,
             X_FRAME_OPTIONS="SAMEORIGIN",
             TEXT_INLINE_EDITING=False,
+            **email_settings,
         )

--- a/testserver.py
+++ b/testserver.py
@@ -5,9 +5,9 @@ import tempfile
 import warnings
 
 import dj_database_url
-from django.core import mail as django_mail
 
 from cms.exceptions import DontUsePageAttributeWarning
+from cms.test_utils.email import get_locmem_email_settings
 
 
 def gettext(s):
@@ -146,18 +146,7 @@ if __name__ == "__main__":
 
     SESSION_ENGINE = "django.contrib.sessions.backends.db"
 
-    # MAILERS exists only on Django 6.1+, so feature detection keeps this
-    # standalone server importable on every supported version.
-    if hasattr(django_mail, "mailers"):
-        email_settings = {
-            "MAILERS": {
-                "default": {
-                    "BACKEND": "django.core.mail.backends.locmem.EmailBackend",
-                },
-            },
-        }
-    else:
-        email_settings = {"EMAIL_BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
+    email_settings = get_locmem_email_settings()
 
     MIDDLEWARES = [
         "django.middleware.cache.UpdateCacheMiddleware",

--- a/testserver.py
+++ b/testserver.py
@@ -146,6 +146,8 @@ if __name__ == "__main__":
 
     SESSION_ENGINE = "django.contrib.sessions.backends.db"
 
+    # MAILERS exists only on Django 6.1+, so feature detection keeps this
+    # standalone server importable on every supported version.
     if hasattr(django_mail, "mailers"):
         email_settings = {
             "MAILERS": {


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Ensure django CMS remains compatible with Django 6.1, including email handling, admin templates, and signal behavior, while updating tests and CI coverage accordingly.

Bug Fixes:
- Prevent missing-page handling and mail helper functions from failing when the mail backend errors, while still allowing callers to surface errors when requested.
- Avoid database access during raw many-to-many fixture events by ignoring `m2m_changed` signals marked as `raw`.

Enhancements:
- Adapt email utilities and test settings to Django 6.1's mailers API and deprecation of `fail_silently`, keeping backwards compatibility with earlier Django versions.
- Align custom admin change-form templates and the email-based user admin configuration with Django 6.1's layout and CSS changes.
- Introduce a version-aware template helper to keep page admin object-tools rendered in the correct location across supported Django versions.

CI:
- Update generated-project workflow to explicitly test against Django 5.2, 6.0, and 6.1 with matching Python versions and version constraints, and to assert the resolved Django version before and after project creation.
- Clarify Django 6.0/6.1 Python-version exclusions in the main test matrix comments.

Documentation:
- Add a detailed Django 6.1 compatibility audit document describing required changes, deprecations, and validation for django CMS.

Tests:
- Extend mail, template tag, admin, and signal tests to cover Django 6.1 behaviors, including mail error handling, admin object-tools placement, removal of the `wide` class, and ignoring raw fixture M2M events.
- Add a template-based regression test to verify the relative placement of admin object tools and main content across Django versions.

Chores:
- Adjust test email configuration in the standalone test server and shared test settings to use `MAILERS` where available, maintaining support for older Django versions.