### PR TITLE
fix: Copying from write-protected (published) content was prohibited

### DIFF
--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -563,10 +563,11 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
             message = _('You do not have permission to copy these plugins.')
             raise PermissionDenied(message)
 
-        if not source_placeholder.check_source(request.user):
-            message = _('You do not have permission to copy these plugins.')
-            raise PermissionDenied(message)
-
+        # Deliberately no ``source_placeholder.check_source()`` here: that is an
+        # editability gate (see ``placeholder_is_immutable``), and copying only
+        # reads the source. Editors must be able to copy out of content they may
+        # not edit, such as a published version or a draft another user has
+        # locked. Read access is covered by the permission check above.
         if not target_placeholder.check_source(request.user):
             message = _('You do not have permission to copy these plugins.')
             raise PermissionDenied(message)
@@ -599,10 +600,11 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
             message = _('You do not have permission to copy this placeholder.')
             raise PermissionDenied(message)
 
-        if not source_placeholder.check_source(request.user):
-            message = _('You do not have permission to copy this placeholder.')
-            raise PermissionDenied(message)
-
+        # Deliberately no ``source_placeholder.check_source()`` here: that is an
+        # editability gate (see ``placeholder_is_immutable``), and copying only
+        # reads the source. Editors must be able to copy out of content they may
+        # not edit, such as a published version or a draft another user has
+        # locked. Read access is covered by the permission check above.
         if not target_placeholder.check_source(request.user):
             message = _('You do not have permission to copy this placeholder.')
             raise PermissionDenied(message)

--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -350,16 +350,19 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
         # Pasting reads the plugins from the placeholder they are pasted from,
         # so a user without access to that placeholder must not be able to
         # exfiltrate its content into a placeholder they do control.
-        clipboard = request.toolbar.clipboard
+        clipboard = get_toolbar_from_request(request).clipboard
 
         if clipboard and source_placeholder.pk == clipboard.pk:
             # Pasting from the user's own clipboard, which is what this
             # operation is for. A user may always read their own clipboard.
             return True
 
-        if not source_placeholder.has_add_plugins_permission(request.user, plugins):
-            return False
-        return source_placeholder.check_source(request.user)
+        # Deliberately no ``source_placeholder.check_source()`` here: that is an
+        # editability gate (see ``placeholder_is_immutable``), and pasting only
+        # reads the source. Editors must be able to paste out of content they
+        # may not edit, such as a published version or a draft another user has
+        # locked. Read access is covered by the permission check below.
+        return source_placeholder.has_add_plugins_permission(request.user, plugins)
 
     def has_copy_from_placeholder_permission(self, request, source_placeholder, target_placeholder, plugins):
         if not source_placeholder.has_add_plugins_permission(request.user, plugins):

--- a/cms/plugin_base.py
+++ b/cms/plugin_base.py
@@ -12,7 +12,8 @@ from django.template import Context
 from django.template.response import TemplateResponse
 from django.utils.encoding import force_str, smart_str
 from django.utils.functional import lazy
-from django.utils.html import escapejs
+from django.utils.html import conditional_escape, escapejs
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext, gettext_lazy as _
 
 from cms import operations
@@ -672,8 +673,11 @@ class CMSPluginBase(admin.ModelAdmin, metaclass=CMSPluginBaseMetaclass):
     def response_change(self, request, obj):
         self.object_successfully_changed = True
         opts = self.model._meta
-        msg_dict = {"name": force_str(opts.verbose_name), "obj": force_str(obj)}
-        msg = _('The %(name)s "%(obj)s" was changed successfully.') % msg_dict
+        msg_dict = {
+            "name": conditional_escape(force_str(opts.verbose_name)),
+            "obj": conditional_escape(force_str(obj)),
+        }
+        msg = mark_safe(_('The %(name)s "%(obj)s" was changed successfully.') % msg_dict)
         self.message_user(request, msg, messages.SUCCESS)
         return self.render_close_frame(request, obj, action="change")
 

--- a/cms/tests/test_placeholder.py
+++ b/cms/tests/test_placeholder.py
@@ -1,3 +1,5 @@
+import json
+import re
 import warnings
 from unittest.mock import patch
 
@@ -597,6 +599,36 @@ class PlaceholderTestCase(TransactionCMSTestCase):
         response = self.client.post(endpoint, {})
         self.assertContains(response, '<script id="data-bridge" type="application/json">')
         self.assertContains(response, f'title=\\"EmptyPlugin ID: {test_plugin.pk}\\"')
+
+    @override_settings(CMS_PERMISSION=False)
+    def test_change_message_escapes_plugin_representation(self):
+        """
+        The plugin change message ends up in the data bridge as raw JSON, where
+        no template autoescaping applies. A plugin's string representation is
+        editor-controlled, so it has to be escaped before it gets there.
+        """
+        payload = '<img src=x onerror="alert(1)">'
+        page = create_page("page", "col_two.html", "en")
+        ph1 = page.get_placeholders("en").get(slot="col_left")
+        test_plugin = add_plugin(
+            ph1, "LinkPlugin", "en", name="A Link", external_link="https://www.django-cms.org"
+        )
+
+        endpoint = self.get_change_plugin_uri(test_plugin)
+        response = self.client.post(
+            endpoint, {"name": payload, "external_link": "https://www.django-cms.org"}
+        )
+
+        bridge = json.loads(
+            re.search(
+                r'<script id="data-bridge" type="application/json">(.*?)</script>',
+                response.content.decode(),
+                re.S,
+            ).group(1)
+        )
+        message = bridge["messages"][0]["message"]
+        self.assertNotIn(payload, message)
+        self.assertIn("&lt;img src=x onerror=&quot;alert(1)&quot;&gt;", message)
 
     def test_placeholder_scanning_fail(self):
         self.assertRaises(TemplateSyntaxError, _get_placeholder_slots, "placeholder_tests/test_eleven.html")

--- a/cms/tests/test_placeholder_checks.py
+++ b/cms/tests/test_placeholder_checks.py
@@ -212,6 +212,59 @@ class ChecksUsedInAdminEndpointsTestCase(CMSTestCase):
 
         self.check.assert_not_called()
 
+    def test_copy_plugin_to_clipboard_from_immutable_source(self):
+        """Copying only reads the source, so a non-editable source is allowed."""
+        superuser = self.get_superuser()
+        page = create_page('test', 'nav_playground.html', 'en')
+        source_placeholder = page.get_placeholders('en').get(slot='body')
+        source_plugin = self._add_plugin_to_placeholder(source_placeholder)
+        uri = self.get_copy_plugin_uri(source_plugin)
+        user_settings = UserSettings.objects.create(
+            language='en',
+            user=superuser,
+            clipboard=Placeholder.objects.create(),
+        )
+        self.check.return_value = False
+
+        with self.login_user_context(superuser):
+            data = {
+                'source_language': 'en',
+                'source_placeholder_id': source_placeholder.pk,
+                'source_plugin_id': source_plugin.pk,
+                'target_language': 'en',
+                'target_placeholder_id': user_settings.clipboard.pk,
+            }
+            response = self.client.post(uri, data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(user_settings.clipboard.get_plugins('en').count(), 1)
+
+    def test_copy_placeholder_to_clipboard_from_immutable_source(self):
+        """Copying only reads the source, so a non-editable source is allowed."""
+        superuser = self.get_superuser()
+        page = create_page('test', 'nav_playground.html', 'en')
+        source_placeholder = page.get_placeholders('en').get(slot='body')
+        source_plugin = self._add_plugin_to_placeholder(source_placeholder)
+        uri = self.get_copy_plugin_uri(source_plugin)
+        user_settings = UserSettings.objects.create(
+            language='en',
+            user=superuser,
+            clipboard=Placeholder.objects.create(),
+        )
+        self.check.return_value = False
+
+        with self.login_user_context(superuser):
+            data = {
+                'source_language': "en",
+                'source_placeholder_id': source_placeholder.pk,
+                'target_language': "en",
+                'target_placeholder_id': user_settings.clipboard.pk,
+            }
+            response = self.client.post(uri, data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(user_settings.clipboard.get_plugins('en').count(), 1)
+
     def test_copy_plugins_to_placeholder_without_source(self):
         superuser = self.get_superuser()
         page = create_page('test', 'nav_playground.html', 'en')

--- a/cms/tests/test_placeholder_checks.py
+++ b/cms/tests/test_placeholder_checks.py
@@ -265,6 +265,31 @@ class ChecksUsedInAdminEndpointsTestCase(CMSTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(user_settings.clipboard.get_plugins('en').count(), 1)
 
+    def test_paste_plugin_from_immutable_source(self):
+        """Pasting only reads the source, so a non-editable source is allowed."""
+        superuser = self.get_superuser()
+        page = create_page('test', 'nav_playground.html', 'en')
+        source_placeholder = page.get_placeholders('en').get(slot='body')
+        source_plugin = self._add_plugin_to_placeholder(source_placeholder)
+        target_placeholder = Placeholder.objects.create(slot='target')
+        uri = self.get_move_plugin_uri(source_plugin)
+        self.check.return_value = False
+
+        with self.login_user_context(superuser):
+            data = {
+                'plugin_id': source_plugin.pk,
+                'placeholder_id': target_placeholder.pk,
+                'move_a_copy': 'true',
+                'target_language': 'en',
+                'target_position': 1,
+            }
+            response = self.client.post(uri, data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(target_placeholder.get_plugins('en').count(), 1)
+        # The source is untouched: pasting copies, it does not move.
+        self.assertEqual(source_placeholder.get_plugins('en').count(), 1)
+
     def test_copy_plugins_to_placeholder_without_source(self):
         superuser = self.get_superuser()
         page = create_page('test', 'nav_playground.html', 'en')


### PR DESCRIPTION
## Summary by Sourcery

Allow read-only content to be copied while safely escaping plugin change messages.

Bug Fixes:
- Allow copying and pasting plugins or placeholders from readable content that is immutable, such as published content or content locked by another user.
- Escape editor-controlled plugin representations in success messages before embedding them in the admin data bridge to prevent HTML injection.

Tests:
- Add coverage for copying and pasting from immutable sources and for escaping plugin representations in change messages.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.