### PR TITLE
chore: Harden pypi publish actions

### DIFF
--- a/.github/requirements/build.txt
+++ b/.github/requirements/build.txt
@@ -1,0 +1,44 @@
+# Hash-pinned build tooling for the PyPI/TestPyPI publish workflows.
+#
+# These packages execute code in the build job, before the distribution is
+# handed to the publish job, so they are pinned by hash rather than resolved
+# fresh on every release.
+#
+# Resolved for CPython 3.12 on linux-x86_64 (the runner used by
+# .github/workflows/publish-to-*-pypi.yml). To regenerate after a version bump:
+#
+#     python -m pip download --only-binary=:all: --python-version 3.12 \
+#         --dest /tmp/pins build check-wheel-contents
+#     for f in /tmp/pins/*.whl; do python -m pip hash "$f"; done
+#
+# Note: this does NOT cover the PEP 517 build backend. ``python -m build``
+# provisions setuptools and setuptools-scm (see [build-system] in
+# pyproject.toml) into an isolated environment at build time, unpinned.
+
+# Direct requirements
+build==1.5.0 \
+    --hash=sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f
+check-wheel-contents==0.6.3 \
+    --hash=sha256:5ae39c8c434b972f0740d04610759168590713175aab584b012b1b84f6771874
+
+# Transitive requirements
+annotated-types==0.8.0 \
+    --hash=sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0
+attrs==26.1.0 \
+    --hash=sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309
+click==8.4.2 \
+    --hash=sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76
+packaging==26.3 \
+    --hash=sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c
+pydantic==2.13.4 \
+    --hash=sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba
+pydantic-core==2.46.4 \
+    --hash=sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce
+pyproject-hooks==1.2.0 \
+    --hash=sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913
+typing-extensions==4.16.0 \
+    --hash=sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8
+typing-inspection==0.4.4 \
+    --hash=sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147
+wheel-filename==1.4.2 \
+    --hash=sha256:3fa599046443d4ca830d06e3d180cd0a675d5871af0a68daa5623318bb4d17e3

--- a/.github/requirements/build.txt
+++ b/.github/requirements/build.txt
@@ -8,18 +8,26 @@
 # .github/workflows/publish-to-*-pypi.yml). To regenerate after a version bump:
 #
 #     python -m pip download --only-binary=:all: --python-version 3.12 \
-#         --dest /tmp/pins build check-wheel-contents
+#         --dest /tmp/pins build check-wheel-contents setuptools setuptools-scm
 #     for f in /tmp/pins/*.whl; do python -m pip hash "$f"; done
 #
-# Note: this does NOT cover the PEP 517 build backend. ``python -m build``
-# provisions setuptools and setuptools-scm (see [build-system] in
-# pyproject.toml) into an isolated environment at build time, unpinned.
+# This includes the PEP 517 build backend from [build-system] in pyproject.toml.
+# The workflows build with ``--no-isolation`` so that the backend comes from
+# here, hash-pinned, instead of being resolved fresh from PyPI into an isolated
+# environment on every run. pyproject.toml stays unpinned so that anyone else
+# building django-cms from source is not held to these exact versions.
 
 # Direct requirements
 build==1.5.0 \
     --hash=sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f
 check-wheel-contents==0.6.3 \
     --hash=sha256:5ae39c8c434b972f0740d04610759168590713175aab584b012b1b84f6771874
+
+# Build backend, matching [build-system] requires in pyproject.toml
+setuptools==84.0.0 \
+    --hash=sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670
+setuptools-scm==10.2.1 \
+    --hash=sha256:b7c82f4102d389ee57dc66ccdb4f9b4bca3c40ba83b43f1f63d68ccd72db2580
 
 # Transitive requirements
 annotated-types==0.8.0 \
@@ -40,5 +48,7 @@ typing-extensions==4.16.0 \
     --hash=sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8
 typing-inspection==0.4.4 \
     --hash=sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147
+vcs-versioning==2.3.0 \
+    --hash=sha256:1b8e76156e50961a29fa9a1bd25c38145a2df86bf47611e134ffbff7852bc801
 wheel-filename==1.4.2 \
     --hash=sha256:3fa599046443d4ca830d06e3d180cd0a675d5871af0a68daa5623318bb4d17e3

--- a/.github/workflows/publish-to-live-pypi.yml
+++ b/.github/workflows/publish-to-live-pypi.yml
@@ -31,9 +31,12 @@ jobs:
         --user
         -r .github/requirements/build.txt
     - name: Build a binary wheel and a source tarball
+      # --no-isolation: use the hash-pinned setuptools/setuptools-scm installed
+      # above instead of letting build resolve the backend from PyPI at runtime.
       run: >-
         python -m
         build
+        --no-isolation
         --sdist
         --wheel
         --outdir dist/

--- a/.github/workflows/publish-to-live-pypi.yml
+++ b/.github/workflows/publish-to-live-pypi.yml
@@ -6,14 +6,14 @@ on:
       - published
 
 jobs:
-  build-n-publish:
-    name: Build and publish Python 🐍 distributions 📦 to pypi
+  build:
+    name: Build Python 🐍 distributions 📦
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/django-cms
+    # No id-token here: the build runs third-party code (pip, the build
+    # backend, check-wheel-contents) and must not be able to mint an OIDC
+    # token for trusted publishing. Publishing happens in a separate job.
     permissions:
-      id-token: write
+      contents: read
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python
@@ -21,12 +21,15 @@ jobs:
       with:
         python-version: '3.12'
 
-    - name: Install pypa/build
+    - name: Install build tooling
+      # Hash-pinned: all of this executes in the build job and shapes the
+      # distribution the publish job uploads. See the file for how to refresh.
       run: >-
         python -m
         pip install
-        build
+        --require-hashes
         --user
+        -r .github/requirements/build.txt
     - name: Build a binary wheel and a source tarball
       run: >-
         python -m
@@ -38,7 +41,6 @@ jobs:
 
     - name: Check wheel contents
       run: |
-        python -m pip install check-wheel-contents
         python -m check_wheel_contents dist/*.whl
         python - <<'EOF'
         import glob, os, sys, zipfile
@@ -72,6 +74,31 @@ jobs:
             fh.write(summary)
         EOF
 
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v7
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish:
+    name: Publish Python 🐍 distributions 📦 to pypi
+    if: "!contains(github.ref_name, 'dev')"
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/django-cms
+    permissions:
+      id-token: write
+    steps:
+    - name: Download the distribution packages
+      uses: actions/download-artifact@v8
+      with:
+        name: python-package-distributions
+        path: dist/
+
     - name: Publish distribution 📦 to PyPI
-      if: "!contains(github.ref_name, 'dev')"
-      uses: pypa/gh-action-pypi-publish@release/v1
+      # pypa/gh-action-pypi-publish v1.14.2. Pinned to a commit rather than the
+      # mutable release/v1 branch: this action receives the OIDC publishing
+      # credential, so it is the one dependency that must not move on its own.
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -33,9 +33,12 @@ jobs:
         --user
         -r .github/requirements/build.txt
     - name: Build a binary wheel and a source tarball
+      # --no-isolation: use the hash-pinned setuptools/setuptools-scm installed
+      # above instead of letting build resolve the backend from PyPI at runtime.
       run: >-
         python -m
         build
+        --no-isolation
         --sdist
         --wheel
         --outdir dist/

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -8,14 +8,14 @@ on:
       - 'fix/**'
 
 jobs:
-  build-n-publish:
-    name: Build and publish Python 🐍 distributions 📦 to TestPyPI
+  build:
+    name: Build Python 🐍 distributions 📦
     runs-on: ubuntu-latest
-    environment:
-      name: test
-      url: https://test.pypi.org/p/django-cms
+    # No id-token here: the build runs third-party code (pip, the build
+    # backend, check-wheel-contents) and must not be able to mint an OIDC
+    # token for trusted publishing. Publishing happens in a separate job.
     permissions:
-      id-token: write
+      contents: read
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python
@@ -23,12 +23,15 @@ jobs:
       with:
         python-version: '3.12'
 
-    - name: Install pypa/build
+    - name: Install build tooling
+      # Hash-pinned: all of this executes in the build job and shapes the
+      # distribution the publish job uploads. See the file for how to refresh.
       run: >-
         python -m
         pip install
-        build
+        --require-hashes
         --user
+        -r .github/requirements/build.txt
     - name: Build a binary wheel and a source tarball
       run: >-
         python -m
@@ -40,7 +43,6 @@ jobs:
 
     - name: Check wheel contents
       run: |
-        python -m pip install check-wheel-contents
         python -m check_wheel_contents dist/*.whl
         python - <<'EOF'
         import glob, os, sys, zipfile
@@ -74,8 +76,33 @@ jobs:
             fh.write(summary)
         EOF
 
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v7
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish:
+    name: Publish Python 🐍 distributions 📦 to TestPyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: test
+      url: https://test.pypi.org/p/django-cms
+    permissions:
+      id-token: write
+    steps:
+    - name: Download the distribution packages
+      uses: actions/download-artifact@v8
+      with:
+        name: python-package-distributions
+        path: dist/
+
     - name: Publish distribution 📦 to Test PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      # pypa/gh-action-pypi-publish v1.14.2. Pinned to a commit rather than the
+      # mutable release/v1 branch: this action receives the OIDC publishing
+      # credential, so it is the one dependency that must not move on its own.
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33
       with:
         repository-url: https://test.pypi.org/legacy/
         skip-existing: true


### PR DESCRIPTION
## Summary by Sourcery

Harden PyPI release workflows by isolating builds from trusted publishing and pinning build and publishing dependencies.

Enhancements:
- Separate package building from PyPI publishing so OIDC credentials are only available to the publishing job.
- Harden distribution builds with hash-pinned tooling, isolated artifact transfer, and a commit-pinned PyPI publishing action.

CI:
- Restrict build-job permissions to read-only contents and grant trusted-publishing permissions only to dedicated publishing jobs for PyPI and TestPyPI.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.