### PR TITLE
fix: Cache invalidation

### DIFF
--- a/cms/models/pagemodel.py
+++ b/cms/models/pagemodel.py
@@ -652,7 +652,13 @@ class Page(MP_Node):
                 permissions_new.append(permission)
 
             if permissions_new:
+                from cms.cache.permissions import clear_permission_cache
+                from cms.utils.permissions import clear_permission_lru_caches
+
                 new_page.pagepermission_set.bulk_create(permissions_new)
+                # bulk_create does not emit the permission signals.
+                clear_permission_cache()
+                clear_permission_lru_caches(user)
         return new_page
 
     def copy_with_descendants(

--- a/cms/tests/test_copy_permissions.py
+++ b/cms/tests/test_copy_permissions.py
@@ -119,6 +119,19 @@ class CopyPermissionsTests(CMSTestCase):
         self.assertTrue(copied.pagepermission_set.filter(user=self.actor, can_view=True).exists())
         self.assertEqual(self.client.get(copied.get_absolute_url()).status_code, 404)
 
+    def test_copy_permissions_invalidates_permission_caches(self):
+        self.add_page_permission(self.actor, self.source, can_change=True, grant_on=ACCESS_PAGE)
+        self.assertTrue(page_permissions.user_can_change_page(self.actor, self.source))
+
+        copied = self.source.copy(
+            self.source.site,
+            parent_page=self.target,
+            permissions=True,
+            user=self.actor,
+        )
+
+        self.assertTrue(page_permissions.user_can_change_page(self.actor, copied))
+
     def test_readable_descendants_can_be_copied_without_permissions(self):
         self.add_page_permission(self.actor, self.secret, can_view=True, grant_on=ACCESS_PAGE)
         response = self.copy("")


### PR DESCRIPTION
## Summary by Sourcery

Fix permission cache invalidation so copied page permissions become immediately and reliably visible after transactions commit.

Bug Fixes:
- Ensure permission caches are invalidated when page permissions are copied, including after the transaction commits.
- Prevent stale per-user permission results from surviving global permission-cache invalidation.

Tests:
- Add coverage for permission cache invalidation during permission copying, including cached actions for other users and concurrent pre-commit cache rebuilds.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* Introduced by #8840 

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.