### PR TITLE
fix: Copy page missed login required property (#8785)

### DIFF
--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -479,9 +479,9 @@ class Page(MP_Node):
             parent_page = parent_page or parent_node
 
         if parent_page:
-            new_page = parent_page.add_child(site=site)
+            new_page = parent_page.add_child(site=site, login_required=self.login_required)
         else:
-            new_page = Page.add_root(site=site)
+            new_page = Page.add_root(site=site, login_required=self.login_required)
 
         new_page._state = ModelState()
         new_page._clear_internal_cache()

--- a/cms/tests/test_page_admin.py
+++ b/cms/tests/test_page_admin.py
@@ -584,6 +584,22 @@ class PageTest(PageTestBase):
 
         self.assertEqual(Page.objects.count() - count, 3)
 
+    def test_copy_page_preserves_login_required(self):
+        source = create_page("source", "nav_playground.html", "en", login_required=True)
+        source_child = create_page("source-child", "nav_playground.html", "en", parent=source, login_required=True)
+        target = create_page("target", "nav_playground.html", "en")
+
+        with self.login_user_context(self.get_superuser()):
+            copied_root = self.copy_page(source, target)
+
+        copied_root.refresh_from_db()
+        copied_child = copied_root.get_child_pages().get()
+        copied_child.refresh_from_db()
+
+        self.assertTrue(copied_root.login_required)
+        self.assertTrue(copied_child.login_required)
+        self.assertTrue(source_child.login_required)
+
     def test_copy_page_under_home(self):
         """
         Users should be able to copy a page and paste under the home page.


### PR DESCRIPTION
## Summary by Sourcery

Preserve access restrictions when copying pages.

Bug Fixes:
- Preserve the login-required setting when copying pages and their child pages.

Tests:
- Add coverage confirming copied page hierarchies retain the source pages’ login-required settings.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.