### PR TITLE
fix: Some inline editing modals did not contain _popup=1 query param for Django

### DIFF
--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -5,6 +5,7 @@ from urllib.parse import parse_qsl, urlparse
 
 from django.contrib import admin
 from django.contrib.admin.helpers import AdminForm
+from django.contrib.admin.options import IS_POPUP_VAR
 from django.contrib.admin.utils import flatten_fieldsets, get_deleted_objects
 from django.core.exceptions import PermissionDenied
 from django.db import models, transaction
@@ -1229,6 +1230,10 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
             "opts": opts,
             "app_label": opts.app_label,
             "delete_confirmation_max_display": getattr(self, "delete_confirmation_max_display", None),
+            # This view is only ever shown inside the CMS modal: render it without the
+            # admin chrome, like the other frontend editing views do.
+            "is_popup": True,
+            "is_popup_var": IS_POPUP_VAR,
         }
         request.current_app = self.admin_site.name
         return TemplateResponse(
@@ -1329,6 +1334,10 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
             "opts": opts,
             "app_label": opts.app_label,
             "delete_confirmation_max_display": getattr(self, "delete_confirmation_max_display", None),
+            # This view is only ever shown inside the CMS modal: render it without the
+            # admin chrome, like the other frontend editing views do.
+            "is_popup": True,
+            "is_popup_var": IS_POPUP_VAR,
         }
         request.current_app = self.admin_site.name
         return TemplateResponse(request, "admin/cms/page/plugin/delete_confirmation.html", context)

--- a/cms/static/cms/js/modules/cms.base.js
+++ b/cms/static/cms/js/modules/cms.base.js
@@ -468,13 +468,14 @@ export const Helpers = {
      * @function updateUrlWithPath
      * @private
      * @param {String} url url
+     * @param {Array[]} [params] additional array of [`param`, `value`] arrays to set on the url
      * @returns {String} modified url
      */
-    updateUrlWithPath: function(url) {
+    updateUrlWithPath: function(url, params) {
         var win = this._getWindow();
         var path = win.location.pathname + win.location.search;
 
-        return this.makeURL(url, [['cms_path', path]]);
+        return this.makeURL(url, [['cms_path', path]].concat(params || []));
     },
 
     /**

--- a/cms/static/cms/js/modules/cms.toolbar.js
+++ b/cms/static/cms/js/modules/cms.toolbar.js
@@ -617,7 +617,7 @@ class Toolbar {
                 });
 
                 modal.open({
-                    url: Helpers.updateUrlWithPath(el.attr('href')) + '&_popup=1',
+                    url: Helpers.updateUrlWithPath(el.attr('href'), [['_popup', 1]]),
                     title: el.data('name')
                 });
                 break;

--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -16,6 +16,7 @@ from classytags.utils import flatten_context
 from classytags.values import ListValue, StringValue
 from django import template
 from django.conf import settings
+from django.contrib.admin.options import IS_POPUP_VAR
 from django.contrib.sites.models import Site
 from django.core.mail import mail_managers
 from django.db.models import Model
@@ -546,6 +547,12 @@ class CMSEditableObject(InclusionTag):
                 extra_context["attribute_name"] = "add"
             extra_context["instance"] = instance
             extra_context["generic"] = opts
+            # Django only renders an admin add/change form without the admin chrome
+            # (branding, nav sidebar, breadcrumbs) - and only answers a successful save
+            # with ``admin/popup_response.html``, which the CMS modal uses to close
+            # itself - if the ``_popup`` flag is present. The CMS' own frontend editing
+            # views (``edit_field``, the changelist) do not take the flag.
+            is_admin_changeform = False
             # view_method has the precedence and we retrieve the corresponding
             # attribute in the instance class.
             # If view_method refers to a method it will be called passing the
@@ -562,6 +569,7 @@ class CMSEditableObject(InclusionTag):
                 if not editmode:
                     view_url = f"admin:{opts.app_label}_{opts.model_name}_add"
                     url_base = reverse(view_url)
+                    is_admin_changeform = True
                 elif not edit_fields:
                     if not view_url:
                         view_url = f"admin:{opts.app_label}_{opts.model_name}_change"
@@ -569,6 +577,7 @@ class CMSEditableObject(InclusionTag):
                         url_base = reverse(view_url, args=(instance.pk, language))
                     else:
                         url_base = reverse(view_url, args=(instance.pk,))
+                    is_admin_changeform = True
                 else:
                     if not view_url:
                         if isinstance(instance, CMSPlugin):
@@ -582,7 +591,11 @@ class CMSEditableObject(InclusionTag):
                         url_base = reverse(view_url, args=(instance.pk, language))
                     querystring["edit_fields"] = ",".join(context["edit_fields"])
             if editmode:
+                if is_admin_changeform:
+                    querystring[IS_POPUP_VAR] = 1
                 extra_context["edit_url"] = f"{url_base}?{urlencode(querystring)}"
+            elif is_admin_changeform:
+                extra_context["edit_url"] = f"{url_base}?{urlencode({IS_POPUP_VAR: 1})}"
             else:
                 extra_context["edit_url"] = "%s" % url_base
             extra_context["refresh_page"] = True

--- a/cms/tests/frontend/unit/cms.base.test.js
+++ b/cms/tests/frontend/unit/cms.base.test.js
@@ -829,6 +829,32 @@ describe('cms.base.js', function() {
 
                 expect(CMS.API.Helpers.updateUrlWithPath('/')).toEqual('/?cms_path=%2Fde%2F%3Flanguage%3Den');
             });
+
+            it('sets additional params on urls that have no query string yet', function() {
+                spyOn(CMS.API.Helpers, '_getWindow').and.returnValue({
+                    location: {
+                        pathname: '/de/',
+                        search: ''
+                    }
+                });
+
+                expect(CMS.API.Helpers.updateUrlWithPath('/admin/app/model/1/change/', [['_popup', 1]])).toEqual(
+                    '/admin/app/model/1/change/?cms_path=%2Fde%2F&_popup=1'
+                );
+            });
+
+            it('sets additional params on urls that already have a query string', function() {
+                spyOn(CMS.API.Helpers, '_getWindow').and.returnValue({
+                    location: {
+                        pathname: '/de/',
+                        search: ''
+                    }
+                });
+
+                expect(
+                    CMS.API.Helpers.updateUrlWithPath('/admin/app/model/1/change/?language=en', [['_popup', 1]])
+                ).toEqual('/admin/app/model/1/change/?language=en&cms_path=%2Fde%2F&_popup=1');
+            });
         });
 
         describe('.setColorScheme() and .getColorScheme()', function() {

--- a/cms/tests/test_plugins.py
+++ b/cms/tests/test_plugins.py
@@ -7,6 +7,7 @@ from unittest import mock, skipIf
 from django import http
 from django.conf import settings
 from django.contrib import admin
+from django.contrib.admin.options import IS_POPUP_VAR
 from django.contrib.admin.widgets import FilteredSelectMultiple, RelatedFieldWidgetWrapper
 from django.core.exceptions import ImproperlyConfigured
 from django.forms.widgets import Media
@@ -44,6 +45,7 @@ from cms.test_utils.util.context_managers import override_placeholder_conf
 from cms.toolbar.toolbar import CMSToolbar
 from cms.toolbar.utils import get_object_edit_url
 from cms.utils.plugins import copy_plugins_to_placeholder, get_plugins
+from cms.utils.urlutils import admin_reverse
 
 
 @contextmanager
@@ -549,6 +551,29 @@ class PluginsTestCase(PluginsTestBaseCase):
         self.assertContains(response, '<div class="success"></div>')
         # there should be no plugins
         self.assertEqual(0, CMSPlugin.objects.all().count())
+
+    def test_delete_confirmation_views_render_as_popup(self):
+        """Both confirmation pages are only ever shown inside the CMS modal, so they
+        have to render without the admin chrome - like the other frontend editing
+        views do."""
+        page = api.create_page(title="test page", language="en", template="nav_playground.html")
+        placeholder = page.get_placeholders("en").get(slot="body")
+        plugin = api.add_plugin(placeholder=placeholder, language="en", plugin_type="TextPlugin", body="")
+
+        endpoints = (
+            self.get_delete_plugin_uri(plugin),
+            admin_reverse("cms_placeholder_clear_placeholder", args=(placeholder.pk,)) + "?language=en",
+        )
+        for endpoint in endpoints:
+            with self.subTest(endpoint=endpoint):
+                response = self.client.get(endpoint)
+                self.assertTrue(response.context["is_popup"])
+                # The admin chrome django renders for a non-popup page
+                self.assertNotContains(response, 'id="site-name"')
+                self.assertNotContains(response, 'id="nav-sidebar"')
+                # ... and the flag has to be available to the confirmation form, so that
+                # django's stock template can carry it through the POST
+                self.assertEqual(response.context["is_popup_var"], IS_POPUP_VAR)
 
     def test_remove_plugin_not_associated_to_page(self):
         """

--- a/cms/tests/test_toolbar.py
+++ b/cms/tests/test_toolbar.py
@@ -2017,6 +2017,77 @@ class EditModelTemplateTagTest(ToolbarTestBase):
             ),
         )
 
+    def test_changeform_url_is_marked_as_popup(self):
+        """The frontend editing modal opens the plain admin changeform, which only
+        renders without the admin chrome - and only closes the modal upon saving -
+        when the ``_popup`` flag is set."""
+        user = self.get_staff()
+        page = create_page("Test", "col_two.html", "en")
+        page_content = self.get_pagecontent_obj(page)
+        edit_url = get_object_edit_url(page_content)
+        ex1 = self._get_example_obj()
+        template_text = """{% extends "base.html" %}
+{% load cms_tags %}
+
+{% block content %}
+{% render_model_block instance %}
+    {{ instance }}
+{% endrender_model_block %}
+{% endblock content %}
+"""
+        request = self.get_page_request(page, user, edit_url)
+        response = detail_view(request, ex1.pk, template_string=template_text)
+        self.assertContains(
+            response,
+            '"edit_plugin": "{}?language=en&amp;_popup=1"'.format(
+                admin_reverse("placeholderapp_example1_change", args=(ex1.pk,))
+            ),
+        )
+
+    def test_add_form_url_is_marked_as_popup(self):
+        user = self.get_staff()
+        page = create_page("Test", "col_two.html", "en")
+        page_content = self.get_pagecontent_obj(page)
+        edit_url = get_object_edit_url(page_content)
+        ex1 = self._get_example_obj()
+        template_text = """{% extends "base.html" %}
+{% load cms_tags %}
+
+{% block content %}
+{% render_model_add instance %}
+{% endblock content %}
+"""
+        request = self.get_page_request(page, user, edit_url)
+        response = detail_view(request, ex1.pk, template_string=template_text)
+        self.assertContains(
+            response,
+            '"edit_plugin": "{}?_popup=1"'.format(admin_reverse("placeholderapp_example1_add")),
+        )
+
+    def test_edit_field_url_is_not_marked_as_popup(self):
+        """``edit_field`` is a cms view rendering its own chrome-less template: it
+        neither needs nor understands the ``_popup`` flag."""
+        user = self.get_staff()
+        page = create_page("Test", "col_two.html", "en")
+        page_content = self.get_pagecontent_obj(page)
+        edit_url = get_object_edit_url(page_content)
+        ex1 = self._get_example_obj()
+        template_text = """{% extends "base.html" %}
+{% load cms_tags %}
+
+{% block content %}
+<h1>{% render_model instance "char_1" "char_1" %}</h1>
+{% endblock content %}
+"""
+        request = self.get_page_request(page, user, edit_url)
+        response = detail_view(request, ex1.pk, template_string=template_text)
+        self.assertContains(
+            response,
+            '"edit_plugin": "{}?language=en&amp;edit_fields=char_1"'.format(
+                admin_reverse("placeholderapp_example1_edit_field", args=(ex1.pk, "en"))
+            ),
+        )
+
     def test_invalid_attribute(self):
         user = self.get_staff()
         page = create_page("Test", "col_two.html", "en")


### PR DESCRIPTION
## Summary by Sourcery

Ensure all Django admin forms and confirmation views opened by CMS modals use the popup behavior required for correct rendering and modal lifecycle.

Bug Fixes:
- Ensure Django admin change and add forms opened in CMS editing modals receive the `_popup=1` flag so they render without admin chrome and close the modal correctly after saving.
- Render plugin deletion and placeholder clearing confirmation views as popup pages.

Enhancements:
- Allow URL updates to include additional query parameters while preserving existing parameters and the CMS path.

Tests:
- Add frontend tests for appending additional URL parameters.
- Add coverage for popup rendering in deletion confirmations and for popup flags on add/change form URLs, while ensuring CMS field-editing URLs remain unchanged.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.