### PR TITLE
fix: Wizard now rejects pages for other sites (#8848)

### DIFF
--- a/cms/forms/wizards.py
+++ b/cms/forms/wizards.py
@@ -126,6 +126,8 @@ class CreateCMSPageForm(AddPageForm):
             parent_page = None
 
         if parent_page:
+            if parent_page.site_id != self._site.pk:
+                raise ValidationError("Site doesn't match the parent's page site")
             has_perm = user_can_add_subpage(self._user, target=parent_page, site=self._site)
         else:
             has_perm = user_can_add_page(self._user, site=self._site)

--- a/cms/tests/test_wizards.py
+++ b/cms/tests/test_wizards.py
@@ -18,6 +18,7 @@ from cms.cms_wizards import cms_page_wizard, cms_subpage_wizard
 from cms.constants import MODAL_HTML_REDIRECT, TEMPLATE_INHERITANCE_MAGIC
 from cms.forms.wizards import CreateCMSPageForm, CreateCMSSubPageForm
 from cms.models import Page, PageContent, UserSettings
+from cms.models.permissionmodels import GlobalPagePermission
 from cms.test_utils.project.backwards_wizards.wizards import wizard
 from cms.test_utils.project.sampleapp.cms_wizards import sample_wizard
 from cms.test_utils.testcases import CMSTestCase, TransactionCMSTestCase
@@ -26,6 +27,7 @@ from cms.toolbar.utils import (
     get_object_preview_url,
 )
 from cms.utils.conf import get_cms_setting
+from cms.utils.page_permissions import user_can_add_subpage
 from cms.utils.setup import setup_cms_apps
 from cms.utils.urlutils import admin_reverse
 from cms.wizards.forms import WizardStep1Form, WizardStep2BaseForm, step2_form_factory
@@ -653,6 +655,99 @@ class TestPageWizardSubmission(CMSTestCase):
         self.assertEqual(new_page.parent_id, parent.pk)
         edit_endpoint = get_object_edit_url(new_page.get_content_obj("en"), "en")
         self.assertContains(response, MODAL_HTML_REDIRECT.format(url=edit_endpoint))
+
+
+@override_settings(
+    CMS_PERMISSION=True,
+    CMS_LANGUAGES={
+        1: [{"code": "en", "name": "English"}],
+        2: [{"code": "en", "name": "English"}],
+    },
+)
+class TestWizardSiteIsolation(CMSTestCase):
+    def setUp(self):
+        self.site = Site.objects.get_current()
+        self.other_site, _ = Site.objects.get_or_create(
+            pk=2, defaults={"domain": "other.example", "name": "Other site"},
+        )
+        self.local_parent = create_page("Local parent", "nav_playground.html", "en", site=self.site)
+        self.other_parent = create_page("Other parent", "nav_playground.html", "en", site=self.other_site)
+        self.other_child = create_page(
+            "Other child", "nav_playground.html", "en", site=self.other_site, parent=self.other_parent,
+        )
+        self.writer = self._create_user(
+            "site_writer", is_staff=True, permissions=["add_page", "change_page"],
+        )
+        permission = GlobalPagePermission.objects.create(user=self.writer, can_add=True, can_change=True)
+        permission.sites.add(self.site)
+
+    def test_cross_site_origin_is_rejected(self):
+        self.assertFalse(user_can_add_subpage(self.writer, self.other_parent, site=self.other_site))
+        endpoint = admin_reverse("cms_wizard_create")
+        page_count = Page.objects.count()
+
+        with self.login_user_context(self.writer):
+            response = self.client.post(endpoint, {
+                "wizard_create_view-current_step": "0",
+                "0-entry": cms_page_wizard.id,
+                "0-language": "en",
+                "0-page": self.other_child.pk,
+            })
+            self.assertEqual(response.status_code, 200)
+            self.assertIn("page", response.context["wizard"]["form"].errors)
+            # Posting step 1 directly must not bypass the rejected origin.
+            response = self.client.post(endpoint, {
+                "wizard_create_view-current_step": "1",
+                "1-title": "Cross-site sibling",
+                "1-slug": "cross-site-sibling",
+            })
+            self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(Page.objects.count(), page_count)
+
+    def test_same_site_subpage_submission(self):
+        endpoint = admin_reverse("cms_wizard_create")
+        with self.login_user_context(self.writer):
+            response = self.client.post(endpoint, {
+                "wizard_create_view-current_step": "0",
+                "0-entry": cms_subpage_wizard.id,
+                "0-language": "en",
+                "0-page": self.local_parent.pk,
+            })
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.context["wizard"]["steps"].current, "1")
+            response = self.client.post(endpoint, {
+                "wizard_create_view-current_step": "1",
+                "1-title": "Local child",
+                "1-slug": "local-child",
+            })
+            self.assertEqual(response.status_code, 200)
+
+        child = Page.objects.get(pagecontent_set__title="Local child")
+        self.assertEqual(child.site_id, self.site.pk)
+        self.assertEqual(child.parent_id, self.local_parent.pk)
+
+    def test_cross_site_parent_is_rejected_by_creation_forms(self):
+        # Tree integrity must also hold for direct form use, including
+        # superusers and projects without CMS per-page permissions.
+        with self.login_user_context(self.get_superuser()):
+            request = self.get_request()
+        for permissions_enabled in (True, False):
+            for form_class, origin in (
+                (CreateCMSPageForm, self.other_child),
+                (CreateCMSSubPageForm, self.other_parent),
+            ):
+                with self.subTest(permissions=permissions_enabled, form=form_class):
+                    with override_settings(CMS_PERMISSION=permissions_enabled):
+                        form = form_class(
+                            data={"title": "Cross-site page", "slug": "cross-site-page"},
+                            wizard_page=origin,
+                            wizard_site=self.site,
+                            wizard_language="en",
+                            wizard_request=request,
+                        )
+                        self.assertFalse(form.is_valid())
+                        self.assertIn("parent_page", form.errors)
 
 
 class TestWizardHelpers(CMSTestCase):

--- a/cms/wizards/forms.py
+++ b/cms/wizards/forms.py
@@ -74,6 +74,7 @@ class WizardStep1Form(BaseFormMixin, forms.Form):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.fields['page'].queryset = Page.objects.on_site(self._site)
         # set the entries here to get an up to date list of entries.
         choices = list(entry_choices(
             user=self._request.user,

--- a/cms/wizards/views.py
+++ b/cms/wizards/views.py
@@ -122,7 +122,7 @@ class WizardCreateView(SessionWizardView):
         else:
             page_pk = self.page_pk or self.request.GET.get('page', None)
             if page_pk and page_pk != 'None':
-                kwargs['wizard_page'] = Page.objects.filter(pk=page_pk).first()
+                kwargs['wizard_page'] = Page.objects.filter(pk=page_pk, site=self.site).first()
             else:
                 kwargs['wizard_page'] = None
             kwargs['wizard_language'] = get_site_language_from_request(


### PR DESCRIPTION
## Summary by Sourcery

Enforce site isolation throughout the page creation wizard.

Bug Fixes:
- Prevent wizard page creation forms from accepting parent pages belonging to a different site.
- Ensure wizard page selection and originating page lookups are restricted to the active site.

Tests:
- Add coverage for cross-site wizard rejection, direct form validation, same-site subpage creation, and attempts to bypass wizard-step validation.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.