### PR TITLE
fix: Add display limit to plugin deletion context

### DIFF
--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -1223,6 +1223,7 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
             "protected": protected,
             "opts": opts,
             "app_label": opts.app_label,
+            "delete_confirmation_max_display": getattr(self, "delete_confirmation_max_display", None),
         }
         request.current_app = self.admin_site.name
         return TemplateResponse(
@@ -1322,6 +1323,7 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
             "protected": protected,
             "opts": opts,
             "app_label": opts.app_label,
+            "delete_confirmation_max_display": getattr(self, "delete_confirmation_max_display", None),
         }
         request.current_app = self.admin_site.name
         return TemplateResponse(request, "admin/cms/page/plugin/delete_confirmation.html", context)

--- a/cms/tests/test_placeholder_admin.py
+++ b/cms/tests/test_placeholder_admin.py
@@ -355,6 +355,23 @@ class PlaceholderAdminTestCase(CMSTestCase):
         self.assertContains(response, '<div class="success"></div>')
         self.assertFalse(CMSPlugin.objects.filter(pk=plugin.pk).exists())
 
+    def test_delete_plugin_confirmation_context(self):
+        superuser = self.get_superuser()
+        placeholder = Placeholder.objects.create(slot="source")
+        plugin = self._add_plugin_to_placeholder(placeholder)
+        endpoint = self.get_delete_plugin_uri(plugin)
+
+        with patch(
+            "cms.admin.placeholderadmin.PlaceholderAdmin.delete_confirmation_max_display",
+            1,
+            create=True,
+        ), self.login_user_context(superuser):
+            response = self.client.get(endpoint)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("delete_confirmation_max_display", response.context)
+        self.assertEqual(response.context["delete_confirmation_max_display"], 1)
+
     def test_clear_placeholder_endpoint(self):
         """
         The Placeholder admin delete_plugin endpoint works
@@ -368,6 +385,19 @@ class PlaceholderAdminTestCase(CMSTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(placeholder.get_plugins("en").count(), 0)
+
+    def test_clear_placeholder_confirmation_context(self):
+        superuser = self.get_superuser()
+        placeholder = Placeholder.objects.create(slot="source")
+        self._add_plugin_to_placeholder(placeholder)
+        endpoint = self.get_clear_placeholder_url(placeholder)
+
+        with self.login_user_context(superuser):
+            response = self.client.get(endpoint)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("delete_confirmation_max_display", response.context)
+        self.assertIsNone(response.context["delete_confirmation_max_display"])
 
     def test_clear_clipboard_requires_post(self):
         """


### PR DESCRIPTION
## Summary

- forward the ModelAdmin deletion display limit from the custom plugin deletion view
- add the same context value to placeholder clearing confirmations
- retain compatibility with Django versions that do not define the setting
- cover both confirmation endpoints with regression tests

Django 6.1 admin deletion templates require delete_confirmation_max_display when rendering deletion trees. The custom django CMS confirmation contexts omitted it, causing VariableDoesNotExist while deleting plugins.

## Testing

- 31 tests in cms.tests.test_placeholder_admin pass on Django 6.1
- ruff passes for the changed files

## Summary by Sourcery

Provide the deletion display limit in custom plugin deletion confirmation views for compatibility with newer Django admin templates.

Bug Fixes:
- Pass Django’s deletion display limit to plugin deletion and placeholder-clearing confirmation contexts to prevent deletion-template rendering errors.

Enhancements:
- Preserve compatibility with Django versions that do not define the deletion display limit setting.

Tests:
- Add regression coverage for the deletion confirmation context in both custom admin endpoints.