### PR TITLE
fix: Preserve best-effort CMS mail delivery

### DIFF
--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -46,6 +46,7 @@ from cms.plugin_pool import plugin_pool
 from cms.toolbar.utils import get_toolbar_from_request
 from cms.utils import get_current_site, get_language_from_request
 from cms.utils.conf import get_site_id
+from cms.utils.mail import MAIL_DELIVERY_ERRORS
 from cms.utils.placeholder import validate_placeholder_name
 from cms.utils.urlutils import admin_reverse
 
@@ -94,7 +95,11 @@ def _get_page_by_untyped_arg(page_lookup, request, site_id):
             raise Page.DoesNotExist(body)
         else:
             if "django.middleware.common.BrokenLinkEmailsMiddleware" in settings.MIDDLEWARE:
-                mail_managers(subject, body, fail_silently=True)
+                try:
+                    mail_managers(subject, body)
+                except MAIL_DELIVERY_ERRORS:
+                    # A delivery failure must not replace the missing-page response.
+                    pass
             return None
 
 

--- a/cms/tests/test_mail.py
+++ b/cms/tests/test_mail.py
@@ -1,9 +1,15 @@
+from smtplib import SMTPException
+from unittest import skipUnless
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
 from django.core import mail
+from django.test import SimpleTestCase, override_settings
 
 from cms.api import create_page_user
 from cms.test_utils.testcases import CMSTestCase
-from cms.utils.mail import mail_page_user_change
+from cms.utils.mail import mail_page_user_change, send_mail
 
 
 class MailTestCase(CMSTestCase):
@@ -15,3 +21,66 @@ class MailTestCase(CMSTestCase):
         user = create_page_user(user, user, grant_all=True)
         mail_page_user_change(user)
         self.assertEqual(len(mail.outbox), 1)
+
+
+@override_settings(
+    TEMPLATES=[
+        {
+            "BACKEND": "django.template.backends.django.DjangoTemplates",
+            "OPTIONS": {
+                "loaders": [
+                    (
+                        "django.template.loaders.locmem.Loader",
+                        {
+                            "mail.txt": "{{ title }}: {{ login_url }}",
+                            "mail.html": "<p>{{ title }}</p>",
+                        },
+                    )
+                ]
+            },
+        }
+    ]
+)
+class MailDeliveryTests(SimpleTestCase):
+    def send_message(self, **kwargs):
+        return send_mail(
+            "Account updated",
+            "mail.txt",
+            ["user@example.com"],
+            site=Site(domain="example.com"),
+            **kwargs,
+        )
+
+    def test_text_mail(self):
+        self.send_message()
+        message = mail.outbox[0]
+        self.assertEqual(message.to, ["user@example.com"])
+        self.assertIn("Account updated: https://example.com/", message.body)
+        self.assertEqual(message.alternatives, [])
+
+    def test_multipart_mail(self):
+        self.send_message(html_template="mail.html")
+        self.assertEqual(mail.outbox[0].alternatives, [("<p>Account updated</p>", "text/html")])
+
+    def test_suppress_delivery_errors(self):
+        for error in (ConnectionError, SMTPException):
+            with self.subTest(error=error), patch("cms.utils.mail.EmailMultiAlternatives.send", side_effect=error):
+                self.send_message()
+
+    def test_raise_delivery_errors(self):
+        for error in (ConnectionError, SMTPException):
+            with self.subTest(error=error), patch("cms.utils.mail.EmailMultiAlternatives.send", side_effect=error):
+                with self.assertRaises(error):
+                    self.send_message(fail_silently=False)
+
+    def test_raise_programming_errors(self):
+        with patch("cms.utils.mail.EmailMultiAlternatives.send", side_effect=ValueError):
+            with self.assertRaises(ValueError):
+                self.send_message()
+
+    @skipUnless(hasattr(mail, "mailers"), "Django < 6.1 has no MAILERS setting")
+    @override_settings(MAILERS={})
+    def test_unconfigured_mailer(self):
+        self.send_message()
+        with self.assertRaises(mail.MailerDoesNotExist):
+            self.send_message(fail_silently=False)

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -378,6 +378,18 @@ class TemplatetagDatabaseTests(TwoPagesFixture, CMSTestCase):
         request = self.get_request("/")
         self.assertRaises(TypeError, _get_page_by_untyped_arg, [], request, 1)
 
+    @override_settings(DEBUG=False, MIDDLEWARE=["django.middleware.common.BrokenLinkEmailsMiddleware"])
+    def test_missing_page_mail_error(self):
+        with patch("cms.templatetags.cms_tags.mail_managers", side_effect=ConnectionError):
+            page = _get_page_by_untyped_arg({"pk": 1003}, self.get_request("/"), 1)
+        self.assertIsNone(page)
+
+    @override_settings(DEBUG=False, MIDDLEWARE=["django.middleware.common.BrokenLinkEmailsMiddleware"])
+    def test_missing_page_code_error(self):
+        with patch("cms.templatetags.cms_tags.mail_managers", side_effect=ValueError):
+            with self.assertRaises(ValueError):
+                _get_page_by_untyped_arg({"pk": 1003}, self.get_request("/"), 1)
+
     def test_show_placeholder_for_page_content_does_not_exist(self):
         """
         Verify ``show_placeholder`` correctly handles being given an

--- a/cms/utils/mail.py
+++ b/cms/utils/mail.py
@@ -1,14 +1,20 @@
 from django.contrib.sites.models import Site
+from django.core import mail
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
 from django.utils.translation import gettext_lazy as _
 
 from cms.utils.urlutils import admin_reverse, urljoin
 
+MAIL_DELIVERY_ERRORS = (OSError,)
+if hasattr(mail, "MailerDoesNotExist"):
+    MAIL_DELIVERY_ERRORS += (mail.MailerDoesNotExist,)
+
 
 def send_mail(subject, txt_template, to, context=None, html_template=None, fail_silently=True, site=None):
     """
-    Multipart message helper with template rendering.
+    Render and send multipart mail. With ``fail_silently=True``, suppress
+    transport errors and an unconfigured mailer, but not programming errors.
     """
     site = site or Site.objects.get_current()
 
@@ -25,7 +31,11 @@ def send_mail(subject, txt_template, to, context=None, html_template=None, fail_
     if html_template:
         body = render_to_string(html_template, context)
         message.attach_alternative(body, 'text/html')
-    message.send(fail_silently=fail_silently)
+    try:
+        message.send()
+    except MAIL_DELIVERY_ERRORS:
+        if not fail_silently:
+            raise
 
 
 def mail_page_user_change(user, created=False, password="", site=None):


### PR DESCRIPTION
Stop forwarding Django's deprecated `fail_silently` argument from CMS mail helpers and missing-page reporting. Keep the public CMS argument: best-effort sending suppresses transport errors and an unconfigured mailer; strict sending and programming errors still propagate.

Cover text and multipart delivery, suppressed and propagated errors, and missing-page reporting failures.

Stacked on #8841, which provides the Django 6.1 test mailer configuration.

Validation: 63 mail/template-tag tests on Django 5.2.6, 6.0.8, and 6.1.1; full Django 6.1.1 SQLite suite (1,809 tests, one skipped) with the deprecated mail argument treated as an error; Ruff and diff checks.

Closes #8763. Part of #8773.
