### PR TITLE
fix: Migration 0044 failed on sqlite when versioning was installed

### DIFF
--- a/cms/migrations/0044_pagecontent_slug_overwrite_url.py
+++ b/cms/migrations/0044_pagecontent_slug_overwrite_url.py
@@ -2,6 +2,61 @@ from django.db import migrations, models
 from django.db.models import Case, Exists, F, OuterRef, Subquery, Value, When
 
 
+def _has_unique_constraint(schema_editor, model, field_names):
+    """Return whether the database really enforces uniqueness over ``field_names``."""
+    columns = {model._meta.get_field(name).column for name in field_names}
+    with schema_editor.connection.cursor() as cursor:
+        constraints = schema_editor.connection.introspection.get_constraints(cursor, model._meta.db_table)
+    return any(
+        constraint["unique"] and not constraint.get("primary_key") and set(constraint["columns"]) == columns
+        for constraint in constraints.values()
+    )
+
+
+class AddFieldKeepingDatabaseUniqueness(migrations.AddField):
+    """``AddField`` that never resurrects a unique constraint the database dropped.
+
+    ``PageContent`` carries ``unique_together = (("language", "page"),)`` in the
+    migration state, but djangocms-versioning removes that constraint from the
+    database only (its ``0009_cms_pagecontent_remove_unique_constraint`` does the
+    work in a ``RunPython``, which cannot alter another app's state). Versioning
+    then stores one row per version, so several rows share a page and language.
+
+    SQLite cannot ``ALTER TABLE ADD COLUMN`` a non-null column and rebuilds the
+    whole table from the state model instead. That rebuild would recreate the
+    stale constraint and fail while copying the versioned rows over. So drop
+    ``unique_together`` for the duration of the rebuild whenever the database
+    turns out not to have the constraint anyway. Installations without a
+    versioning package still have it and keep it.
+
+    See django-cms#8776; djangocms-versioning#599 tracks reconciling state and
+    database for good.
+    """
+
+    unique_together = (("language", "page"),)
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        from_model = from_state.apps.get_model(app_label, self.model_name)
+        to_model = to_state.apps.get_model(app_label, self.model_name)
+
+        if not self.allow_migrate_model(schema_editor.connection.alias, to_model) or _has_unique_constraint(
+            schema_editor, from_model, self.unique_together[0]
+        ):
+            super().database_forwards(app_label, schema_editor, from_state, to_state)
+            return
+
+        originals = [(model, model._meta.unique_together) for model in (from_model, to_model)]
+        for model, original in originals:
+            model._meta.unique_together = tuple(
+                fields for fields in original if tuple(fields) not in self.unique_together
+            )
+        try:
+            super().database_forwards(app_label, schema_editor, from_state, to_state)
+        finally:
+            for model, original in originals:
+                model._meta.unique_together = original
+
+
 def _copy_urls_to_content(apps, schema_editor):
     """Copy the authored URL values from the (unversioned) PageUrl objects onto
     every PageContent object of the same page and language.
@@ -40,7 +95,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddField(
+        AddFieldKeepingDatabaseUniqueness(
             model_name="pagecontent",
             name="slug",
             field=models.SlugField(
@@ -51,7 +106,7 @@ class Migration(migrations.Migration):
             ),
             preserve_default=False,
         ),
-        migrations.AddField(
+        AddFieldKeepingDatabaseUniqueness(
             model_name="pagecontent",
             name="overwrite_url",
             field=models.CharField(

--- a/cms/models/contentmodels.py
+++ b/cms/models/contentmodels.py
@@ -10,6 +10,8 @@ from cms.utils.conf import get_cms_setting
 
 
 class PageContent(models.Model):
+    # Field changes need a custom migration operation as in 0044: versioning packages drop the
+    # unique_together below in the database only, and SQLite rebuilds the table from the state.
     LIMIT_VISIBILITY_IN_MENU_CHOICES = (
         (constants.VISIBILITY_ALL, _("no limit set")),
         (constants.VISIBILITY_USERS, _("for logged in users only")),

--- a/cms/tests/test_migrations.py
+++ b/cms/tests/test_migrations.py
@@ -3,11 +3,15 @@ from io import StringIO
 
 from django.apps import apps
 from django.core.management import call_command
-from django.test import TestCase, override_settings
+from django.db import IntegrityError, connection, migrations, models, transaction
+from django.db.migrations.state import ProjectState
+from django.test import TestCase, TransactionTestCase, override_settings
 
 from cms.api import create_page, create_page_content
 from cms.models import PageContent
 from cms.test_utils.testcases import CMSTestCase
+
+migration_0044 = importlib.import_module("cms.migrations.0044_pagecontent_slug_overwrite_url")
 
 
 class MigrationTestCase(TestCase):
@@ -42,8 +46,7 @@ class CopyUrlsToContentMigrationTestCase(CMSTestCase):
     """
 
     def _run_migration(self):
-        migration = importlib.import_module("cms.migrations.0044_pagecontent_slug_overwrite_url")
-        migration._copy_urls_to_content(apps, None)
+        migration_0044._copy_urls_to_content(apps, None)
 
     def test_copies_urls_onto_contents(self):
         managed = create_page("Managed", "nav_playground.html", "en", slug="managed")
@@ -81,3 +84,93 @@ class CopyUrlsToContentMigrationTestCase(CMSTestCase):
 
         self.assertEqual(PageContent.objects.get(page=page, language="en").slug, "english")
         self.assertEqual(PageContent.objects.get(page=page, language="de").slug, "deutsch")
+
+
+class AddFieldKeepingDatabaseUniquenessTestCase(TransactionTestCase):
+    """Regression tests for the ``AddField`` guard of 0044 (#8776).
+
+    A versioning package may drop ``PageContent``'s ``("language", "page")``
+    unique constraint from the database without being able to remove it from
+    the migration state. SQLite rebuilds a table from that state whenever a
+    non-null column is added, so a plain ``AddField`` recreates the constraint
+    and then trips over the rows the versioning package stores per version.
+
+    The operation is exercised against a throwaway model of the same shape so
+    that the test does not depend on migrations being enabled.
+    """
+
+    app_label = "cms"
+    model_name = "AddFieldGuardModel"
+
+    def create_table(self):
+        operation = migrations.CreateModel(
+            name=self.model_name,
+            fields=[
+                ("id", models.AutoField(primary_key=True)),
+                ("language", models.CharField(max_length=15)),
+                ("page", models.IntegerField()),
+            ],
+            options={"unique_together": {("language", "page")}},
+        )
+        before, after = ProjectState(), ProjectState()
+        operation.state_forwards(self.app_label, after)
+        with connection.schema_editor() as schema_editor:
+            operation.database_forwards(self.app_label, schema_editor, before, after)
+        self.addCleanup(self.drop_table, after)
+        return after
+
+    def drop_table(self, state):
+        operation = migrations.DeleteModel(self.model_name)
+        after = state.clone()
+        operation.state_forwards(self.app_label, after)
+        with connection.schema_editor() as schema_editor:
+            operation.database_forwards(self.app_label, schema_editor, state, after)
+
+    def add_slug(self, before):
+        """Add a non-null column, the case that makes SQLite rebuild the table."""
+        operation = migration_0044.AddFieldKeepingDatabaseUniqueness(
+            model_name=self.model_name,
+            name="slug",
+            field=models.SlugField(default="", max_length=255),
+            preserve_default=False,
+        )
+        after = before.clone()
+        operation.state_forwards(self.app_label, after)
+        with connection.schema_editor() as schema_editor:
+            operation.database_forwards(self.app_label, schema_editor, before, after)
+        return after.apps.get_model(self.app_label, self.model_name)
+
+    def drop_unique_constraint(self, state):
+        """Do what djangocms-versioning's 0009 does: drop it in the database only."""
+        model = state.apps.get_model(self.app_label, self.model_name)
+        with connection.schema_editor() as schema_editor:
+            schema_editor.alter_unique_together(model, {("language", "page")}, set())
+        return model
+
+    def has_unique_constraint(self, model):
+        with connection.schema_editor() as schema_editor:
+            return migration_0044._has_unique_constraint(schema_editor, model, ("language", "page"))
+
+    def test_does_not_restore_a_constraint_the_database_dropped(self):
+        state = self.create_table()
+        model = self.drop_unique_constraint(state)
+        model.objects.create(language="en", page=1)
+        model.objects.create(language="en", page=1)
+
+        new_model = self.add_slug(state)
+
+        self.assertFalse(self.has_unique_constraint(new_model))
+        self.assertEqual(new_model.objects.count(), 2)
+        # Existing rows receive the default of the new column
+        self.assertEqual(list(new_model.objects.values_list("slug", flat=True)), ["", ""])
+
+    def test_keeps_a_constraint_the_database_still_has(self):
+        state = self.create_table()
+        model = state.apps.get_model(self.app_label, self.model_name)
+        model.objects.create(language="en", page=1)
+
+        new_model = self.add_slug(state)
+
+        self.assertTrue(self.has_unique_constraint(new_model))
+        with self.assertRaises(IntegrityError), transaction.atomic():
+            new_model.objects.create(language="en", page=1, slug="duplicate")


### PR DESCRIPTION
## Summary by Sourcery

Guard the 0044 PageContent slug/overwrite_url migration against resurrecting dropped uniqueness constraints so it succeeds on SQLite installations using versioning packages.

Bug Fixes:
- Prevent migration 0044 from failing on SQLite when versioning has removed PageContent’s (language, page) unique constraint from the database while it remains in migration state.

Enhancements:
- Introduce a custom AddFieldKeepingDatabaseUniqueness migration operation that respects the actual database unique constraints when adding non-null fields.
- Document in the PageContent model that field changes require the custom migration operation due to versioning packages altering database uniqueness.

Tests:
- Add regression tests exercising AddFieldKeepingDatabaseUniqueness against a throwaway model to verify it preserves or omits the unique constraint in line with the database state and handles duplicate rows safely.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.