### PR TITLE
fix: Migration 0045 failed on PostgreSQL for databases with duplicate page paths (#8823)

### DIFF
--- a/cms/migrations/0045_pageurl_site_unique_path.py
+++ b/cms/migrations/0045_pageurl_site_unique_path.py
@@ -38,6 +38,24 @@ def _resolve_duplicate_paths(apps, schema_editor):
         ).exclude(pk=duplicate["first_pk"]).update(path=None)
 
 
+def _flush_deferred_constraints(apps, schema_editor):
+    """Run the deferred constraint checks the updates above have queued.
+
+    ``_fill_site`` writes a new version of every ``PageUrl`` row and
+    ``_resolve_duplicate_paths`` writes some of them a second time. PostgreSQL
+    queues a deferred foreign key check for every row whose previous version
+    was written by the current transaction -- even when no key column changed
+    -- so the twice-written rows leave pending trigger events behind. The
+    ``ALTER TABLE`` of the unique constraint below then fails with "cannot
+    ALTER TABLE cms_pageurl because it has pending trigger events" (#8818).
+
+    ``SET CONSTRAINTS ALL IMMEDIATE`` runs those checks now and keeps
+    deferrable constraints immediate for the rest of this transaction.
+    """
+    if schema_editor is not None and schema_editor.connection.vendor == "postgresql":
+        schema_editor.execute("SET CONSTRAINTS ALL IMMEDIATE")
+
+
 class Migration(migrations.Migration):
     dependencies = [
         ("cms", "0044_pagecontent_slug_overwrite_url"),
@@ -70,6 +88,9 @@ class Migration(migrations.Migration):
             ),
         ),
         migrations.RunPython(_resolve_duplicate_paths, migrations.RunPython.noop, elidable=False),
+        migrations.RunPython(
+            _flush_deferred_constraints, migrations.RunPython.noop, elidable=False
+        ),
         migrations.AddConstraint(
             model_name="pageurl",
             constraint=models.UniqueConstraint(

--- a/cms/tests/test_migrations.py
+++ b/cms/tests/test_migrations.py
@@ -8,10 +8,11 @@ from django.db.migrations.state import ProjectState
 from django.test import TestCase, TransactionTestCase, override_settings
 
 from cms.api import create_page, create_page_content
-from cms.models import PageContent
+from cms.models import PageContent, PageUrl
 from cms.test_utils.testcases import CMSTestCase
 
 migration_0044 = importlib.import_module("cms.migrations.0044_pagecontent_slug_overwrite_url")
+migration_0045 = importlib.import_module("cms.migrations.0045_pageurl_site_unique_path")
 
 
 class MigrationTestCase(TestCase):
@@ -174,3 +175,140 @@ class AddFieldKeepingDatabaseUniquenessTestCase(TransactionTestCase):
         self.assertTrue(self.has_unique_constraint(new_model))
         with self.assertRaises(IntegrityError), transaction.atomic():
             new_model.objects.create(language="en", page=1, slug="duplicate")
+
+
+class ResolveDuplicatePathsMigrationTestCase(TransactionTestCase):
+    """Exercises 0045 against a database that holds duplicate paths.
+
+    ``TransactionTestCase`` because the unique constraint the migration adds
+    has to be dropped in the database before duplicates can be created, and
+    because the regression of #8818 only shows when the row updates and the
+    ``ALTER TABLE`` share one transaction, as they do in the migration.
+    """
+
+    constraint_name = "unique_site_language_path"
+
+    def setUp(self):
+        self.original_constraints = PageUrl._meta.constraints
+        self.constraint = next(
+            constraint
+            for constraint in self.original_constraints
+            if constraint.name == self.constraint_name
+        )
+        self.constraint_dropped = False
+        self.addCleanup(self.restore_constraint)
+        self.drop_constraint()
+
+    def drop_constraint(self):
+        """Undo what 0045 adds, so that duplicate paths can be created.
+
+        SQLite rebuilds the table from the model's ``Meta`` when a constraint
+        is dropped, so the constraint has to leave ``_meta`` as well. During a
+        migration it does: the model is rendered from the state the operation
+        leaves behind and no longer carries the constraint either.
+        """
+        PageUrl._meta.constraints = [
+            constraint
+            for constraint in self.original_constraints
+            if constraint.name != self.constraint_name
+        ]
+        with connection.schema_editor() as schema_editor:
+            schema_editor.remove_constraint(PageUrl, self.constraint)
+        self.constraint_dropped = True
+
+    def add_constraint(self, schema_editor):
+        PageUrl._meta.constraints = self.original_constraints
+        schema_editor.add_constraint(PageUrl, self.constraint)
+        self.constraint_dropped = False
+
+    def restore_constraint(self):
+        PageUrl._meta.constraints = self.original_constraints
+        if not self.constraint_dropped:
+            return
+        migration_0045._resolve_duplicate_paths(apps, None)
+        with connection.schema_editor() as schema_editor:
+            self.add_constraint(schema_editor)
+
+    def create_page(self, title, slug):
+        return create_page(title, "nav_playground.html", "en", slug=slug)
+
+    def run_migration_operations(self, schema_editor):
+        """Replay 0045 against the live schema, in the order it declares.
+
+        The schema operations are skipped -- the column and the constraint they
+        add are what this test starts from -- but everything else runs in the
+        migration's own order, so that dropping an operation from
+        ``Migration.operations`` shows up here.
+        """
+        for operation in migration_0045.Migration.operations:
+            if isinstance(operation, migrations.RunPython):
+                operation.code(apps, schema_editor)
+            elif isinstance(operation, migrations.AddConstraint):
+                self.add_constraint(schema_editor)
+
+    def assertConstraintEnforced(self, path):
+        page = self.create_page("Conflict", "conflict")
+        with self.assertRaises(IntegrityError), transaction.atomic():
+            PageUrl.objects.filter(page=page, language="en").update(path=path)
+
+    def test_resolves_duplicate_paths(self):
+        """Of each set of duplicates only the first row keeps its path."""
+        first = self.create_page("First", "first")
+        second = self.create_page("Second", "second")
+        third = self.create_page("Third", "third")
+        untouched = self.create_page("Untouched", "untouched")
+        # A race condition of the kind the new constraint prevents could leave
+        # several rows on the same path.
+        PageUrl.objects.filter(page__in=[second, third], language="en").update(path="first")
+
+        migration_0045._fill_site(apps, None)
+        migration_0045._resolve_duplicate_paths(apps, None)
+
+        self.assertEqual(PageUrl.objects.get(page=first, language="en").path, "first")
+        self.assertIsNone(PageUrl.objects.get(page=second, language="en").path)
+        self.assertIsNone(PageUrl.objects.get(page=third, language="en").path)
+        self.assertEqual(PageUrl.objects.get(page=untouched, language="en").path, "untouched")
+
+    def test_resolves_duplicate_paths_per_language(self):
+        """The same path in two languages is not a duplicate."""
+        first = self.create_page("First", "first")
+        second = self.create_page("Second", "second")
+        create_page_content("de", "Zweite", second, slug="zweite")
+        PageUrl.objects.filter(page=second, language="de").update(path="first")
+
+        migration_0045._fill_site(apps, None)
+        migration_0045._resolve_duplicate_paths(apps, None)
+
+        self.assertEqual(PageUrl.objects.get(page=first, language="en").path, "first")
+        self.assertEqual(PageUrl.objects.get(page=second, language="de").path, "first")
+
+    def test_leaves_rows_without_a_path_alone(self):
+        """Rows with ``path=None`` are already unreachable and never group."""
+        first = self.create_page("First", "first")
+        second = self.create_page("Second", "second")
+        PageUrl.objects.filter(page__in=[first, second], language="en").update(path=None)
+
+        migration_0045._fill_site(apps, None)
+        migration_0045._resolve_duplicate_paths(apps, None)
+
+        self.assertEqual(PageUrl.objects.filter(path__isnull=True).count(), 2)
+
+    def test_adds_the_constraint_in_the_same_transaction(self):
+        """Regression test for #8818.
+
+        On PostgreSQL the rows that ``_fill_site`` and
+        ``_resolve_duplicate_paths`` both write queue deferred foreign key
+        checks, and the trailing ``ALTER TABLE`` fails with "cannot ALTER TABLE
+        cms_pageurl because it has pending trigger events" unless the migration
+        runs those checks first.
+        """
+        first = self.create_page("First", "first")
+        second = self.create_page("Second", "second")
+        PageUrl.objects.filter(page=second, language="en").update(path="first")
+
+        with connection.schema_editor(atomic=True) as schema_editor:
+            self.run_migration_operations(schema_editor)
+
+        self.assertEqual(PageUrl.objects.get(page=first, language="en").path, "first")
+        self.assertIsNone(PageUrl.objects.get(page=second, language="en").path)
+        self.assertConstraintEnforced("first")

--- a/test_requirements/requirements_base.txt
+++ b/test_requirements/requirements_base.txt
@@ -8,7 +8,7 @@ django-formtools
 django-sekizai>=0.7
 django-treebeard>=4.3,<6
 djangocms-admin-style>=1.5
-djangocms-text
+djangocms-text!=1.0.0
 iptools
 mock>=2.0.0
 Pillow


### PR DESCRIPTION
## Summary by Sourcery

Ensure migration 0045 safely resolves duplicate page paths and adds the unique constraint across supported databases, including PostgreSQL.

Bug Fixes:
- Fix PostgreSQL migration 0045 failures when duplicate page paths cause pending deferred constraint checks before the unique constraint is added.

Tests:
- Add transaction-based migration tests covering duplicate-path resolution, language scoping, null paths, and constraint creation on PostgreSQL.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.