### PR TITLE
fix: Require permission to change previous home page to set new one

### DIFF
--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -329,14 +329,21 @@ class PageAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
     def set_home(self, request, object_id):
         page = self.get_object(request, object_id=object_id)
 
-        if not self.has_change_permission(request, page):
-            raise PermissionDenied("You do not have permission to set 'home'.")
-
         if page is None:
             raise self._get_404_exception(object_id)
 
+        if not self.has_change_permission(request, page):
+            raise PermissionDenied("You do not have permission to set 'home'.")
+
         if not page.is_potential_home():
             return HttpResponseBadRequest(_("The page is not eligible to be home."))
+
+        # Setting a new home page demotes the current one and rewrites the url
+        # paths of both trees, so it takes change permission on both pages.
+        old_home = self.model.objects.filter(is_home=True, site=page.site_id).first()
+
+        if old_home and not self.has_change_permission(request, old_home):
+            raise PermissionDenied("You do not have permission to change the current home page.")
 
         new_home_tree, old_home_tree = page.set_as_homepage(request.user)
 

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -3917,6 +3917,46 @@ class PermissionsOnPageTest(PermissionsTestCase):
             response = self.client.get(endpoint)
             self.assertEqual(response.status_code, 200)
 
+    def test_set_home_requires_permission_on_old_home(self):
+        """
+        Setting a new home page demotes the current one and rewrites its urls,
+        so change permission on the target page alone is not enough.
+        """
+        old_home = create_page("old-home", "nav_playground.html", "en")
+        old_home.set_as_homepage()
+        new_home = create_page("new-home", "nav_playground.html", "en")
+        endpoint = self.get_admin_url(Page, "set_home", new_home.pk)
+        staff_user = self.get_staff_user_with_no_permissions()
+
+        self.add_permission(staff_user, "change_page")
+        self.add_page_permission(staff_user, new_home, can_change=True)
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertTrue(old_home.reload().is_home)
+        self.assertFalse(new_home.reload().is_home)
+
+    def test_set_home_with_permission_on_both_pages(self):
+        """Change permission on both the old and the new home page is enough."""
+        old_home = create_page("old-home", "nav_playground.html", "en")
+        old_home.set_as_homepage()
+        new_home = create_page("new-home", "nav_playground.html", "en")
+        endpoint = self.get_admin_url(Page, "set_home", new_home.pk)
+        staff_user = self.get_staff_user_with_no_permissions()
+
+        self.add_permission(staff_user, "change_page")
+        self.add_page_permission(staff_user, new_home, can_change=True)
+        self.add_page_permission(staff_user, old_home, can_change=True)
+
+        with self.login_user_context(staff_user):
+            response = self.client.post(endpoint)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(old_home.reload().is_home)
+        self.assertTrue(new_home.reload().is_home)
+
     def test_get_permissions_page_permissions_can_change_without_global_permission(self):
         """Ensure PageAdmin.get_permissions computes can_change from allowed page paths.
 


### PR DESCRIPTION
## Summary by Sourcery

Enforce permissions for both the current and replacement home pages when changing the site home page.

Bug Fixes:
- Require change permission on the existing home page before allowing another page to become the site home page.

Tests:
- Add admin tests covering denial when permission is missing on the old home page and successful home-page replacement when both pages are permitted.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.