### PR TITLE
fix: page-tree copy can disclose view-restrictions

### DIFF
--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -568,6 +568,14 @@ class DuplicatePageForm(AddPageForm):
             raise ValidationError(_("You do not have permission to copy this page."))
         return source
 
+    def from_source(self, source, parent=None):
+        new_page = super().from_source(source, parent=parent)
+        # ``Page.copy()`` is called with ``permissions=False``, so a duplicate of
+        # a view-restricted page would be world-readable. Carry the source's view
+        # restrictions -- its own and the ones it inherits -- over to the copy.
+        new_page.apply_view_restrictions(source.get_view_restrictions(), user=self._user)
+        return new_page
+
 
 class ChangePageForm(BasePageContentForm):
     overwrite_url = forms.CharField(
@@ -1031,8 +1039,8 @@ class MovePageForm(PageTreeForm):
         # The user is moving from right to left.
         return target_page, "left"
 
-    def move_page(self):
-        self.page.move_page(*self.get_tree_options())
+    def move_page(self, user=None):
+        self.page.move_page(*self.get_tree_options(), user=user)
 
     def _determine_new_parent(self, target_page, position):
         if position in ("first-child", "last-child"):

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -663,6 +663,16 @@ class PageAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
             # User can only copy / paste a page if he has permission to add a page
             can_copy_page = page_permissions.user_can_add_page(user, site)
 
+        if can_copy_page:
+            target_page, position = form.get_tree_options()
+            if position in ("first-child", "last-child"):
+                parent_page = target_page
+            else:
+                parent_page = target_page.parent if target_page else None
+            can_copy_page = page_permissions.user_can_copy_descendants(
+                user, page, site, parent_page, form.cleaned_data["copy_permissions"]
+            )
+
         if not can_copy_page:
             message = _("Error! You don't have permissions to copy this page.")
             return jsonify_request(HttpResponseForbidden(message))

--- a/cms/admin/pageadmin.py
+++ b/cms/admin/pageadmin.py
@@ -562,6 +562,18 @@ class PageAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
             message = _("Error! You don't have permissions to move this page. Please reload the page")
             return jsonify_request(HttpResponseForbidden(message))
 
+        # The whole subtree moves along, so authorize the whole subtree: the
+        # destination may grant access that the source did not.
+        target_page, position = form.get_tree_options()
+        if position in ("first-child", "last-child"):
+            parent_page = target_page
+        else:
+            parent_page = target_page.parent if target_page else None
+
+        if not page_permissions.user_can_move_descendants(user, page, page.site, parent_page):
+            message = _("Error! You don't have permissions to move this page. Please reload the page")
+            return jsonify_request(HttpResponseForbidden(message))
+
         operation_token = send_pre_page_operation(
             request=request,
             operation=operations.MOVE_PAGE,
@@ -569,7 +581,7 @@ class PageAdmin(PageDeleteMessageMixin, admin.ModelAdmin):
             sender=self.model,
         )
 
-        form.move_page()
+        form.move_page(user=user)
 
         send_post_page_operation(
             request=request,

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -602,7 +602,19 @@ class Page(MP_Node):
                 Prefetch("pagecontent_set", queryset=PageContent.admin_manager.all()),
             )
         )
-        new_root_page = self.copy(target_site, parent_page=parent_page, user=user)
+        if copy_permissions and get_cms_setting("PERMISSION"):
+            from cms.models import ACCESS_PAGE, ACCESS_PAGE_AND_DESCENDANTS, PagePermission, PermissionTuple
+            from cms.models.permissionmodels import MASK_DESCENDANTS
+
+            # Snapshot paths before inserting the copy can move source nodes.
+            inherited_restrictions = list(
+                PagePermission.objects.filter(
+                    page__in=self.get_ancestor_pages(), can_view=True
+                ).select_related("page")
+            )
+        new_root_page = self.copy(
+            target_site, parent_page=parent_page, permissions=copy_permissions, user=user
+        )
 
         if target_page and position in ("first-child"):
             # target page is a parent and user has requested to
@@ -621,6 +633,31 @@ class Page(MP_Node):
             pages_by_id[page.id] = page.copy(
                 target_site, parent_page=parent, translations=True, permissions=copy_permissions, user=user
             )
+
+        if copy_permissions and get_cms_setting("PERMISSION"):
+            from cms.cache.permissions import clear_permission_cache
+            from cms.utils.permissions import clear_permission_lru_caches
+
+            # Ancestors outside the copied subtree will no longer protect it.
+            # Materialize their view grants on the new root, retaining descendant
+            # scope but not importing unrelated ancestor editing privileges.
+            restrictions = []
+            for permission in inherited_restrictions:
+                if PermissionTuple((permission.grant_on, permission.page.path)).contains(self.path):
+                    restrictions.append(PagePermission(
+                        page=new_root_page,
+                        user_id=permission.user_id,
+                        group_id=permission.group_id,
+                        grant_on=(
+                            ACCESS_PAGE_AND_DESCENDANTS
+                            if permission.grant_on & MASK_DESCENDANTS else ACCESS_PAGE
+                        ),
+                        **{flag: flag == "can_view" for flag in PagePermission.get_all_permissions()},
+                    ))
+            PagePermission.objects.bulk_create(restrictions)
+            # bulk_create does not emit the permission signals.
+            clear_permission_cache()
+            clear_permission_lru_caches(user)
         return new_root_page
 
     def delete(self, *args, **kwargs):

--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -423,7 +423,7 @@ class Page(MP_Node):
         else:
             self.parent.add_sibling(pos=position, instance=self)
 
-    def move_page(self, target_page, position="first-child"):
+    def move_page(self, target_page, position="first-child", user=None):
         """
         Called from admin interface when page is moved. Should be used on
         all the places which are changing page position. Used like an interface
@@ -431,6 +431,10 @@ class Page(MP_Node):
         """
         assert isinstance(target_page, Page), f"{target_page} is not an instance of Page."
         inherited_template = self.template == constants.TEMPLATE_INHERITANCE_MAGIC
+
+        # Snapshot before the move: the ancestors protecting this subtree stop
+        # doing so as soon as its path changes.
+        inherited_restrictions = self.get_view_restrictions(inherited_only=True)
 
         if inherited_template and target_page.is_root() and position in ("left", "right"):
             # The page is being moved to a root position.
@@ -455,6 +459,10 @@ class Page(MP_Node):
         self.update(parent=self.parent)
         self.refresh_from_db(fields=("path", "depth"))
 
+        # The subtree left the ancestors it inherited its view restrictions
+        # from, so they have to be materialized on its new root.
+        self.apply_view_restrictions(inherited_restrictions, user=user)
+
         # Update the urls for the page being moved and its descendants.
         _lock_tree_roots(self)
 
@@ -475,6 +483,85 @@ class Page(MP_Node):
         plugins = CMSPlugin.objects.filter(placeholder__in=placeholder_ids, language=language)
         models.query.QuerySet.delete(plugins)
         return placeholders
+
+    def get_view_restrictions(self, inherited_only=False):
+        """Snapshot the ``can_view`` grants that currently protect this page.
+
+        Each entry is a ``(user_id, group_id, grant_on)`` tuple whose scope is
+        expressed relative to *this* page: a grant inherited from an ancestor
+        becomes ``ACCESS_PAGE_AND_DESCENDANTS`` when it also covers what is
+        below this page, and ``ACCESS_PAGE`` when it stops here. The page's own
+        rows keep their own scope.
+        """
+        from cms.models import ACCESS_PAGE, ACCESS_PAGE_AND_DESCENDANTS, PagePermission
+        from cms.models.permissionmodels import MASK_DESCENDANTS
+
+        if not get_cms_setting("PERMISSION"):
+            return []
+
+        restrictions = [
+            (
+                permission.user_id,
+                permission.group_id,
+                ACCESS_PAGE_AND_DESCENDANTS if permission.grant_on & MASK_DESCENDANTS else ACCESS_PAGE,
+            )
+            for permission in PagePermission.objects.for_page(self).filter(can_view=True)
+            if permission.page_id != self.pk
+        ]
+
+        if not inherited_only:
+            restrictions += [
+                (permission.user_id, permission.group_id, permission.grant_on)
+                for permission in self.pagepermission_set.filter(can_view=True)
+            ]
+        return restrictions
+
+    def apply_view_restrictions(self, restrictions, user=None):
+        """Recreate ``restrictions`` (from ``get_view_restrictions``) on this page.
+
+        Used when a page leaves the subtree its view restrictions came from: the
+        ancestors that protected it no longer do, so their grants have to be
+        materialized here. Only ``can_view`` is carried over -- the editing
+        privileges attached to the original rows are not privileges of the new
+        location. Grants the page already inherits at its new position with at
+        least the same scope are skipped, so repeated moves do not pile up
+        redundant rows.
+        """
+        from cms.cache.permissions import clear_permission_cache
+        from cms.models import PagePermission
+        from cms.models.permissionmodels import MASK_DESCENDANTS
+        from cms.utils.permissions import clear_permission_lru_caches
+
+        if not restrictions or not get_cms_setting("PERMISSION"):
+            return []
+
+        def scope(grant_on):
+            return 2 if grant_on & MASK_DESCENDANTS else 1
+
+        covered = {}
+        for permission in PagePermission.objects.for_page(self).filter(can_view=True):
+            audience = (permission.user_id, permission.group_id)
+            covered[audience] = max(covered.get(audience, 0), scope(permission.grant_on))
+
+        new_permissions = [
+            PagePermission(
+                page=self,
+                user_id=user_id,
+                group_id=group_id,
+                grant_on=grant_on,
+                **{flag: flag == "can_view" for flag in PagePermission.get_all_permissions()},
+            )
+            for user_id, group_id, grant_on in restrictions
+            if scope(grant_on) > covered.get((user_id, group_id), 0)
+        ]
+
+        if new_permissions:
+            PagePermission.objects.bulk_create(new_permissions)
+            # bulk_create does not emit the permission signals.
+            clear_permission_cache()
+            if user is not None:
+                clear_permission_lru_caches(user)
+        return new_permissions
 
     def copy(
         self,
@@ -602,19 +689,10 @@ class Page(MP_Node):
                 Prefetch("pagecontent_set", queryset=PageContent.admin_manager.all()),
             )
         )
-        if copy_permissions and get_cms_setting("PERMISSION"):
-            from cms.models import ACCESS_PAGE, ACCESS_PAGE_AND_DESCENDANTS, PagePermission, PermissionTuple
-            from cms.models.permissionmodels import MASK_DESCENDANTS
-
+        if copy_permissions:
             # Snapshot paths before inserting the copy can move source nodes.
-            inherited_restrictions = list(
-                PagePermission.objects.filter(
-                    page__in=self.get_ancestor_pages(), can_view=True
-                ).select_related("page")
-            )
-        new_root_page = self.copy(
-            target_site, parent_page=parent_page, permissions=copy_permissions, user=user
-        )
+            inherited_restrictions = self.get_view_restrictions(inherited_only=True)
+        new_root_page = self.copy(target_site, parent_page=parent_page, permissions=copy_permissions, user=user)
 
         if target_page and position in ("first-child"):
             # target page is a parent and user has requested to
@@ -634,30 +712,9 @@ class Page(MP_Node):
                 target_site, parent_page=parent, translations=True, permissions=copy_permissions, user=user
             )
 
-        if copy_permissions and get_cms_setting("PERMISSION"):
-            from cms.cache.permissions import clear_permission_cache
-            from cms.utils.permissions import clear_permission_lru_caches
-
+        if copy_permissions:
             # Ancestors outside the copied subtree will no longer protect it.
-            # Materialize their view grants on the new root, retaining descendant
-            # scope but not importing unrelated ancestor editing privileges.
-            restrictions = []
-            for permission in inherited_restrictions:
-                if PermissionTuple((permission.grant_on, permission.page.path)).contains(self.path):
-                    restrictions.append(PagePermission(
-                        page=new_root_page,
-                        user_id=permission.user_id,
-                        group_id=permission.group_id,
-                        grant_on=(
-                            ACCESS_PAGE_AND_DESCENDANTS
-                            if permission.grant_on & MASK_DESCENDANTS else ACCESS_PAGE
-                        ),
-                        **{flag: flag == "can_view" for flag in PagePermission.get_all_permissions()},
-                    ))
-            PagePermission.objects.bulk_create(restrictions)
-            # bulk_create does not emit the permission signals.
-            clear_permission_cache()
-            clear_permission_lru_caches(user)
+            new_root_page.apply_view_restrictions(inherited_restrictions, user=user)
         return new_root_page
 
     def delete(self, *args, **kwargs):

--- a/cms/tests/test_copy_permissions.py
+++ b/cms/tests/test_copy_permissions.py
@@ -1,0 +1,153 @@
+from django.contrib.auth.models import AnonymousUser, Group
+from django.contrib.sites.models import Site
+from django.test import override_settings
+
+from cms.api import add_plugin, create_page
+from cms.models import (
+    ACCESS_CHILDREN,
+    ACCESS_PAGE,
+    ACCESS_PAGE_AND_DESCENDANTS,
+    CMSPlugin,
+    Page,
+    PagePermission,
+)
+from cms.test_utils.testcases import CMSTestCase
+from cms.utils import page_permissions
+
+
+@override_settings(CMS_PERMISSION=True, CMS_PUBLIC_FOR="all")
+class CopyPermissionsTests(CMSTestCase):
+    def setUp(self):
+        super().setUp()
+        self.admin = self.get_superuser()
+        self.actor = self.get_staff_user_with_no_permissions()
+        for codename in ("add_page", "change_page", "add_text", "change_text"):
+            self.add_permission(self.actor, codename)
+        self.target = create_page("target", "nav_playground.html", "en")
+        self.target_permission = self.add_page_permission(
+            self.actor, self.target, can_add=True, can_change=True, grant_on=ACCESS_PAGE
+        )
+        self.source = create_page("source", "nav_playground.html", "en")
+        self.secret = create_page("secret", "nav_playground.html", "en", parent=self.source)
+        self.add_page_permission(self.admin, self.secret, can_view=True, grant_on=ACCESS_PAGE)
+        self.marker = "CONFIDENTIAL-COPY-REGRESSION"
+        add_plugin(self.secret.get_placeholders("en").get(slot="body"), "TextPlugin", "en", body=self.marker)
+
+    def copy(self, copy_permissions, source=None, position=0):
+        with self.login_user_context(self.actor):
+            response = self.client.post(
+                self.get_admin_url(Page, "copy_page", (source or self.source).pk),
+                {"position": position, "target": self.target.pk, "copy_permissions": copy_permissions},
+            )
+        # Permission checks after the POST should use a fresh request's user.
+        self.actor = type(self.actor).objects.get(pk=self.actor.pk)
+        return response
+
+    def assertCopyDenied(self, copy_permissions):
+        counts = (Page.objects.count(), CMSPlugin.objects.count(), PagePermission.objects.count())
+        response = self.copy(copy_permissions)
+        self.assertEqual(response.json()["status"], 403)
+        self.assertEqual(counts, (Page.objects.count(), CMSPlugin.objects.count(), PagePermission.objects.count()))
+
+    def test_unreadable_descendant_requires_copy_permissions(self):
+        self.assertTrue(page_permissions.user_can_view_page(self.actor, self.source))
+        self.assertFalse(page_permissions.user_can_view_page(self.actor, self.secret))
+        self.assertFalse(page_permissions.user_can_change_page(self.actor, self.secret))
+        self.assertEqual(self.client.get(self.secret.get_absolute_url()).status_code, 404)
+        self.assertCopyDenied("")
+
+    def test_unreadable_descendant_can_be_copied_with_permissions(self):
+        response = self.copy("on")
+        self.assertEqual(response.status_code, 200)
+        copied = Page.objects.get(pk=response.json()["id"]).get_child_pages().get()
+        self.assertTrue(copied.has_view_restrictions(copied.site))
+        self.assertFalse(page_permissions.user_can_view_page(self.actor, copied))
+        self.assertEqual(self.client.get(copied.get_absolute_url()).status_code, 404)
+        with self.login_user_context(self.admin):
+            self.assertContains(self.client.get(copied.get_absolute_url()), self.marker)
+
+    def test_destination_change_grant_cannot_expose_unreadable_descendant(self):
+        self.target_permission.grant_on = ACCESS_PAGE_AND_DESCENDANTS
+        self.target_permission.save()
+        self.assertCopyDenied("on")
+
+    def test_destination_view_grant_cannot_expose_unreadable_descendant(self):
+        self.add_page_permission(self.actor, self.target, can_view=True, grant_on=ACCESS_PAGE_AND_DESCENDANTS)
+        self.assertCopyDenied("on")
+
+    def test_destination_group_grant_cannot_expose_unreadable_descendant(self):
+        group = Group.objects.create(name="Destination viewers")
+        self.actor.groups.add(group)
+        self.add_page_permission(None, self.target, group=group, can_view=True, grant_on=ACCESS_PAGE_AND_DESCENDANTS)
+        self.assertCopyDenied("on")
+
+    @override_settings(
+        CMS_LANGUAGES={
+            1: [{"code": "en", "name": "English"}],
+            2: [{"code": "en", "name": "English"}],
+        }
+    )
+    def test_destination_site_global_grant_cannot_expose_unreadable_descendant(self):
+        site = Site.objects.create(domain="destination.example", name="Destination")
+        self.target = create_page("other-site", "nav_playground.html", "en", site=site)
+        permission = self.add_global_permission(self.actor, can_add=True, can_change=True)
+        permission.sites.set([site])
+        self.assertFalse(page_permissions.user_can_view_page(self.actor, self.secret))
+        with self.settings(SITE_ID=site.pk):
+            self.assertCopyDenied("on")
+
+    def test_unreadable_grandchild_requires_copy_permissions(self):
+        self.secret.pagepermission_set.all().delete()
+        grandchild = create_page("grandchild", "nav_playground.html", "en", parent=self.secret)
+        self.add_page_permission(self.admin, grandchild, can_view=True, grant_on=ACCESS_PAGE)
+        self.assertTrue(page_permissions.user_can_view_page(self.actor, self.secret))
+        self.assertCopyDenied("")
+
+    def test_destination_immediate_children_grant_does_not_expose_descendant(self):
+        self.add_page_permission(self.actor, self.target, can_view=True, grant_on=ACCESS_CHILDREN)
+        response = self.copy("on")
+        self.assertEqual(response.status_code, 200)
+        copied = Page.objects.get(pk=response.json()["id"]).get_child_pages().get()
+        self.assertFalse(page_permissions.user_can_view_page(self.actor, copied))
+
+    def test_copy_permissions_preserves_root_restriction(self):
+        self.add_page_permission(self.actor, self.source, can_view=True, grant_on=ACCESS_PAGE)
+        response = self.copy("on")
+        self.assertEqual(response.status_code, 200)
+        copied = Page.objects.get(pk=response.json()["id"])
+        self.assertTrue(copied.pagepermission_set.filter(user=self.actor, can_view=True).exists())
+        self.assertEqual(self.client.get(copied.get_absolute_url()).status_code, 404)
+
+    def test_readable_descendants_can_be_copied_without_permissions(self):
+        self.add_page_permission(self.actor, self.secret, can_view=True, grant_on=ACCESS_PAGE)
+        response = self.copy("")
+        self.assertEqual(response.status_code, 200)
+        copied = Page.objects.get(pk=response.json()["id"]).get_child_pages().get()
+        self.assertFalse(copied.has_view_restrictions(copied.site))
+        self.assertContains(self.client.get(copied.get_absolute_url()), self.marker)
+
+    def test_inherited_restrictions_survive_outside_source_subtree(self):
+        ancestor = create_page("ancestor", "nav_playground.html", "en")
+        source = create_page("nested-source", "nav_playground.html", "en", parent=ancestor)
+        child = create_page("nested-child", "nav_playground.html", "en", parent=source)
+        self.add_page_permission(self.admin, ancestor, can_view=True, grant_on=ACCESS_PAGE_AND_DESCENDANTS)
+        self.add_page_permission(self.actor, ancestor, can_view=True, grant_on=ACCESS_CHILDREN)
+        self.assertTrue(page_permissions.user_can_view_page(self.actor, source))
+        self.assertFalse(page_permissions.user_can_view_page(self.actor, child))
+        response = self.copy("on", source=source)
+        self.assertEqual(response.status_code, 200)
+        copied = Page.objects.get(pk=response.json()["id"])
+        copied_child = copied.get_child_pages().get()
+        self.assertTrue(page_permissions.user_can_view_page(self.actor, copied))
+        self.assertFalse(page_permissions.user_can_view_page(self.actor, copied_child))
+        for page in (copied, copied_child):
+            self.assertFalse(page_permissions.user_can_view_page(AnonymousUser(), page))
+            self.assertTrue(PagePermission.objects.for_page(page).filter(user=self.admin, can_view=True).exists())
+            self.assertFalse(page.pagepermission_set.filter(can_change=True).exists())
+        added_child = create_page("later-child", "nav_playground.html", "en", parent=copied_child)
+        self.assertFalse(page_permissions.user_can_view_page(AnonymousUser(), added_child))
+        self.assertFalse(page_permissions.user_can_view_page(self.actor, added_child))
+
+    def test_unreadable_root_is_still_rejected(self):
+        response = self.copy("on", source=self.secret)
+        self.assertEqual(response.json()["status"], 403)

--- a/cms/tests/test_copy_permissions.py
+++ b/cms/tests/test_copy_permissions.py
@@ -9,6 +9,7 @@ from cms.models import (
     ACCESS_PAGE_AND_DESCENDANTS,
     CMSPlugin,
     Page,
+    PageContent,
     PagePermission,
 )
 from cms.test_utils.testcases import CMSTestCase
@@ -151,3 +152,223 @@ class CopyPermissionsTests(CMSTestCase):
     def test_unreadable_root_is_still_rejected(self):
         response = self.copy("on", source=self.secret)
         self.assertEqual(response.json()["status"], 403)
+
+
+@override_settings(CMS_PERMISSION=True, CMS_PUBLIC_FOR="all")
+class MovePermissionsTests(CMSTestCase):
+    """A moved subtree leaves the ancestors that restricted it behind."""
+
+    def setUp(self):
+        super().setUp()
+        self.admin = self.get_superuser()
+        self.actor = self.get_staff_user_with_no_permissions()
+        for codename in ("add_page", "change_page", "add_text", "change_text"):
+            self.add_permission(self.actor, codename)
+        self.target = create_page("target", "nav_playground.html", "en")
+        self.target_permission = self.add_page_permission(
+            self.actor, self.target, can_add=True, can_change=True, grant_on=ACCESS_PAGE
+        )
+        self.ancestor = create_page("ancestor", "nav_playground.html", "en")
+        self.add_page_permission(self.admin, self.ancestor, can_view=True, grant_on=ACCESS_PAGE_AND_DESCENDANTS)
+        self.source = create_page("source", "nav_playground.html", "en", parent=self.ancestor)
+        self.secret = create_page("secret", "nav_playground.html", "en", parent=self.source)
+        self.marker = "CONFIDENTIAL-MOVE-REGRESSION"
+        add_plugin(self.secret.get_placeholders("en").get(slot="body"), "TextPlugin", "en", body=self.marker)
+
+    def move(self, page=None, target=None, position=0):
+        page = page or self.source
+        with self.login_user_context(self.actor):
+            response = self.client.post(
+                self.get_admin_url(Page, "move_page", page.pk),
+                {"id": page.pk, "position": position, "target": (target or self.target).pk},
+            )
+        # Permission checks after the POST should use a fresh request's user.
+        self.actor = type(self.actor).objects.get(pk=self.actor.pk)
+        return response
+
+    def grant_source(self, grant_on=ACCESS_PAGE_AND_DESCENDANTS):
+        return self.add_page_permission(
+            self.actor, self.source, can_change=True, can_move_page=True, grant_on=grant_on
+        )
+
+    def test_move_preserves_inherited_restriction(self):
+        """The editor of a restricted branch cannot publish it by moving it."""
+        self.grant_source()
+        self.assertTrue(page_permissions.user_can_view_page(self.actor, self.secret))
+
+        response = self.move()
+        self.assertEqual(response.json().get("status", 200), 200)
+
+        source = Page.objects.get(pk=self.source.pk)
+        secret = Page.objects.get(pk=self.secret.pk)
+        self.assertEqual(source.parent_id, self.target.pk)
+        for page in (source, secret):
+            self.assertTrue(page.has_view_restrictions(page.site))
+            self.assertFalse(page_permissions.user_can_view_page(AnonymousUser(), page))
+            self.assertEqual(self.client.get(page.get_absolute_url()).status_code, 404)
+        with self.login_user_context(self.admin):
+            self.assertContains(self.client.get(secret.get_absolute_url()), self.marker)
+
+    def test_move_grants_no_editing_privileges(self):
+        """Only ``can_view`` is materialized, never the ancestor's other flags."""
+        self.add_page_permission(self.admin, self.ancestor, can_change=True, grant_on=ACCESS_PAGE_AND_DESCENDANTS)
+        self.grant_source()
+        self.move()
+
+        source = Page.objects.get(pk=self.source.pk)
+        self.assertTrue(source.pagepermission_set.filter(user=self.admin, can_view=True).exists())
+        # The actor's own grant stays; the ancestor's can_change is not imported.
+        self.assertFalse(source.pagepermission_set.filter(user=self.admin, can_change=True).exists())
+
+    def test_move_keeps_unreadable_descendant_hidden(self):
+        """The mover may not read ``secret``; the move must not change that."""
+        self.grant_source(grant_on=ACCESS_PAGE)
+        self.assertTrue(page_permissions.user_can_view_page(self.actor, self.source))
+        self.assertFalse(page_permissions.user_can_view_page(self.actor, self.secret))
+
+        response = self.move()
+        self.assertEqual(response.json().get("status", 200), 200)
+
+        secret = Page.objects.get(pk=self.secret.pk)
+        self.assertFalse(page_permissions.user_can_view_page(self.actor, secret))
+        self.assertFalse(page_permissions.user_can_view_page(AnonymousUser(), secret))
+        self.assertEqual(self.client.get(secret.get_absolute_url()).status_code, 404)
+
+    def test_destination_change_grant_cannot_expose_unreadable_descendant(self):
+        """A destination grant would widen access, so the move is refused."""
+        self.grant_source(grant_on=ACCESS_PAGE)
+        self.target_permission.grant_on = ACCESS_PAGE_AND_DESCENDANTS
+        self.target_permission.save()
+
+        response = self.move()
+        self.assertEqual(response.json()["status"], 403)
+        self.assertEqual(Page.objects.get(pk=self.source.pk).parent_id, self.ancestor.pk)
+
+    def test_destination_view_grant_cannot_expose_unreadable_descendant(self):
+        self.grant_source(grant_on=ACCESS_PAGE)
+        self.add_page_permission(self.actor, self.target, can_view=True, grant_on=ACCESS_PAGE_AND_DESCENDANTS)
+
+        response = self.move()
+        self.assertEqual(response.json()["status"], 403)
+        self.assertEqual(Page.objects.get(pk=self.source.pk).parent_id, self.ancestor.pk)
+
+    def test_move_inside_restricted_branch_adds_no_permissions(self):
+        """Reordering inside the branch keeps inheritance, so nothing is copied."""
+        self.grant_source()
+        self.add_page_permission(self.actor, self.ancestor, can_add=True, can_change=True,
+                                 grant_on=ACCESS_PAGE_AND_DESCENDANTS)
+        count = PagePermission.objects.count()
+
+        response = self.move(target=self.ancestor)
+        self.assertEqual(response.json().get("status", 200), 200)
+
+        source = Page.objects.get(pk=self.source.pk)
+        self.assertEqual(PagePermission.objects.count(), count)
+        self.assertTrue(source.has_view_restrictions(source.site))
+
+    def test_move_into_restricted_branch_adds_no_permissions(self):
+        """An unrestricted page moved into a restricted branch inherits, no rows."""
+        public = create_page("public", "nav_playground.html", "en")
+        self.add_page_permission(self.actor, public, can_change=True, can_move_page=True, grant_on=ACCESS_PAGE)
+        self.add_page_permission(self.actor, self.ancestor, can_add=True, can_change=True,
+                                 grant_on=ACCESS_PAGE_AND_DESCENDANTS)
+        count = PagePermission.objects.count()
+
+        response = self.move(page=public, target=self.ancestor)
+        self.assertEqual(response.json().get("status", 200), 200)
+
+        public = Page.objects.get(pk=public.pk)
+        self.assertEqual(PagePermission.objects.count(), count)
+        self.assertTrue(public.has_view_restrictions(public.site))
+        self.assertFalse(page_permissions.user_can_view_page(AnonymousUser(), public))
+
+    def test_move_of_unrestricted_page_adds_no_permissions(self):
+        public = create_page("public", "nav_playground.html", "en")
+        self.add_page_permission(self.actor, public, can_change=True, can_move_page=True, grant_on=ACCESS_PAGE)
+        count = PagePermission.objects.count()
+
+        response = self.move(page=public)
+        self.assertEqual(response.json().get("status", 200), 200)
+
+        public = Page.objects.get(pk=public.pk)
+        self.assertEqual(PagePermission.objects.count(), count)
+        self.assertFalse(public.has_view_restrictions(public.site))
+        self.assertEqual(self.client.get(public.get_absolute_url()).status_code, 200)
+
+
+@override_settings(CMS_PERMISSION=True, CMS_PUBLIC_FOR="all")
+class DuplicatePermissionsTests(CMSTestCase):
+    """``Duplicate`` copies a single page; its restrictions come along."""
+
+    def setUp(self):
+        super().setUp()
+        self.admin = self.get_superuser()
+        self.actor = self.get_staff_user_with_no_permissions()
+        for codename in ("add_page", "change_page", "add_text", "change_text"):
+            self.add_permission(self.actor, codename)
+        self.target = create_page("target", "nav_playground.html", "en")
+        self.add_page_permission(self.actor, self.target, can_add=True, can_change=True, grant_on=ACCESS_PAGE)
+        self.marker = "CONFIDENTIAL-DUPLICATE-REGRESSION"
+
+    def duplicate(self, source):
+        content = source.get_admin_content("en")
+        endpoint = self.get_admin_url(PageContent, "duplicate", content.pk)
+        with self.login_user_context(self.actor):
+            response = self.client.post(
+                f"{endpoint}?parent_page={self.target.pk}",
+                {
+                    "title": "duplicate",
+                    "slug": "duplicate",
+                    "template": "nav_playground.html",
+                    "language": "en",
+                    "source": source.pk,
+                    "parent_page": self.target.pk,
+                    "_save": 1,
+                },
+            )
+        self.actor = type(self.actor).objects.get(pk=self.actor.pk)
+        return response, self.target.get_child_pages().first()
+
+    def test_duplicate_preserves_own_restriction(self):
+        source = create_page("source", "nav_playground.html", "en")
+        add_plugin(source.get_placeholders("en").get(slot="body"), "TextPlugin", "en", body=self.marker)
+        self.add_page_permission(self.admin, source, can_view=True, grant_on=ACCESS_PAGE)
+        self.add_page_permission(self.actor, source, can_view=True, grant_on=ACCESS_PAGE)
+        self.assertTrue(page_permissions.user_can_view_page(self.actor, source))
+
+        response, copy = self.duplicate(source)
+        self.assertEqual(response.status_code, 302)
+        self.assertIsNotNone(copy)
+        self.assertTrue(copy.has_view_restrictions(copy.site))
+        self.assertFalse(page_permissions.user_can_view_page(AnonymousUser(), copy))
+        self.assertEqual(self.client.get(copy.get_absolute_url()).status_code, 404)
+        self.assertFalse(copy.pagepermission_set.filter(can_change=True).exists())
+        with self.login_user_context(self.admin):
+            self.assertContains(self.client.get(copy.get_absolute_url()), self.marker)
+
+    def test_duplicate_preserves_inherited_restriction(self):
+        ancestor = create_page("ancestor", "nav_playground.html", "en")
+        self.add_page_permission(self.admin, ancestor, can_view=True, grant_on=ACCESS_PAGE_AND_DESCENDANTS)
+        self.add_page_permission(self.actor, ancestor, can_view=True, grant_on=ACCESS_PAGE_AND_DESCENDANTS)
+        source = create_page("source", "nav_playground.html", "en", parent=ancestor)
+        add_plugin(source.get_placeholders("en").get(slot="body"), "TextPlugin", "en", body=self.marker)
+
+        response, copy = self.duplicate(source)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(copy.has_view_restrictions(copy.site))
+        self.assertFalse(page_permissions.user_can_view_page(AnonymousUser(), copy))
+        self.assertEqual(self.client.get(copy.get_absolute_url()).status_code, 404)
+        # A page added below the copy stays protected, as it would below the source.
+        child = create_page("child", "nav_playground.html", "en", parent=copy)
+        self.assertFalse(page_permissions.user_can_view_page(AnonymousUser(), child))
+
+    def test_duplicate_of_unrestricted_page_adds_no_permissions(self):
+        source = create_page("source", "nav_playground.html", "en")
+        add_plugin(source.get_placeholders("en").get(slot="body"), "TextPlugin", "en", body=self.marker)
+        count = PagePermission.objects.count()
+
+        response, copy = self.duplicate(source)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(PagePermission.objects.count(), count)
+        self.assertFalse(copy.has_view_restrictions(copy.site))
+        self.assertContains(self.client.get(copy.get_absolute_url()), self.marker)

--- a/cms/utils/page_permissions.py
+++ b/cms/utils/page_permissions.py
@@ -364,6 +364,43 @@ def user_can_view_all_pages(user, site):
     return has_global_permission(user, site, action='view_page')
 
 
+def user_can_copy_descendants(user, page, site, parent_page, copy_permissions):
+    """Allow unreadable descendants only when the copy keeps them unreadable.
+
+    The caller checks root view access and destination add access separately.
+    ``copy_with_descendants`` preserves inherited source view restrictions when
+    copying permissions. Destination grants can nevertheless widen access:
+    change permission also confers view access, even on a restricted page.
+    """
+    unreadable = [
+        descendant for descendant in page.get_descendant_pages()
+        if not user_can_view_page(user, descendant, page.site)
+    ]
+    if not unreadable:
+        return True
+    if not copy_permissions:
+        return False
+
+    # Fetch destination permissions without reusing source-site permission caches.
+    view_permissions = get_view_perm_tuples(user, site, use_cache=False)
+    change_permissions = (
+        get_change_perm_tuples(user, site, use_cache=False)
+        if user.has_perm(PAGE_CHANGE_CODENAME) else []
+    )
+    if GRANT_ALL_PERMISSIONS in (view_permissions, change_permissions):
+        return False
+
+    # An all-zero segment cannot identify an existing page. Only permissions
+    # inherited from the destination ancestors can match these prospective paths.
+    root_path = (parent_page.path if parent_page else '') + '0' * Page.steplen
+    destination_permissions = [PermissionTuple(perm) for perm in (*view_permissions, *change_permissions)]
+    return not any(
+        permission.contains(root_path + descendant.path[len(page.path):])
+        for descendant in unreadable
+        for permission in destination_permissions
+    )
+
+
 def get_add_perm_tuples(user, site, check_global=True, use_cache=True):
     """
     Give a list of page where the user has add page rights or the string

--- a/cms/utils/page_permissions.py
+++ b/cms/utils/page_permissions.py
@@ -364,13 +364,13 @@ def user_can_view_all_pages(user, site):
     return has_global_permission(user, site, action='view_page')
 
 
-def user_can_copy_descendants(user, page, site, parent_page, copy_permissions):
-    """Allow unreadable descendants only when the copy keeps them unreadable.
+def user_can_relocate_descendants(user, page, site, parent_page, keep_restrictions=True):
+    """Allow unreadable descendants only when they stay unreadable at ``parent_page``.
 
     The caller checks root view access and destination add access separately.
-    ``copy_with_descendants`` preserves inherited source view restrictions when
-    copying permissions. Destination grants can nevertheless widen access:
-    change permission also confers view access, even on a restricted page.
+    ``copy_with_descendants`` and ``Page.move_page`` preserve inherited source
+    view restrictions. Destination grants can nevertheless widen access: change
+    permission also confers view access, even on a restricted page.
     """
     unreadable = [
         descendant for descendant in page.get_descendant_pages()
@@ -378,7 +378,7 @@ def user_can_copy_descendants(user, page, site, parent_page, copy_permissions):
     ]
     if not unreadable:
         return True
-    if not copy_permissions:
+    if not keep_restrictions:
         return False
 
     # Fetch destination permissions without reusing source-site permission caches.
@@ -399,6 +399,22 @@ def user_can_copy_descendants(user, page, site, parent_page, copy_permissions):
         for descendant in unreadable
         for permission in destination_permissions
     )
+
+
+def user_can_copy_descendants(user, page, site, parent_page, copy_permissions):
+    """Whether ``page`` may be copied below ``parent_page`` with its descendants."""
+    return user_can_relocate_descendants(
+        user, page, site, parent_page, keep_restrictions=copy_permissions
+    )
+
+
+def user_can_move_descendants(user, page, site, parent_page):
+    """Whether ``page`` may be moved below ``parent_page`` with its descendants.
+
+    A move always preserves the subtree's view restrictions, so only the
+    destination's own grants can widen access.
+    """
+    return user_can_relocate_descendants(user, page, site, parent_page)
 
 
 def get_add_perm_tuples(user, site, check_global=True, use_cache=True):

--- a/docs/explanation/permissions.rst
+++ b/docs/explanation/permissions.rst
@@ -269,6 +269,59 @@ CMS, rather than relying on a view restriction to conceal it in the
 admin.
 
 
+**********************************
+Moving, copying and deleting pages
+**********************************
+
+Because a view restriction can cascade to a page's descendants, who is
+allowed to see a page depends on *where that page sits* in the tree.
+Moving or copying a page therefore raises a question no permission form
+can answer on its own: should the page keep the audience it had, or
+adopt the one implied by its new position?
+
+django CMS answers it conservatively. No relocation may hand you — or
+the public — content you were not allowed to read in the first place,
+and a restriction is never dropped by accident:
+
+* **Move.** When a page leaves the branch whose ancestors restricted
+  it, those view grants are written onto the moved page itself. The
+  page, and everything below it, stays as restricted at its new
+  position as it was at the old one. Publishing it is a separate,
+  deliberate act: remove the restriction, which requires the *can
+  change permissions* right on the page.
+* **Copy and paste.** Here you choose. The *Copy permissions* checkbox
+  in the paste dialog — shown only with ``CMS_PERMISSION = True`` —
+  decides whether the pasted pages keep the permission rows of the
+  originals, edit rights included. Ticked, the copy is as restricted as
+  the source, inherited restrictions included. Cleared, the copy has no
+  permissions at all, and the paste is refused if the subtree contains
+  a page you are not allowed to view.
+* **Duplicate.** Duplicating a single page always carries its view
+  restrictions across, its own and the ones it inherited. It never
+  copies edit rights.
+
+Both move and paste are refused outright when the subtree contains
+pages you may not view *and* the destination would grant you access to
+them — for instance when you hold "can change" on the target page and
+its descendants. Change permission implies view permission, so such a
+relocation would hand you content you could not read before.
+
+Deleting needs no rule of its own: deleting a page deletes its
+descendants, and the confirmation step checks your delete permission on
+every one of them. A branch that contains a page you may not delete
+cannot be deleted at its root either.
+
+So an editor who owns a restricted branch cannot publish it by dragging
+it out of the branch, nor by duplicating it. Copying it with *Copy
+permissions* cleared does produce an unrestricted copy — but only of
+pages that editor was already allowed to read.
+
+..  versionchanged:: 5.2
+    Earlier versions dropped the inherited view restrictions when a page
+    was moved, copied with descendants, or duplicated, and authorized
+    only the root of a copied or moved subtree.
+
+
 *************************
 Delegated user management
 *************************

--- a/docs/upgrade/5.2.0.rst
+++ b/docs/upgrade/5.2.0.rst
@@ -108,25 +108,26 @@ always ``False`` there. Each of them needs a staff session that may add pages;
 none is exploitable anonymously, but the content they expose is readable
 anonymously afterwards. We recommend that all users upgrade as soon as possible.
 
-TODO: replace the ``GHSA-xxxx-xxxx-xxxx`` placeholders with the advisory
-identifiers once the advisories are published.
+`GHSA-976q-w6ch-6w82 <https://github.com/django-cms/django-cms/security/advisories/GHSA-976q-w6ch-6w82>`_
+covers all three, which share a root cause, their prerequisites and their fix:
 
-* ``GHSA-xxxx-xxxx-xxxx``: *Copy* in the page tree authorized only the root of
-  the subtree it was asked to copy, while every descendant below it was copied
-  and recreated without its view restrictions. A delegated editor who could view
-  one public page therefore obtained a publicly readable copy of every
-  view-restricted page below it. Copying now authorizes the whole subtree and
-  preserves the view restrictions the source inherited from ancestors outside
-  it.
-* ``GHSA-xxxx-xxxx-xxxx``: *Duplicate* created the new page with no permissions
-  at all, so duplicating a view-restricted page republished its content to
-  anonymous visitors. The duplicate now carries the source's view restrictions,
-  both its own and the ones it inherited.
-* ``GHSA-xxxx-xxxx-xxxx``: Moving a page out of a restricted branch dropped the
-  view restrictions that it and its descendants inherited from their ancestors,
-  exposing the pages themselves -- including descendants the moving user was not
-  allowed to view -- to anonymous visitors. Moving now authorizes the whole
-  subtree and materializes the inherited view restrictions on the moved page.
+* *Copy* authorized only the root of the subtree it was asked to copy, while
+  every descendant below it was copied and recreated without its view
+  restrictions. A delegated editor who could view one public page therefore
+  obtained a publicly readable copy of every view-restricted page below it.
+  Selecting *Copy permissions* did not help: the flag was passed to the
+  descendants but not to the copied root, so the root lost its own permission
+  records as well. Copying now authorizes the whole subtree and preserves the
+  view restrictions the source inherited from ancestors outside it.
+* *Duplicate* created the new page with no permissions at all, so duplicating a
+  view-restricted page republished its content to anonymous visitors. The
+  duplicate now carries the source's view restrictions, both its own and the
+  ones it inherited.
+* *Move* dropped the view restrictions that a page and its descendants
+  inherited from the ancestors they left behind, exposing the pages themselves
+  -- including descendants the moving user was not allowed to view -- to
+  anonymous visitors. Moving now authorizes the whole subtree and materializes
+  the inherited view restrictions on the moved page.
 
 No action beyond upgrading is required. Pages that were copied, duplicated or
 moved *before* the upgrade keep the permissions they were created with, so

--- a/docs/upgrade/5.2.0.rst
+++ b/docs/upgrade/5.2.0.rst
@@ -100,11 +100,37 @@ Minor features
 Security fixes
 ==============
 
-TODO: describe each security-relevant fix, who is affected, and any action
-required beyond upgrading. Reference the advisory where one was published.
+This release fixes broken access control in the page tree's *Copy*, *Duplicate*
+and *Move* operations. All three require ``CMS_PERMISSION = True`` and at least
+one per-page view restriction: an installation that does not use the permission
+system has nothing to disclose, because ``Page.has_view_restrictions()`` is
+always ``False`` there. Each of them needs a staff session that may add pages;
+none is exploitable anonymously, but the content they expose is readable
+anonymously afterwards. We recommend that all users upgrade as soon as possible.
 
-* TODO: security fix 1
-* TODO: security fix 2
+TODO: replace the ``GHSA-xxxx-xxxx-xxxx`` placeholders with the advisory
+identifiers once the advisories are published.
+
+* ``GHSA-xxxx-xxxx-xxxx``: *Copy* in the page tree authorized only the root of
+  the subtree it was asked to copy, while every descendant below it was copied
+  and recreated without its view restrictions. A delegated editor who could view
+  one public page therefore obtained a publicly readable copy of every
+  view-restricted page below it. Copying now authorizes the whole subtree and
+  preserves the view restrictions the source inherited from ancestors outside
+  it.
+* ``GHSA-xxxx-xxxx-xxxx``: *Duplicate* created the new page with no permissions
+  at all, so duplicating a view-restricted page republished its content to
+  anonymous visitors. The duplicate now carries the source's view restrictions,
+  both its own and the ones it inherited.
+* ``GHSA-xxxx-xxxx-xxxx``: Moving a page out of a restricted branch dropped the
+  view restrictions that it and its descendants inherited from their ancestors,
+  exposing the pages themselves -- including descendants the moving user was not
+  allowed to view -- to anonymous visitors. Moving now authorizes the whole
+  subtree and materializes the inherited view restrictions on the moved page.
+
+No action beyond upgrading is required. Pages that were copied, duplicated or
+moved *before* the upgrade keep the permissions they were created with, so
+review restricted branches for unrestricted copies made earlier.
 
 Bug Fixes
 =========
@@ -121,10 +147,37 @@ TODO: point at the full list of fixes in ``CHANGELOG.rst``.
 Backward incompatible changes in 5.2.0
 **************************************
 
-Backward incompatible change 1
-==============================
+View restrictions follow pages that are copied, duplicated or moved
+===================================================================
 
-TODO: what changed, who is affected, and what to do instead.
+The security fixes above change how permissions behave around page copies and
+moves:
+
+* A page moved out of a restricted branch stays restricted at its new location.
+  The view grants it inherited are written to the moved page as ``can_view``
+  ``PagePermission`` rows (no other flag is carried over). To publish such a
+  page, remove the restriction explicitly -- which requires the *can change
+  permissions* right on it.
+* ``Page.move_page()`` accepts a new optional ``user`` argument and now writes
+  ``PagePermission`` rows. Pass the acting user so that the permission caches
+  are invalidated for them::
+
+      page.move_page(target, position, user=request.user)
+* The move endpoint answers ``403`` when the moved subtree contains pages the
+  user may not view and the destination would grant them access, mirroring the
+  behaviour of copy.
+* Two new methods support this: ``Page.get_view_restrictions()`` snapshots the
+  ``can_view`` grants that protect a page, and ``Page.apply_view_restrictions()``
+  recreates such a snapshot on a page at its new location. Code that relocates
+  pages outside of ``Page.move_page()`` or ``Page.copy_with_descendants()``
+  should use them.
+* ``cms.utils.page_permissions`` gained ``user_can_relocate_descendants()`` with
+  the thin wrappers ``user_can_copy_descendants()`` and
+  ``user_can_move_descendants()`` for authorizing an operation against a whole
+  subtree rather than its root.
+
+See :doc:`/explanation/permissions` for the full picture of how permissions
+behave when pages are moved, copied or deleted.
 
 Backward incompatible change 2
 ==============================


### PR DESCRIPTION
## Summary by Sourcery

Preserve page view restrictions and validate descendant access when copying or moving page trees.

Bug Fixes:
- Prevent page-tree copies, moves, and duplicates from exposing pages protected by view restrictions.
- Preserve inherited and explicit view restrictions when relocated content leaves its original hierarchy.
- Reject copy and move operations when destination permissions would make previously unreadable descendants accessible.

Enhancements:
- Add permission handling that materializes inherited view restrictions without carrying over editing privileges and avoids redundant permission records.

Documentation:
- Document the permission behavior and upgrade considerations for protected page-tree operations.

Tests:
- Add regression coverage for restricted descendants across copy, move, and duplicate operations, including destination grants, inherited restrictions, and unrestricted pages.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.