### PR TITLE
fix: cross-placeholder parent authorization in paste-a-copy

### DIFF
--- a/cms/admin/placeholderadmin.py
+++ b/cms/admin/placeholderadmin.py
@@ -803,23 +803,26 @@ class PlaceholderAdmin(BaseEditableAdminMixin, admin.ModelAdmin):
             except PluginLimitReached as er:
                 return HttpResponseBadRequest(er)
 
-        # True if the plugin is not being moved from the clipboard
-        # to a placeholder or from a placeholder to the clipboard.
-        move_a_plugin = not move_a_copy and not move_to_clipboard
-
         if parent_id and plugin.parent_id != parent_id:
             target_pl = placeholder or plugin.placeholder
 
-            if move_a_plugin:
-                target_parent = get_object_or_404(
-                    CMSPlugin,
-                    pk=parent_id,
-                    language=target_language,
-                    placeholder=target_pl,
-                )
-            else:
-                target_parent = get_object_or_404(CMSPlugin, pk=parent_id)
-        elif parent_id:
+            # The new parent must live in the placeholder (and language) the
+            # plugin ends up in. This holds for pastes and cuts just as much as
+            # for moves: ``plugin_parent`` is client supplied, so an unscoped
+            # lookup would let a user name a plugin in a placeholder they have
+            # no permission for. That both parents the new plugin outside its
+            # own placeholder and returns the foreign parent's rendered subtree
+            # in the response.
+            target_parent = get_object_or_404(
+                CMSPlugin,
+                pk=parent_id,
+                language=target_language,
+                placeholder=target_pl,
+            )
+        elif parent_id and placeholder is None:
+            # ``plugin_parent`` names the plugin's current parent. Keeping it
+            # only makes sense while the plugin stays in its placeholder; the
+            # parent does not travel to another one.
             target_parent = plugin.parent
         else:
             target_parent = None

--- a/cms/tests/test_placeholder_admin.py
+++ b/cms/tests/test_placeholder_admin.py
@@ -943,3 +943,99 @@ class PlaceholderAdminSecurityTestCase(CMSTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(target.get_plugins("en").count(), 1)
+
+    def test_paste_plugin_rejects_parent_in_other_placeholder(self):
+        """``plugin_parent`` must live in the placeholder the copy lands in.
+
+        The id is client-supplied, so an unscoped lookup would let a staff user
+        name a plugin in a placeholder they have no permission on. The copy
+        would then be parented outside its own placeholder, and the response
+        renders the foreign parent's whole subtree back to the caller.
+        """
+        user = self._create_user(
+            "attacker",
+            is_staff=True,
+            is_superuser=False,
+            permissions=["add_link", "change_link", "change_example1"],
+        )
+        clipboard = self._get_clipboard(user)
+
+        # A page placeholder the user has no permission on.
+        page = create_page("restricted", "nav_playground.html", "en")
+        restricted = page.get_placeholders("en")[0]
+        foreign_parent = add_plugin(
+            restricted,
+            "LinkPlugin",
+            "en",
+            name="VictimSecretLink",
+            external_link="https://secret.example.com",
+        )
+        self.assertFalse(restricted.has_change_permission(user))
+
+        # A placeholder the user does control.
+        target = Example1.objects.create(
+            char_1="one", char_2="two", char_3="tree", char_4="four"
+        ).placeholder
+        plugin = add_plugin(
+            clipboard,
+            "LinkPlugin",
+            "en",
+            name="A Link",
+            external_link="https://www.django-cms.org",
+        )
+
+        endpoint = self.get_move_plugin_uri(plugin)
+        with self.login_user_context(user):
+            data = {
+                "plugin_id": plugin.pk,
+                "placeholder_id": target.pk,
+                "plugin_parent": foreign_parent.pk,
+                "move_a_copy": "true",
+                "target_language": "en",
+                "target_position": 1,
+            }
+            response = self.client.post(endpoint, data)
+
+        self.assertEqual(response.status_code, 404)
+        self.assertNotContains(response, "VictimSecretLink", status_code=404)
+        self.assertFalse(target.get_plugins("en").exists())
+        self.assertEqual(foreign_parent.cmsplugin_set.count(), 0)
+
+    def test_paste_plugin_accepts_parent_in_target_placeholder(self):
+        """The regular case still works: a parent inside the target placeholder."""
+        user = self._create_user(
+            "editor",
+            is_staff=True,
+            is_superuser=False,
+            permissions=["add_link", "change_link", "change_example1"],
+        )
+        clipboard = self._get_clipboard(user)
+        target = Example1.objects.create(
+            char_1="one", char_2="two", char_3="tree", char_4="four"
+        ).placeholder
+        parent = add_plugin(
+            target, "LinkPlugin", "en", name="Parent", external_link="https://example.com"
+        )
+        plugin = add_plugin(
+            clipboard,
+            "LinkPlugin",
+            "en",
+            name="A Link",
+            external_link="https://www.django-cms.org",
+        )
+
+        endpoint = self.get_move_plugin_uri(plugin)
+        with self.login_user_context(user):
+            data = {
+                "plugin_id": plugin.pk,
+                "placeholder_id": target.pk,
+                "plugin_parent": parent.pk,
+                "move_a_copy": "true",
+                "target_language": "en",
+                "target_position": 2,
+            }
+            response = self.client.post(endpoint, data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(target.get_plugins("en").count(), 2)
+        self.assertEqual(parent.cmsplugin_set.get().placeholder_id, target.pk)


### PR DESCRIPTION
## Summary by Sourcery

Enforce destination-scoped parent authorization for plugin paste and move operations.

Bug Fixes:
- Restrict pasted and moved plugins to parents in the destination placeholder and language, preventing unauthorized cross-placeholder parenting and exposure of foreign plugin subtrees.

Tests:
- Add coverage for rejecting unauthorized parents from other placeholders and accepting valid parents in the target placeholder.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.