### PR TITLE
fix: Release scripts silently produced an empty changelog

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -18,6 +18,12 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v7
+        with:
+          # The changelog is generated from the commits between the previous
+          # tag and HEAD. The default shallow checkout has no such history and
+          # silently produces an empty changelog.
+          fetch-depth: 0
+          fetch-tags: true
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7
       - name: Start building version ${{ inputs.version }}

--- a/scripts/make-changelog
+++ b/scripts/make-changelog
@@ -10,13 +10,17 @@ source "${SCRIPTS}/functions"
 
 # Scopes used in this script. Keep this compatible with the Bash 3 version
 # shipped by macOS, which does not support associative arrays.
-SCOPES=("feat" "security" "fix" "perf" "style" "refactor" "docs" "tools")
+# Not every type accepted by .github/workflows/lint-pr.yml belongs in the
+# changelog: build, chore, ci and test are deliberately left out as internal
+# noise. Reverts are user visible and share the "Bug Fixes:" heading.
+SCOPES=("feat" "security" "fix" "revert" "perf" "style" "refactor" "docs" "tools")
 
 scope_heading() {
     case "$1" in
         feat) echo "Features:" ;;
         security) echo "Security Updates:" ;;
         fix) echo "Bug Fixes:" ;;
+        revert) echo "Bug Fixes:" ;;
         perf) echo "Performance Improvements:" ;;
         style) echo "Styles:" ;;
         refactor) echo "Refactoring and Cleanups:" ;;
@@ -29,6 +33,28 @@ scope_heading() {
 # Conventional commit types included in the generated changelog. Backward
 # incompatible changes deliberately remain a manually maintained section.
 CHANGELOG_TYPES=$(IFS='|'; echo "${SCOPES[*]}")
+
+# awk helper shared by the entry, contributor and reviewer passes: bots and the
+# release automation must not be credited as contributors.
+read -r -d '' AWK_AUTOMATED <<'AWK'
+function automated(name, normalized) {
+    normalized=tolower(name)
+    return normalized ~ /\[bot\]/ || normalized ~ /(^|[^a-z])copilot([^a-z]|$)/ \
+        || normalized ~ /(^|[^a-z])claude([^a-z]|$)/ || normalized ~ /sourcery/ \
+        || normalized ~ /dependabot/ || normalized ~ /github release action/ \
+        || normalized ~ /django cms release/ || normalized == "unknown"
+}
+# Backports repeat the subject of the commit they port, with an extra pull
+# request reference. Strip every reference to recognise them as one entry.
+function entry_key(subject, normalized) {
+    normalized=tolower(subject)
+    gsub(/\(#[0-9]+\)/, "", normalized)
+    gsub(/[[:space:]]+/, " ", normalized)
+    sub(/^[[:space:]]+/, "", normalized)
+    sub(/[[:space:]]+$/, "", normalized)
+    return normalized
+}
+AWK
 VERSION_FIELD_RE='^[0-9]+\.[0-9]+\.[0-9]+'
 
 changelog_check_version() {
@@ -80,6 +106,24 @@ fi
 # Sanity checks
 if [ -z "$(git tag -l "${OLD_FULL_VERSION}")" ]; then
     error "Can not find tag for version ${OLD_FULL_VERSION} aborting ..."
+    exit 1
+fi
+
+# The changelog is built from the commits between the previous tag and HEAD. A
+# shallow clone (the GitHub Actions checkout default) has none of that history,
+# so the generated sections would silently come out empty.
+if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+    status "Repository is shallow, fetching the full history ..."
+    git fetch --unshallow --tags --quiet || true
+fi
+if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+    error "Repository history is shallow, the changelog would be incomplete."
+    error "Re-run with a full clone (actions/checkout with fetch-depth: 0)."
+    exit 1
+fi
+if ! git merge-base --is-ancestor "${OLD_FULL_VERSION}" HEAD; then
+    error "Tag ${OLD_FULL_VERSION} is not an ancestor of HEAD."
+    error "The changelog would miss the commits of that release line."
     exit 1
 fi
 
@@ -170,12 +214,11 @@ else
         /^unreleased$/ { getline; next }
         { print }
     ' "${current}" > "${previous}"
+    # No released version carries a "Highlights:" section in the changelog:
+    # highlights belong in docs/upgrade/<version>.rst instead.
     {
         echo "${title}"
         echo "${line}"
-        echo
-        echo "Highlights:"
-        echo "-----------"
         echo
         cat "${previous}"
     } > "${current}"
@@ -184,6 +227,7 @@ fi
 
 # computing / updating each section
 
+ENTRY_COUNT=0
 for scope in "${SCOPES[@]}"; do
     content=$(mktemp)
     heading=$(scope_heading "${scope}")
@@ -191,17 +235,23 @@ for scope in "${SCOPES[@]}"; do
     # only checking on the last version *in the changelog" (ex:rc1 to rc2, the changelog already includes old to rc1)
     # Accept conventional commit scopes and breaking-change markers, for
     # example feat(admin): and fix!:, not only the unscoped "feat:" form.
-    git log "${LAST_FULL_VERSION}..HEAD" --pretty="format:%s (%h) -- %aN" \
-        | awk -v scope="${scope}" '
+    git log "${LAST_FULL_VERSION}..HEAD" --pretty="format:%s%x09%h%x09%aN" \
+        | awk -F '\t' -v scope="${scope}" "${AWK_AUTOMATED}"'
             BEGIN { pattern="^" scope "(\\([^)]*\\))?!?:[[:space:]]*" }
-            tolower($0) ~ pattern {
-                sub(/^[^:]*:[[:space:]]*/, "", $0)
-                print "* " $0
+            tolower($1) ~ pattern && !automated($3) {
+                subject=$1
+                sub(/^[^:]*:[[:space:]]*/, "", subject)
+                key=entry_key(subject)
+                if (key in seen) next
+                seen[key]=1
+                print "* " subject " (" $2 ") -- " $3
             }
         ' > "${content}"
     if [ -z "$(cat "${content}")" ]; then
+        rm "${content}"
         continue
     fi
+    ENTRY_COUNT=$(( ENTRY_COUNT + $(wc -l < "${content}") ))
 
     # making sure the heading is there:
     if ! grep -q "^${heading}\$" "${current}"; then
@@ -228,21 +278,27 @@ for scope in "${SCOPES[@]}"; do
    rm "${content}"
 done
 
+if [ "${ENTRY_COUNT}" -eq 0 ]; then
+    error "No changelog entries found between ${LAST_FULL_VERSION} and HEAD."
+    error "Either no conventional commits (${CHANGELOG_TYPES}) were made since"
+    error "${LAST_FULL_VERSION}, or the history available to git is incomplete."
+    rm -f "${current}" "${legacy}"
+    exit 1
+fi
+
 # Generate statistics from the same conventional commits that produce the
 # changelog. Calling every commit a pull request caused incorrect totals when
 # release commits, merges, or uncategorized maintenance commits were present.
 statistics=$(mktemp)
 git log "${RELEASE_BASE_VERSION}..HEAD" --pretty="format:%s%x09%aN" \
-    | awk -F '\t' -v types="${CHANGELOG_TYPES}" '
+    | awk -F '\t' -v types="${CHANGELOG_TYPES}" "${AWK_AUTOMATED}"'
         BEGIN { pattern="^(" types ")(\\([^)]*\\))?!?:[[:space:]]*" }
-        function automated(name, normalized) {
-            normalized=tolower(name)
-            return normalized ~ /\[bot\]/ || normalized ~ /(^|[^a-z])copilot([^a-z]|$)/ \
-                || normalized ~ /(^|[^a-z])claude([^a-z]|$)/ || normalized ~ /sourcery/ \
-                || normalized ~ /dependabot/ || normalized ~ /github release action/ \
-                || normalized ~ /django cms release/ || normalized == "unknown"
+        tolower($1) ~ pattern && !automated($2) {
+            key=entry_key($1)
+            if (key in seen) next
+            seen[key]=1
+            print $2
         }
-        tolower($1) ~ pattern && !automated($2) { print $2 }
     ' > "${statistics}"
 CHANGE_NUMBER=$(wc -l < "${statistics}" | tr -d ' ')
 if [ "${CHANGE_NUMBER}" -eq 1 ]; then
@@ -263,11 +319,11 @@ EOF
 while read -r name; do
     count=$(grep -Fxc "${name}" "${statistics}")
     if [ "${count}" -gt 1 ]; then
-        pl="s"
+        label="entries"
     else
-        pl=""
+        label="entry"
     fi
-    echo "* ${name} (${count} changelog entr${pl:+ies}${pl:-y})" >> "${current}"
+    echo "* ${name} (${count} changelog ${label})" >> "${current}"
 done < <(sort -u "${statistics}")
 
 # shellcheck disable=SC2129
@@ -277,14 +333,7 @@ With the review help of the following contributors:
 
 EOF
 
-git log "${RELEASE_BASE_VERSION}..HEAD" | awk '
-    function automated(name, normalized) {
-        normalized=tolower(name)
-        return normalized ~ /\[bot\]/ || normalized ~ /(^|[^a-z])copilot([^a-z]|$)/ \
-            || normalized ~ /(^|[^a-z])claude([^a-z]|$)/ || normalized ~ /sourcery/ \
-            || normalized ~ /dependabot/ || normalized ~ /github release action/ \
-            || normalized ~ /django cms release/ || normalized == "unknown"
-    }
+git log "${RELEASE_BASE_VERSION}..HEAD" | awk "${AWK_AUTOMATED}"'
     tolower($0) ~ /^[[:space:]]*co-authored-by:/ {
         sub(/^[^:]*:[[:space:]]*/, "* ")
         sub(/ <.*$/, "")

--- a/scripts/make-release
+++ b/scripts/make-release
@@ -68,20 +68,15 @@ if [ ! -d .git ] || [ ! -d "cms" ]; then
     exit 1
 fi
 
-# setup commit
-git config --local user.email "info@django-cms.org"
-git config --local user.name "Github Release Action"
-
-# check that git is configured for commit
-if ! git config user.name >/dev/null || ! git config user.email >/dev/null; then
-    error "Git must be configured for commit, please run the following commands first:"
-    echo ""
-    echo 'git config --local user.email "you@example.com"'
-    echo 'git config --local user.name "Your Name"'
-    echo ""
-    echo "or use --global to configure your git for all repo by default"
-    exit 1
-fi
+# Identity for the automated release commits. Exported as environment
+# variables (rather than written with `git config`) so the release process
+# never mutates the local git configuration of the repo it runs in, while
+# still guaranteeing an identity is available for commits (e.g. on a fresh CI
+# checkout). The bot name is excluded from the changelog contributor stats.
+export GIT_AUTHOR_NAME="Github Release Action"
+export GIT_AUTHOR_EMAIL="info@django-cms.org"
+export GIT_COMMITTER_NAME="Github Release Action"
+export GIT_COMMITTER_EMAIL="info@django-cms.org"
 
 origin=$(git remote -v | grep push | grep origin | awk '{print $2}')
 
@@ -116,6 +111,12 @@ fi
 OLDVER=$(python -c "import cms; print(cms.__version__)" )
 
 git fetch --all --tags --quiet
+# Deepen a shallow checkout (e.g. actions/checkout default depth 1), otherwise
+# `git log <tag>..` in make-changelog is truncated at the shallow boundary and
+# silently drops PRs from the changelog and statistics.
+if [ "$(git rev-parse --is-shallow-repository 2>/dev/null)" = "true" ]; then
+    git fetch --unshallow --quiet
+fi
 if [ -z "$(git tag -l "${OLDVER}")" ]; then
     error "Can not find tag for version ${OLDVER} aborting ..."
     exit 1


### PR DESCRIPTION
Release-tooling only — no release content, no merge-back.

## The bug

`.github/workflows/make-release.yml` checked out at the default depth of 1. `make-changelog` builds every section from `git log <previous-tag>..HEAD`, which on a shallow clone has no history to walk, so all sections came out empty and the statistics counted zero. That is how 5.1.2 was built: a release section with no entries and no contributors. Nothing failed — `make-changelog` exited 0, so `make-release`'s `|| echo "Manual update of changelog necessary"` fallback never fired.

`release/5.0.x` has always had `fetch-depth: 0`, with a comment explaining why. It was never on this line.

## Changes

**`.github/workflows/make-release.yml`** — `fetch-depth: 0` and `fetch-tags: true`.

**`scripts/make-changelog`**

* Aborts before touching `CHANGELOG.rst` if the repository is still shallow after trying to unshallow, if the base tag is not an ancestor of `HEAD`, or if zero entries were collected. Any of the three used to produce a silently wrong file.
* Adds `revert` to the scanned commit types (it shares the `Bug Fixes:` heading). `build`, `chore`, `ci` and `test` stay out deliberately, now with a comment saying so rather than looking like an oversight.
* Filters bot authors out of the generated entries, not only out of the statistics — dependabot bumps previously would have been listed.
* Collapses backports against their originals by stripping `(#NNNN)` references when comparing subjects, so a fix and its backport count once.
* Drops the `Highlights:` heading. It is emitted for every new version line and then deleted by hand every release — no released changelog has ever carried one. Highlights belong in `docs/upgrade/<version>.rst`, where they are a real section.
* Fixes the contributor plural: `entr${pl:+ies}${pl:-y}` renders `entriess` for any count above one.
* De-duplicates the `automated()` awk helper that was copy-pasted three times.

**`scripts/make-release`**

* Deepens a shallow checkout defensively, so a manual run against one works too.
* Sets the release identity through `GIT_AUTHOR_*` / `GIT_COMMITTER_*` instead of `git config --local`. The old code permanently rewrote `user.name` and `user.email` in whatever repository it ran in, which is unpleasant for a release manager running it locally. This matches what `release/5.0.x` already does.

## Verification

Replayed `make-changelog` against `13b99be83`, the commit 5.1.2's changelog was generated from: 16 entries — 1 feature, 12 bug fixes, 3 internal tools — with `#8779` collapsed into `#8777` and the three dependabot bumps excluded, against zero entries before. Replayed the same from a `--depth 1` clone: the guard fired, unshallowed, and produced identical output. Also ran it against `release/5.0.x` at `040a7b1ba` asking for 5.0.11, where the older script on that branch had merged the entries into the *previous* release's section — the rewritten one opens the section correctly.

## Follow-up

`release/5.0.x` carries an older `make-changelog` with three further bugs of its own (a version regex that cannot parse a two-digit patch number, a second regex that disagrees with it, and a heading insertion anchored on an `unreleased` marker that no longer exists). That is what mis-filed 5.0.11's entries into the 5.0.10 section. It is handled separately in the 5.0.11 release PR.

## Summary by Sourcery

Harden release tooling to generate accurate changelogs and fail safely when the required repository history is unavailable.

Bug Fixes:
- Prevent release changelog generation from silently producing empty or incorrect content when history is unavailable, invalid, or yields no entries.
- Correct changelog entry filtering, duplicate backport handling, contributor statistics, and release-section placement.

Enhancements:
- Improve release tooling by excluding automated authors, removing unused Highlights sections, and simplifying shared commit classification logic.
- Preserve developers’ local Git identity settings by configuring release commit identity through environment variables.

CI:
- Use complete commit history and tags in the release workflow so changelog generation can inspect commits between release tags.

Tests:
- Verify changelog generation from full and shallow checkouts, including history recovery and representative previous-release scenarios.