### PR TITLE
fix: Hardened toolbar JS

### DIFF
--- a/cms/static/cms/js/modules/cms.toolbar.js
+++ b/cms/static/cms/js/modules/cms.toolbar.js
@@ -794,7 +794,11 @@ class Toolbar {
     _refreshMarkup(newToolbar) {
         const switcher = this.ui.toolbarSwitcher.detach();
 
-        $(this.ui.toolbar).html(newToolbar.children());
+        // Only ever take the first match: callers build this collection with a
+        // page-wide .cms-toolbar search, and jQuery's children() would collect
+        // from every match. Editable content rendering a .cms-toolbar element
+        // must not get its markup copied into the live toolbar.
+        $(this.ui.toolbar).html(newToolbar.first().children());
 
         $('.cms-toolbar-item-cms-mode-switcher').replaceWith(switcher);
 

--- a/cms/tests/frontend/unit/cms.toolbar.test.js
+++ b/cms/tests/frontend/unit/cms.toolbar.test.js
@@ -912,5 +912,19 @@ describe('CMS.Toolbar', function () {
             expect(trigger).toHaveBeenCalledWith('resize');
             expect(CMS.API.Clipboard._toolbarEvents).toHaveBeenCalledTimes(1);
         });
+
+        it('only takes markup from the first matched toolbar', () => {
+            // Callers search a whole refreshed page for .cms-toolbar, so the
+            // collection can contain an element authored in editable content.
+            const toolbars = $(
+                '<div class="cms-toolbar"><span class="official-item"></span></div>' +
+                '<div class="cms-toolbar"><span class="injected-item"></span></div>'
+            );
+
+            toolbar._refreshMarkup(toolbars);
+
+            expect(toolbar.ui.toolbar.find('.official-item').length).toEqual(1);
+            expect(toolbar.ui.toolbar.find('.injected-item').length).toEqual(0);
+        });
     });
 });


### PR DESCRIPTION
## Summary by Sourcery

Restrict toolbar markup refreshes to the first matched toolbar and prevent unintended content injection.

Bug Fixes:
- Prevent editable content containing a `.cms-toolbar` element from being copied into the live toolbar during markup refreshes.

Tests:
- Add frontend coverage verifying that only the first matched toolbar contributes markup during refresh.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.