### PR TITLE
ci: add PostgreSQL 15 minimum version coverage for Django 6.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,8 @@ jobs:
           django-6.0.txt,
           django-6.1.txt
         ]
-        # On nightly runs, test all postgres versions. On push/PR, only test latest.
-        postgres-version: ${{ github.event_name == 'schedule' && fromJSON('["16", "17", "18"]') || fromJSON('["16"]') }}
+        # On nightly runs, test all postgres versions (15, 16, 17, 18). On push/PR, test minimum supported (15) and latest.
+        postgres-version: ${{ github.event_name == 'schedule' && fromJSON('["15", "16", "17", "18"]') || fromJSON('["15"]') }}
         os: [
           ubuntu-latest,
         ]


### PR DESCRIPTION
## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.

Resolves #8770

This PR updates the PostgreSQL testing matrix in `.github/workflows/test.yml` to include PostgreSQL 15, matching the minimum supported database version requirement for Django 6.1.

## Summary by Sourcery

CI:
- Update test workflow matrix to include PostgreSQL 15 in scheduled runs and as the default version for push/PR builds.