### PR TITLE
fix: Language column in page tree ignored multi-hyphen language codes like de-x-l

### DIFF
--- a/cms/static/cms/js/modules/cms.pagetree.js
+++ b/cms/static/cms/js/modules/cms.pagetree.js
@@ -132,10 +132,12 @@ class PageTree {
                     value: function(node) {
                         // it needs to have the "colde" format and not "col-de"
                         // as jstree will convert "col-de" to "colde"
-                        // also we strip dashes, in case language code contains it
-                        // e.g. zh-hans, zh-cn etc
+                        // all dashes are stripped and the key is lowercased to
+                        // match the "data-col..." attribute rendered by
+                        // admin/cms/page/tree/menu.html, in case the language
+                        // code contains them, e.g. zh-hans, de-x-l, zh-Hant
                         if (node.data) {
-                            return node.data['col' + obj.key.replace('-', '')];
+                            return node.data['col' + obj.key.replace(/-/g, '').toLowerCase()];
                         }
 
                         return '';

--- a/cms/tests/frontend/unit/cms.pagetree.test.js
+++ b/cms/tests/frontend/unit/cms.pagetree.test.js
@@ -295,6 +295,48 @@ describe('CMS.PageTree', function () {
         });
     });
 
+    describe('_setup() column values', function () {
+        var pagetree;
+
+        // resolves a column by its header, as the value functions are anonymous
+        function columnFor(header) {
+            return pagetree.ui.tree
+                .jstree(true)
+                .settings.grid.columns.filter(function (column) {
+                    return column.header === header;
+                })[0];
+        }
+
+        beforeEach(function (done) {
+            $(function () {
+                // the template renders "data-col<language>" with every dash
+                // stripped, so the lookup key has to be stripped the same way
+                var opts = $('.js-cms-pagetree').data('json');
+
+                opts.columns.push({ title: 'DE-X-L', key: 'de-x-l' });
+                opts.columns.push({ title: 'ZH-Hant', key: 'zh-Hant' });
+                $('.js-cms-pagetree').data('json', opts);
+
+                pagetree = new CMS.PageTree();
+                done();
+            });
+        });
+
+        it('reads the cell from the matching data attribute', function () {
+            expect(columnFor('EN').value({ data: { colen: 'en cell' } })).toEqual('en cell');
+            expect(columnFor('Menu').value({ data: { colmenu: 'menu cell' } })).toEqual('menu cell');
+        });
+
+        it('strips every dash of the language code, not only the first one', function () {
+            expect(columnFor('ZH-CN').value({ data: { colzhcn: 'zh-cn cell' } })).toEqual('zh-cn cell');
+            expect(columnFor('DE-X-L').value({ data: { coldexl: 'de-x-l cell' } })).toEqual('de-x-l cell');
+        });
+
+        it('lowercases the language code', function () {
+            expect(columnFor('ZH-Hant').value({ data: { colzhhant: 'zh-Hant cell' } })).toEqual('zh-Hant cell');
+        });
+    });
+
     describe('_getNodeId()', function () {
         var pagetree;
         var node;


### PR DESCRIPTION
## Summary by Sourcery

Ensure page tree language columns correctly resolve values for language codes with multiple hyphens and case variations.

Bug Fixes:
- Fix page tree grid column lookup so language codes with multiple hyphens (e.g. de-x-l) map to the correct data-col attributes.

Tests:
- Add unit tests covering page tree column value resolution for standard, single-hyphen, multi-hyphen, and mixed-case language codes.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* fixes #8780 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.