### PR TITLE
chore: Harden JS to prevent future security issues

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main", "develop-4", "release/0.10.x", "release/2.1.x", "release/2.2.x", "release/2.3.x", "release/2.4.x", "release/3.0.x", "release/3.1.x", "release/3.2.x", "release/3.3.x", "release/3.4.x", "release/3.5.x", "release/3.6.x", "release/3.7.x", "release/3.8.x", "release/3.9.x", "release/3.10.x", "release/3.11.x", "release/4.0.x", "release/4.0.0.x", "release/4.0.1.x", "release/4.1.x" , "release/5.0.x"]
+    branches: [ "main", "release/5.0.x", "release/5.1.x"]
   pull_request:
-    branches: [ "develop" ]
+    branches: [ "main" ]
   schedule:
     - cron: "40 4 * * 6"
 
@@ -30,7 +30,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          queries: +security-and-quality
+          queries: +security-extended
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4

--- a/cms/static/cms/js/admin/actions.js
+++ b/cms/static/cms/js/admin/actions.js
@@ -24,23 +24,34 @@
                     }
                 } else {
                     e.preventDefault();
-                    /* Get csrftoken either from form (admin) or from the toolbar */
-                    let formToken = document.querySelector('form input[name="csrfmiddlewaretoken"]');
-                    let csrfToken = '<input type="hidden" name="csrfmiddlewaretoken" value="' +
-                        ((formToken ? formToken.value : formToken) || window.CMS.config.csrf) + '">';
-                    let fakeForm = $(
-                        '<form style="display: none" action="' + action.attr('href') + '" method="' +
-                               formMethod + '">' + csrfToken +
-                        '</form>'
-                    );
                     let body = window.top.document.body;
 
                     if (keepSideFrame) {
                         body = window.document.body;
-                    } else {
+                    }
+
+                    /* Get csrftoken either from form (admin) or from the toolbar */
+                    let formToken = document.querySelector('form input[name="csrfmiddlewaretoken"]');
+                    /* Build the form through the DOM API: the href and the token must never be
+                       interpolated into an HTML string, since jQuery hands back the *decoded*
+                       attribute value and a quote in it would break out of the attribute. */
+                    let doc = body.ownerDocument;
+                    let fakeForm = doc.createElement('form');
+                    let tokenInput = doc.createElement('input');
+
+                    fakeForm.style.display = 'none';
+                    fakeForm.setAttribute('method', formMethod);
+                    fakeForm.setAttribute('action', action.attr('href'));
+
+                    tokenInput.setAttribute('type', 'hidden');
+                    tokenInput.setAttribute('name', 'csrfmiddlewaretoken');
+                    tokenInput.value = (formToken ? formToken.value : formToken) || window.CMS.config.csrf;
+                    fakeForm.appendChild(tokenInput);
+
+                    if (!keepSideFrame) {
                         closeSideFrame();
                     }
-                    fakeForm.appendTo(body).submit();
+                    $(fakeForm).appendTo(body).submit();
                 }
             });
 

--- a/cms/static/cms/js/modules/cms.modal.js
+++ b/cms/static/cms/js/modules/cms.modal.js
@@ -754,7 +754,11 @@ class Modal {
                 cls = 'cms-btn cms-btn-caution';
             }
 
-            var el = $('<a href="#" class="' + cls + ' ' + item.attr('class') + '">' + title + '</a>');
+            // the title comes from the admin page inside the iframe, so it is set as text
+            // rather than interpolated into an HTML string
+            var el = $('<a href="#"></a>')
+                .attr('class', cls + ' ' + item.attr('class'))
+                .text(title);
 
 
             el.on(that.click + ' ' + that.touchEnd, function(e) {

--- a/cms/static/cms/js/modules/cms.pagetree.js
+++ b/cms/static/cms/js/modules/cms.pagetree.js
@@ -899,11 +899,22 @@ class PageTree {
                     parent = window.parent;
                 }
                 let formToken = document.querySelector('form input[name="csrfmiddlewaretoken"]');
-                let csrfToken = '<input type="hidden" name="csrfmiddlewaretoken" value="' +
-                    ((formToken ? formToken.value : formToken) || window.CMS.config.csrf) + '">';
+                /* Build the form through the DOM API: the href and the token must never be
+                   interpolated into an HTML string, since jQuery hands back the *decoded*
+                   attribute value and a quote in it would break out of the attribute. */
+                let doc = parent.document;
+                let fakeForm = doc.createElement('form');
+                let tokenInput = doc.createElement('input');
 
-                $('<form method="post" action="' + element.attr('href') + '">' +
-                    csrfToken + '</form>')
+                fakeForm.setAttribute('method', 'post');
+                fakeForm.setAttribute('action', element.attr('href'));
+
+                tokenInput.setAttribute('type', 'hidden');
+                tokenInput.setAttribute('name', 'csrfmiddlewaretoken');
+                tokenInput.value = (formToken ? formToken.value : formToken) || window.CMS.config.csrf;
+                fakeForm.appendChild(tokenInput);
+
+                $(fakeForm)
                     .appendTo($(parent.document.body))
                     .submit();
                 return;


### PR DESCRIPTION
## Summary by Sourcery

Harden JavaScript-generated DOM content and expand security analysis to reduce future injection risks.

Bug Fixes:
- Prevent JavaScript-generated forms from allowing URLs or CSRF tokens to break out of HTML attributes.
- Prevent modal action titles from being interpreted as HTML.

Enhancements:
- Harden client-side DOM handling by constructing forms and modal links without unsafe HTML interpolation.

CI:
- Restrict CodeQL scanning to active branches and pull requests targeting main.
- Expand CodeQL analysis to the security-extended query set.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.