### PR TITLE
fix: Manual page slug was overwritten when changing page title (#8796)

### DIFF
--- a/cms/static/cms/js/modules/slug.js
+++ b/cms/static/cms/js/modules/slug.js
@@ -1,46 +1,113 @@
-var $ = require('jquery');
+import $ from 'jquery';
 
-module.exports = function addSlugHandlers(title, slug) {
-    if (!slug.length) {
+/**
+ * Returns true if the slug field is already handled by django admin's own
+ * prepopulate.js, so that both mechanisms do not fight over the same input.
+ *
+ * @function isPrepopulatedByAdmin
+ * @param {HTMLElement} slug slug input element
+ * @returns {Boolean} true if django admin takes care of the field
+ */
+function isPrepopulatedByAdmin(slug) {
+    var constants = document.getElementById('django-admin-prepopulated-fields-constants');
+
+    if (!constants) {
+        return false;
+    }
+    var fields;
+
+    try {
+        fields = JSON.parse(constants.dataset.prepopulatedFields || '[]');
+    } catch (e) {
+        return false;
+    }
+    return fields.some(function(field) {
+        return field.id && document.querySelector(field.id) === slug;
+    });
+}
+
+/**
+ * Binds the automatic slug generation to a title/slug field pair.
+ *
+ * @function addSlugHandlers
+ * @param {jQuery} title title input element
+ * @param {jQuery} slug slug input element
+ * @returns {void}
+ */
+export default function addSlugHandlers(title, slug) {
+    if (!title || !title.length || !slug || !slug.length) {
         return;
     }
 
-    // set local variables
-    var prefill = false;
+    var titleField = title[0];
+    var slugField = slug[0];
 
-    // determine if slug is empty
-    if (slug.val().trim() === '') {
-        prefill = true;
+    if (slugField.dataset.slugHandlers === 'true' || isPrepopulatedByAdmin(slugField)) {
+        // The field is already taken care of - either by another bundle on the
+        // same page or by django admin's prepopulated fields.
+        return;
     }
+    slugField.dataset.slugHandlers = 'true';
+
     if (window.unihandecode) {
         // eslint-disable-next-line new-cap
         window.UNIHANDECODER = window.unihandecode.Unihan(slug.data('decoder'));
     }
 
-    // always bind the title > slug generation and do the validation inside for better ux
-    title.on('keyup keypress', function() {
-        var value = title.val();
+    // The slug is only generated from the title as long as the user has not typed
+    // into it themselves. A slug that already has a value (change form, redisplay
+    // after a validation error) counts as user-provided.
+    var prefill = slugField.value.trim() === '';
+
+    /**
+     * Generates the slug from the title, as long as the user has not taken over.
+     *
+     * @function updateSlug
+     * @returns {void}
+     */
+    function updateSlug() {
+        if (!prefill) {
+            return;
+        }
+        var value = titleField.value;
 
         // international language handling
         if (window.UNIHANDECODER) {
             value = window.UNIHANDECODER.decode(value);
         }
-        // if slug is empty, prefill again
-        if (prefill === false && slug.val() === '') {
-            prefill = true;
-        }
         // urlify
         // eslint-disable-next-line
-        var urlified = URLify(value, 64);
-        if (prefill) {
-            slug.val(urlified);
-        }
-    });
-    // autocall
-    title.trigger('keyup');
+        slugField.value = URLify(value, 64);
+    }
+
+    /**
+     * Emptying the slug hands control back to the auto-generation.
+     *
+     * @function slugTouched
+     * @returns {void}
+     */
+    function slugTouched() {
+        prefill = slugField.value.trim() === '';
+    }
+
+    /**
+     * Marks a field as changed, used to warn before switching language tabs.
+     *
+     * @function markChanged
+     * @returns {void}
+     */
+    function markChanged() {
+        $(this).data('changed', true);
+    }
+
+    // Programmatic changes from updateSlug() do not fire "input", so the
+    // auto-generated value never marks the slug as user-provided.
+    title.on('input', updateSlug);
+    slug.on('input', slugTouched);
 
     // add changed data bindings to elements
-    slug.add(title).bind('change', function() {
-        $(this).data('changed', true);
-    });
-};
+    slug.add(title).on('change', markChanged);
+
+    // autocall
+    updateSlug();
+}

--- a/cms/static/cms/js/widgets/forms.slugwidget.js
+++ b/cms/static/cms/js/widgets/forms.slugwidget.js
@@ -7,16 +7,41 @@
 // eslint-disable-next-line
 __webpack_public_path__ = require('../modules/get-dist-path')('bundle.forms.slugwidget');
 
+/**
+ * Finds the title field belonging to a slug field. Form fields can be prefixed
+ * (``id_1-slug`` in the wizard, ``id_content__slug`` in grouper admins), so the
+ * title is looked up by the slug's own id first and only then guessed.
+ *
+ * @function findTitle
+ * @param {HTMLElement} slug slug input element
+ * @returns {HTMLElement|null} matching title input element
+ */
+function findTitle(slug) {
+    var derivedId = slug.id.replace(/slug$/, 'title');
+
+    if (derivedId !== slug.id) {
+        var derived = document.getElementById(derivedId);
+
+        if (derived) {
+            return derived;
+        }
+    }
+    return document.querySelector('[id$=title]') || document.querySelector('[id*=title]');
+}
+
 require.ensure([], function (require) {
     var $ = require('jquery');
-    var addSlugHandlers = require('../modules/slug');
+    var addSlugHandlers = require('../modules/slug').default;
 
     // init
     $(function () {
         // set local variables
-        var title = $('[id*=title]');
-        var slug = $('[id*=slug]');
+        var slug = document.querySelector('[id$=slug]') || document.querySelector('[id*=slug]');
 
-        addSlugHandlers(title, slug);
+        if (!slug) {
+            return;
+        }
+
+        addSlugHandlers($(findTitle(slug)), $(slug));
     });
 }, 'admin.widget');

--- a/cms/tests/frontend/unit/index.js
+++ b/cms/tests/frontend/unit/index.js
@@ -25,6 +25,7 @@ if (files[0] === '*') {
     require('./dom-diff.test');
     // require('./keyboard.test');
     require('./preload-images.test');
+    require('./slug.test');
     // FIXME this has to be last because it messes with the url
     require('./cms.structureboard.test'); // missing some tests
 } else {

--- a/cms/tests/frontend/unit/slug.test.js
+++ b/cms/tests/frontend/unit/slug.test.js
@@ -1,0 +1,169 @@
+'use strict';
+var $ = require('jquery');
+var addSlugHandlers = require('../../../static/cms/js/modules/slug').default;
+
+describe('addSlugHandlers', function() {
+    var container;
+    var title;
+    var slug;
+
+    /**
+     * Types into an input the way a user would - the value is set and an "input"
+     * event is dispatched, which is what the handlers listen to.
+     *
+     * @function type
+     * @param {jQuery} input the field to type into
+     * @param {String} value the new value
+     * @returns {void}
+     */
+    function type(input, value) {
+        input.val(value);
+        input.trigger('input');
+    }
+
+    /**
+     * Simulates leaving a field after having edited it.
+     *
+     * @function blur
+     * @param {jQuery} input the field to blur
+     * @returns {void}
+     */
+    function blur(input) {
+        input.trigger('change');
+    }
+
+    beforeEach(function() {
+        container = document.createElement('div');
+        container.innerHTML = '<input id="id_title"><input id="id_slug">';
+        document.body.appendChild(container);
+        title = $(container).find('#id_title');
+        slug = $(container).find('#id_slug');
+
+        window.URLify = jasmine.createSpy('URLify').and.callFake(function(value) {
+            return value
+                .toLowerCase()
+                .trim()
+                .replace(/[^a-z0-9]+/g, '-')
+                .replace(/^-|-$/g, '');
+        });
+    });
+
+    afterEach(function() {
+        document.body.removeChild(container);
+        delete window.UNIHANDECODER;
+        window.URLify = undefined;
+    });
+
+    it('does not fail if there is no slug or no title field', function() {
+        expect(function() {
+            addSlugHandlers(title, null);
+        }).not.toThrow();
+        expect(function() {
+            addSlugHandlers(null, slug);
+        }).not.toThrow();
+        expect(function() {
+            addSlugHandlers(title, $('#does-not-exist'));
+        }).not.toThrow();
+    });
+
+    it('generates the slug from the title while the slug is empty', function() {
+        addSlugHandlers(title, slug);
+
+        type(title, 'I AM A TILE');
+
+        expect(slug.val()).toEqual('i-am-a-tile');
+    });
+
+    it('keeps a manually entered slug when the title changes', function() {
+        addSlugHandlers(title, slug);
+
+        type(title, 'I AM A TILE');
+        expect(slug.val()).toEqual('i-am-a-tile');
+
+        type(slug, 'some-page');
+        blur(slug);
+
+        type(title, 'I AM A TITLE');
+
+        expect(slug.val()).toEqual('some-page');
+    });
+
+    it('resumes generating the slug once the user empties it', function() {
+        addSlugHandlers(title, slug);
+
+        type(slug, 'some-page');
+        type(title, 'I AM A TILE');
+        expect(slug.val()).toEqual('some-page');
+
+        type(slug, '');
+        type(title, 'I AM A TITLE');
+
+        expect(slug.val()).toEqual('i-am-a-title');
+    });
+
+    it('does not touch a slug that already has a value', function() {
+        slug.val('existing-page');
+
+        addSlugHandlers(title, slug);
+        type(title, 'New title');
+
+        expect(slug.val()).toEqual('existing-page');
+    });
+
+    it('does not bind twice if called again for the same field', function() {
+        addSlugHandlers(title, slug);
+        addSlugHandlers(title, slug);
+
+        window.URLify.calls.reset();
+        type(title, 'Title');
+
+        // a second set of handlers would generate the slug twice per keystroke
+        expect(window.URLify).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not bind if django admin prepopulates the field', function() {
+        var constants = document.createElement('span');
+
+        constants.id = 'django-admin-prepopulated-fields-constants';
+        constants.dataset.prepopulatedFields = JSON.stringify([{ id: '#id_slug' }]);
+        container.appendChild(constants);
+
+        addSlugHandlers(title, slug);
+        type(title, 'Title');
+
+        expect(slug.val()).toEqual('');
+        container.removeChild(constants);
+    });
+
+    it('marks title and slug as changed when they are edited', function() {
+        addSlugHandlers(title, slug);
+
+        expect(slug.data('changed')).toBeUndefined();
+
+        blur(title);
+        blur(slug);
+
+        expect(title.data('changed')).toEqual(true);
+        expect(slug.data('changed')).toEqual(true);
+    });
+
+    it('does not mark an auto-generated slug as changed', function() {
+        addSlugHandlers(title, slug);
+
+        type(title, 'Some title');
+        blur(title);
+
+        expect(slug.val()).toEqual('some-title');
+        expect(slug.data('changed')).toBeUndefined();
+    });
+
+    it('uses the unihandecoder if available', function() {
+        window.UNIHANDECODER = { decode: jasmine.createSpy('decode').and.returnValue('decoded') };
+
+        addSlugHandlers(title, slug);
+        type(title, '日本語');
+
+        expect(window.UNIHANDECODER.decode).toHaveBeenCalledWith('日本語');
+        expect(slug.val()).toEqual('decoded');
+    });
+});


### PR DESCRIPTION
## Summary by Sourcery

Preserve user-managed page slugs during title edits while retaining reliable automatic slug generation for untouched fields.

Bug Fixes:
- Preserve manually entered or existing page slugs when the page title changes, while allowing automatic generation to resume after the slug is cleared.

Enhancements:
- Prevent duplicate slug handlers and coordinate with Django admin's slug prepopulation to avoid conflicting updates.
- Improve title-field discovery for prefixed form fields and make slug handling resilient when fields are missing.

Tests:
- Add frontend unit coverage for automatic generation, manual slug preservation, reset behavior, duplicate binding prevention, Django admin integration, change tracking, and Unicode handling.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.