### PR TITLE
fix: Slug uniqueness ignored site

### DIFF
--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -1017,7 +1017,11 @@ class MovePageForm(PageTreeForm):
         return target_page.parent
 
     def _validate_slug_uniqueness(self, parent, language, slug):
-        target_siblings = Page.objects.filter(parent=parent).exclude(pk=self.page.pk)
+        target_siblings = Page.objects.filter(
+            parent=parent,
+            site=self._site,
+            is_page_type=self.page.is_page_type,
+        ).exclude(pk=self.page.pk)
         if target_siblings.filter(urls__slug=slug, urls__language=language).exists():
             raise ValidationError(
                 _(

--- a/cms/static/cms/sass/components/_toolbar.scss
+++ b/cms/static/cms/sass/components/_toolbar.scss
@@ -123,6 +123,7 @@
         padding: $toolbar-menu-item-padding;
         line-height: $toolbar-height;
         height: $toolbar-height;
+        text-decoration: none;
         cursor: default;
     }
     li ul {

--- a/cms/tests/test_forms.py
+++ b/cms/tests/test_forms.py
@@ -24,7 +24,7 @@ from cms.forms.utils import (
     update_site_and_page_choices,
 )
 from cms.forms.widgets import ApplicationConfigSelect
-from cms.models import ACCESS_PAGE, ACCESS_PAGE_AND_CHILDREN
+from cms.models import ACCESS_PAGE, ACCESS_PAGE_AND_CHILDREN, Page
 from cms.test_utils.testcases import (
     URL_CMS_PAGE_ADVANCED_CHANGE,
     URL_CMS_PAGE_PERMISSIONS,
@@ -337,6 +337,26 @@ class FormsTestCase(CMSTestCase):
             str(form.errors["__all__"]),
             "Form should report slug collision error",
         )
+
+    def test_move_root_page_form_ignores_other_sites(self):
+        """Moving a root page must only check its siblings on the page's own site (#8830)"""
+        site2 = Site.objects.create(pk=2, domain="site2.com", name="site2")
+
+        # Identical root level trees on both sites, as produced by ``manage.py cms copy-site``
+        for site in (self.site, site2):
+            create_page("A", "nav_playground.html", "de", slug="a", site=site)
+            create_page("B", "nav_playground.html", "de", slug="b", site=site)
+
+        page_b = Page.objects.filter(site=site2, urls__slug="b", urls__language="de").distinct().get()
+
+        data = {
+            "target": "",  # root level
+            "position": 0,
+            "site": site2.pk,
+        }
+        with force_language("de"):
+            form = forms.MovePageForm(data=data, page=page_b, site=site2)
+            self.assertTrue(form.is_valid(), form.errors)
 
     def test_move_page_form_child_parent_slug_collision(self):
         """Test that pages cannot be moved to create duplicate slugs at the same level"""


### PR DESCRIPTION
## Summary by Sourcery

Ensure page moves validate slug uniqueness within the correct site and page type while refining toolbar link styling.

Bug Fixes:
- Restrict page slug uniqueness checks to sibling pages on the same site and of the same page type, preventing false collisions across sites.

Enhancements:
- Prevent toolbar menu links from displaying underlined text.

Tests:
- Add coverage for moving root pages between sites with identical slugs.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* fixes #8830
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.