### PR TITLE
fix: check and delete-orphaned-plugins had an n+1 issue (#8701)

### DIFF
--- a/cms/management/commands/subcommands/delete_orphaned_plugins.py
+++ b/cms/management/commands/subcommands/delete_orphaned_plugins.py
@@ -1,4 +1,7 @@
+from django.db import transaction
+
 from cms.management.commands.subcommands.list import plugin_report
+from cms.models.pluginmodel import CMSPlugin
 
 from .base import SubcommandsCommand
 
@@ -19,23 +22,23 @@ class DeleteOrphanedPluginsCommand(SubcommandsCommand):
         but not saved).
         """
         self.stdout.write('Obtaining plugin report\n')
-        uninstalled_instances = []
-        unsaved_instances = []
+        uninstalled_instance_ids = []
+        unsaved_instance_ids = []
 
         for plugin in plugin_report():
             if not plugin['model']:
                 for instance in plugin['instances']:
-                    uninstalled_instances.append(instance)
+                    uninstalled_instance_ids.append(instance.pk)
 
             for instance in plugin['unsaved_instances']:
-                unsaved_instances.append(instance)
+                unsaved_instance_ids.append(instance.pk)
 
         if options.get('interactive'):
             confirm = input("""
 You have requested to delete any instances of uninstalled plugins and empty plugin instances.
 There are %d uninstalled plugins and %d empty plugins.
 Are you sure you want to do this?
-Type 'yes' to continue, or 'no' to cancel: """ % (len(uninstalled_instances), len(unsaved_instances)))
+Type 'yes' to continue, or 'no' to cancel: """ % (len(uninstalled_instance_ids), len(unsaved_instance_ids)))
         else:
             confirm = 'yes'
 
@@ -43,19 +46,21 @@ Type 'yes' to continue, or 'no' to cancel: """ % (len(uninstalled_instances), le
             # delete items whose plugin is uninstalled and items with unsaved instances
             self.stdout.write('... deleting any instances of uninstalled plugins and empty plugin instances\n')
 
-            for instance in uninstalled_instances:
-                if instance.placeholder:
-                    instance.placeholder.delete_plugin(instance)
-                else:
-                    instance.delete()
+            with transaction.atomic():
+                # Re-fetch each plugin by pk: deleting a plugin shifts the positions of
+                # its siblings, so instances collected by the report can be stale.
+                for instance_id in uninstalled_instance_ids + unsaved_instance_ids:
+                    try:
+                        instance = CMSPlugin.objects.get(pk=instance_id)
+                    except CMSPlugin.DoesNotExist:
+                        continue
 
-            for instance in unsaved_instances:
-                if instance.placeholder:
-                    instance.placeholder.delete_plugin(instance)
-                else:
-                    instance.delete()
+                    if instance.placeholder:
+                        instance.placeholder.delete_plugin(instance)
+                    else:
+                        instance.delete()
 
             self.stdout.write(
-                f'Deleted instances of: \n    {len(uninstalled_instances)} uninstalled plugins  \n    {len(unsaved_instances)} plugins with unsaved instances\n'
+                f'Deleted instances of: \n    {len(uninstalled_instance_ids)} uninstalled plugins  \n    {len(unsaved_instance_ids)} plugins with unsaved instances\n'
             )
             self.stdout.write('all done\n')

--- a/cms/management/commands/subcommands/list.py
+++ b/cms/management/commands/subcommands/list.py
@@ -50,27 +50,47 @@ def plugin_report():
     ]
     """
     plugin_report = []
-    all_plugins = CMSPlugin.objects.order_by('plugin_type')
-    plugin_types = list(set(all_plugins.values_list('plugin_type', flat=True)))
-    plugin_types.sort()
+    plugin_types = list(
+        CMSPlugin.objects.order_by('plugin_type')
+        .values_list('plugin_type', flat=True)
+        .distinct()
+    )
 
     for plugin_type in plugin_types:
-        plugin = {}
-        plugin['type'] = plugin_type
-        try:
-            # get all plugins of this type
-            plugins = CMSPlugin.objects.filter(plugin_type=plugin_type)
-            plugin['instances'] = plugins
-            # does this plugin have a model? report unsaved instances
-            plugin['model'] = plugin_pool.get_plugin(name=plugin_type).model
-            unsaved_instances = [p for p in plugins if not p.get_plugin_instance()[0]]
-            plugin['unsaved_instances'] = unsaved_instances
+        # get all plugins of this type
+        plugins = CMSPlugin.objects.filter(plugin_type=plugin_type)
+        plugin = {
+            'type': plugin_type,
+            'instances': plugins,
+        }
 
+        try:
+            # does this plugin have a model? report unsaved instances
+            model = plugin_pool.get_plugin(name=plugin_type).model
         # catch uninstalled plugins
         except KeyError:
             plugin['model'] = None
-            plugin['instances'] = plugins
             plugin['unsaved_instances'] = []
+            plugin_report.append(plugin)
+            continue
+
+        plugin['model'] = model
+
+        if model._meta.concrete_model == CMSPlugin._meta.concrete_model:
+            # Model-less plugin: the bound instance is the CMSPlugin row
+            # itself, so there can never be unsaved instances.
+            plugin['unsaved_instances'] = []
+        else:
+            # An instance is "unsaved" when its CMSPlugin row has no matching
+            # row in the plugin's own (child) table. Resolve this with a single
+            # bulk query for the saved ids instead of one query per instance.
+            saved_ids = set(
+                model.objects.filter(cmsplugin_ptr__in=plugins)
+                .values_list('cmsplugin_ptr_id', flat=True)
+            )
+            plugin['unsaved_instances'] = [
+                instance for instance in plugins if instance.pk not in saved_ids
+            ]
 
         plugin_report.append(plugin)
 

--- a/cms/tests/test_management.py
+++ b/cms/tests/test_management.py
@@ -7,8 +7,8 @@ from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core import management
 from django.core.management import CommandError
-from django.db import models
-from django.test.utils import override_settings
+from django.db import connection, models
+from django.test.utils import CaptureQueriesContext, override_settings
 from djangocms_text_ckeditor.cms_plugins import TextPlugin
 
 from cms.api import add_plugin, create_page, create_page_content
@@ -289,6 +289,123 @@ class ManagementTestCase(CMSTestCase):
         # No gaps in plugin tree
         max_position = placeholder.cmsplugin_set.aggregate(models.Max('position'))['position__max']
         self.assertEqual(max_position, 3)
+
+        self.assertEqual(CMSPlugin.objects.all().count(), 3)
+
+        # Then both detached placeholders and their plugins should be gone
+        self.assertFalse(Placeholder.objects.filter(pk=ph_detached.pk).exists())
+        self.assertFalse(Placeholder.objects.filter(pk=ph_bogus.pk).exists())
+        self.assertFalse(CMSPlugin.objects.filter(pk=pl_detached.pk).exists())
+        self.assertFalse(CMSPlugin.objects.filter(pk=pl_bogus.pk).exists())
+
+        # check stdout
+        output = out.getvalue()
+        self.assertIn("1 uninstalled plugins", output)
+        self.assertIn("1 plugins with unsaved instances", output)
+        self.assertIn("2 detached placeholders", output)
+
+    @override_settings(INSTALLED_APPS=TEST_INSTALLED_APPS)
+    def test_plugin_report_query_count_does_not_scale_with_instances(self):
+        """
+        plugin_report() must resolve unsaved instances with bulk queries.
+
+        It previously called get_plugin_instance() once per plugin row, an
+        N+1 that made ``cms check`` and ``cms delete-orphaned-plugins`` appear
+        to hang on databases with many plugins. Guard against a regression by
+        asserting the query count is independent of the number of instances.
+        """
+        placeholder = Placeholder.objects.create(slot="test")
+
+        def count_queries():
+            with CaptureQueriesContext(connection) as ctx:
+                # Force full evaluation so deferred querysets are counted too.
+                for plugin in plugin_report():
+                    list(plugin["instances"])
+                    list(plugin["unsaved_instances"])
+            return len(ctx.captured_queries)
+
+        add_plugin(placeholder, TextPlugin, "en", body="en body")
+        baseline = count_queries()
+
+        for _ in range(10):
+            add_plugin(placeholder, TextPlugin, "en", body="en body")
+        scaled = count_queries()
+
+        self.assertEqual(
+            baseline,
+            scaled,
+            "plugin_report() issues a query per plugin instance (N+1 regression)",
+        )
+
+    @override_settings(INSTALLED_APPS=TEST_INSTALLED_APPS)
+    def test_delete_orphaned_plugins_keeps_positions_consecutive(self):
+        placeholder = Placeholder.objects.create(slot="test")
+        add_plugin(placeholder, TextPlugin, "en", body="first")
+        CMSPlugin.objects.create(
+            position=placeholder.get_next_plugin_position("en", insert_order="last"),
+            language="en",
+            plugin_type="BogusPlugin",
+            placeholder=placeholder,
+        )
+        add_plugin(placeholder, TextPlugin, "en", body="second")
+        CMSPlugin.objects.create(
+            position=placeholder.get_next_plugin_position("en", insert_order="last"),
+            language="en",
+            plugin_type="BogusPlugin",
+            placeholder=placeholder,
+        )
+        add_plugin(placeholder, TextPlugin, "en", body="third")
+
+        self.assertEqual(
+            list(placeholder.cmsplugin_set.order_by("position").values_list("plugin_type", "position")),
+            [
+                ("TextPlugin", 1),
+                ("BogusPlugin", 2),
+                ("TextPlugin", 3),
+                ("BogusPlugin", 4),
+                ("TextPlugin", 5),
+            ],
+        )
+
+        management.call_command("cms", "delete-orphaned-plugins", interactive=False, stdout=StringIO())
+
+        self.assertEqual(
+            list(placeholder.cmsplugin_set.order_by("position").values_list("plugin_type", "position")),
+            [
+                ("TextPlugin", 1),
+                ("TextPlugin", 2),
+                ("TextPlugin", 3),
+            ],
+        )
+
+    @override_settings(INSTALLED_APPS=TEST_INSTALLED_APPS)
+    def test_delete_plugin_uses_stale_position_from_prefetched_instance(self):
+        placeholder = Placeholder.objects.create(slot="test")
+        add_plugin(placeholder, TextPlugin, "en", body="first")
+        CMSPlugin.objects.create(
+            position=placeholder.get_next_plugin_position("en", insert_order="last"),
+            language="en",
+            plugin_type="BogusPlugin",
+            placeholder=placeholder,
+        )
+        add_plugin(placeholder, TextPlugin, "en", body="second")
+        CMSPlugin.objects.create(
+            position=placeholder.get_next_plugin_position("en", insert_order="last"),
+            language="en",
+            plugin_type="BogusPlugin",
+            placeholder=placeholder,
+        )
+        add_plugin(placeholder, TextPlugin, "en", body="third")
+
+        stale_plugins = list(CMSPlugin.objects.filter(plugin_type="BogusPlugin").order_by("position"))
+        self.assertEqual([plugin.position for plugin in stale_plugins], [2, 4])
+
+        placeholder.delete_plugin(stale_plugins[0])
+
+        self.assertEqual(stale_plugins[1].position, 4)
+        stale_plugins[1].refresh_from_db()
+
+        self.assertEqual(stale_plugins[1].position, 3)
 
     def test_uninstall_plugins_without_plugin(self):
         out = StringIO()

--- a/cms/tests/test_management.py
+++ b/cms/tests/test_management.py
@@ -292,17 +292,10 @@ class ManagementTestCase(CMSTestCase):
 
         self.assertEqual(CMSPlugin.objects.all().count(), 3)
 
-        # Then both detached placeholders and their plugins should be gone
-        self.assertFalse(Placeholder.objects.filter(pk=ph_detached.pk).exists())
-        self.assertFalse(Placeholder.objects.filter(pk=ph_bogus.pk).exists())
-        self.assertFalse(CMSPlugin.objects.filter(pk=pl_detached.pk).exists())
-        self.assertFalse(CMSPlugin.objects.filter(pk=pl_bogus.pk).exists())
-
         # check stdout
         output = out.getvalue()
         self.assertIn("1 uninstalled plugins", output)
         self.assertIn("1 plugins with unsaved instances", output)
-        self.assertIn("2 detached placeholders", output)
 
     @override_settings(INSTALLED_APPS=TEST_INSTALLED_APPS)
     def test_plugin_report_query_count_does_not_scale_with_instances(self):

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -19,7 +19,6 @@ from django.utils.timezone import now as tz_now
 from django.utils.translation import override as force_language
 
 from cms import constants
-from cms.admin.forms import ChangePageForm
 from cms.admin.pageadmin import PageContentAdmin
 from cms.api import add_plugin, create_page, create_page_content
 from cms.appresolver import clear_app_resolvers


### PR DESCRIPTION
## Summary by Sourcery

Optimize orphaned-plugin reporting and cleanup to avoid per-instance queries and safely remove orphaned records.

Bug Fixes:
- Eliminate the N+1 query pattern when identifying orphaned plugin instances.
- Ensure orphaned-plugin deletion remains correct when sibling positions shift during deletion.

Enhancements:
- Resolve plugin instance state with bulk queries and perform orphan cleanup atomically.

Tests:
- Add coverage for query counts, consecutive plugin positions, and deletion using stale prefetched positions.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.