### PR TITLE
ci: Complete Django 6.1 minimum database coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -238,6 +238,21 @@ jobs:
         uv pip install --system -r test_requirements/databases.txt
         uv pip install --system -e .
 
+    - name: Build SQLite 3.37.2
+      if: matrix.requirements-file == 'django-6.1.txt' && matrix.python-version == '3.12'
+      working-directory: ${{ runner.temp }}
+      run: |
+        curl --fail --silent --show-error --location --retry 3 \
+          https://www.sqlite.org/2022/sqlite-autoconf-3370200.tar.gz -o sqlite.tar.gz
+        echo "4089a8d9b467537b3f246f217b84cd76e00b1d1a971fe5aca1e30e230e46b2d8  sqlite.tar.gz" | sha256sum --check
+        tar -xzf sqlite.tar.gz
+        cd sqlite-autoconf-3370200
+        ./configure --prefix="$RUNNER_TEMP/sqlite-minimum" --disable-static --enable-shared
+        make -j2
+        make install
+        # Make Python load the minimum library for the subsequent checks and suite.
+        echo "LD_LIBRARY_PATH=$RUNNER_TEMP/sqlite-minimum/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
+
     - name: Verify Django 6.1 SQLite minimum
       if: matrix.requirements-file == 'django-6.1.txt'
       run: |
@@ -246,6 +261,8 @@ jobs:
 
         print(f"SQLite {sqlite3.sqlite_version}")
         assert sqlite3.sqlite_version_info >= (3, 37), "Django 6.1 requires SQLite 3.37 or newer"
+        if "${{ matrix.python-version }}" == "3.12":
+            assert sqlite3.sqlite_version_info == (3, 37, 2), "Expected the minimum SQLite library"
         PY
 
     - name: Test final Django 6.1 without deprecations

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,6 +151,51 @@ jobs:
         include-hidden-files: true
         path: '.coverage*'
 
+  mariadb-minimum:
+    runs-on: ubuntu-latest
+    services:
+      mariadb:
+        image: mariadb:10.11
+        env:
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'yes'
+          MARIADB_DATABASE: djangocms_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s --health-timeout=5s --health-retries=3
+    env:
+      DATABASE_URL: mysql://root@127.0.0.1/djangocms_test
+      DJANGO_SETTINGS_MODULE: cms.tests.settings
+    steps:
+    - uses: actions/checkout@v7
+    - uses: actions/setup-python@v7
+      with:
+        python-version: '3.14'
+        cache: 'pip'
+    - name: Install dependencies
+      run: |
+        sudo apt install gettext gcc -y
+        python -m pip install --upgrade pip uv
+        uv pip install --system pytest -r test_requirements/django-6.1.txt -r test_requirements/databases.txt
+    - name: Verify MariaDB minimum and run tests
+      run: |
+        python - <<'PY'
+        import django
+        django.setup()
+        from django.db import connection
+
+        print(f"Django {django.get_version()}, MariaDB {connection.mysql_server_info}", flush=True)
+        assert connection.mysql_is_mariadb and connection.mysql_version[:2] == (10, 11), "Expected MariaDB 10.11"
+        PY
+        coverage run manage.py test
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v7
+      with:
+        name: coverage-data-mariadb-10.11-django-6.1
+        include-hidden-files: true
+        path: '.coverage*'
+
   sqlite:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -192,6 +237,16 @@ jobs:
         uv pip install --system -r test_requirements/${{ matrix.requirements-file }}
         uv pip install --system -r test_requirements/databases.txt
         uv pip install --system -e .
+
+    - name: Verify Django 6.1 SQLite minimum
+      if: matrix.requirements-file == 'django-6.1.txt'
+      run: |
+        python - <<'PY'
+        import sqlite3
+
+        print(f"SQLite {sqlite3.sqlite_version}")
+        assert sqlite3.sqlite_version_info >= (3, 37), "Django 6.1 requires SQLite 3.37 or newer"
+        PY
 
     - name: Test with django test runner (coverage enabled)
       run: coverage run manage.py test
@@ -369,7 +424,7 @@ jobs:
     name: Coverage
     runs-on: ${{ matrix.os }}
     needs: [
-      postgres, mysql, sqlite,
+      postgres, mysql, mariadb-minimum, sqlite,
       django-main-sqlite,
       django-main-postgres,
       django-main-mysql,


### PR DESCRIPTION
Complete the remaining database checks from #8770 after #8774 added PostgreSQL 15. Add one Django 6.1/Python 3.14 job against MariaDB 10.11, verify the connected server's family and minor version, and include its results in combined coverage.

Build checksum-verified SQLite 3.37.2 for the existing Django 6.1/Python 3.12 row. Configure its shared library for the test interpreter and assert the loaded version is exactly 3.37.2 before running the strict-warning suite. Other Django 6.1 SQLite rows assert 3.37+. Retain PostgreSQL 15 and MySQL 8.4 coverage without expanding the Python/database Cartesian matrix.

Validation: workflow YAML and shell syntax pass. The combined 1,811-test suite passes locally on Django 5.2.6, 6.0.8, and 6.1.1. The minimum SQLite check rejects the default 3.50.4 library. A separate full Django 6.1 run uses CPython's SQLite extension rebuilt against SQLite 3.37.2, with deprecation warnings treated as errors. MariaDB execution is covered by the hosted job; no local container runtime is available.

Refs #8770 and #8773. Stacked on #8843 (which includes #8841 and #8842) to keep the database checks and strict Django 6.1 warning gate together.

## Summary by Sourcery

Complete Django 6.1 minimum database compatibility coverage across MariaDB and SQLite in CI.

New Features:
- Add Django 6.1/Python 3.14 coverage against MariaDB 10.11 with server-version validation.

Enhancements:
- Enforce Django 6.1 SQLite minimum-version coverage, including an exact SQLite 3.37.2 check for the Django 6.1/Python 3.12 job.
- Include MariaDB coverage in the combined coverage job while retaining the existing PostgreSQL and MySQL coverage.

Build:
- Build and configure checksum-verified SQLite 3.37.2 for the minimum-version test job.

CI:
- Expand the CI database matrix to validate MariaDB 10.11 and minimum SQLite compatibility without broadening the full Python/database matrix.

Tests:
- Run the Django 6.1 test suite with minimum MariaDB and SQLite versions.