### PR TITLE
fix: Check page source when adding a apage

### DIFF
--- a/cms/admin/forms.py
+++ b/cms/admin/forms.py
@@ -285,6 +285,7 @@ class AddPageForm(BasePageContentForm):
     content_defaults = {
         "in_navigation": get_cms_setting("DEFAULT_IN_NAVIGATION"),
     }
+    source_permission_denied = _("You do not have permission to use this page type.")
 
     class Meta:
         model = PageContent
@@ -310,8 +311,13 @@ class AddPageForm(BasePageContentForm):
             titles = PageContent.objects.filter(page__in=descendants, language=self._language)
             choices = [("", "---------")]
             choices.extend((title.page_id, title.title) for title in titles)
+            # Narrow the queryset and not just the choices: ``source`` is validated
+            # against the queryset, which otherwise spans the page types of every
+            # site, while the choices are merely what the widget renders.
+            source_field.queryset = descendants
             source_field.choices = choices
         else:
+            source_field.queryset = source_field.queryset.none()
             choices = []
 
         if len(choices) < 2:
@@ -346,6 +352,16 @@ class AddPageForm(BasePageContentForm):
         else:
             data["path"] = path
         return data
+
+    def clean_source(self):
+        source = self.cleaned_data.get("source")
+        # ``source`` is a hidden field whose value is fully controlled by the
+        # client on POST and ``has_add_permission`` only checks that the user may
+        # create *a* page, not that they may read ``source`` -- whose placeholders,
+        # plugins and extensions ``save()`` copies into the new page.
+        if source and not user_can_view_page(self._user, source):
+            raise ValidationError(self.source_permission_denied)
+        return source
 
     def clean_parent_page(self):
         parent_page = self.cleaned_data.get("parent_page")
@@ -415,6 +431,10 @@ class AddPageForm(BasePageContentForm):
             user=self._user,
         )
         new_page.update(is_page_type=False)
+        # ``Page.copy()`` is called with ``permissions=False``, so a copy of a
+        # view-restricted source would be world-readable. Carry the source's view
+        # restrictions -- its own and the ones it inherits -- over to the copy.
+        new_page.apply_view_restrictions(source.get_view_restrictions(), user=self._user)
         return new_page
 
     def get_template(self):
@@ -557,24 +577,7 @@ class DuplicatePageForm(AddPageForm):
         required=True,
         widget=forms.HiddenInput(),
     )
-
-    def clean_source(self):
-        source = self.cleaned_data.get("source")
-        # ``source`` is a hidden field whose value is fully controlled by the
-        # client on POST and whose queryset spans every page on every site.
-        # ``has_add_permission`` only checks that the user may create *a* page,
-        # not that they may read ``source``.
-        if source and not user_can_view_page(self._user, source):
-            raise ValidationError(_("You do not have permission to copy this page."))
-        return source
-
-    def from_source(self, source, parent=None):
-        new_page = super().from_source(source, parent=parent)
-        # ``Page.copy()`` is called with ``permissions=False``, so a duplicate of
-        # a view-restricted page would be world-readable. Carry the source's view
-        # restrictions -- its own and the ones it inherits -- over to the copy.
-        new_page.apply_view_restrictions(source.get_view_restrictions(), user=self._user)
-        return new_page
+    source_permission_denied = _("You do not have permission to copy this page.")
 
 
 class ChangePageForm(BasePageContentForm):

--- a/cms/tests/test_copy_permissions.py
+++ b/cms/tests/test_copy_permissions.py
@@ -3,6 +3,7 @@ from django.contrib.sites.models import Site
 from django.test import override_settings
 
 from cms.api import add_plugin, create_page
+from cms.constants import PAGE_TYPES_ID
 from cms.models import (
     ACCESS_CHILDREN,
     ACCESS_PAGE,
@@ -372,3 +373,96 @@ class DuplicatePermissionsTests(CMSTestCase):
         self.assertEqual(PagePermission.objects.count(), count)
         self.assertFalse(copy.has_view_restrictions(copy.site))
         self.assertContains(self.client.get(copy.get_absolute_url()), self.marker)
+
+
+@override_settings(CMS_PERMISSION=True, CMS_PUBLIC_FOR="all")
+class PageTypeSourcePermissionsTests(CMSTestCase):
+    """``Add page`` can copy a page type; its restrictions come along.
+
+    Page types can no longer be created through the UI, but rows migrated from
+    django CMS 3.x are still offered as ``source`` on the add form.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.admin = self.get_superuser()
+        self.actor = self.get_staff_user_with_no_permissions()
+        for codename in ("add_page", "change_page", "add_text", "change_text"):
+            self.add_permission(self.actor, codename)
+        self.target = create_page("target", "nav_playground.html", "en")
+        self.add_page_permission(self.actor, self.target, can_add=True, can_change=True, grant_on=ACCESS_PAGE)
+        self.marker = "CONFIDENTIAL-PAGE-TYPE-REGRESSION"
+
+    def create_page_type(self, title, site=None):
+        root = create_page("Page Types", "nav_playground.html", "en", site=site, reverse_id=PAGE_TYPES_ID)
+        page_type = create_page(title, "nav_playground.html", "en", site=site, parent=root)
+        Page.objects.filter(pk__in=(root.pk, page_type.pk)).update(is_page_type=True)
+        add_plugin(page_type.get_placeholders("en").get(slot="body"), "TextPlugin", "en", body=self.marker)
+        return Page.objects.get(pk=page_type.pk)
+
+    def add_from_source(self, source):
+        endpoint = self.get_admin_url(PageContent, "add")
+        with self.login_user_context(self.actor):
+            response = self.client.post(
+                f"{endpoint}?parent_page={self.target.pk}",
+                {
+                    "title": "from-page-type",
+                    "slug": "from-page-type",
+                    "template": "nav_playground.html",
+                    "language": "en",
+                    "source": source.pk,
+                    "parent_page": self.target.pk,
+                    "_save": 1,
+                },
+            )
+        self.actor = type(self.actor).objects.get(pk=self.actor.pk)
+        return response, self.target.get_child_pages().first()
+
+    def assertAddDenied(self, source):
+        counts = (Page.objects.count(), CMSPlugin.objects.count())
+        response, copy = self.add_from_source(source)
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(copy)
+        self.assertEqual(counts, (Page.objects.count(), CMSPlugin.objects.count()))
+
+    def test_rejects_page_type_user_cannot_view(self):
+        source = self.create_page_type("secret-type")
+        self.add_page_permission(self.admin, source, can_view=True, grant_on=ACCESS_PAGE)
+        self.assertFalse(page_permissions.user_can_view_page(self.actor, source))
+        self.assertAddDenied(source)
+
+    @override_settings(
+        CMS_LANGUAGES={
+            1: [{"code": "en", "name": "English"}],
+            2: [{"code": "en", "name": "English"}],
+        }
+    )
+    def test_rejects_page_type_from_another_site(self):
+        site = Site.objects.create(domain="other.example", name="Other")
+        self.assertAddDenied(self.create_page_type("other-site-type", site=site))
+
+    def test_rejects_page_type_root(self):
+        source = self.create_page_type("visible-type")
+        self.assertAddDenied(source.parent)
+
+    def test_readable_page_type_can_be_used(self):
+        source = self.create_page_type("visible-type")
+        self.assertTrue(page_permissions.user_can_view_page(self.actor, source))
+
+        response, copy = self.add_from_source(source)
+        self.assertEqual(response.status_code, 302)
+        self.assertIsNotNone(copy)
+        self.assertFalse(copy.is_page_type)
+        self.assertContains(self.client.get(copy.get_absolute_url()), self.marker)
+
+    def test_restricted_page_type_keeps_its_restriction(self):
+        source = self.create_page_type("restricted-type")
+        self.add_page_permission(self.admin, source, can_view=True, grant_on=ACCESS_PAGE)
+        self.add_page_permission(self.actor, source, can_view=True, grant_on=ACCESS_PAGE)
+        self.assertTrue(page_permissions.user_can_view_page(self.actor, source))
+
+        response, copy = self.add_from_source(source)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(copy.has_view_restrictions(copy.site))
+        self.assertFalse(page_permissions.user_can_view_page(AnonymousUser(), copy))
+        self.assertEqual(self.client.get(copy.get_absolute_url()).status_code, 404)


### PR DESCRIPTION
## Summary by Sourcery

Secure page creation from page sources by validating access, preserving restrictions, and rejecting invalid translation combinations.

Bug Fixes:
- Validate page sources against the current user's view permissions before copying their content.
- Prevent page sources from being supplied when creating translations.
- Preserve source page view restrictions on pages created from page types.

Enhancements:
- Restrict page-source querysets to eligible descendant pages and exclude sources when none are available.

Tests:
- Add coverage for inaccessible, cross-site, root, restricted, and valid page-type sources, including translation behavior.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.

Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``main``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined [our Discord Server](https://discord-pr-review-channel.django-cms.org) and the channel [#pr-reviews](https://discord.com/channels/800813886689247262/1236299181761630249) to find a “pr review buddy” who is going to review my pull request.