### PR TITLE
fix: Configure test mailers for Django 6.1

### DIFF
--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -46,6 +46,7 @@ from cms.plugin_pool import plugin_pool
 from cms.toolbar.utils import get_toolbar_from_request
 from cms.utils import get_current_site, get_language_from_request
 from cms.utils.conf import get_site_id
+from cms.utils.mail import MAIL_DELIVERY_ERRORS
 from cms.utils.placeholder import validate_placeholder_name
 from cms.utils.urlutils import admin_reverse
 
@@ -94,7 +95,11 @@ def _get_page_by_untyped_arg(page_lookup, request, site_id):
             raise Page.DoesNotExist(body)
         else:
             if "django.middleware.common.BrokenLinkEmailsMiddleware" in settings.MIDDLEWARE:
-                mail_managers(subject, body, fail_silently=True)
+                try:
+                    mail_managers(subject, body)
+                except MAIL_DELIVERY_ERRORS:
+                    # A delivery failure must not replace the missing-page response.
+                    pass
             return None
 
 

--- a/cms/test_utils/mail.py
+++ b/cms/test_utils/mail.py
@@ -1,0 +1,12 @@
+from django.core import mail
+
+MAILERS_SUPPORTED = hasattr(mail, "mailers")
+LOCMEM_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+
+
+def get_email_settings():
+    """Configure in-memory email using the running Django's settings API."""
+    if MAILERS_SUPPORTED:
+        return {"MAILERS": {"default": {"BACKEND": LOCMEM_BACKEND}}}
+
+    return {"EMAIL_BACKEND": LOCMEM_BACKEND}

--- a/cms/tests/settings.py
+++ b/cms/tests/settings.py
@@ -18,6 +18,8 @@ import tempfile
 
 import dj_database_url
 
+from cms.test_utils.mail import get_email_settings
+
 
 def gettext(s):
     return s
@@ -172,7 +174,7 @@ CMS_MEDIA_URL = "/cms-media/"
 MEDIA_URL = "/media/"
 STATIC_URL = "/static/"
 ADMIN_MEDIA_PREFIX = "/static/admin/"
-EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+globals().update(get_email_settings())
 DEBUG_TOOLBAR_PATCH_SETTINGS = False
 INTERNAL_IPS = ["127.0.0.1"]
 AUTHENTICATION_BACKENDS = (

--- a/cms/tests/test_mail.py
+++ b/cms/tests/test_mail.py
@@ -1,14 +1,17 @@
+from smtplib import SMTPException
 from unittest import skipUnless
+from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.core import mail
+from django.test import SimpleTestCase, override_settings
 
 from cms.api import create_page_user
 from cms.test_utils.mail import MAILERS_SUPPORTED
 from cms.test_utils.testcases import CMSTestCase
-from cms.utils.mail import mail_page_user_change
+from cms.utils.mail import mail_page_user_change, send_mail
 
 
 class MailTestCase(CMSTestCase):
@@ -20,6 +23,7 @@ class MailTestCase(CMSTestCase):
         user = create_page_user(user, user, grant_all=True)
         mail_page_user_change(user)
         self.assertEqual(len(mail.outbox), 1)
+
 
     @skipUnless(MAILERS_SUPPORTED, "Django < 6.1 has no MAILERS setting")
     def test_mailers_only_project(self):
@@ -40,3 +44,66 @@ class MailTestCase(CMSTestCase):
         self.assertEqual(message.to, [user.email])
         self.assertIn("https://example.com/en/admin/", message.body)
         self.assertEqual(message.alternatives[0][1], "text/html")
+
+
+@override_settings(
+    TEMPLATES=[
+        {
+            "BACKEND": "django.template.backends.django.DjangoTemplates",
+            "OPTIONS": {
+                "loaders": [
+                    (
+                        "django.template.loaders.locmem.Loader",
+                        {
+                            "mail.txt": "{{ title }}: {{ login_url }}",
+                            "mail.html": "<p>{{ title }}</p>",
+                        },
+                    )
+                ]
+            },
+        }
+    ]
+)
+class MailDeliveryTests(SimpleTestCase):
+    def send_message(self, **kwargs):
+        return send_mail(
+            "Account updated",
+            "mail.txt",
+            ["user@example.com"],
+            site=Site(domain="example.com"),
+            **kwargs,
+        )
+
+    def test_text_mail(self):
+        self.send_message()
+        message = mail.outbox[0]
+        self.assertEqual(message.to, ["user@example.com"])
+        self.assertIn("Account updated: https://example.com/", message.body)
+        self.assertEqual(message.alternatives, [])
+
+    def test_multipart_mail(self):
+        self.send_message(html_template="mail.html")
+        self.assertEqual(mail.outbox[0].alternatives, [("<p>Account updated</p>", "text/html")])
+
+    def test_suppress_delivery_errors(self):
+        for error in (ConnectionError, SMTPException):
+            with self.subTest(error=error), patch("cms.utils.mail.EmailMultiAlternatives.send", side_effect=error):
+                self.send_message()
+
+    def test_raise_delivery_errors(self):
+        for error in (ConnectionError, SMTPException):
+            with self.subTest(error=error), patch("cms.utils.mail.EmailMultiAlternatives.send", side_effect=error):
+                with self.assertRaises(error):
+                    self.send_message(fail_silently=False)
+
+    def test_raise_programming_errors(self):
+        with patch("cms.utils.mail.EmailMultiAlternatives.send", side_effect=ValueError):
+            with self.assertRaises(ValueError):
+                self.send_message()
+
+    @skipUnless(MAILERS_SUPPORTED, "Django < 6.1 has no MAILERS setting")
+    @override_settings(MAILERS={})
+    def test_unconfigured_mailer(self):
+        self.send_message()
+        with self.assertRaises(mail.MailerDoesNotExist):
+            self.send_message(fail_silently=False)

--- a/cms/tests/test_mail.py
+++ b/cms/tests/test_mail.py
@@ -1,7 +1,12 @@
+from unittest import skipUnless
+
+from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
 from django.core import mail
 
 from cms.api import create_page_user
+from cms.test_utils.mail import MAILERS_SUPPORTED
 from cms.test_utils.testcases import CMSTestCase
 from cms.utils.mail import mail_page_user_change
 
@@ -15,3 +20,23 @@ class MailTestCase(CMSTestCase):
         user = create_page_user(user, user, grant_all=True)
         mail_page_user_change(user)
         self.assertEqual(len(mail.outbox), 1)
+
+    @skipUnless(MAILERS_SUPPORTED, "Django < 6.1 has no MAILERS setting")
+    def test_mailers_only_project(self):
+        self.assertEqual(
+            settings.MAILERS["default"]["BACKEND"],
+            "django.core.mail.backends.locmem.EmailBackend",
+        )
+        # MAILERS must work without falling back to legacy email settings.
+        for name in ("EMAIL_BACKEND", "EMAIL_HOST", "EMAIL_HOST_USER"):
+            with self.subTest(setting=name), self.assertRaises(AttributeError):
+                getattr(settings, name)
+
+        user = get_user_model()(email="username@django-cms.org")
+        mail_page_user_change(user, site=Site(domain="example.com"))
+
+        self.assertEqual(len(mail.outbox), 1)
+        message = mail.outbox[0]
+        self.assertEqual(message.to, [user.email])
+        self.assertIn("https://example.com/en/admin/", message.body)
+        self.assertEqual(message.alternatives[0][1], "text/html")

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -381,6 +381,18 @@ class TemplatetagDatabaseTests(TwoPagesFixture, CMSTestCase):
         request = self.get_request("/")
         self.assertRaises(TypeError, _get_page_by_untyped_arg, [], request, 1)
 
+    @override_settings(DEBUG=False, MIDDLEWARE=["django.middleware.common.BrokenLinkEmailsMiddleware"])
+    def test_missing_page_mail_error(self):
+        with patch("cms.templatetags.cms_tags.mail_managers", side_effect=ConnectionError):
+            page = _get_page_by_untyped_arg({"pk": 1003}, self.get_request("/"), 1)
+        self.assertIsNone(page)
+
+    @override_settings(DEBUG=False, MIDDLEWARE=["django.middleware.common.BrokenLinkEmailsMiddleware"])
+    def test_missing_page_code_error(self):
+        with patch("cms.templatetags.cms_tags.mail_managers", side_effect=ValueError):
+            with self.assertRaises(ValueError):
+                _get_page_by_untyped_arg({"pk": 1003}, self.get_request("/"), 1)
+
     def test_show_placeholder_for_page_content_does_not_exist(self):
         """
         Verify ``show_placeholder`` correctly handles being given an

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -39,12 +39,15 @@ from cms.templatetags.cms_tags import (
     render_plugin,
 )
 from cms.test_utils.fixtures.templatetags import TwoPagesFixture
+from cms.test_utils.mail import MAILERS_SUPPORTED
 from cms.test_utils.project.placeholderapp.models import Example1
 from cms.test_utils.testcases import CMSTestCase
 from cms.toolbar.toolbar import CMSToolbar
 from cms.toolbar.utils import get_object_edit_url, get_object_preview_url
 from cms.utils.conf import get_cms_setting, get_site_id
 from cms.utils.placeholder import get_placeholders
+
+TEST_MANAGERS = ["Jenkins <tests@django-cms.org>"] if MAILERS_SUPPORTED else [("Jenkins", "tests@django-cms.org")]
 
 
 class TemplatetagTests(CMSTestCase):
@@ -354,7 +357,7 @@ class TemplatetagDatabaseTests(TwoPagesFixture, CMSTestCase):
         with self.settings(
             MIDDLEWARE=settings.MIDDLEWARE + ["django.middleware.common.BrokenLinkEmailsMiddleware"],
             DEBUG=False,
-            MANAGERS=[("Jenkins", "tests@django-cms.org")],
+            MANAGERS=TEST_MANAGERS,
         ):
             request = self.get_request("/")
             page = _get_page_by_untyped_arg({"pk": 1003}, request, 1)
@@ -367,7 +370,7 @@ class TemplatetagDatabaseTests(TwoPagesFixture, CMSTestCase):
                 mw for mw in settings.MIDDLEWARE if mw != "django.middleware.common.BrokenLinkEmailsMiddleware"
             ],
             DEBUG=False,
-            MANAGERS=[("Jenkins", "tests@django-cms.org")],
+            MANAGERS=TEST_MANAGERS,
         ):
             request = self.get_request("/")
             page = _get_page_by_untyped_arg({"pk": 1003}, request, 1)

--- a/cms/utils/mail.py
+++ b/cms/utils/mail.py
@@ -1,14 +1,20 @@
 from django.contrib.sites.models import Site
+from django.core import mail
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
 from django.utils.translation import gettext_lazy as _
 
 from cms.utils.urlutils import admin_reverse, urljoin
 
+MAIL_DELIVERY_ERRORS = (OSError,)
+if hasattr(mail, "MailerDoesNotExist"):
+    MAIL_DELIVERY_ERRORS += (mail.MailerDoesNotExist,)
+
 
 def send_mail(subject, txt_template, to, context=None, html_template=None, fail_silently=True, site=None):
     """
-    Multipart message helper with template rendering.
+    Render and send multipart mail. With ``fail_silently=True``, suppress
+    transport errors and an unconfigured mailer, but not programming errors.
     """
     site = site or Site.objects.get_current()
 
@@ -25,7 +31,11 @@ def send_mail(subject, txt_template, to, context=None, html_template=None, fail_
     if html_template:
         body = render_to_string(html_template, context)
         message.attach_alternative(body, 'text/html')
-    message.send(fail_silently=fail_silently)
+    try:
+        message.send()
+    except MAIL_DELIVERY_ERRORS:
+        if not fail_silently:
+            raise
 
 
 def mail_page_user_change(user, created=False, password="", site=None):

--- a/testserver.py
+++ b/testserver.py
@@ -7,6 +7,7 @@ import warnings
 import dj_database_url
 
 from cms.exceptions import DontUsePageAttributeWarning
+from cms.test_utils.mail import get_email_settings
 
 
 def gettext(s):
@@ -186,7 +187,7 @@ if __name__ == "__main__":
             MEDIA_URL="/media/",
             STATIC_URL="/static/",
             ADMIN_MEDIA_PREFIX="/static/admin/",
-            EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+            **get_email_settings(),
             PLUGIN_APPS=PLUGIN_APPS,
             DEBUG_TOOLBAR_PATCH_SETTINGS=False,
             INTERNAL_IPS=["127.0.0.1"],


### PR DESCRIPTION
Use Django 6.1's `MAILERS` configuration for the test suite and standalone server through one shared feature-detection helper. Retain `EMAIL_BACKEND` on Django 5.2 and 6.0, and select the supported manager-address format.

Add a regression that verifies CMS multipart mail delivery while legacy email settings are unavailable.

Validation: 56 mail/template-tag tests on Django 5.2.6, 6.0.8, and 6.1.1; standalone-server settings and delivery checks on all three; full Django 6.1.1 SQLite suite (1,802 tests, one skipped), with the reported settings warnings treated as errors; Ruff and diff checks.

Closes #8764. Part of #8773.

## Summary by Sourcery

Support Django 6.1 mailer configuration across test and standalone-server environments while preserving compatible email behavior on earlier versions.

Bug Fixes:
- Prevent missing-page email delivery failures from replacing the original missing-page response while still propagating programming errors.
- Ensure mail delivery suppresses only transport and unconfigured-mailer errors when silent failure is requested.

Enhancements:
- Configure the test suite and standalone server with Django 6.1 MAILERS when available while retaining legacy email settings on older Django versions.
- Add cross-version coverage for text and multipart email delivery, mailer configuration, and delivery-error behavior.

Tests:
- Add regression coverage for multipart email delivery when only Django 6.1 MAILERS settings are available.
- Expand template-tag tests for mail delivery and error handling.