### PR TITLE
fix: GrouperAdmin wrote to the wrong content object when one was selected by pk (#8826)

### DIFF
--- a/cms/admin/utils.py
+++ b/cms/admin/utils.py
@@ -169,11 +169,16 @@ class GrouperChangeListBase(ChangeList):
 
     current_language: str | None = None
     available_languages: tuple[tuple[str, str], ...] = ()
-    _extra_grouping_fields = []
+    _extra_grouping_fields: list[str] = []
+    _content_pk_url_param: str | None = None
 
     def get_filters_params(self, params: dict | None = None):
         lookup_params = super().get_filters_params(params)
-        for field in self._extra_grouping_fields:
+        # The content pk parameter selects a content object in the change view. It is preserved
+        # across the change form's submission and can therefore reach the changelist, where it is
+        # meaningless (the changelist always lists the latest content) - and would be rejected as
+        # an unknown filter.
+        for field in (*self._extra_grouping_fields, self._content_pk_url_param):
             if field in lookup_params:
                 del lookup_params[field]
         return lookup_params
@@ -473,7 +478,10 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
         return type(
             GrouperChangeListBase.__name__,
             (GrouperChangeListBase,),
-            dict(_extra_grouping_fields=self.extra_grouping_fields),
+            dict(
+                _extra_grouping_fields=self.extra_grouping_fields,
+                _content_pk_url_param=self.content_pk_url_param,
+            ),
         )
 
     def get_urls(self) -> list:
@@ -562,6 +570,15 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
         self.get_grouping_from_request(request)
         return super().history_view(request, object_id, extra_context)
 
+    def response_change(self, request: HttpRequest, obj: models.Model) -> HttpResponse:
+        """Drop the content selection unless the user stays in the change form: only "save and
+        continue editing" returns to the very content object that was just edited. Every other
+        target (the changelist, the add view) shows or creates the latest content, so the
+        parameter would only stick to their urls."""
+        if "_continue" not in request.POST:
+            self._requested_content_obj = None
+        return super().response_change(request, obj)
+
     def get_preserved_filters(self, request: HttpRequest) -> str:
         """Always preserve grouping get parameters! Also, add them to changelist filters:
         * Save and continue will keep the grouping parameters
@@ -577,6 +594,14 @@ class GrouperModelAdmin(ChangeListActionsMixin, ModelAdmin):
         preserved_filters.update(grouping_filters)
         if "_changelist_filters" not in preserved_filters:
             preserved_filters["_changelist_filters"] = urlencode(grouping_filters)
+        # Keep a specifically requested content object selected: the change form is submitted to the
+        # url built from the preserved filters, and "save and continue editing" returns to it. Without
+        # the parameter both would silently fall back to the latest content object - and saving would
+        # write the form's data to a different content object than the one being edited.
+        # It is deliberately not part of "_changelist_filters": the changelist always lists the
+        # latest content.
+        if self._requested_content_obj is not None:
+            preserved_filters[self.content_pk_url_param] = self._requested_content_obj.pk
         return urlencode(preserved_filters)
 
     def get_extra_context(self, request: HttpRequest, object_id: str | None = None) -> dict[str, typing.Any]:

--- a/cms/tests/test_grouper_admin.py
+++ b/cms/tests/test_grouper_admin.py
@@ -737,6 +737,81 @@ class GrouperChangeTestCase(SetupMixin, CMSTestCase):
         self.assertEqual(content_instance_de.secret_greeting, data["content__secret_greeting"])  # Has new content
 
 
+class SimpleGrouperContentSelectionTestCase(SimpleSetupMixin, CMSTestCase):
+    """The content object selected by :attr:`GrouperModelAdmin.content_pk_url_param` has to survive
+    the change form's submission: the form is posted to the url built from the preserved filters,
+    and "save and continue editing" returns to it."""
+
+    def get_change_form(self, content_obj, **values) -> tuple[str, dict]:
+        """Open the change form for a specific content object and return the url it is submitted
+        to together with the data of a full submission (mimicking the rendered form)."""
+        param = self.admin.content_pk_url_param
+        response = self.client.get(f"{self.change_url}?{param}={content_obj.pk}")
+        self.assertEqual(response.status_code, 200)
+        form = response.context["adminform"].form
+        data = {}
+        for name, field in form.fields.items():
+            value = form.initial.get(name, field.initial)
+            value = getattr(value, "pk", value)
+            if field.required and value in (None, ""):
+                value = "some content"
+            data[name] = "" if value is None else value
+        data[f"{CONTENT_PREFIX}secret_greeting"] = "Changed content"
+        data.update(values)
+        return self.change_url + response.context["form_url"], data
+
+    def test_change_form_saves_requested_content_obj(self) -> None:
+        """Saving writes to the content object shown, not to the latest one."""
+        param = self.admin.content_pk_url_param
+        latest = self.createContentInstance("en")  # lower pk: picked as latest by .first()
+        other = self.createContentInstance("en")  # higher pk: a different content object
+        with self.login_user_context(self.admin_user):
+            post_url, data = self.get_change_form(other)
+            self.assertIn(f"{param}={other.pk}", post_url)
+            response = self.client.post(post_url, data=data)
+        self.assertEqual(response.status_code, 302)
+        other.refresh_from_db()
+        latest.refresh_from_db()
+        self.assertEqual(other.secret_greeting, "Changed content")
+        self.assertNotEqual(latest.secret_greeting, "Changed content")
+
+    def test_save_and_continue_keeps_requested_content_obj(self) -> None:
+        """Saving and continuing to edit returns to the very content object that was edited."""
+        param = self.admin.content_pk_url_param
+        self.createContentInstance("en")
+        other = self.createContentInstance("en")
+        with self.login_user_context(self.admin_user):
+            post_url, data = self.get_change_form(other)
+            response = self.client.post(post_url, data={**data, "_continue": "1"})
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(f"{param}={other.pk}", response.url)
+
+    def test_save_returns_to_changelist_without_content_selection(self) -> None:
+        """Plain saving returns to the changelist, which always lists the latest content."""
+        param = self.admin.content_pk_url_param
+        self.createContentInstance("en")
+        other = self.createContentInstance("en")
+        with self.login_user_context(self.admin_user):
+            post_url, data = self.get_change_form(other)
+            response = self.client.post(post_url, data=data)
+        self.assertEqual(response.status_code, 302)
+        self.assertNotIn(param, response.url)
+
+    def test_changelist_ignores_content_selection(self) -> None:
+        """The content selection is no filter: the changelist ignores it instead of rejecting it
+        as an unknown lookup."""
+        param = self.admin.content_pk_url_param
+        content = self.createContentInstance("en")
+        with self.login_user_context(self.admin_user):
+            response = self.client.get(f"{self.changelist_url}?{param}={content.pk}")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, content.secret_greeting)
+
+
+class GrouperContentSelectionTestCase(SetupMixin, SimpleGrouperContentSelectionTestCase):
+    """Same, for a grouper admin that groups by language."""
+
+
 class GrouperCanChangeContentTestCase(SetupMixin, CMSTestCase):
     """Tests for ``GrouperModelAdmin.can_change_content`` in both the add and change case.
 

--- a/cms/tests/test_mptree_backend.py
+++ b/cms/tests/test_mptree_backend.py
@@ -41,7 +41,7 @@ TEMPLATE = "nav_playground.html"
 
 mptree_only = skipIf(
     get_tree_backend() == "treebeard",
-    "mptree backend only -- run with CMS_TREE_BACKEND=mptree",
+    "mptree backend only -- run with CMS_TREE_BACKEND=\"mptree\"",
 )
 
 


### PR DESCRIPTION
## Summary by Sourcery

Preserve explicitly selected GrouperAdmin content objects through change-form submissions while ignoring selection parameters on the changelist.

Bug Fixes:
- Ensure GrouperAdmin saves changes to the specifically selected content object instead of silently updating the latest object.
- Prevent content-selection parameters from being treated as invalid changelist filters while preserving them for save-and-continue editing.

Tests:
- Add coverage for saving, save-and-continue behavior, changelist handling, and content selection across grouped and ungrouped admins.

Chores:
- Clarify the mptree backend test skip message.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.