### PR TITLE
fix: edit and view endpoint did not check placholder perms (#8794)

### DIFF
--- a/cms/tests/test_toolbar_enabled_models.py
+++ b/cms/tests/test_toolbar_enabled_models.py
@@ -112,6 +112,10 @@ class ToolbarEnabledModelsTestCase(CMSTestCase):
         unsupported model returns 400 response.
         """
         request = self.get_request('/')
+        # The view is called directly here, bypassing the admin_view staff gate,
+        # so give the request an authorized user: the endpoint now runs an
+        # object-level view check before the "supported model" check.
+        request.user = self.get_superuser()
         request.toolbar = CMSToolbar(request)
         ctype = ContentType.objects.get_for_model(Page)
         page = create_page('home', 'nav_playground.html', 'en')
@@ -172,6 +176,9 @@ class ToolbarEnabledModelsTestCase(CMSTestCase):
         with provided model in CMS config.
         """
         request = self.get_request('/')
+        # See test_render_preview_not_supported: the direct call needs an
+        # authorized user for the object-level view check.
+        request.user = self.get_superuser()
         request.toolbar = CMSToolbar(request)
         ctype = ContentType.objects.get_for_model(Page)
         page = create_page('home', 'nav_playground.html', 'en')

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -697,3 +697,78 @@ class NonPageContentStructureEndpointTests(CMSTestCase):
         with self.login_user_context(self.get_superuser()):
             response = self.client.get(self._url())
         self.assertContains(response, self._marker())
+
+
+class NonPageContentObjectEndpointTests(CMSTestCase):
+    """The preview and edit endpoints must also authorize non-PageContent objects.
+
+    Companion to :class:`NonPageContentStructureEndpointTests`. Registered
+    through ``admin_site.admin_view`` these endpoints only require an active
+    staff user, and unlike the structure board they render the object's full
+    plugin output. Without an object-level check, any staff user could read the
+    rendered content of any frontend-editable object (e.g. a model registered
+    via ``cms_toolbar_enabled_models``) without permission to view it.
+    """
+
+    def setUp(self) -> None:
+        from cms.api import add_plugin
+        from cms.test_utils.project.placeholderapp.models import Example1
+
+        self.target = Example1.objects.create(
+            char_1="private-object", char_2="b", char_3="c", char_4="d",
+        )
+        self.placeholder = self.target.placeholder
+        add_plugin(
+            self.placeholder, "LinkPlugin", "en",
+            name="SuperSecretLinkName", external_link="https://secret.example.com",
+        )
+
+    def _staff_with_perm(self, codename):
+        staff = self._create_user(f"staff_{codename}", is_staff=True, is_superuser=False)
+        staff.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="placeholderapp", codename=codename
+            )
+        )
+        return staff
+
+    def _urls(self):
+        return {
+            "preview": get_object_preview_url(self.target, language="en"),
+            "edit": get_object_edit_url(self.target, language="en"),
+        }
+
+    def test_denies_staff_without_view_permission(self):
+        staff = self.get_staff_user_with_no_permissions()
+        with self.login_user_context(staff):
+            for name, url in self._urls().items():
+                with self.subTest(endpoint=name):
+                    response = self.client.get(url)
+                    self.assertEqual(
+                        response.status_code,
+                        404,
+                        msg=f"{name} endpoint leaked a non-PageContent object's content",
+                    )
+                    self.assertNotContains(
+                        response, "SuperSecretLinkName", status_code=404
+                    )
+
+    def test_allows_staff_with_view_permission(self):
+        staff = self._staff_with_perm("view_example1")
+        with self.login_user_context(staff):
+            for name, url in self._urls().items():
+                with self.subTest(endpoint=name):
+                    self.assertContains(self.client.get(url), "SuperSecretLinkName")
+
+    def test_allows_staff_with_change_permission(self):
+        staff = self._staff_with_perm("change_example1")
+        with self.login_user_context(staff):
+            for name, url in self._urls().items():
+                with self.subTest(endpoint=name):
+                    self.assertContains(self.client.get(url), "SuperSecretLinkName")
+
+    def test_allows_superuser(self):
+        with self.login_user_context(self.get_superuser()):
+            for name, url in self._urls().items():
+                with self.subTest(endpoint=name):
+                    self.assertContains(self.client.get(url), "SuperSecretLinkName")

--- a/cms/views.py
+++ b/cms/views.py
@@ -329,6 +329,13 @@ def render_object_endpoint(request, content_type_id, object_id, require_editable
                     return _handle_no_apphook(request)
         else:
             content_type_obj = content_type.get_object_for_this_type(pk=object_id)
+            # Enforce the same object-level view check as the structure endpoint
+            # (and, for the page branch above, render_page()'s user_can_view_page).
+            # Without this, any staff user could read the rendered plugin content
+            # of any frontend-editable object. Mutations remain gated by change
+            # permission at the plugin endpoints.
+            if not user_can_view_placeholder_source(request.user, content_type_obj):
+                raise Http404
     except ObjectDoesNotExist as err:
         raise Http404 from err
 


### PR DESCRIPTION
## Summary by Sourcery

Protect frontend edit and preview endpoints with placeholder source permissions to prevent unauthorized content disclosure.

Bug Fixes:
- Enforce object-level view permissions for edit and preview endpoints serving non-PageContent objects, preventing unauthorized staff users from accessing rendered plugin content.

Tests:
- Add coverage verifying preview and edit access for users with view, change, or superuser permissions and denying users without object permissions.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.