### PR TITLE
fix: Grouper admin ignored read-only context for content objects without language field (#8799)

### DIFF
--- a/cms/admin/utils.py
+++ b/cms/admin/utils.py
@@ -600,9 +600,7 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
         # it has to be in the context for every grouper admin, or the change form cannot
         # tell an editable content object from a read-only one. Gate on ``can_change_content``,
         # the same predicate ``get_readonly_fields`` uses, so the note and the actually
-        # read-only fields cannot disagree; the message only explains a denial.
-        can_change_content = self.can_change_content(request, content_instance)
-        readonly_message = None if can_change_content else self.get_content_readonly_message(request, content_instance)
+        # read-only fields cannot disagree.
 
         extra_context = {
             "changed_message": _(
@@ -612,8 +610,7 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
             "title": title,
             "content_instance": content_instance,
             "subtitle": subtitle,
-            "content_readonly_message": readonly_message,
-            "can_change_content_obj": can_change_content,
+            "can_change_content_obj": self.can_change_content(request, content_instance),
         }
 
         """Provide the grouping fields to edit"""

--- a/cms/admin/utils.py
+++ b/cms/admin/utils.py
@@ -596,6 +596,14 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
         else:
             subtitle = _("Add content")
 
+        # Whether the content object may be changed is independent of the grouping fields:
+        # it has to be in the context for every grouper admin, or the change form cannot
+        # tell an editable content object from a read-only one. Gate on ``can_change_content``,
+        # the same predicate ``get_readonly_fields`` uses, so the note and the actually
+        # read-only fields cannot disagree; the message only explains a denial.
+        can_change_content = self.can_change_content(request, content_instance)
+        readonly_message = None if can_change_content else self.get_content_readonly_message(request, content_instance)
+
         extra_context = {
             "changed_message": _(
                 'Content for the current language has been changed. Click "Cancel" to '
@@ -604,6 +612,8 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
             "title": title,
             "content_instance": content_instance,
             "subtitle": subtitle,
+            "content_readonly_message": readonly_message,
+            "can_change_content_obj": can_change_content,
         }
 
         """Provide the grouping fields to edit"""
@@ -622,7 +632,6 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
                 extra_context["language_tabs"] = self.get_language_tuple()
             extra_context["language"] = language
             extra_context["filled_languages"] = filled_languages
-            extra_context["can_change_content_obj"] = self.can_change_content(request, content_instance)
             if content_instance is None:
                 subtitle = _("Add %(language)s content") % dict(language=get_language_dict().get(self.language))
                 extra_context["subtitle"] = subtitle

--- a/cms/tests/test_grouper_admin.py
+++ b/cms/tests/test_grouper_admin.py
@@ -809,6 +809,128 @@ class GrouperCanChangeContentTestCase(SetupMixin, CMSTestCase):
         self.assertTrue(self._can_change_content(request, content_obj))
 
 
+class ReasonedBool(int):
+    """Test stand-in for a "rich bool" as returned by e.g. djangocms-versioning's
+    ``as_bool``: truthy/falsy via the int value, with the reason exposed by ``str()``."""
+
+    def __new__(cls, value, reason=""):
+        obj = super().__new__(cls, bool(value))
+        obj.reason = reason
+        return obj
+
+    def __str__(self):
+        return self.reason
+
+
+class GrouperReadonlyMessageTestCase(SetupMixin, CMSTestCase):
+    """Tests for ``GrouperModelAdmin.get_content_readonly_message``: the permission
+    case plus both plain-bool and rich-bool returns from ``is_editable``."""
+
+    def _message(self, request, content_obj):
+        return GrouperModelAdmin.get_content_readonly_message(self.admin, request, content_obj)
+
+    def _request(self, has_perm_return=True):
+        request = self.get_request()
+        request.user = MagicMock()
+        request.user.has_perm.return_value = has_perm_return
+        return request
+
+    def test_missing_permission_returns_permission_message(self):
+        """Without the change permission, the permission message is returned, regardless
+        of editability."""
+        content_obj = self.createContentInstance("en")
+        request = self._request(has_perm_return=False)
+
+        self.assertEqual(
+            self._message(request, content_obj),
+            "You do not have permission to change this content.",
+        )
+
+    def test_editable_content_returns_none(self):
+        """Editable content (with permission) has no read-only message."""
+        content_obj = self.createContentInstance("en")
+        content_obj.is_editable = lambda *_: True
+        request = self._request(has_perm_return=True)
+
+        self.assertIsNone(self._message(request, content_obj))
+
+    def test_plain_false_returns_generic_message(self):
+        """A plain ``False`` from ``is_editable`` carries no reason, so the generic
+        message is used."""
+        content_obj = self.createContentInstance("en")
+        content_obj.is_editable = lambda *_: False
+        request = self._request(has_perm_return=True)
+
+        self.assertEqual(self._message(request, content_obj), " ")
+
+    def test_rich_bool_returns_its_reason(self):
+        """A falsy rich bool surfaces its own reason via ``str()``."""
+        content_obj = self.createContentInstance("en")
+        content_obj.is_editable = lambda *_: ReasonedBool(False, "Version is not a draft")
+        request = self._request(has_perm_return=True)
+
+        self.assertEqual(self._message(request, content_obj), "Version is not a draft")
+
+    def test_truthy_rich_bool_returns_none(self):
+        """A truthy rich bool means editable, so no message even though it has a str()."""
+        content_obj = self.createContentInstance("en")
+        content_obj.is_editable = lambda *_: ReasonedBool(True)
+        request = self._request(has_perm_return=True)
+
+        self.assertIsNone(self._message(request, content_obj))
+
+
+class GrouperReadonlyContextMixin:
+    """The change form has to be told whether the content object is read-only.
+
+    ``can_change_content_obj`` used to be added to the context only when ``language``
+    was among the extra grouping fields, so grouper admins without grouping fields
+    always rendered the read-only note -- even for perfectly editable content."""
+
+    readonly_note = "Some fields cannot be changed since they are read-only content."
+
+    def test_editable_content_sets_can_change_content_obj(self):
+        """Editable content: the flag is set and the read-only note is not rendered."""
+        self.createContentInstance("en")
+
+        with self.login_user_context(self.admin_user):
+            response = self.client.get(self.change_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context["can_change_content_obj"])
+        self.assertIsNone(response.context["content_readonly_message"])
+        self.assertNotContains(response, self.readonly_note)
+
+    @wo_content_permission
+    def test_readonly_content_clears_can_change_content_obj(self):
+        """Read-only content: the flag is cleared and the note is rendered."""
+        self.createContentInstance("en")
+
+        with self.login_user_context(self.admin_user):
+            response = self.client.get(self.change_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context["can_change_content_obj"])
+        self.assertContains(response, self.readonly_note)
+
+    def test_add_view_sets_can_change_content_obj(self):
+        """The add view has no content object yet, so content is never read-only there."""
+        with self.login_user_context(self.admin_user):
+            response = self.client.get(self.add_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context["can_change_content_obj"])
+        self.assertNotContains(response, self.readonly_note)
+
+
+class SimpleGrouperReadonlyContextTestCase(GrouperReadonlyContextMixin, SimpleSetupMixin, CMSTestCase):
+    """Grouper admin without extra grouping fields."""
+
+
+class GrouperReadonlyContextTestCase(GrouperReadonlyContextMixin, SetupMixin, CMSTestCase):
+    """Grouper admin with ``language`` as an extra grouping field."""
+
+
 class SimpleGrouperChangeTestCase(SimpleSetupMixin, CMSTestCase):
     def test_save_grouper_model(self) -> None:
         # Arrange

--- a/cms/tests/test_grouper_admin.py
+++ b/cms/tests/test_grouper_admin.py
@@ -809,77 +809,6 @@ class GrouperCanChangeContentTestCase(SetupMixin, CMSTestCase):
         self.assertTrue(self._can_change_content(request, content_obj))
 
 
-class ReasonedBool(int):
-    """Test stand-in for a "rich bool" as returned by e.g. djangocms-versioning's
-    ``as_bool``: truthy/falsy via the int value, with the reason exposed by ``str()``."""
-
-    def __new__(cls, value, reason=""):
-        obj = super().__new__(cls, bool(value))
-        obj.reason = reason
-        return obj
-
-    def __str__(self):
-        return self.reason
-
-
-class GrouperReadonlyMessageTestCase(SetupMixin, CMSTestCase):
-    """Tests for ``GrouperModelAdmin.get_content_readonly_message``: the permission
-    case plus both plain-bool and rich-bool returns from ``is_editable``."""
-
-    def _message(self, request, content_obj):
-        return GrouperModelAdmin.get_content_readonly_message(self.admin, request, content_obj)
-
-    def _request(self, has_perm_return=True):
-        request = self.get_request()
-        request.user = MagicMock()
-        request.user.has_perm.return_value = has_perm_return
-        return request
-
-    def test_missing_permission_returns_permission_message(self):
-        """Without the change permission, the permission message is returned, regardless
-        of editability."""
-        content_obj = self.createContentInstance("en")
-        request = self._request(has_perm_return=False)
-
-        self.assertEqual(
-            self._message(request, content_obj),
-            "You do not have permission to change this content.",
-        )
-
-    def test_editable_content_returns_none(self):
-        """Editable content (with permission) has no read-only message."""
-        content_obj = self.createContentInstance("en")
-        content_obj.is_editable = lambda *_: True
-        request = self._request(has_perm_return=True)
-
-        self.assertIsNone(self._message(request, content_obj))
-
-    def test_plain_false_returns_generic_message(self):
-        """A plain ``False`` from ``is_editable`` carries no reason, so the generic
-        message is used."""
-        content_obj = self.createContentInstance("en")
-        content_obj.is_editable = lambda *_: False
-        request = self._request(has_perm_return=True)
-
-        self.assertEqual(self._message(request, content_obj), " ")
-
-    def test_rich_bool_returns_its_reason(self):
-        """A falsy rich bool surfaces its own reason via ``str()``."""
-        content_obj = self.createContentInstance("en")
-        content_obj.is_editable = lambda *_: ReasonedBool(False, "Version is not a draft")
-        request = self._request(has_perm_return=True)
-
-        self.assertEqual(self._message(request, content_obj), "Version is not a draft")
-
-    def test_truthy_rich_bool_returns_none(self):
-        """A truthy rich bool means editable, so no message even though it has a str()."""
-        content_obj = self.createContentInstance("en")
-        content_obj.is_editable = lambda *_: ReasonedBool(True)
-        request = self._request(has_perm_return=True)
-
-        self.assertIsNone(self._message(request, content_obj))
-
-
 class GrouperReadonlyContextMixin:
     """The change form has to be told whether the content object is read-only.
 
@@ -898,7 +827,6 @@ class GrouperReadonlyContextMixin:
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.context["can_change_content_obj"])
-        self.assertIsNone(response.context["content_readonly_message"])
         self.assertNotContains(response, self.readonly_note)
 
     @wo_content_permission


### PR DESCRIPTION
## Summary by Sourcery

Ensure Grouper admin change forms consistently receive the content editability state.

Bug Fixes:
- Ensure Grouper admin forms correctly identify editable and read-only content regardless of whether the content model includes a language grouping field.

Tests:
- Add coverage for editable, read-only, and add views with and without language grouping fields.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.