### PR TITLE
fix: Object tools moved in Django 6.1 admin templates

### DIFF
--- a/cms/templates/admin/cms/page/change_form.html
+++ b/cms/templates/admin/cms/page/change_form.html
@@ -30,19 +30,25 @@
 {% endblock %}
 
 {% block content_title %}
+    {% django_version_gte 6 1 as object_tools_in_title_bar %}
     {% if title %}<h1>{{ title }}</h1>{% endif %}
-    {% get_edit_url original as admin_url %}
-    {% if not popup and not add %}
-        <ul class="object-tools hide-in-modal">
-            <li>
-                <a href="{{ admin_url }}" target="_parent">{% trans "View on site" %}</a>
-            </li>
-        </ul>
-    {% endif %}
+    {# Django 6.1 has a dedicated tools slot next to the title: see the object-tools block below. #}
+    {% if not object_tools_in_title_bar %}{% include "admin/cms/page/includes/object_tools.html" %}{% endif %}
 {% endblock %}
 {% block content %}
+{% django_version_gte 6 1 as object_tools_in_title_bar %}
 <div id="content-main">
-{% block object-tools %}{% endblock %}
+{# Django 6.1 moved the object-tools block out of the content block, into the ".titles-and-tools" #}
+{# bar of admin/base.html. Keep defining the block here, so that it still replaces the admin's #}
+{# default History / View on site tools, but only render it in the legacy nested position on #}
+{# Django < 6.1: on 6.1 the parent template already renders it above, and rendering it here as #}
+{# well would emit any downstream override twice. #}
+{% if not object_tools_in_title_bar %}
+{% block object-tools %}
+    {% django_version_gte 6 1 as object_tools_in_title_bar %}
+    {% if object_tools_in_title_bar %}{% include "admin/cms/page/includes/object_tools.html" %}{% endif %}
+{% endblock %}
+{% endif %}
 
 <form {% if has_file_field %}enctype="multipart/form-data" {% endif %}action="?language={{ language }}{% if request.GET.site %}&amp;site={{ request.GET.site }}{% endif %}{% if request.GET.parent_page %}&amp;parent_page={{ request.GET.parent_page }}{% endif %}{%if request.GET.source %}&amp;source={{ request.GET.source }}{% endif %}" method="post" id="{{ opts.model_name }}_form">
 {% csrf_token %}

--- a/cms/templates/admin/cms/page/includes/object_tools.html
+++ b/cms/templates/admin/cms/page/includes/object_tools.html
@@ -1,0 +1,9 @@
+{% load i18n cms_admin %}
+{% get_edit_url original as admin_url %}
+{% if not popup and not add %}
+    <ul class="object-tools hide-in-modal">
+        <li>
+            <a href="{{ admin_url }}" target="_parent">{% trans "View on site" %}</a>
+        </li>
+    </ul>
+{% endif %}

--- a/cms/test_utils/project/templates/admin/cms/page/change_form_object_tools_test.html
+++ b/cms/test_utils/project/templates/admin/cms/page/change_form_object_tools_test.html
@@ -1,0 +1,9 @@
+{# Used by cms.tests.test_templatetags.AdminObjectToolsPlacementTests: a real downstream child #}
+{# template overriding {% block object-tools %}, the way a project or third-party app would. #}
+{% extends "admin/cms/page/change_form.html" %}
+
+{% block object-tools %}
+<ul class="object-tools downstream-object-tools">
+    <li><a href="/downstream/" class="downstream-tool-link">Downstream tool</a></li>
+</ul>
+{% endblock %}

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -2,6 +2,7 @@ import os
 from copy import deepcopy
 from unittest.mock import patch
 
+import django
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.sessions.backends.base import SessionBase
@@ -21,6 +22,7 @@ from djangocms_text.cms_plugins import TextPlugin
 from sekizai.context import SekizaiContext
 
 import cms
+from cms.admin.pageadmin import PageContentAdmin
 from cms.api import add_plugin, create_page, create_page_content
 from cms.middleware.toolbar import ToolbarMiddleware
 from cms.models import (
@@ -911,3 +913,88 @@ class AdminBreadcrumbMarkupTests(CMSTestCase):
         self.assertIn('<ol class="breadcrumbs">', html)
         self.assertIn('aria-current="page"', html)
         self.assertNotIn('<div class="breadcrumbs">', html)
+
+
+class AdminObjectToolsPlacementTests(CMSTestCase):
+    """Django 6.1 moved ``{% block object-tools %}`` out of ``{% block content %}``: it is now a
+    top-level block that ``admin/base.html`` renders in the ``.titles-and-tools`` bar next to the
+    page title. ``admin/cms/page/change_form.html`` still has to *define* the block nested inside
+    its own ``content`` override (that is what suppresses the admin's default History tool), so the
+    block node has to be rendered conditionally -- otherwise Django renders it both from the 6.1
+    top-level position and again from the nested one, and every downstream override shows up twice.
+    """
+
+    #: ``True`` when the running Django renders ``object-tools`` outside ``content``.
+    OBJECT_TOOLS_OUTSIDE_CONTENT = django.VERSION[:2] >= (6, 1)
+
+    #: A real child template overriding ``{% block object-tools %}``, the way a project or a
+    #: third-party app (djangocms-versioning, djangocms-alias, ...) would.
+    DOWNSTREAM_TEMPLATE = "admin/cms/page/change_form_object_tools_test.html"
+    DOWNSTREAM_MARKER = "downstream-tool-link"
+
+    def _get_page_change_html(self, page, change_form_template=None):
+        with self.login_user_context(self.get_superuser()):
+            if change_form_template is None:
+                response = self.client.get(self.get_page_change_uri("en", page))
+            else:
+                with patch.object(PageContentAdmin, "change_form_template", change_form_template):
+                    response = self.client.get(self.get_page_change_uri("en", page))
+        self.assertEqual(response.status_code, 200)
+        return response.content.decode("utf-8")
+
+    # -- downstream overrides of {% block object-tools %} --
+
+    def test_downstream_object_tools_rendered_once(self):
+        """A child template's object-tools must not be emitted twice on Django 6.1."""
+        page = create_page("Home", "nav_playground.html", "en")
+        html = self._get_page_change_html(page, self.DOWNSTREAM_TEMPLATE)
+        self.assertEqual(
+            html.count(self.DOWNSTREAM_MARKER),
+            1,
+            "Downstream object-tools override must render exactly once.",
+        )
+
+    def test_downstream_object_tools_placement_relative_to_content_main(self):
+        """The single render must sit in the position the running Django expects."""
+        page = create_page("Home", "nav_playground.html", "en")
+        html = self._get_page_change_html(page, self.DOWNSTREAM_TEMPLATE)
+
+        content_main_index = html.index('id="content-main"')
+
+        if self.OBJECT_TOOLS_OUTSIDE_CONTENT:
+            # ``rindex``: the *last* occurrence must already be before #content-main, so a stray
+            # second render in the legacy nested position fails here too.
+            self.assertLess(
+                html.rindex(self.DOWNSTREAM_MARKER),
+                content_main_index,
+                "On Django >= 6.1 object-tools belong outside (before) #content-main.",
+            )
+        else:
+            self.assertGreater(
+                html.index(self.DOWNSTREAM_MARKER),
+                content_main_index,
+                "On Django < 6.1 object-tools belong in the legacy position inside #content-main.",
+            )
+
+    # -- the default page actions shipped by django CMS --
+
+    def test_default_page_object_tools_rendered_once(self):
+        """django CMS' own "View on site" tool renders once, and replaces the admin default."""
+        page = create_page("Home", "nav_playground.html", "en")
+        html = self._get_page_change_html(page)
+
+        self.assertEqual(html.count('class="object-tools hide-in-modal"'), 1)
+        self.assertEqual(html.count("View on site"), 1)
+        # The admin's default object tools are replaced, not added to.
+        self.assertNotIn("historylink", html)
+
+    def test_default_page_object_tools_outside_content_main(self):
+        """The page actions render in the title/tools area, never inside the form column."""
+        page = create_page("Home", "nav_playground.html", "en")
+        html = self._get_page_change_html(page)
+
+        self.assertLess(
+            html.index('class="object-tools hide-in-modal"'),
+            html.index('id="content-main"'),
+        )
+


### PR DESCRIPTION
## Summary by Sourcery

Fix page object-tools placement for Django 6.1 while retaining compatibility with earlier admin template layouts.

Bug Fixes:
- Ensure Django CMS page object tools render in the correct location on Django 6.1 and are not duplicated for downstream template overrides.

Enhancements:
- Extract the page object-tools markup into a reusable template include while preserving compatibility with older Django admin layouts.

Tests:
- Add coverage for default and downstream object-tools rendering, placement, and suppression of Django’s default history tool across supported Django versions.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* fixes #8765
* This is for downstream apps (no issue with Django CMS) which fill the object tools for Django CMS admin endpoints

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.