### PR TITLE
chore: Explicitly escape csrf code for post methods

### DIFF
--- a/cms/static/cms/js/modules/cms.toolbar.js
+++ b/cms/static/cms/js/modules/cms.toolbar.js
@@ -669,14 +669,27 @@ class Toolbar {
     _sendPostRequest(el) {
         /* Allow post method to be used */
         var formToken = document.querySelector('form input[name="csrfmiddlewaretoken"]');
-        var csrfToken = '<input type="hidden" name="csrfmiddlewaretoken" value="' +
-            ((formToken ? formToken.value : formToken) || window.CMS.config.csrf) + '">';
-        var fakeForm = $(
-            '<form style="display: none" action="' + el.attr('href') + '" method="POST">' + csrfToken +
-            '</form>'
-        );
+        var targetDocument = Helpers._getWindow().document;
 
-        fakeForm.appendTo(Helpers._getWindow().document.body).submit();
+        // Build the form through DOM APIs rather than an HTML string: both the
+        // href and the token end up as attribute *values*, never as markup, so
+        // quotes or angle brackets in either cannot break out of the attribute.
+        var fakeForm = $(targetDocument.createElement('form'))
+            .css('display', 'none')
+            .attr({
+                action: el.attr('href'),
+                method: 'POST'
+            });
+
+        $(targetDocument.createElement('input'))
+            .attr({
+                type: 'hidden',
+                name: 'csrfmiddlewaretoken'
+            })
+            .val((formToken ? formToken.value : formToken) || window.CMS.config.csrf)
+            .appendTo(fakeForm);
+
+        fakeForm.appendTo(targetDocument.body).submit();
     }
 
     /**

--- a/cms/static/cms/js/modules/cms.toolbar.js
+++ b/cms/static/cms/js/modules/cms.toolbar.js
@@ -668,8 +668,8 @@ class Toolbar {
 
     _sendPostRequest(el) {
         /* Allow post method to be used */
-        var formToken = document.querySelector('form input[name="csrfmiddlewaretoken"]');
         var targetDocument = Helpers._getWindow().document;
+        var formToken = targetDocument.querySelector('form input[name="csrfmiddlewaretoken"]');
 
         // Build the form through DOM APIs rather than an HTML string: both the
         // href and the token end up as attribute *values*, never as markup, so

--- a/cms/tests/frontend/unit/cms.toolbar.test.js
+++ b/cms/tests/frontend/unit/cms.toolbar.test.js
@@ -780,6 +780,41 @@ describe('CMS.Toolbar', function () {
             );
             expect(fakeWindow.location.href).toEqual('href');
         });
+
+        describe('POST requests', function () {
+            var hostileToken = '"><img class="injected-token">';
+            var hostileHref = '/publish/"><img class="injected-href">';
+
+            beforeEach(function () {
+                fakeWindow.document = document;
+                CMS.config.csrf = 'fallback-token';
+                // Has to be the first form in the document so that the token
+                // lookup picks it up.
+                $('<form class="cms-post-request-test"><input name="csrfmiddlewaretoken"></form>')
+                    .prependTo('body')
+                    .find('input')
+                    .val(hostileToken);
+                spyOn(window.HTMLFormElement.prototype, 'submit');
+            });
+
+            afterEach(function () {
+                $('form.cms-post-request-test').remove();
+            });
+
+            it('treats href and token as values, not as markup', function () {
+                toolbar._sendPostRequest($('<a class="cms-form-post-method"></a>').attr('href', hostileHref));
+
+                var form = $('body > form').last().addClass('cms-post-request-test');
+
+                expect(window.HTMLFormElement.prototype.submit).toHaveBeenCalled();
+                expect(form.attr('action')).toEqual(hostileHref);
+                expect(form.attr('method')).toEqual('POST');
+                expect(form.find('input[name="csrfmiddlewaretoken"]').val()).toEqual(hostileToken);
+                // Nothing was parsed as HTML, so no elements were injected.
+                expect(form.find('img').length).toEqual(0);
+                expect($('img.injected-href, img.injected-token').length).toEqual(0);
+            });
+        });
     });
 
     describe('._debug()', function () {


### PR DESCRIPTION
## Summary by Sourcery

Safely submit toolbar POST requests without allowing CSRF tokens or destinations to inject markup.

Bug Fixes:
- Prevent CSRF tokens and POST request URLs containing quotes or angle brackets from being interpreted as HTML markup.

Enhancements:
- Construct hidden POST forms through DOM APIs while preserving the active document context.

Tests:
- Add coverage verifying hostile CSRF tokens and URLs remain attribute and input values without injecting elements.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.