### PR TITLE
ci: Gate final Django 6.1 deprecations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,7 +193,31 @@ jobs:
         uv pip install --system -r test_requirements/databases.txt
         uv pip install --system -e .
 
+    - name: Test final Django 6.1 without deprecations
+      if: matrix.requirements-file == 'django-6.1.txt'
+      env:
+        DATABASE_URL: sqlite://localhost/testdb.sqlite
+      run: |
+        python - <<'PY'
+        import sys
+        import warnings
+
+        import django
+        from coverage.cmdline import main
+        from django.utils import deprecation
+
+        print(f"Testing Django {django.get_version()}", flush=True)
+        assert django.VERSION[:2] == (6, 1) and django.VERSION[3] == "final", "Expected final Django 6.1"
+        # Django renamed this warning when adopting calendar versioning.
+        removed_warning = getattr(deprecation, "RemovedInDjango2028Warning", None)
+        if removed_warning is None:
+            removed_warning = deprecation.RemovedInDjango70Warning
+        warnings.simplefilter("error", removed_warning)
+        sys.exit(main(["run", "manage.py", "test"]))
+        PY
+
     - name: Test with django test runner (coverage enabled)
+      if: matrix.requirements-file != 'django-6.1.txt'
       run: coverage run manage.py test
       env:
         DATABASE_URL: sqlite://localhost/testdb.sqlite

--- a/test_requirements/django-6.1.txt
+++ b/test_requirements/django-6.1.txt
@@ -1,2 +1,2 @@
 -r requirements_base.txt
-Django>=6.1a1,<6.2
+Django>=6.1,<6.2


### PR DESCRIPTION
Require a final Django 6.1 release and run each Django 6.1 SQLite matrix row with Django's next-removal warnings treated as errors. Keep Python 3.12–3.14 coverage and leave other warning categories unchanged. Support both the original and calendar-version warning names.

Validation: executed the exact workflow command locally on Django 6.1.1: 1,810 tests, one skipped, with coverage and the warning gate enabled. Confirmed that Django 6.0 is rejected before tests start; checked YAML, shell syntax, and the diff.

Stacked on #8842, which includes the mail-settings prerequisite #8841. The PR diff contains only this ticket's CI and requirement changes.

Closes #8768. Part of #8773.

## Summary by Sourcery

Enforce resolution of Django 6.1 deprecations in CI before upgrading to the next Django release.

Enhancements:
- Gate the Django 6.1 test matrix on a final Django 6.1 release and treat its next-removal deprecation warnings as errors while preserving existing coverage.

Build:
- Update the Django 6.1 test requirement to require the final release.

CI:
- Add dedicated Django 6.1 CI coverage across the existing supported Python matrix, including compatibility with both legacy and calendar-version deprecation warning names.