### PR TITLE
docs: Document the Django 6.1 upgrade contract

### DIFF
--- a/docs/upgrade/5.1.0.rst
+++ b/docs/upgrade/5.1.0.rst
@@ -22,7 +22,21 @@ django CMS 5.1 supports **Django 5.2, 6.0, and 6.1**. Django 4.2, 5.0, and
 maintenance. We highly recommend and only support the latest release of each
 supported series.
 
-It supports **Python 3.10, 3.11, 3.12, 3.13, and 3.14**.
+Use the latest patch release of a supported combination:
+
+.. list-table:: Django and Python versions
+   :header-rows: 1
+
+   * - Django
+     - Python
+   * - `5.2 <https://docs.djangoproject.com/en/5.2/releases/5.2/#python-compatibility>`_
+     - 3.10, 3.11, 3.12, 3.13, 3.14
+   * - `6.0 <https://docs.djangoproject.com/en/6.0/releases/6.0/#python-compatibility>`_
+     - 3.12, 3.13, 3.14
+   * - `6.1 <https://docs.djangoproject.com/en/6.1/releases/6.1/#python-compatibility>`_
+     - 3.12, 3.13, 3.14
+
+Python 3.10 and 3.11 require Django 5.2.
 
 ******************
 Release highlights
@@ -54,8 +68,8 @@ more precise plugin configuration, and a modernized editing interface.
   spacing, visual consistency, and light/dark color-scheme support. The
   previous theme remains available as a migration aid.
 
-* **Deploy on all maintained platform versions.** django CMS 5.1 supports Django
-  5.2, 6.0, and 6.1 and Python 3.10 through 3.14.
+* **Deploy on maintained platform versions.** django CMS 5.1 supports the
+  Django/Python combinations listed above.
 
 * **Benefit from security and reliability improvements.** The release
   strengthens authorization around editing and clipboard operations, improves
@@ -85,6 +99,41 @@ Then apply migrations, collect static files, and run the django CMS checks::
 Test custom plugins, apphooks, permissions, frontend editing, and all templates
 in a staging environment before deploying. Projects that customize or replace
 django CMS migrations should also review the new squashed initial migration.
+
+Upgrading to Django 6.1
+======================
+
+Django 6.1 requires `PostgreSQL 15+
+<https://docs.djangoproject.com/en/6.1/releases/6.1/#dropped-support-for-postgresql-14>`_,
+`MySQL 8.4+
+<https://docs.djangoproject.com/en/6.1/releases/6.1/#dropped-support-for-mysql-8-4>`_,
+`MariaDB 10.11+
+<https://docs.djangoproject.com/en/6.1/releases/6.1/#dropped-support-for-mariadb-10-11>`_,
+or `SQLite 3.37+
+<https://docs.djangoproject.com/en/6.1/releases/6.1/#miscellaneous>`_.
+
+Page and template-fragment caches that vary on headers or arguments use new
+keys. Existing entries become cold misses and are repopulated on demand; no
+cache data migration is required. See `Django's cache-key changes
+<https://docs.djangoproject.com/en/6.1/releases/6.1/#miscellaneous>`_.
+
+Legacy signed cookies may be rejected after upgrading. Django's
+``SIGNED_COOKIE_LEGACY_SALT_FALLBACK`` setting can temporarily accept them
+during a transition; it is deprecated and should not remain enabled
+permanently. Review the `signed-cookie fallback guidance
+<https://docs.djangoproject.com/en/6.1/ref/settings/#signed-cookie-legacy-salt-fallback>`_.
+
+Projects using CMS email features can configure the default backend through
+``MAILERS["default"]``. Migrate the deprecated ``EMAIL_*`` settings together:
+they are unavailable once ``MAILERS`` is defined. Check other email-sending
+dependencies for compatibility and migrate ``ADMINS``/``MANAGERS`` address
+pairs to strings. See `Django's mailers migration guide
+<https://docs.djangoproject.com/en/6.1/howto/mailers-migration/>`_.
+
+No django CMS model migration is required solely by Django 6.1. Still run
+the normal migrations for django CMS, Django, and installed applications as
+described above, and review `Django's version-upgrade guide
+<https://docs.djangoproject.com/en/6.1/howto/upgrade-version/>`_.
 
 *******************
 What's new in 5.1.0

--- a/docs/upgrade/5.1.0.rst
+++ b/docs/upgrade/5.1.0.rst
@@ -101,7 +101,7 @@ in a staging environment before deploying. Projects that customize or replace
 django CMS migrations should also review the new squashed initial migration.
 
 Upgrading to Django 6.1
-======================
+=======================
 
 Django 6.1 requires `PostgreSQL 15+
 <https://docs.djangoproject.com/en/6.1/releases/6.1/#dropped-support-for-postgresql-14>`_,

--- a/docs/upgrade/version.rst.template
+++ b/docs/upgrade/version.rst.template
@@ -20,11 +20,23 @@ updating an existing project.
 Django and Python compatibility
 *******************************
 
-django CMS supports **Django 4.2, 5.0, 5.1, and 5.2**. We highly recommend and only
-support the latest release of each series.
+django CMS supports **Django 5.2, 6.0, and 6.1**. Use the latest patch release
+of a supported combination:
 
-It supports **Python 3.11, 3.12, 3.13, and 3.14**. As for Django we highly recommend and only
-support the latest release of each series.
+.. list-table:: Django and Python versions
+   :header-rows: 1
+
+   * - Django
+     - Python
+   * - `5.2 <https://docs.djangoproject.com/en/5.2/releases/5.2/#python-compatibility>`_
+     - 3.10, 3.11, 3.12, 3.13, 3.14
+   * - `6.0 <https://docs.djangoproject.com/en/6.0/releases/6.0/#python-compatibility>`_
+     - 3.12, 3.13, 3.14
+   * - `6.1 <https://docs.djangoproject.com/en/6.1/releases/6.1/#python-compatibility>`_
+     - 3.12, 3.13, 3.14
+
+Python 3.10 and 3.11 require Django 5.2. Review this table when changing
+the supported Django or Python series.
 
 ***********************
 How to upgrade to 5.X.X
@@ -69,4 +81,3 @@ Removal of deprecated functionality
 ===================================
 
 Empty sections are to be removed before release.
-


### PR DESCRIPTION
Document supported Django/Python combinations explicitly, including the Django 5.2 restriction for Python 3.10/3.11. Add the Django 6.1 database floors and explain cache misses, transitional signed-cookie handling, mailer migration, and migration expectations, with primary Django references beside the operational guidance.

Update the reusable release-note template and remove the ambiguous platform summary from the release highlights.

Validation: rendered the new compatibility table and upgrade section with Docutils with warnings treated as errors; checked the diff. The existing documentation workflow builds the complete documentation.

Closes #8771. Part of #8773.

## Summary by Sourcery

Document the Django 6.1 upgrade contract and supported runtime combinations.

New Features:
- Document supported Django and Python version combinations, including Django 5.2’s Python 3.10/3.11 restriction.
- Add Django 6.1 database requirements and upgrade guidance for cache misses, signed cookies, mailer migration, and migrations.

Enhancements:
- Add primary Django references alongside operational upgrade guidance.
- Clarify release-note template guidance and remove the ambiguous platform summary from release highlights.

Documentation:
- Expand the Django upgrade documentation with an explicit compatibility table and Django 6.1 upgrade contract.