### PR TITLE
feat: Support Django 6.1 CSP nonces

### DIFF
--- a/cms/templates/admin/cms/page/change_form.html
+++ b/cms/templates/admin/cms/page/change_form.html
@@ -23,9 +23,9 @@
 {% endblock %}
 
 {% block extrahead %}
-<script src="{% static "admin/js/urlify.js" %}" type="text/javascript"></script>
-<script src="{% static_with_version "cms/js/dist/bundle.admin.base.min.js" %}" type="text/javascript"></script>
-<script src="{% static_with_version "cms/js/dist/bundle.admin.changeform.min.js" %}" type="text/javascript"></script>
+<script src="{% static "admin/js/urlify.js" %}" type="text/javascript" {% csp_nonce_attr %}></script>
+<script src="{% static_with_version "cms/js/dist/bundle.admin.base.min.js" %}" type="text/javascript" {% csp_nonce_attr %}></script>
+<script src="{% static_with_version "cms/js/dist/bundle.admin.changeform.min.js" %}" type="text/javascript" {% csp_nonce_attr %}></script>
 {{ block.super }}
 {% endblock %}
 

--- a/cms/templates/admin/cms/page/delete_confirmation.html
+++ b/cms/templates/admin/cms/page/delete_confirmation.html
@@ -1,7 +1,7 @@
 {% extends "admin/delete_confirmation.html" %}
-{% load i18n admin_urls static cms_admin %}
+{% load i18n admin_urls static cms_admin cms_static %}
 {% block extrahead %}{{ block.super }}
-    <style>
+    <style {% csp_nonce_attr %}>
         .flexbox {
             display: flex;
             justify-content: space-between;

--- a/cms/templates/admin/cms/page/plugin/change_form.html
+++ b/cms/templates/admin/cms/page/plugin/change_form.html
@@ -3,7 +3,7 @@
 
 {% block extrahead %}
     {# in case plugins require widgets, they need to have bundle here #}
-    <script src="{% static_with_version "cms/js/dist/bundle.admin.base.min.js" %}" type="text/javascript"></script>
+    <script src="{% static_with_version "cms/js/dist/bundle.admin.base.min.js" %}" type="text/javascript" {% csp_nonce_attr %}></script>
     {{ block.super }}
 {% endblock %}
 

--- a/cms/templates/admin/cms/page/tree/base.html
+++ b/cms/templates/admin/cms/page/tree/base.html
@@ -11,10 +11,10 @@
 {% block extrahead %}
     {{ block.super }}
     {# INFO: we need to add styles here instead of "extrastyle" to avoid conflicts with adminstyle #}
-    <link rel="stylesheet" href="{% static_with_version 'cms/css/cms.base.css' %}">
-    <link rel="stylesheet" href="{% static_with_version 'cms/css/cms.pagetree.css' %}">
-    <script src="{% static_with_version 'cms/js/dist/bundle.admin.base.min.js' %}"></script>
-    <script src="{% static_with_version 'cms/js/dist/bundle.admin.pagetree.min.js' %}"></script>
+    <link rel="stylesheet" href="{% static_with_version 'cms/css/cms.base.css' %}" {% csp_nonce_attr %}>
+    <link rel="stylesheet" href="{% static_with_version 'cms/css/cms.pagetree.css' %}" {% csp_nonce_attr %}>
+    <script src="{% static_with_version 'cms/js/dist/bundle.admin.base.min.js' %}" {% csp_nonce_attr %}></script>
+    <script src="{% static_with_version 'cms/js/dist/bundle.admin.pagetree.min.js' %}" {% csp_nonce_attr %}></script>
 {% endblock extrahead %}
 
 {% if not is_popup %}

--- a/cms/templates/admin/cms/usersettings/change_form.html
+++ b/cms/templates/admin/cms/usersettings/change_form.html
@@ -1,8 +1,8 @@
-{% extends "admin/change_form.html" %}{% load i18n static cms_tags cms_admin %}
+{% extends "admin/change_form.html" %}{% load i18n static cms_tags cms_admin cms_static %}
 
 {% block extrahead %}
 {{ block.super }}
-<script src="{% static "cms/js/admin/usersettings.js" %}"></script>
+<script src="{% static "cms/js/admin/usersettings.js" %}" {% csp_nonce_attr %}></script>
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/cms/templates/cms/headless/placeholder.html
+++ b/cms/templates/cms/headless/placeholder.html
@@ -5,7 +5,7 @@
             <meta charset="utf-8"/>
             <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
             <title>{% block title %}{{ request.current_page.get_page_title|striptags }}{% endblock %}</title>
-            <link rel="stylesheet" href="{% static_with_version 'cms/css/cms.headless.css' %}"/>
+            <link rel="stylesheet" href="{% static_with_version 'cms/css/cms.headless.css' %}" {% csp_nonce_attr %}/>
 {% endspaceless %}{% render_block 'css' %}{% spaceless %}
     {% block page_head %}{% endblock %}
         </head>

--- a/cms/templates/cms/noapphook.html
+++ b/cms/templates/cms/noapphook.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <link rel="icon" type="image/png" href="{% static 'cms/img/favicon.png' %}">
     {% render_block "css" %}
-    <link rel="stylesheet" href="{% static_with_version 'cms/css/cms.base.css' %}">
+    <link rel="stylesheet" href="{% static_with_version 'cms/css/cms.base.css' %}" {% csp_nonce_attr %}>
 </head>
 <body class="cms-welcome-bg">
     {% cms_toolbar %}

--- a/cms/templates/cms/toolbar/toolbar_javascript.html
+++ b/cms/templates/cms/toolbar/toolbar_javascript.html
@@ -1,12 +1,14 @@
 {% load i18n l10n sekizai_tags static cms_tags cms_js_tags cms_static %}
 
-{% addtoblock "css" %}<link rel="stylesheet" href="{% static_with_version "cms/css/cms.base.css" %}" />{% endaddtoblock %}
-{% for css in cms_toolbar.media.render_css %}
+{% addtoblock "css" %}<link rel="stylesheet" href="{% static_with_version "cms/css/cms.base.css" %}" {% csp_nonce_attr %}/>{% endaddtoblock %}
+{% render_media_assets cms_toolbar.media "css" as cms_toolbar_css %}
+{% for css in cms_toolbar_css %}
     {% addtoblock "css" %}{{ css }}{% endaddtoblock %}
 {% endfor %}
 
 {% addtoblock "js" %}
-<script data-cms src="{% static_with_version "cms/js/dist/bundle.toolbar.min.js" %}" type="text/javascript"></script>
+<script data-cms src="{% static_with_version "cms/js/dist/bundle.toolbar.min.js" %}" type="text/javascript" {% csp_nonce_attr %}></script>
+{# INFO: a non-executable JSON data block; browsers never run it, so CSP does not check it and it must stay nonce-free #}
 <script data-cms-config id="cms-config-json" type="application/json">
 {
     "mode": {% if cms_toolbar.edit_mode_active or cms_toolbar.structure_mode_active %}"draft"{% else %}"live"{% endif %},
@@ -128,6 +130,7 @@
 </script>
 {% endaddtoblock %}
 {% if cms_toolbar.clipboard_plugin %}{% render_plugin_init_js cms_toolbar.clipboard_plugin %}{% endif %}
-{% for js in cms_toolbar.media.render_js %}
+{% render_media_assets cms_toolbar.media "js" as cms_toolbar_js %}
+{% for js in cms_toolbar_js %}
     {% addtoblock "js" %}{{ js }}{% endaddtoblock %}
 {% endfor %}

--- a/cms/templates/cms/welcome.html
+++ b/cms/templates/cms/welcome.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <link rel="icon" type="image/png" href="{% static 'cms/img/favicon.png' %}">
     {% render_block "css" %}
-    <link rel="stylesheet" href="{% static_with_version 'cms/css/cms.base.css' %}">
-    <link rel="stylesheet" href="{% static_with_version 'cms/css/cms.welcome.css' %}">
+    <link rel="stylesheet" href="{% static_with_version 'cms/css/cms.base.css' %}" {% csp_nonce_attr %}>
+    <link rel="stylesheet" href="{% static_with_version 'cms/css/cms.welcome.css' %}" {% csp_nonce_attr %}>
 </head>
 <body class="cms-welcome-bg">
     {% cms_toolbar %}
@@ -117,6 +117,6 @@
              data-login-url="{% url "admin:login" %}?next={{ next_url }}"></div>
     {% endif %}
     {% endlanguage %}
-    <script src="{% static "cms/js/welcome.js" %}"></script>
+    <script src="{% static "cms/js/welcome.js" %}" {% csp_nonce_attr %}></script>
 </body>
 </html>

--- a/cms/templates/cms/wizards/base.html
+++ b/cms/templates/cms/wizards/base.html
@@ -3,7 +3,7 @@
 
 {% block extrastyle %}
     {{ block.super }}
-    <link rel="stylesheet" href="{% static "admin/css/forms.css" %}">
+    <link rel="stylesheet" href="{% static "admin/css/forms.css" %}" {% csp_nonce_attr %}>
 {% endblock %}
 
 {% block bodyclass %}cms-admin cms-admin-modal{% endblock %}
@@ -16,6 +16,6 @@
 
 {% block extrahead %}
     {{ block.super }}
-    <script src="{% static_with_version "cms/js/dist/bundle.admin.base.min.js" %}" type="text/javascript"></script>
-    {{ form.media }}
+    <script src="{% static_with_version "cms/js/dist/bundle.admin.base.min.js" %}" type="text/javascript" {% csp_nonce_attr %}></script>
+    {% csp_nonce_attr form.media %}
 {% endblock %}

--- a/cms/templatetags/cms_static.py
+++ b/cms/templatetags/cms_static.py
@@ -3,6 +3,21 @@ from django.templatetags.static import StaticNode
 
 from cms.utils.urlutils import static_with_version
 
+try:
+    # Django >= 6.1 ships Content Security Policy support. ``nonce_attr`` renders
+    # ``nonce="..."`` when the CSP context processor put a nonce in the context,
+    # and an empty string otherwise.
+    from django.utils.csp import CONTEXT_KEY as CSP_CONTEXT_KEY, nonce_attr as _nonce_attr
+
+    CSP_NONCE_SUPPORTED = True
+except ImportError:  # Django < 6.1
+    CSP_NONCE_SUPPORTED = False
+    CSP_CONTEXT_KEY = "csp_nonce"
+
+    def _nonce_attr(context, media=None):
+        return media.render() if media is not None else ""
+
+
 register = template.Library()
 
 
@@ -30,3 +45,58 @@ class StaticWithVersionNode(StaticNode):
         path_with_version = static_with_version(path)
 
         return self.handle_simple(path_with_version)
+
+
+@register.simple_tag(takes_context=True)
+def csp_nonce_attr(context, media=None):
+    """Render the request's Content Security Policy nonce.
+
+    This is a cross-version stand-in for Django 6.1's built-in tag of the same
+    name. Django 6.1 registers ``csp_nonce_attr`` as a built-in, so loading
+    ``cms_static`` shadows it with this identical implementation; on Django 5.2
+    and 6.0, where the built-in does not exist, the fallback renders nothing.
+
+    Usage::
+
+        <script src="..." {% csp_nonce_attr %}></script>
+        {% csp_nonce_attr form.media %}
+
+    Without an argument it renders ``nonce="..."`` when a nonce is available and
+    an empty string otherwise. Given a :class:`~django.forms.Media` object it
+    renders that media, adding the nonce to every element.
+
+    Note that non-executable ``<script type="application/json">`` data blocks
+    must *not* carry a nonce: browsers never run them, so CSP does not check
+    them, and Django's own ``json_script`` leaves them bare.
+    """
+    return _nonce_attr(context, media)
+
+
+@register.simple_tag(takes_context=True)
+def render_media_assets(context, media, media_type):
+    """Render each asset of ``media`` separately, carrying the CSP nonce.
+
+    ``{% csp_nonce_attr media %}`` renders a whole :class:`~django.forms.Media`
+    object as one blob. Callers that need to place assets individually -- the
+    toolbar wraps every asset in its own sekizai ``{% addtoblock %}`` so that
+    sekizai can deduplicate per file -- use this instead::
+
+        {% render_media_assets cms_toolbar.media "css" as toolbar_css %}
+        {% for css in toolbar_css %}
+            {% addtoblock "css" %}{{ css }}{% endaddtoblock %}
+        {% endfor %}
+
+    ``media_type`` is either ``"css"`` or ``"js"``.
+    """
+    if media_type not in ("css", "js"):
+        raise template.TemplateSyntaxError(
+            f"render_media_assets expects a media type of 'css' or 'js', got {media_type!r}"
+        )
+
+    renderer = getattr(media, f"render_{media_type}")
+
+    if CSP_NONCE_SUPPORTED:
+        nonce = context.get(CSP_CONTEXT_KEY)
+        if nonce is not None:
+            return list(renderer(attrs={"nonce": nonce}))
+    return list(renderer())

--- a/cms/templatetags/cms_static.py
+++ b/cms/templatetags/cms_static.py
@@ -15,6 +15,8 @@ except ImportError:  # Django < 6.1
     CSP_CONTEXT_KEY = "csp_nonce"
 
     def _nonce_attr(context, media=None):
+        # No nonce to render -- but media still has to be rendered, or the
+        # assets it carries would silently disappear from the page.
         return media.render() if media is not None else ""
 
 
@@ -53,8 +55,8 @@ def csp_nonce_attr(context, media=None):
 
     This is a cross-version stand-in for Django 6.1's built-in tag of the same
     name. Django 6.1 registers ``csp_nonce_attr`` as a built-in, so loading
-    ``cms_static`` shadows it with this identical implementation; on Django 5.2
-    and 6.0, where the built-in does not exist, the fallback renders nothing.
+    ``cms_static`` shadows it with this identical implementation. Django 5.2 and
+    6.0 have no CSP support at all, so there the tag renders no nonce.
 
     Usage::
 

--- a/cms/tests/test_csp.py
+++ b/cms/tests/test_csp.py
@@ -1,0 +1,336 @@
+"""Tests for Content Security Policy nonce support in django CMS templates.
+
+Django 6.1 introduced a built-in ``{% csp_nonce_attr %}`` tag. django CMS ships
+its own implementation in ``cms_static`` so that the very same templates render
+on Django 5.2 and 6.0, where the built-in does not exist.
+"""
+import re
+import unittest
+from copy import deepcopy
+
+from django.conf import settings
+from django.forms import Media
+from django.template import Context, Template, TemplateSyntaxError
+from django.test.utils import override_settings
+from django.urls import clear_url_caches
+
+from cms.api import add_plugin, create_page
+from cms.templatetags.cms_static import CSP_NONCE_SUPPORTED
+from cms.test_utils.testcases import CMSTestCase
+from cms.toolbar.utils import get_object_edit_url
+from cms.utils.urlutils import admin_reverse
+
+NONCE = "cms-test-nonce"
+
+#: Matches ``nonce="..."`` on any element.
+NONCE_RE = re.compile(r'nonce="([^"]*)"')
+#: Matches the nonce echoed back in the ``Content-Security-Policy`` header.
+HEADER_NONCE_RE = re.compile(r"'nonce-([^']+)'")
+#: Matches an opening ``<script>``/``<link>``/``<style>`` tag with its attributes.
+ASSET_TAG_RE = re.compile(r"<(script|link|style)\b([^>]*)>", re.IGNORECASE)
+#: Everything django CMS itself ships is served from below this prefix.
+CMS_STATIC_PREFIX = "/static/cms/"
+
+requires_csp = unittest.skipUnless(CSP_NONCE_SUPPORTED, "Django < 6.1 has no CSP nonce support")
+
+
+def render_template(template_string, **context):
+    return Template("{% load cms_static %}" + template_string).render(Context(context))
+
+
+def csp_overrides():
+    """Settings that turn on Django 6.1's nonce-based CSP for the test project."""
+    from django.utils.csp import CSP
+
+    templates = deepcopy(settings.TEMPLATES)
+    templates[0]["OPTIONS"]["context_processors"].append("django.template.context_processors.csp")
+    return {
+        "TEMPLATES": templates,
+        "MIDDLEWARE": ["django.middleware.csp.ContentSecurityPolicyMiddleware", *settings.MIDDLEWARE],
+        "SECURE_CSP": {
+            "default-src": [CSP.SELF],
+            "script-src": [CSP.SELF, CSP.NONCE],
+            "style-src": [CSP.SELF, CSP.NONCE],
+        },
+    }
+
+
+class CspNonceTagTests(CMSTestCase):
+    """Unit tests for the ``cms_static`` template tags."""
+
+    def setUp(self):
+        super().setUp()
+        self.media = Media(css={"screen": ["cms/css/test.css"]}, js=["cms/js/test.js"])
+
+    def test_nonce_attr_renders_nothing_without_a_nonce(self):
+        self.assertHTMLEqual(
+            render_template("<script src='x' {% csp_nonce_attr %}></script>"),
+            "<script src='x'></script>",
+        )
+
+    def test_media_renders_without_a_nonce(self):
+        rendered = render_template("{% csp_nonce_attr media %}", media=self.media)
+        self.assertIn("cms/css/test.css", rendered)
+        self.assertIn("cms/js/test.js", rendered)
+        self.assertNotIn("nonce=", rendered)
+
+    def test_render_media_assets_returns_one_string_per_asset(self):
+        for media_type, expected in (("css", "cms/css/test.css"), ("js", "cms/js/test.js")):
+            with self.subTest(media_type=media_type):
+                rendered = render_template(
+                    '{%% render_media_assets media "%s" as assets %%}'
+                    "{%% for asset in assets %%}[{{ asset }}]{%% endfor %%}" % media_type,
+                    media=self.media,
+                )
+                self.assertEqual(rendered.count("["), 1)
+                self.assertIn(expected, rendered)
+
+    def test_render_media_assets_rejects_unknown_media_type(self):
+        with self.assertRaises(TemplateSyntaxError):
+            render_template('{% render_media_assets media "images" as assets %}', media=self.media)
+
+    @requires_csp
+    def test_nonce_attr_renders_the_nonce(self):
+        self.assertHTMLEqual(
+            render_template("<script src='x' {% csp_nonce_attr %}></script>", csp_nonce=NONCE),
+            f"<script src='x' nonce='{NONCE}'></script>",
+        )
+
+    @requires_csp
+    def test_media_carries_the_nonce(self):
+        rendered = render_template("{% csp_nonce_attr media %}", media=self.media, csp_nonce=NONCE)
+        self.assertEqual(NONCE_RE.findall(rendered), [NONCE, NONCE])
+
+    @requires_csp
+    def test_render_media_assets_carries_the_nonce(self):
+        for media_type in ("css", "js"):
+            with self.subTest(media_type=media_type):
+                rendered = render_template(
+                    '{%% render_media_assets media "%s" as assets %%}'
+                    "{%% for asset in assets %%}{{ asset }}{%% endfor %%}" % media_type,
+                    media=self.media,
+                    csp_nonce=NONCE,
+                )
+                self.assertEqual(NONCE_RE.findall(rendered), [NONCE])
+
+
+class NonceAssertionsMixin:
+    """Helpers shared by the view level tests.
+
+    Only django CMS' own assets -- everything served from ``/static/cms/`` -- are
+    asserted on. Django's admin templates nonce their assets themselves, and
+    assets contributed by third party apps or by the project's own templates are
+    outside django CMS' control.
+    """
+
+    def assertNoNonces(self, response):
+        self.assertNotIn("nonce=", response.content.decode())
+
+    def get_header_nonce(self, response):
+        """Return the nonce the CSP middleware put in the response header."""
+        policy = response.headers["Content-Security-Policy"]
+        nonces = set(HEADER_NONCE_RE.findall(policy))
+        self.assertEqual(len(nonces), 1, f"expected exactly one nonce in {policy!r}")
+        return nonces.pop()
+
+    def get_cms_asset_tags(self, response):
+        """Yield the attribute strings of every nonce-relevant ``/static/cms/`` tag.
+
+        ``<link>`` elements that are not stylesheets -- favicons, for instance --
+        are governed by ``img-src`` rather than ``style-src`` and take no nonce.
+        """
+        return [
+            attributes
+            for tag, attributes in ASSET_TAG_RE.findall(response.content.decode())
+            if CMS_STATIC_PREFIX in attributes
+            and not (tag.lower() == "link" and 'rel="stylesheet"' not in attributes)
+        ]
+
+    def assertCmsAssetsAreNonced(self, response, minimum=1):
+        """Every django CMS asset must carry the response's nonce.
+
+        Non-executable ``<script type="application/json">`` data blocks are
+        exempt: browsers never run them, so CSP never checks them, and Django's
+        own ``json_script()`` leaves them bare.
+        """
+        nonce = self.get_header_nonce(response)
+        tags = self.get_cms_asset_tags(response)
+
+        for attributes in tags:
+            self.assertIn(
+                f'nonce="{nonce}"',
+                attributes,
+                f"<... {attributes.strip()}> is missing the CSP nonce",
+            )
+
+        self.assertGreaterEqual(
+            len(tags), minimum, f"expected at least {minimum} django CMS asset(s) in the response"
+        )
+        return tags
+
+    def assertJsonBlocksAreNonceFree(self, response):
+        json_tags = [
+            attributes
+            for tag, attributes in ASSET_TAG_RE.findall(response.content.decode())
+            if tag.lower() == "script" and 'type="application/json"' in attributes
+        ]
+        self.assertGreater(len(json_tags), 0, "expected JSON data blocks in the response")
+        for attributes in json_tags:
+            self.assertNotIn("nonce=", attributes, "JSON data blocks must not carry a nonce")
+
+
+@requires_csp
+class CspNonceAdminViewTests(NonceAssertionsMixin, CMSTestCase):
+    """django CMS admin pages must emit the request nonce on their own assets."""
+
+    def setUp(self):
+        super().setUp()
+        self.page = create_page("home", "nav_playground.html", "en")
+        self.superuser = self.get_superuser()
+
+    def test_page_tree(self):
+        with override_settings(**csp_overrides()):
+            with self.login_user_context(self.superuser):
+                response = self.client.get(self.get_pages_admin_list_uri())
+        self.assertEqual(response.status_code, 200)
+        self.assertCmsAssetsAreNonced(response)
+
+    def test_page_change_form(self):
+        with override_settings(**csp_overrides()):
+            with self.login_user_context(self.superuser):
+                response = self.client.get(self.get_page_change_uri("en", self.page))
+        self.assertEqual(response.status_code, 200)
+        self.assertCmsAssetsAreNonced(response)
+
+    def test_plugin_change_form(self):
+        placeholder = self.page.get_placeholders("en").get(slot="body")
+        plugin = add_plugin(placeholder, "LinkPlugin", "en", name="link", external_link="http://example.com")
+        with override_settings(**csp_overrides()):
+            with self.login_user_context(self.superuser):
+                response = self.client.get(self.get_change_plugin_uri(plugin))
+        self.assertEqual(response.status_code, 200)
+        self.assertCmsAssetsAreNonced(response)
+
+    def test_usersettings_change_form(self):
+        with override_settings(**csp_overrides()):
+            with self.login_user_context(self.superuser):
+                response = self.client.get(admin_reverse("cms_usersettings_change", args=(self.superuser.pk,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertCmsAssetsAreNonced(response)
+
+    def test_page_delete_confirmation(self):
+        """The delete confirmation carries django CMS' only inline ``<style>``.
+
+        It has no ``href``, so it is checked by hand rather than through
+        :meth:`assertCmsAssetsAreNonced`.
+        """
+        with override_settings(**csp_overrides()):
+            with self.login_user_context(self.superuser):
+                response = self.client.get(self.get_admin_url(type(self.page), "delete", self.page.pk))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f'<style nonce="{self.get_header_nonce(response)}">')
+
+    def test_wizard(self):
+        with override_settings(**csp_overrides()):
+            with self.login_user_context(self.superuser):
+                response = self.client.get(admin_reverse("cms_wizard_create"))
+        self.assertEqual(response.status_code, 200)
+        self.assertCmsAssetsAreNonced(response)
+
+
+@requires_csp
+class CspNonceToolbarViewTests(NonceAssertionsMixin, CMSTestCase):
+    """The toolbar injects its assets into arbitrary front end pages."""
+
+    def setUp(self):
+        super().setUp()
+        clear_url_caches()
+        self.superuser = self.get_superuser()
+
+    def tearDown(self):
+        super().tearDown()
+        clear_url_caches()
+
+    def get_edit_response(self, page):
+        with override_settings(**csp_overrides()):
+            with self.login_user_context(self.superuser):
+                return self.client.get(get_object_edit_url(page.get_content_obj("en"), "en"))
+
+    def test_toolbar_on_a_cms_page(self):
+        response = self.get_edit_response(create_page("home", "nav_playground.html", "en"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "cms-config-json")
+        self.assertCmsAssetsAreNonced(response)
+        self.assertJsonBlocksAreNonceFree(response)
+
+    def test_toolbar_assets_carry_the_nonce(self):
+        """The toolbar's assets are emitted one at a time through sekizai.
+
+        ``cms.text.css`` comes from the toolbar's ``Media`` and therefore
+        exercises ``{% render_media_assets %}``; the other two are plain tags.
+        """
+        response = self.get_edit_response(create_page("home", "nav_playground.html", "en"))
+        nonce = self.get_header_nonce(response)
+        content = response.content.decode()
+        for asset in ("cms.base.css", "bundle.toolbar.min.js", "djangocms_text/css/cms.text.css"):
+            with self.subTest(asset=asset):
+                tag = next(
+                    (attrs for _, attrs in ASSET_TAG_RE.findall(content) if asset in attrs),
+                    None,
+                )
+                self.assertIsNotNone(tag, f"{asset} is missing from the response")
+                self.assertIn(f'nonce="{nonce}"', tag)
+
+    def test_welcome_page(self):
+        with override_settings(**csp_overrides()):
+            response = self.client.get("/en/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.template_name, "cms/welcome.html")
+        self.assertCmsAssetsAreNonced(response)
+
+
+class NoCspConfiguredTests(NonceAssertionsMixin, CMSTestCase):
+    """Without CSP configured no ``nonce`` attribute may appear anywhere.
+
+    These run on every supported Django version, and are the regression test
+    for templates referencing a tag that does not exist below Django 6.1.
+    """
+
+    def setUp(self):
+        super().setUp()
+        clear_url_caches()
+        self.page = create_page("home", "nav_playground.html", "en")
+        self.superuser = self.get_superuser()
+
+    def tearDown(self):
+        super().tearDown()
+        clear_url_caches()
+
+    def test_admin_views_render_without_nonces(self):
+        endpoints = {
+            "page tree": self.get_pages_admin_list_uri(),
+            "page change form": self.get_page_change_uri("en", self.page),
+            "usersettings": admin_reverse("cms_usersettings_change", args=(self.superuser.pk,)),
+            "wizard": admin_reverse("cms_wizard_create"),
+            "delete confirmation": self.get_admin_url(type(self.page), "delete", self.page.pk),
+        }
+        with self.login_user_context(self.superuser):
+            for name, endpoint in endpoints.items():
+                with self.subTest(view=name):
+                    response = self.client.get(endpoint)
+                    self.assertEqual(response.status_code, 200)
+                    self.assertNoNonces(response)
+
+    def test_toolbar_renders_without_nonces(self):
+        with self.login_user_context(self.superuser):
+            response = self.client.get(get_object_edit_url(self.page.get_content_obj("en"), "en"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "cms-config-json")
+        self.assertNoNonces(response)
+
+    def test_welcome_page_renders_without_nonces(self):
+        self.page.delete()
+        response = self.client.get("/en/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.template_name, "cms/welcome.html")
+        self.assertNoNonces(response)

--- a/docs/explanation/request_lifecycle.rst
+++ b/docs/explanation/request_lifecycle.rst
@@ -75,18 +75,17 @@ Before the CMS view runs, Django's middleware stack fires in order.
     ``request._current_page_cache`` — an in-process attribute that
     prevents resolving the same page twice during a single request.
 
-``LanguageCookieMiddleware`` (optional — add it to
-:setting:`django:MIDDLEWARE` to enable)
+``LanguageCookieMiddleware`` (optional — add it to :setting:`django:MIDDLEWARE` to enable)
     Persists the user's language preference in a cookie so that
     subsequent visits default to the same language.
 
 ``ToolbarMiddleware``
     Attaches the toolbar if the user is staff and the request is in
-    edit mode (``?edit`` or ``?toolbar_on``). The toolbar's presence
+    edit mode (``?toolbar_on``). The toolbar's presence
     disables CMS-level caching for the request.
 
 
-2. URL resolution
+1. URL resolution
 -----------------
 
 The request arrives at :func:`cms.views.details` via the CMS URLconf.
@@ -181,7 +180,7 @@ plugin rendering, and menu building entirely.
 The check runs only when :setting:`CMS_PAGE_CACHE` is ``True``
 (default), the user is anonymous, the toolbar is not in edit mode, and
 no placeholder on the page uses the legacy ``cache = False`` flag (see
-`Step 7`_).
+:ref:`Step 7 <placeholder_rendering_step>`).
 
 If the conditions are met, ``get_page_cache(request)`` queries
 Django's cache backend for a key composed from the site ID, language,
@@ -229,6 +228,8 @@ The template defines which placeholders exist through ``{% placeholder
 "name" %}`` tags. These are the rendering anchor points for the next
 step.
 
+
+.. _placeholder_rendering_step:
 
 7. Placeholder rendering
 ------------------------

--- a/docs/explanation/request_lifecycle.rst
+++ b/docs/explanation/request_lifecycle.rst
@@ -85,7 +85,7 @@ Before the CMS view runs, Django's middleware stack fires in order.
     disables CMS-level caching for the request.
 
 
-1. URL resolution
+2. URL resolution
 -----------------
 
 The request arrives at :func:`cms.views.details` via the CMS URLconf.
@@ -322,9 +322,9 @@ serializes the result. The cache is invalidated by
 deleted — selectively by site and language or globally.
 
 Menu building and toolbar authorization also consult the permission
-cache (see `Step 7`_) to determine which pages are visible to the
-current user based on ``hide_untranslated``, login-required, and
-view-restriction settings.
+cache (see :ref:`Step 7 <placeholder_rendering_step>`) to determine
+which pages are visible to the current user based on
+``hide_untranslated``, login-required, and view-restriction settings.
 
 For the full menu system, see :doc:`menu_system`.
 

--- a/docs/how_to/25-content_security_policy.rst
+++ b/docs/how_to/25-content_security_policy.rst
@@ -1,0 +1,140 @@
+########################################
+How to use a Content Security Policy
+########################################
+
+A Content Security Policy (CSP) tells the browser which scripts and stylesheets it is
+allowed to run. The strictest practical policy is a *nonce-based* one: the server
+generates a random token for every response, puts it in the
+``Content-Security-Policy`` header, and repeats it on every asset it trusts. Anything
+without the token -- including markup injected by an attacker -- is refused.
+
+django CMS renders the nonce on all assets it emits itself, so the admin, the page
+tree, the toolbar and the wizards keep working under such a policy.
+
+.. versionadded:: 5.1
+    Nonce support requires Django 6.1 or later. On Django 5.2 and 6.0 the templates
+    render exactly as before, without a ``nonce`` attribute.
+
+
+******
+Set-up
+******
+
+Django 6.1 ships CSP support out of the box. Three pieces are needed:
+
+#. Add the middleware that generates the nonce and writes the header::
+
+    MIDDLEWARE = [
+        "django.middleware.csp.ContentSecurityPolicyMiddleware",
+        ...
+    ]
+
+#. Add the context processor that makes the nonce available to templates::
+
+    TEMPLATES = [
+        {
+            ...
+            "OPTIONS": {
+                "context_processors": [
+                    ...
+                    "django.template.context_processors.csp",
+                ],
+            },
+        },
+    ]
+
+#. Declare a policy that uses the nonce placeholder::
+
+    from django.utils.csp import CSP
+
+    SECURE_CSP = {
+        "default-src": [CSP.SELF],
+        "script-src": [CSP.SELF, CSP.NONCE],
+        "style-src": [CSP.SELF, CSP.NONCE],
+    }
+
+``CSP.NONCE`` is replaced with the request's nonce when the header is built. See
+`Django's CSP how-to <https://docs.djangoproject.com/en/6.1/howto/csp/>`_ for the
+full picture.
+
+.. note::
+    Start with ``SECURE_CSP_REPORT_ONLY`` instead of ``SECURE_CSP``. The browser then
+    reports violations without blocking anything, which lets you find assets from your
+    own templates or from third-party apps that do not carry the nonce yet.
+
+
+*******************************
+Nonces in your own templates
+*******************************
+
+Any script or stylesheet **you** add has to carry the nonce as well. Django 6.1
+registers a built-in ``{% csp_nonce_attr %}`` tag for that, but it does not exist on
+Django 5.2 and 6.0. If your project or add-on supports those versions too, load
+django CMS' cross-version version of the tag instead:
+
+.. code-block:: html+django
+
+    {% load cms_static %}
+
+    <script src="{% static 'myapp/js/app.js' %}" {% csp_nonce_attr %}></script>
+    <link rel="stylesheet" href="{% static 'myapp/css/app.css' %}" {% csp_nonce_attr %}>
+    <style {% csp_nonce_attr %}>...</style>
+
+The tag renders ``nonce="..."`` when a nonce is available and nothing at all
+otherwise, so a single template works on every supported Django version.
+
+Form and widget media take the nonce as an argument:
+
+.. code-block:: html+django
+
+    {% csp_nonce_attr form.media %}
+
+If you need the assets one at a time -- for example to wrap each of them in a
+separate sekizai ``{% addtoblock %}``, the way the toolbar does -- use
+``{% render_media_assets %}``:
+
+.. code-block:: html+django
+
+    {% render_media_assets form.media "css" as css_assets %}
+    {% for css in css_assets %}
+        {% addtoblock "css" %}{{ css }}{% endaddtoblock %}
+    {% endfor %}
+
+The second argument is either ``"css"`` or ``"js"``.
+
+
+**********************************
+What does *not* need a nonce
+**********************************
+
+``<script type="application/json">`` data blocks -- such as the toolbar's
+``cms-config-json`` element and the JSON emitted by ``json_script`` -- carry **no**
+nonce, and must not be given one. Browsers never execute them, so CSP never checks
+them; this matches Django's own ``json_script()``.
+
+``<link rel="icon">`` and other non-stylesheet links are governed by ``img-src``
+rather than ``style-src`` and take no nonce either.
+
+
+********************
+Caching and nonces
+********************
+
+A nonce is valid for exactly one response. Never store a rendered page that contains
+one in a shared cache, or the browser will reject the assets of every later visitor.
+
+django CMS' own page cache is safe here: it only serves cached responses to anonymous
+visitors who see no toolbar, so no nonce-bearing markup ever enters it. Take the same
+care with any caching you add yourself, and be aware that Django's
+:class:`~django.middleware.cache.UpdateCacheMiddleware` does not know about nonces.
+
+
+*******************
+Inline JavaScript
+*******************
+
+django CMS itself contains no inline JavaScript and no inline event handlers, so a
+policy without ``'unsafe-inline'`` needs no exceptions for the CMS. If your own
+templates still use ``onclick="..."`` attributes or inline ``<script>`` blocks, move
+them into static files -- a nonce cannot rescue inline event handlers, which are only
+allowed by ``'unsafe-inline'`` or ``'unsafe-hashes'``.

--- a/docs/how_to/index.rst
+++ b/docs/how_to/index.rst
@@ -27,6 +27,7 @@ Using core functionality
     Serve multiple sites <03-multi-site>
     Work with templates <04-templates>
     Manage caching <05-caching>
+    Use a Content Security Policy <25-content_security_policy>
     Enable frontend editing for Page and Django models <06-frontend_models>
     Create sitemaps <07-sitemaps>
     Manage Page Types <08-page_types>

--- a/docs/reference/pages.rst
+++ b/docs/reference/pages.rst
@@ -16,4 +16,8 @@ Pages
     :show-inheritance:
     :exclude-members: DoesNotExist, MultipleObjectsReturned
 
-.
+
+Views
+-----
+
+.. autofunction:: cms.views.details

--- a/docs/reference/utility-functions.rst
+++ b/docs/reference/utility-functions.rst
@@ -28,6 +28,15 @@ Grouper admin
     :show-inheritance:
 
 
+*****
+Pages
+*****
+
+.. module:: cms.utils.page
+
+.. autofunction:: get_page_from_request
+
+
 ************
 Placeholders
 ************


### PR DESCRIPTION
## Summary by Sourcery

Support Content Security Policy nonces across django CMS templates on Django versions with and without built-in CSP support.

New Features:
- Add cross-version CSP nonce template support for Django CMS assets, including toolbar media and form media.

Bug Fixes:
- Ensure Django CMS styles, scripts, and inline styles comply with configured Content Security Policies while leaving non-executable JSON blocks nonce-free.

Enhancements:
- Apply nonce-aware rendering across CMS admin, toolbar, welcome, wizard, headless, and fallback templates.

Documentation:
- Add documentation for configuring and using Content Security Policy support.

Tests:
- Add coverage for nonce rendering, media assets, CMS admin views, toolbar pages, and behavior when CSP is unavailable or unconfigured.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* fix #8772
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.