### PR TITLE
ci: Constrain generated-project Django versions

### DIFF
--- a/.github/workflows/test_startcmsproject.yml
+++ b/.github/workflows/test_startcmsproject.yml
@@ -43,14 +43,33 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Create project from template (${{ matrix.mode }} / ${{ matrix.switches.name }})
+      env:
+        DJANGO_SERIES: ${{ matrix.django-version }}
       run: |
+        set -euo pipefail
         sudo apt install gettext gcc -y
         python -m venv .venv
         source ./.venv/bin/activate
         python -m pip install --upgrade pip
-        pip install Django~=${{ matrix.django-version }}
-        pip install -e .
+        # Keep nested pip installs during project generation on the same series.
+        export PIP_CONSTRAINT="$PWD/.venv/django-constraints.txt"
+        printf 'Django~=%s.0\n' "$DJANGO_SERIES" > "$PIP_CONSTRAINT"
+        pip install -e . "Django~=${DJANGO_SERIES}.0"
+
+        check_django() {
+          python - <<'PY'
+        import os
+        import django
+
+        expected = tuple(map(int, os.environ["DJANGO_SERIES"].split(".")))
+        print(f"Django {django.get_version()} (expected {os.environ['DJANGO_SERIES']})", flush=True)
+        assert django.VERSION[:2] == expected, "Project generation changed the selected Django series"
+        PY
+        }
+
+        check_django
         djangocms mysite --noinput --mode ${{ matrix.mode }} ${{ matrix.switches.flags }}
+        check_django
     - name: Verify requirements.in reflects the selected options
       env:
         MODE: ${{ matrix.mode }}


### PR DESCRIPTION
Keep generated projects on the Django minor series named by each CI row. Resolve the editable CMS package with a minor-series constraint in one pip invocation, propagate that constraint to the generator's nested pip calls, and assert the running version before and after generation.

Retain all 18 combinations of Django 5.2/6.0/6.1, traditional/headless/hybrid modes, and all-on/all-off features, including the existing generated-requirements checks.

Validation: YAML and shell syntax checks; the version assertion accepts the matching 5.2, 6.0, and 6.1 runtimes and rejects a 6.1 runtime in a 6.0 row. The PR workflow runs the full generation matrix.

Closes #8769. Part of #8773.

## Summary by Sourcery

Ensure generated-project CI consistently uses and validates the Django minor series selected by each matrix configuration.

Bug Fixes:
- Keep generated-project CI jobs on the Django minor-version series selected by each matrix row, including during nested project-generation installs.

Enhancements:
- Add pre- and post-generation assertions that the active Django version matches the CI matrix selection while preserving the full generation matrix and requirements checks.

CI:
- Constrain Django dependencies and propagate the constraint through generated-project CI workflows.