### PR TITLE
fix: Preserve best-effort CMS mail delivery (#8842)

### DIFF
--- a/cms/templatetags/cms_tags.py
+++ b/cms/templatetags/cms_tags.py
@@ -47,6 +47,7 @@ from cms.plugin_pool import plugin_pool
 from cms.toolbar.utils import get_toolbar_from_request
 from cms.utils import get_current_site, get_language_from_request
 from cms.utils.conf import get_site_id
+from cms.utils.mail import MAIL_DELIVERY_ERRORS
 from cms.utils.placeholder import validate_placeholder_name
 from cms.utils.urlutils import admin_reverse
 
@@ -96,7 +97,11 @@ def _get_page_by_untyped_arg(page_lookup, request, site_id):
             raise Page.DoesNotExist(body)
         else:
             if "django.middleware.common.BrokenLinkEmailsMiddleware" in settings.MIDDLEWARE:
-                mail_managers(subject, body, fail_silently=True)
+                try:
+                    mail_managers(subject, body)
+                except MAIL_DELIVERY_ERRORS:
+                    # A delivery failure must not replace the missing-page response.
+                    pass
             return None
 
 

--- a/cms/tests/test_mail.py
+++ b/cms/tests/test_mail.py
@@ -1,9 +1,15 @@
+from smtplib import SMTPException
+from unittest import skipUnless
+from unittest.mock import patch
+
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core import mail
+from django.test import SimpleTestCase, override_settings
 
 from cms.api import create_page_user
 from cms.test_utils.testcases import CMSTestCase
-from cms.utils.mail import mail_page_user_change
+from cms.utils.mail import mail_page_user_change, send_mail
 
 
 class MailTestCase(CMSTestCase):
@@ -15,3 +21,87 @@ class MailTestCase(CMSTestCase):
         user = create_page_user(user, user, grant_all=True)
         mail_page_user_change(user)
         self.assertEqual(len(mail.outbox), 1)
+
+
+    @skipUnless(MAILERS_SUPPORTED, "Django < 6.1 has no MAILERS setting")
+    def test_mailers_only_project(self):
+        self.assertEqual(
+            settings.MAILERS["default"]["BACKEND"],
+            "django.core.mail.backends.locmem.EmailBackend",
+        )
+        # MAILERS must work without falling back to legacy email settings.
+        for name in ("EMAIL_BACKEND", "EMAIL_HOST", "EMAIL_HOST_USER"):
+            with self.subTest(setting=name), self.assertRaises(AttributeError):
+                getattr(settings, name)
+
+        user = get_user_model()(email="username@django-cms.org")
+        mail_page_user_change(user, site=Site(domain="example.com"))
+
+        self.assertEqual(len(mail.outbox), 1)
+        message = mail.outbox[0]
+        self.assertEqual(message.to, [user.email])
+        self.assertIn("https://example.com/en/admin/", message.body)
+        self.assertEqual(message.alternatives[0][1], "text/html")
+
+
+@override_settings(
+    TEMPLATES=[
+        {
+            "BACKEND": "django.template.backends.django.DjangoTemplates",
+            "OPTIONS": {
+                "loaders": [
+                    (
+                        "django.template.loaders.locmem.Loader",
+                        {
+                            "mail.txt": "{{ title }}: {{ login_url }}",
+                            "mail.html": "<p>{{ title }}</p>",
+                        },
+                    )
+                ]
+            },
+        }
+    ]
+)
+class MailDeliveryTests(SimpleTestCase):
+    def send_message(self, **kwargs):
+        return send_mail(
+            "Account updated",
+            "mail.txt",
+            ["user@example.com"],
+            site=Site(domain="example.com"),
+            **kwargs,
+        )
+
+    def test_text_mail(self):
+        self.send_message()
+        message = mail.outbox[0]
+        self.assertEqual(message.to, ["user@example.com"])
+        self.assertIn("Account updated: https://example.com/", message.body)
+        self.assertEqual(message.alternatives, [])
+
+    def test_multipart_mail(self):
+        self.send_message(html_template="mail.html")
+        self.assertEqual(mail.outbox[0].alternatives, [("<p>Account updated</p>", "text/html")])
+
+    def test_suppress_delivery_errors(self):
+        for error in (ConnectionError, SMTPException):
+            with self.subTest(error=error), patch("cms.utils.mail.EmailMultiAlternatives.send", side_effect=error):
+                self.send_message()
+
+    def test_raise_delivery_errors(self):
+        for error in (ConnectionError, SMTPException):
+            with self.subTest(error=error), patch("cms.utils.mail.EmailMultiAlternatives.send", side_effect=error):
+                with self.assertRaises(error):
+                    self.send_message(fail_silently=False)
+
+    def test_raise_programming_errors(self):
+        with patch("cms.utils.mail.EmailMultiAlternatives.send", side_effect=ValueError):
+            with self.assertRaises(ValueError):
+                self.send_message()
+
+    @skipUnless(MAILERS_SUPPORTED, "Django < 6.1 has no MAILERS setting")
+    @override_settings(MAILERS={})
+    def test_unconfigured_mailer(self):
+        self.send_message()
+        with self.assertRaises(mail.MailerDoesNotExist):
+            self.send_message(fail_silently=False)

--- a/cms/tests/test_mail.py
+++ b/cms/tests/test_mail.py
@@ -2,8 +2,8 @@ from smtplib import SMTPException
 from unittest import skipUnless
 from unittest.mock import patch
 
-from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
 from django.core import mail
 from django.test import SimpleTestCase, override_settings
 
@@ -21,28 +21,6 @@ class MailTestCase(CMSTestCase):
         user = create_page_user(user, user, grant_all=True)
         mail_page_user_change(user)
         self.assertEqual(len(mail.outbox), 1)
-
-
-    @skipUnless(MAILERS_SUPPORTED, "Django < 6.1 has no MAILERS setting")
-    def test_mailers_only_project(self):
-        self.assertEqual(
-            settings.MAILERS["default"]["BACKEND"],
-            "django.core.mail.backends.locmem.EmailBackend",
-        )
-        # MAILERS must work without falling back to legacy email settings.
-        for name in ("EMAIL_BACKEND", "EMAIL_HOST", "EMAIL_HOST_USER"):
-            with self.subTest(setting=name), self.assertRaises(AttributeError):
-                getattr(settings, name)
-
-        user = get_user_model()(email="username@django-cms.org")
-        mail_page_user_change(user, site=Site(domain="example.com"))
-
-        self.assertEqual(len(mail.outbox), 1)
-        message = mail.outbox[0]
-        self.assertEqual(message.to, [user.email])
-        self.assertIn("https://example.com/en/admin/", message.body)
-        self.assertEqual(message.alternatives[0][1], "text/html")
-
 
 @override_settings(
     TEMPLATES=[
@@ -64,13 +42,13 @@ class MailTestCase(CMSTestCase):
 )
 class MailDeliveryTests(SimpleTestCase):
     def send_message(self, **kwargs):
-        return send_mail(
-            "Account updated",
-            "mail.txt",
-            ["user@example.com"],
-            site=Site(domain="example.com"),
-            **kwargs,
-        )
+        with patch("cms.utils.mail.Site.objects.get_current", return_value=Site(domain="example.com")):
+            return send_mail(
+                "Account updated",
+                "mail.txt",
+                ["user@example.com"],
+                **kwargs,
+            )
 
     def test_text_mail(self):
         self.send_message()
@@ -99,7 +77,7 @@ class MailDeliveryTests(SimpleTestCase):
             with self.assertRaises(ValueError):
                 self.send_message()
 
-    @skipUnless(MAILERS_SUPPORTED, "Django < 6.1 has no MAILERS setting")
+    @skipUnless(hasattr(mail, "MailerDoesNotExist"), "Django < 6.1 has no MAILERS setting")
     @override_settings(MAILERS={})
     def test_unconfigured_mailer(self):
         self.send_message()

--- a/cms/tests/test_mail.py
+++ b/cms/tests/test_mail.py
@@ -22,6 +22,7 @@ class MailTestCase(CMSTestCase):
         mail_page_user_change(user)
         self.assertEqual(len(mail.outbox), 1)
 
+
 @override_settings(
     TEMPLATES=[
         {

--- a/cms/tests/test_templatetags.py
+++ b/cms/tests/test_templatetags.py
@@ -375,6 +375,18 @@ class TemplatetagDatabaseTests(TwoPagesFixture, CMSTestCase):
         request = self.get_request("/")
         self.assertRaises(TypeError, _get_page_by_untyped_arg, [], request, 1)
 
+    @override_settings(DEBUG=False, MIDDLEWARE=["django.middleware.common.BrokenLinkEmailsMiddleware"])
+    def test_missing_page_mail_error(self):
+        with patch("cms.templatetags.cms_tags.mail_managers", side_effect=ConnectionError):
+            page = _get_page_by_untyped_arg({"pk": 1003}, self.get_request("/"), 1)
+        self.assertIsNone(page)
+
+    @override_settings(DEBUG=False, MIDDLEWARE=["django.middleware.common.BrokenLinkEmailsMiddleware"])
+    def test_missing_page_code_error(self):
+        with patch("cms.templatetags.cms_tags.mail_managers", side_effect=ValueError):
+            with self.assertRaises(ValueError):
+                _get_page_by_untyped_arg({"pk": 1003}, self.get_request("/"), 1)
+
     def test_show_placeholder_for_page_content_does_not_exist(self):
         """
         Verify ``show_placeholder`` correctly handles being given an

--- a/cms/utils/mail.py
+++ b/cms/utils/mail.py
@@ -1,14 +1,20 @@
 from django.contrib.sites.models import Site
+from django.core import mail
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
 from django.utils.translation import gettext_lazy as _
 
 from cms.utils.urlutils import admin_reverse, urljoin
 
+MAIL_DELIVERY_ERRORS = (OSError,)
+if hasattr(mail, "MailerDoesNotExist"):
+    MAIL_DELIVERY_ERRORS += (mail.MailerDoesNotExist,)
+
 
 def send_mail(subject, txt_template, to, context=None, html_template=None, fail_silently=True):
     """
-    Multipart message helper with template rendering.
+    Render and send multipart mail. With ``fail_silently=True``, suppress
+    transport errors and an unconfigured mailer, but not programming errors.
     """
     site = Site.objects.get_current()
 
@@ -25,7 +31,11 @@ def send_mail(subject, txt_template, to, context=None, html_template=None, fail_
     if html_template:
         body = render_to_string(html_template, context)
         message.attach_alternative(body, 'text/html')
-    message.send(fail_silently=fail_silently)
+    try:
+        message.send()
+    except MAIL_DELIVERY_ERRORS:
+        if not fail_silently:
+            raise
 
 
 def mail_page_user_change(user, created=False, password=""):


### PR DESCRIPTION
## Summary by Sourcery

Preserve application behavior when best-effort CMS email delivery encounters transport failures while still surfacing unexpected errors.

Bug Fixes:
- Preserve missing-page responses when best-effort broken-link notification delivery fails.
- Suppress transport and unconfigured-mailer errors for best-effort email while continuing to surface programming errors.

Enhancements:
- Define shared mail delivery error handling for CMS email helpers and support multipart mail behavior.

Tests:
- Add coverage for successful text and multipart email delivery, suppressed and propagated delivery failures, programming errors, unconfigured mailers, and missing-page notification behavior.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.